### PR TITLE
Multipart formdata

### DIFF
--- a/example/src/main/scala/HelloWorldAdvanced.scala
+++ b/example/src/main/scala/HelloWorldAdvanced.scala
@@ -2,6 +2,7 @@ import zhttp.http._
 import zhttp.service._
 import zhttp.service.server.ServerChannelFactory
 import zio._
+import zio.stream.ZStream
 
 import scala.util.Try
 
@@ -14,15 +15,29 @@ object HelloWorldAdvanced extends App {
     case Method.GET -> Root / "bar" => Response.text("foo")
   }
 
+  private def streamSize[R, E, A](stream: ZStream[R, E, A]): ZIO[R, E, Long] =
+    stream.mapChunks(c => Chunk(c.size)).fold(0L)(_ + _)
+
   private val app = HttpApp.collectM {
-    case Method.GET -> Root / "random" => random.nextString(10).map(Response.text)
-    case Method.GET -> Root / "utc"    => clock.currentDateTime.map(s => Response.text(s.toString))
+    case Method.GET -> Root / "random"             => random.nextString(10).map(Response.text)
+    case Method.GET -> Root / "utc"                =>
+      clock.currentDateTime.map(s => Response.text(s.toString))
+    case req @ Method.POST -> Root / "file-upload" =>
+      req.content match {
+        case fd: HttpData.MultipartFormData =>
+          val attributes = fd.attributes.map { case (name, attr) =>
+            streamSize(attr.content).map(size => s"$name: $size")
+          }
+          val files      = fd.files.map { case (name, file) => streamSize(file.content).map(size => s"$name: $size") }
+          ZIO.collectAllParN(3)(attributes ++ files).map(sizes => Response.text(sizes.mkString(",")))
+        case _                              => UIO.succeed(Response.status(Status.BAD_REQUEST))
+      }
   }
 
   private val server =
-    Server.port(PORT) ++              // Setup port
-      Server.paranoidLeakDetection ++ // Paranoid leak detection (affects performance)
-      Server.app(fooBar +++ app)      // Setup the Http app
+    Server.port(PORT) ++             // Setup port
+      Server.disableLeakDetection ++ // Paranoid leak detection (affects performance)
+      Server.app(fooBar +++ app)     // Setup the Http app
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {
     // Configure thread count using CLI

--- a/example/src/main/scala/SimpleClient.scala
+++ b/example/src/main/scala/SimpleClient.scala
@@ -9,9 +9,10 @@ object SimpleClient extends App {
     res <- Client.request("https://api.github.com/users/zio/repos")
     _   <- console.putStrLn {
       res.content match {
-        case HttpData.CompleteData(data) => data.map(_.toChar).mkString
-        case HttpData.StreamData(_)      => "<Chunked>"
-        case HttpData.Empty              => ""
+        case HttpData.CompleteData(data)      => data.map(_.toChar).mkString
+        case HttpData.StreamData(_)           => "<Chunked>"
+        case HttpData.MultipartFormData(_, _) => "<Multipart-FormData>"
+        case HttpData.Empty                   => ""
       }
     }
   } yield ()

--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -15,7 +15,6 @@ final case class Request(
     case HttpData.CompleteData(data) => Option(data.map(_.toChar).mkString)
     case _                           => Option.empty
   }
-
 }
 
 object Request {}

--- a/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
@@ -1,7 +1,14 @@
 package zhttp.service
 
+import io.netty.handler.codec.http.multipart.{Attribute, FileUpload, HttpData => JHttpData, HttpPostRequestDecoder}
+import io.netty.handler.codec.http.{HttpHeaders, HttpMethod}
 import zhttp.core.JFullHttpRequest
+import zhttp.http.HttpData.{AttributeData, FileData, MultipartFormData}
 import zhttp.http._
+import zio.blocking.Blocking
+import zio.stream.ZStream
+
+import scala.util.{Success, Try}
 
 trait DecodeJRequest {
 
@@ -15,4 +22,38 @@ trait DecodeJRequest {
     endpoint = method -> url
     data     = HttpData.fromByteBuf(jReq.content())
   } yield Request(endpoint, headers, data)
+
+  def decodeMultipart(
+    url: String,
+    reqHeaders: HttpHeaders,
+    decoder: HttpPostRequestDecoder,
+  ): Either[Throwable, Request] = for {
+    url <- URL.fromString(url)
+    method   = Method.fromJHttpMethod(HttpMethod.POST)
+    headers  = Header.make(reqHeaders)
+    endpoint = method -> url
+    bodies <-
+      decoder
+        .getBodyHttpDatas()
+        .toArray()
+        .foldLeft(Try(MultipartFormData.empty)) {
+          case (Success(acc), f: FileUpload) =>
+            httpDataToStream(f).map(data =>
+              acc.copy(files = acc.files + (f.getName -> FileData(f.getName, f.getContentType, data))),
+            )
+          case (Success(acc), a: Attribute)  =>
+            httpDataToStream(a).map(data =>
+              acc.copy(attributes = acc.attributes + (a.getName -> AttributeData(a.getName, data))),
+            )
+          case (acc, _)                      =>
+            acc
+        }
+        .toEither
+  } yield Request(endpoint, headers, bodies)
+
+  private def httpDataToStream(data: JHttpData): Try[ZStream[Blocking, Throwable, Byte]] = {
+    // First try to get the underlying File (for larger uploads). If this doesn't exist,
+    // get the in-memory data. Both calls may fail with an IOException
+    Try(data.getFile.toPath).map(ZStream.fromFile(_)).orElse(Try(ZStream.fromIterable(data.get())))
+  }
 }

--- a/zio-http/src/main/scala/zhttp/service/EncodeResponse.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeResponse.scala
@@ -33,6 +33,10 @@ trait EncodeResponse {
 
       case HttpData.Empty =>
         jHttpHeaders.set(JHttpHeaderNames.CONTENT_LENGTH, 0)
+
+      case HttpData.MultipartFormData(_, _) =>
+        // We don't support sending a Multipart/Formdata response
+        ()
     }
     new JDefaultHttpResponse(jVersion, jStatus, jHttpHeaders)
   }

--- a/zio-http/src/main/scala/zhttp/service/package.scala
+++ b/zio-http/src/main/scala/zhttp/service/package.scala
@@ -4,12 +4,13 @@ import zhttp.core._
 import zio.Has
 
 package object service {
-  private[service] val AUTO_RELEASE_REQUEST   = false
-  private[service] val SERVER_CODEC_HANDLER   = "SERVER_CODEC"
-  private[service] val OBJECT_AGGREGATOR      = "OBJECT_AGGREGATOR"
-  private[service] val HTTP_REQUEST_HANDLER   = "HTTP_REQUEST"
-  private[service] val HTTP_KEEPALIVE_HANDLER = "HTTP_KEEPALIVE"
-  private[service] val WEB_SOCKET_HANDLER     = "WEB_SOCKET_HANDLER"
+  private[service] val AUTO_RELEASE_REQUEST       = false
+  private[service] val SERVER_CODEC_HANDLER       = "SERVER_CODEC"
+  private[service] val OBJECT_AGGREGATOR          = "OBJECT_AGGREGATOR"
+  private[service] val HTTP_REQUEST_HANDLER       = "HTTP_REQUEST"
+  private[service] val HTTP_KEEPALIVE_HANDLER     = "HTTP_KEEPALIVE"
+  private[service] val WEB_SOCKET_HANDLER         = "WEB_SOCKET_HANDLER"
+  private[service] val MULTIPART_FORMDATA_HANDLER = "MULTIPART_FORMDATA_HANDLER"
 
   type ChannelFactory       = Has[JChannelFactory[JChannel]]
   type EventLoopGroup       = Has[JEventLoopGroup]

--- a/zio-http/src/main/scala/zhttp/service/server/ServerChannelInitializer.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerChannelInitializer.scala
@@ -1,19 +1,33 @@
 package zhttp.service.server
 
+import io.netty.handler.codec.http.HttpObjectDecoder.{
+  DEFAULT_MAX_CHUNK_SIZE,
+  DEFAULT_MAX_HEADER_SIZE,
+  DEFAULT_MAX_INITIAL_LINE_LENGTH,
+}
 import io.netty.handler.codec.http.HttpServerKeepAliveHandler
 import zhttp.core._
-import zhttp.service.{HTTP_KEEPALIVE_HANDLER, HTTP_REQUEST_HANDLER, OBJECT_AGGREGATOR, SERVER_CODEC_HANDLER}
+import zhttp.service._
 
 /**
  * Initializes the netty channel with default handlers
  */
 @JSharable
-final case class ServerChannelInitializer(httpH: JChannelHandler, maxSize: Int) extends JChannelInitializer[JChannel] {
+final case class ServerChannelInitializer(httpH: JChannelHandler, hhtpMfdH: JChannelHandler, maxSize: Int)
+    extends JChannelInitializer[JChannel] {
   override def initChannel(channel: JChannel): Unit = {
     channel
       .pipeline()
-      .addLast(SERVER_CODEC_HANDLER, new JHttpServerCodec)
+      // Without increasing the DEFAULT_MAX_CHUNK_SIZE uploads are rather slow. Probably because Netty is chunking up messages
+      // itself. With a file upload, that causes lots of overhead. A factor >8 (resulting in 65K chunks) is ignored so it seems.
+      .addLast(
+        SERVER_CODEC_HANDLER,
+        new JHttpServerCodec(DEFAULT_MAX_INITIAL_LINE_LENGTH, DEFAULT_MAX_HEADER_SIZE, DEFAULT_MAX_CHUNK_SIZE * 8),
+      )
       .addLast(HTTP_KEEPALIVE_HANDLER, new HttpServerKeepAliveHandler)
+      // This handler should always be in front of the `JHttpObjectAggregator` or we won't be able to
+      // decode multipart/form-data requests correctly.
+      .addLast(MULTIPART_FORMDATA_HANDLER, hhtpMfdH)
       .addLast(OBJECT_AGGREGATOR, new JHttpObjectAggregator(maxSize))
       .addLast(HTTP_REQUEST_HANDLER, httpH)
     ()

--- a/zio-http/src/main/scala/zhttp/service/server/ServerMultipartRequestHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerMultipartRequestHandler.scala
@@ -1,0 +1,166 @@
+package zhttp.service.server
+
+import io.netty.buffer.{Unpooled => JUnpooled}
+import io.netty.handler.codec.http.multipart._
+import io.netty.handler.codec.http.{HttpContent => JHttpContent, LastHttpContent => JLastHttpContent, _}
+import io.netty.util.AttributeKey
+import zhttp.core.{JChannelHandlerContext, JSharable, JSimpleChannelInboundHandler}
+import zhttp.http.{HttpData, _}
+import zhttp.service.Server.Settings
+import zhttp.service.{ChannelFuture, HttpMessageCodec, UnsafeChannelExecutor}
+import zio.Exit
+
+@JSharable
+final case class ServerMultipartRequestHandler[R](
+  zExec: UnsafeChannelExecutor[R],
+  settings: Settings[R, Throwable],
+) extends JSimpleChannelInboundHandler[HttpObject](true)
+    with HttpMessageCodec {
+
+  self =>
+
+  private val factory                                          = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE)
+  private val decoderKey: AttributeKey[HttpPostRequestDecoder] = AttributeKey.valueOf("decoder")
+  private val uriKey: AttributeKey[String]                     = AttributeKey.valueOf("uri")
+  private val headersKey: AttributeKey[HttpHeaders]            = AttributeKey.valueOf("headers")
+  private val protocolVersionKey: AttributeKey[HttpVersion]    = AttributeKey.valueOf("protocolVersion")
+
+  // TODO: nearly the samve as the one in `ServerRequestHandler`. Generalize and lift?
+  private def executeAsync(ctx: JChannelHandlerContext, jReq: Either[Throwable, Request])(
+    cb: Response[R, Throwable] => Unit,
+  ): Unit =
+    jReq match {
+      case Left(err)  => cb(HttpError.InternalServerError("Request decoding failure", Option(err)).toResponse)
+      case Right(req) =>
+        settings.http.execute(req).evaluate match {
+          case HttpResult.Empty      => cb(Response.fromHttpError(HttpError.NotFound(req.url.path)))
+          case HttpResult.Success(a) => cb(a)
+          case HttpResult.Failure(e) => cb(SilentResponse[Throwable].silent(e))
+          case HttpResult.Effect(z)  =>
+            zExec.unsafeExecute(ctx, z) {
+              case Exit.Success(res)   => cb(res)
+              case Exit.Failure(cause) =>
+                cause.failureOption match {
+                  case Some(Some(e)) => cb(SilentResponse[Throwable].silent(e))
+                  case Some(None)    => cb(Response.fromHttpError(HttpError.NotFound(req.url.path)))
+                  case None          => {
+                    ctx.close()
+                    ()
+                  }
+                }
+            }
+        }
+    }
+
+  private def removeHandler(ctx: JChannelHandlerContext, httpObject: HttpObject): Unit = {
+    ctx.channel().pipeline().remove(this)
+    ctx.fireChannelRead(httpObject)
+    ()
+  }
+
+  private def cleanupDecoder(ctx: JChannelHandlerContext): Unit = {
+    val decoder = ctx.channel().attr(decoderKey).get()
+    try {
+      decoder.cleanFiles()
+      decoder.destroy()
+    } catch {
+      case _: Throwable =>
+    }
+  }
+
+  override def channelRead0(ctx: JChannelHandlerContext, httpObject: HttpObject): Unit = httpObject match {
+    case httpRequest: HttpRequest if httpRequest.method() != HttpMethod.POST =>
+      // Stop handling this message and ignore all
+      // following httpObjects for this request
+      removeHandler(ctx, httpObject)
+      ()
+    case httpRequest: HttpRequest if httpRequest.method() == HttpMethod.POST =>
+      val httpPostDecoder = new HttpPostRequestDecoder(factory, httpRequest)
+      ctx.channel().attr(decoderKey).set(httpPostDecoder)
+
+      if (!httpPostDecoder.isMultipart) {
+        // Stop handling this message and ignore all
+        // following httpObjects for this request
+        removeHandler(ctx, httpObject)
+        ()
+      } else {
+        ctx.channel().attr(uriKey).set(httpRequest.uri())
+        ctx.channel().attr(headersKey).set(httpRequest.headers())
+        ctx.channel().attr(protocolVersionKey).set(httpRequest.protocolVersion())
+
+        if (HttpUtil.is100ContinueExpected(httpRequest)) {
+          ctx
+            .channel()
+            .writeAndFlush(
+              new DefaultFullHttpResponse(httpRequest.protocolVersion(), HttpResponseStatus.CONTINUE),
+              ctx.channel().voidPromise(),
+            )
+        }
+        ()
+      }
+
+    case httpContent: JLastHttpContent =>
+      val decoder = ctx.channel().attr(decoderKey).get()
+      decoder.offer(httpContent)
+      ctx.channel().attr(headersKey).get().add(httpContent.trailingHeaders())
+      val req     = decodeMultipart(
+        ctx.channel().attr(uriKey).get(),
+        ctx.channel().attr(headersKey).get(),
+        decoder,
+      )
+
+      executeAsync(ctx, req) {
+        case res @ Response.HttpResponse(_, _, _) =>
+          // TODO: share this logic with ServerRequestHandler
+          ctx.write(encodeResponse(ctx.channel().attr(protocolVersionKey).get(), res), ctx.channel().voidPromise())
+          res.content match {
+            case HttpData.StreamData(data)        =>
+              zExec.unsafeExecute_(ctx) {
+                for {
+                  _ <- data.foreachChunk(c => ChannelFuture.unit(ctx.writeAndFlush(JUnpooled.copiedBuffer(c.toArray))))
+                  _ <- ChannelFuture.unit(ctx.writeAndFlush(JLastHttpContent.EMPTY_LAST_CONTENT))
+                } yield ()
+              }
+            case HttpData.CompleteData(data)      =>
+              ctx.write(JUnpooled.copiedBuffer(data.toArray), ctx.channel().voidPromise())
+              ctx.writeAndFlush(JLastHttpContent.EMPTY_LAST_CONTENT)
+            case HttpData.MultipartFormData(_, _) => ctx.writeAndFlush(JLastHttpContent.EMPTY_LAST_CONTENT)
+            case HttpData.Empty                   => ctx.writeAndFlush(JLastHttpContent.EMPTY_LAST_CONTENT)
+          }
+
+          cleanupDecoder(ctx)
+          ()
+        case _                                    =>
+          // We don't deal with Websockets here
+          ()
+      }
+
+    case httpContent: JHttpContent =>
+      ctx.channel().attr(decoderKey).get().offer(httpContent)
+      ()
+
+    case _ =>
+      ()
+  }
+
+  override def channelInactive(ctx: JChannelHandlerContext): Unit = {
+    cleanupDecoder(ctx)
+  }
+
+  override def handlerRemoved(ctx: JChannelHandlerContext): Unit = {
+    cleanupDecoder(ctx)
+  }
+
+  /**
+   * Handles exceptions that throws
+   */
+  override def exceptionCaught(ctx: JChannelHandlerContext, cause: Throwable): Unit = {
+    settings.error match {
+      case Some(v) => zExec.unsafeExecute_(ctx)(v(cause).uninterruptible)
+      case None    => {
+        ctx.fireExceptionCaught(cause)
+        ()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi!

I created a multipart/form-data request handler to also support those requests. Although I tried to minimize the amount of changes I couldn't get around changing the `Request.Data.content` to `HttpContent[Any, Byte]` instead of `HttpContent[Any, String]`. You probably have some better ideas about this setup than I do so I just want to put this out here and hear your thoughts on this.

Best,

DJ