### PR TITLE
feat: Add provide* combinators to Http and HttpResult

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -303,8 +303,7 @@ object Http {
   private final case class ProvideLayer[E, E1 >: E, R, R0, R1 <: R, A, B](
     self: Http[R, E, A, B],
     layer: ZLayer[R0, E1, R1],
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R])
-      extends Http[R0, E1, A, B]
+  ) extends Http[R0, E1, A, B]
 
   // Ctor Help
   final case class MakeCollectM[A](unit: Unit) extends AnyVal {

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -290,21 +290,18 @@ sealed trait Http[-R, +E, -A, +B] { self =>
    */
   final private[zhttp] def execute(a: A): HttpResult[R, E, B] = {
     self match {
-      case Empty                        => HttpResult.empty
-      case Identity                     => HttpResult.succeed(a.asInstanceOf[B])
-      case Succeed(b)                   => HttpResult.succeed(b)
-      case Fail(e)                      => HttpResult.fail(e)
-      case FromEffectFunction(f)        => HttpResult.effect(f(a))
-      case Collect(pf)                  => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
-      case Chain(self, other)           => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
-      case FoldM(self, ee, bb, dd)      =>
+      case Empty                   => HttpResult.empty
+      case Identity                => HttpResult.succeed(a.asInstanceOf[B])
+      case Succeed(b)              => HttpResult.succeed(b)
+      case Fail(e)                 => HttpResult.fail(e)
+      case FromEffectFunction(f)   => HttpResult.effect(f(a))
+      case Collect(pf)             => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
+      case Chain(self, other)      => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
+      case FoldM(self, ee, bb, dd) =>
         HttpResult.suspend {
           self.execute(a).foldM(ee(_).execute(a), bb(_).execute(a), dd.execute(a))
         }
-      case p @ Provide(_, _)            => p.execute(a)
-      case ps @ ProvideSome(_, _)       => ps.execute(a)
-      case pl @ ProvideLayer(_, _)      => pl.execute(a)
-      case psl @ ProvideSomeLayer(_, _) => psl.execute(a)
+      case x                       => x.execute(a)
     }
   }
 

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -290,21 +290,21 @@ sealed trait Http[-R, +E, -A, +B] { self =>
    */
   final private[zhttp] def execute(a: A): HttpResult[R, E, B] = {
     self match {
-      case Empty                             => HttpResult.empty
-      case Identity                          => HttpResult.succeed(a.asInstanceOf[B])
-      case Succeed(b)                        => HttpResult.succeed(b)
-      case Fail(e)                           => HttpResult.fail(e)
-      case FromEffectFunction(f)             => HttpResult.effect(f(a))
-      case Collect(pf)                       => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
-      case Chain(self, other)                => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
-      case FoldM(self, ee, bb, dd)           =>
+      case Empty                        => HttpResult.empty
+      case Identity                     => HttpResult.succeed(a.asInstanceOf[B])
+      case Succeed(b)                   => HttpResult.succeed(b)
+      case Fail(e)                      => HttpResult.fail(e)
+      case FromEffectFunction(f)        => HttpResult.effect(f(a))
+      case Collect(pf)                  => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
+      case Chain(self, other)           => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
+      case FoldM(self, ee, bb, dd)      =>
         HttpResult.suspend {
           self.execute(a).foldM(ee(_).execute(a), bb(_).execute(a), dd.execute(a))
         }
-      case p @ Provide(_, _)                 => p.execute(a)
-      case ps @ ProvideSome(_, _)            => ps.execute(a)
-      case pl @ Http.ProvideLayer(_, _)      => pl.execute(a)
-      case psl @ Http.ProvideSomeLayer(_, _) => psl.execute(a)
+      case p @ Provide(_, _)            => p.execute(a)
+      case ps @ ProvideSome(_, _)       => ps.execute(a)
+      case pl @ ProvideLayer(_, _)      => pl.execute(a)
+      case psl @ ProvideSomeLayer(_, _) => psl.execute(a)
     }
   }
 

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -1,6 +1,5 @@
 package zhttp.http
 
-// import zhttp.http.Http.{Chain, Collect, FoldM, FromEffectFunction}
 import zio._
 
 import scala.annotation.unused

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -263,19 +263,19 @@ sealed trait Http[-R, +E, -A, +B] { self =>
    */
   final private[zhttp] def execute[R0, R1 <: R, E1 >: E](a: A): HttpResult[R, E, B] = {
     self match {
-      case Empty                   => HttpResult.empty
-      case Identity                => HttpResult.succeed(a.asInstanceOf[B])
-      case Succeed(b)              => HttpResult.succeed(b)
-      case Fail(e)                 => HttpResult.fail(e)
-      case FromEffectFunction(f)   => HttpResult.effect(f(a))
-      case Collect(pf)             => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
-      case Chain(self, other)      => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
-      case FoldM(self, ee, bb, dd) =>
+      case Empty                                => HttpResult.empty
+      case Identity                             => HttpResult.succeed(a.asInstanceOf[B])
+      case Succeed(b)                           => HttpResult.succeed(b)
+      case Fail(e)                              => HttpResult.fail(e)
+      case FromEffectFunction(f)                => HttpResult.effect(f(a))
+      case Collect(pf)                          => if (pf.isDefinedAt(a)) HttpResult.succeed(pf(a)) else HttpResult.empty
+      case Chain(self, other)                   => HttpResult.suspend(self.execute(a) >>= (other.execute(_)))
+      case FoldM(self, ee, bb, dd)              =>
         HttpResult.suspend {
           self.execute(a).foldM(ee(_).execute(a), bb(_).execute(a), dd.execute(a))
         }
-      case p @ Provide(_, _)       => p.evaluate(a)
-      case p @ ProvideLayer(_, _)  => p.evaluate(a)
+      case p: Provide[_, _, _, _]               => p.evaluate(a)
+      case p: ProvideLayer[_, _, _, _, _, _, _] => p.evaluate(a)
     }
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpResult.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpResult.scala
@@ -106,8 +106,7 @@ object HttpResult {
   private final case class ProvideLayer[E, E1 >: E, R, R0, R1 <: R, A](
     r: HttpResult[R, E, A],
     layer: ZLayer[R0, Option[E1], R1],
-  )(implicit ev1: R1 <:< R, ev2: NeedsEnv[R])
-      extends HttpResult[R0, E1, A]
+  ) extends HttpResult[R0, E1, A]
 
   // Help
   def succeed[A](a: A): HttpResult.Out[Any, Nothing, A] = Success(a)

--- a/zio-http/src/main/scala/zhttp/http/HttpResult.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpResult.scala
@@ -205,18 +205,14 @@ object HttpResult {
     result: HttpResult[R, E, A],
   )(implicit ev: NeedsEnv[R]): Out[R0, E, A] = {
     result match {
-      case m: Out[_, _, _]            => m
-      case Suspend(r)                 => evaluate(r())
-      case FoldM(self, ee, aa, dd)    =>
+      case m: Out[_, _, _]         => m
+      case Suspend(r)              => evaluate(r())
+      case FoldM(self, ee, aa, dd) =>
         evaluate(self match {
           case Empty                      => dd
           case Success(a)                 => aa(a)
           case Failure(e)                 => ee(e)
           case Suspend(r)                 => r().foldM(ee, aa, dd)
-          case p @ Provide(_, _)          => p.evaluate.foldM(ee, aa, dd)
-          case p @ ProvideSome(_, _)      => p.evaluate.foldM(ee, aa, dd)
-          case p @ ProvideLayer(_, _)     => p.evaluate.foldM(ee, aa, dd)
-          case p @ ProvideSomeLayer(_, _) => p.evaluate.foldM(ee, aa, dd)
           case Effect(z)                  =>
             Effect(
               z.foldM(
@@ -233,11 +229,10 @@ object HttpResult {
               a => aa0(a).foldM(ee, aa, dd),
               dd0.foldM(ee, aa, dd),
             )
+          case x                          => x.evaluate.foldM(ee, aa, dd)
         })
-      case p @ Provide(_, _)          => p.evaluate
-      case p @ ProvideSome(_, _)      => p.evaluate
-      case p @ ProvideLayer(_, _)     => p.evaluate
-      case p @ ProvideSomeLayer(_, _) => p.evaluate
+
+      case x => x.evaluate
     }
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpResult.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpResult.scala
@@ -1,6 +1,7 @@
 package zhttp.http
 
 import zio._
+
 import scala.annotation.{tailrec, unused}
 
 sealed trait HttpResult[-R, +E, +A] { self =>

--- a/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
@@ -1,11 +1,10 @@
 package zhttp.http
 
-import zio._
-import zio.UIO
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
+import zio.{UIO, ZIO, ZLayer}
 
 object HttpResultSpec extends DefaultRunnableSpec with HttpResultAssertion {
   def spec: ZSpec[Environment, Failure] = {

--- a/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
@@ -4,7 +4,7 @@ import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.{UIO, ZIO, ZLayer}
+import zio._
 
 object HttpResultSpec extends DefaultRunnableSpec with HttpResultAssertion {
   def spec: ZSpec[Environment, Failure] = {
@@ -57,52 +57,96 @@ object HttpResultSpec extends DefaultRunnableSpec with HttpResultAssertion {
         },
       ),
       suite("provide")(
-        testM("provides the environment") {
-          val app = effect(for {
-            _ <- ZIO.environment[String]
-          } yield 1)
+        testM("provide") {
+          val app = HttpResult.effect(ZIO.environment[Int]).provide(1).evaluate.asEffect
+          assertM(app)(equalTo(1))
+        },
+        testM("foldM") {
+          val app = (effect(ZIO.environment[Int]) *> succeed(1)).provide(1).evaluate.asEffect
+          assertM(app)(equalTo(1))
+        },
+      ),
+      suite("provideSome")(
+        testM("provideSome") {
+          trait HasInt {
+            val int: Int
+          }
+
+          val needsEnv = effect(for {
+            int <- ZIO.environment[HasInt]
+          } yield int.int)
+
+          val app = needsEnv.provideSome[Any](_ => {
+            new HasInt {
+              val int = 2
+            }
+          })
 
           for {
-            res <- app.provide("string").evaluate.asEffect
-          } yield assert(res)(equalTo(1))
+            res <- app.evaluate.asEffect
+          } yield assert(res)(equalTo(2))
         },
-        testM("it composes with foldM") {
+        testM("foldM 1") {
+          trait HasInt {
+            val int: Int
+          }
+
           val needsEnv = effect(for {
-            _ <- ZIO.environment[String]
-          } yield 0)
-          val app      = (needsEnv *> succeed(1)).provide("string")
+            int <- ZIO.environment[HasInt]
+          } yield int.int)
+
+          val app = (needsEnv *> succeed(1)).provideSome[Any](_ => {
+            new HasInt { val int = 1 }
+          })
 
           for {
             res <- app.evaluate.asEffect
           } yield assert(res)(equalTo(1))
         },
+        testM("foldM 2") {
+          trait HasInt {
+            val int: Int
+          }
+
+          val needsEnv = effect(for {
+            int <- ZIO.environment[HasInt]
+          } yield int.int)
+
+          val app = (succeed(1) *> needsEnv).provideSome[Any](_ => {
+            new HasInt { val int = 1 }
+          })
+
+          for {
+            res <- app.evaluate.asEffect
+          } yield assert(res)(equalTo(1))
+        },
+        testM("it provides parts of the environment") {
+          trait HasInt    {
+            val int: Int
+          }
+          trait HasString {
+            val string: String
+          }
+
+          val needsEnv = effect(for {
+            _   <- ZIO.environment[HasString]
+            int <- ZIO.environment[HasInt]
+          } yield int.int)
+
+          val app = (needsEnv *> needsEnv).provideSome[HasInt](env =>
+            new HasInt with HasString {
+              val int    = env.int
+              val string = "String"
+            },
+          )
+
+          for {
+            res <- app.provide(new HasInt { val int = 2 }).evaluate.asEffect
+          } yield assert(res)(equalTo(2))
+        },
       ),
-      suite("provideSome")(testM("it provides parts of the environment") {
-        trait HasInt    {
-          val int: Int
-        }
-        trait HasString {
-          val string: String
-        }
-
-        val needsEnv = effect(for {
-          _   <- ZIO.environment[HasString]
-          int <- ZIO.environment[HasInt]
-        } yield int.int)
-
-        val app = (needsEnv *> needsEnv).provideSome[HasInt](env =>
-          new HasInt with HasString {
-            val int    = env.int
-            val string = "String"
-          },
-        )
-
-        for {
-          res <- app.provide(new HasInt { val int = 2 }).evaluate.asEffect
-        } yield assert(res)(equalTo(2))
-      }),
       suite("provideLayer")(
-        testM("it provides the environment") {
+        testM("provideLayer") {
           val app = effect(for {
             _   <- ZIO.service[String]
             int <- ZIO.service[Int]
@@ -112,16 +156,14 @@ object HttpResultSpec extends DefaultRunnableSpec with HttpResultAssertion {
             app.provideLayer(ZLayer.succeed("String") ++ ZLayer.succeed(2)).evaluate.asEffect
           assertM(res)(equalTo(2))
         },
-      ),
-      suite("provideCustomLayer")(
-        testM("it provides the environment") {
+        testM("foldM") {
           val app = effect(for {
             _   <- ZIO.service[String]
             int <- ZIO.service[Int]
-          } yield int)
+          } yield int) *> succeed(2)
 
           val res =
-            app.provideCustomLayer(ZLayer.succeed("String") ++ ZLayer.succeed(2)).evaluate.asEffect
+            app.provideLayer(ZLayer.succeed("String") ++ ZLayer.succeed(2)).evaluate.asEffect
           assertM(res)(equalTo(2))
         },
       ),

--- a/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpResultSpec.scala
@@ -1,10 +1,10 @@
 package zhttp.http
 
+import zio._
 import zio.duration._
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio._
 
 object HttpResultSpec extends DefaultRunnableSpec with HttpResultAssertion {
   def spec: ZSpec[Environment, Failure] = {


### PR DESCRIPTION
This follows up on the work done in #189 and instead adds the `provide*` combinators to the `HttpResult`.

I also added all of the combinators to `Http` itself, just acting as wrappers on top.