### PR TITLE
add provide methods to Http

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -1,7 +1,7 @@
 package zhttp.http
 
 import zhttp.http.Http.{Chain, Combine, FoldM, FromEffectFunction}
-import zio.{CanFail, Has, NeedsEnv, Tag, ZEnv, ZIO, ZLayer}
+import zio._
 
 import scala.annotation.unused
 


### PR DESCRIPTION
In writing a larger Http application, in order to keep things clean, it makes sense to be able to provide local dependencies to the application.  This helps keep logic from getting entangled in the larger application.

Because `Http` wraps the ZIO objects, you loose the ability to provide the dependencies without providing it in each specific `collectM` instance.  It's a lot nicer to provide the dependencies in one place.

This PR adds the ability to provide the dependencies on the HTTP object itself, which in-turn provides it to each underlying ZIO instance where necessary, allowing providing dependencies once after composition of Http objects.

** Note: Not sure what to write for tests at this point, the types are already pretty restrictive.  Definitely up for suggestions here.