### PR TITLE
feat: Add optional remoteAddress to Request

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -1,10 +1,15 @@
 package zhttp.http
 
+import zhttp.core.JChannelHandlerContext
+
+import java.net.{InetAddress, InetSocketAddress}
+
 // REQUEST
 final case class Request(
   endpoint: Endpoint,
   headers: List[Header] = List.empty,
   content: HttpData[Any, Nothing] = HttpData.empty,
+  private val channelContext: JChannelHandlerContext = null,
 ) extends HasHeaders
     with HeadersHelpers { self =>
   val method: Method = endpoint._1
@@ -14,6 +19,13 @@ final case class Request(
   def getBodyAsString: Option[String] = content match {
     case HttpData.CompleteData(data) => Option(data.map(_.toChar).mkString)
     case _                           => Option.empty
+  }
+
+  def remoteAddress: Option[InetAddress] = {
+    if (channelContext != null && channelContext.channel().remoteAddress().isInstanceOf[InetSocketAddress])
+      Some(channelContext.channel().remoteAddress().asInstanceOf[InetSocketAddress].getAddress)
+    else
+      None
   }
 
 }

--- a/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
@@ -1,6 +1,6 @@
 package zhttp.service
 
-import zhttp.core.JFullHttpRequest
+import zhttp.core.{JChannelHandlerContext, JFullHttpRequest}
 import zhttp.http._
 
 trait DecodeJRequest {
@@ -8,11 +8,12 @@ trait DecodeJRequest {
   /**
    * Tries to decode the [io.netty.handler.codec.http.FullHttpRequest] to [Request].
    */
-  def decodeJRequest(jReq: JFullHttpRequest): Either[HttpError, Request] = for {
+  def decodeJRequest(jReq: JFullHttpRequest, ctx: JChannelHandlerContext): Either[HttpError, Request] = for {
     url <- URL.fromString(jReq.uri())
     method   = Method.fromJHttpMethod(jReq.method())
     headers  = Header.make(jReq.headers())
     endpoint = method -> url
     data     = HttpData.fromByteBuf(jReq.content())
-  } yield Request(endpoint, headers, data)
+  } yield Request(endpoint, headers, data, ctx)
+
 }

--- a/zio-http/src/main/scala/zhttp/service/server/ServerRequestHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerRequestHandler.scala
@@ -32,7 +32,7 @@ final case class ServerRequestHandler[R](
   private def executeAsync(ctx: JChannelHandlerContext, jReq: JFullHttpRequest)(
     cb: Response[R, Throwable] => Unit,
   ): Unit =
-    decodeJRequest(jReq) match {
+    decodeJRequest(jReq, ctx) match {
       case Left(err)  => cb(err.toResponse)
       case Right(req) =>
         settings.http.execute(req).evaluate match {


### PR DESCRIPTION
This is only applicable in server context where this information can be very useful for example to provide rate-limiting per IP address or logging/debugging purposes.
