### PR TITLE
feat: Use implicit class for HttpApp syntax

### DIFF
--- a/example/src/main/scala/Authentication.scala
+++ b/example/src/main/scala/Authentication.scala
@@ -27,22 +27,23 @@ object Authentication extends App {
   // Takes in a Failing HttpApp and a Succeed HttpApp which are called based on Authentication success or failure
   // For each request tries to read the `X-ACCESS-TOKEN` header
   // Validates JWT Claim
-  def authenticate[R, E](fail: HttpApp[R, E], success: JwtClaim => HttpApp[R, E]): HttpApp[R, E] =
+  def authenticate[R, E](fail: HttpApp[R, E], success: JwtClaim => HttpApp[R, E]): HttpApp[R, E] = Http.flatten {
     HttpApp.fromFunction {
       _.getHeader("X-ACCESS-TOKEN")
         .flatMap(header => jwtDecode(header.value.toString))
         .fold[HttpApp[R, E]](fail)(success)
     }
+  }
 
   // Http app that requires a JWT claim
-  def user(claim: JwtClaim): UHttpApp = HttpApp.collect {
+  def user(claim: JwtClaim): UHttpApp = Http.collect {
     case Method.GET -> Root / "user" / name / "greet" => Response.text(s"Welcome to the ZIO party! ${name}")
     case Method.GET -> Root / "user" / "expiration"   => Response.text(s"Expires in: ${claim.expiration.getOrElse(-1L)}")
   }
 
   // App that let's the user login
   // Login is successful only if the password is the reverse of the username
-  def login: UHttpApp = HttpApp.collect { case Method.GET -> Root / "login" / username / password =>
+  def login: UHttpApp = Http.collect { case Method.GET -> Root / "login" / username / password =>
     if (password.reverse == username) Response.text(jwtEncode(username))
     else Response.fromHttpError(HttpError.Unauthorized("Invalid username of password\n"))
   }

--- a/example/src/main/scala/ConcreteEntity.scala
+++ b/example/src/main/scala/ConcreteEntity.scala
@@ -23,5 +23,5 @@ object ConcreteEntity extends App {
 
   // Run it like any simple app
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-    Server.start(8090, HttpApp(app)).exitCode
+    Server.start(8090, app).exitCode
 }

--- a/zio-http/src/main/scala/zhttp/http/CORS.scala
+++ b/zio-http/src/main/scala/zhttp/http/CORS.scala
@@ -16,7 +16,7 @@ object CORS {
   def DefaultCORSConfig =
     CORSConfig(anyOrigin = true, allowCredentials = true)
 
-  def apply[R, E](httpApp: HttpApp[R, E], config: CORSConfig = DefaultCORSConfig): HttpApp[R, E] = HttpApp {
+  def apply[R, E](httpApp: HttpApp[R, E], config: CORSConfig = DefaultCORSConfig): HttpApp[R, E] = {
     def allowCORS(origin: Header, acrm: Method): Boolean =
       (config.anyOrigin, config.anyMethod, origin.value.toString(), acrm) match {
         case (true, true, _, _)           => true
@@ -80,7 +80,7 @@ object CORS {
               ),
             )
           case (_, Some(origin), _) if allowCORS(origin, req.method) =>
-            httpApp.asHttp >>>
+            httpApp >>>
               Http.fromFunction[Response[R, E]](r =>
                 r match {
                   case r: Response.HttpResponse[R, E] =>
@@ -89,7 +89,7 @@ object CORS {
                     x
                 },
               )
-          case _                                                     => httpApp.asHttp
+          case _                                                     => httpApp
         }
       })
     }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -294,4 +294,18 @@ object Http {
   final class MkTotal[A](val unit: Unit) extends AnyVal {
     def apply[B](f: A => B): Http[Any, Nothing, A, B] = Http.identity[A].map(f)
   }
+
+  implicit final class HttpAppSyntax[R, E](val self: HttpApp[R, E]) extends AnyVal {
+
+    /**
+     * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
+     */
+    def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
+      self.catchAll(e => Http.succeed(s.silent(e)))
+
+    /**
+     * Converts a ZIO to an Http type
+     */
+    def responseM[R1, E1](res: ResponseM[R1, E1]): Http[R1, E1, Request, Response[R1, E1]] = Http.fromEffect(res)
+  }
 }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -302,10 +302,5 @@ object Http {
      */
     def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
       self.catchAll(e => Http.succeed(s.silent(e)))
-
-    /**
-     * Converts a ZIO to an Http type
-     */
-    def responseM[R1, E1](res: ResponseM[R1, E1]): Http[R1, E1, Request, Response[R1, E1]] = Http.fromEffect(res)
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -294,13 +294,4 @@ object Http {
   final class MkTotal[A](val unit: Unit) extends AnyVal {
     def apply[B](f: A => B): Http[Any, Nothing, A, B] = Http.identity[A].map(f)
   }
-
-  implicit final class HttpAppSyntax[R, E](val self: HttpApp[R, E]) extends AnyVal {
-
-    /**
-     * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
-     */
-    def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
-      self.catchAll(e => Http.succeed(s.silent(e)))
-  }
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -1,77 +1,32 @@
 package zhttp.http
 
-import zio.ZIO
-
-final case class HttpApp[-R, +E](asHttp: Http[R, E, Request, Response[R, E]]) extends AnyVal {
-
-  /**
-   * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
-   */
-  def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) = HttpApp(
-    asHttp.catchAll(e => Http.succeed(s.silent(e))),
-  )
-
-  /**
-   * Combines two HttpApps into one.
-   */
-  def +++[R1 <: R, E1 >: E](other: HttpApp[R1, E1]) = HttpApp(asHttp +++ other.asHttp)
-
-  /**
-   * Evaluates the app and returns an HttpResult that can be resolved further
-   */
-  private[zhttp] final def execute(r: Request) = asHttp.execute(r)
-}
-
 object HttpApp {
-
-  /**
-   * Creates an Http app from a function that returns a ZIO
-   */
-  def fromEffectFunction[R, E](f: Request => ZIO[R, E, Response[R, E]]): HttpApp[R, E] =
-    HttpApp(Http.fromEffectFunction(f))
-
-  /**
-   * Converts a ZIO to an Http type
-   */
-  def responseM[R, E](res: ResponseM[R, E]): HttpApp[R, E] = HttpApp(Http.fromEffect(res))
-
-  /**
-   * Creates an HTTP app which accepts a request and produces response.
-   */
-  def collect[R, E](pf: PartialFunction[Request, Response[R, E]]): HttpApp[R, E] =
-    HttpApp(Http.collect[Request](pf))
-
-  /**
-   * Creates an HTTP app which accepts a requests and produces another Http app as response.
-   */
-  def collectM[R, E](pf: PartialFunction[Request, ResponseM[R, E]]): HttpApp[R, E] =
-    HttpApp(Http.collectM[Request](pf))
 
   /**
    * Creates an HTTP app which always responds with the same plain text.
    */
-  def text(str: String): HttpApp[Any, Nothing] = HttpApp(Http.succeed(Response.text(str)))
+  def text(str: String): HttpApp[Any, Nothing] = Http.succeed(Response.text(str))
 
   /**
    * Creates an HTTP app which always responds with the same value.
    */
-  def response[R, E](response: Response[R, E]): HttpApp[R, E] = HttpApp(Http.succeed(response))
+  def response[R, E](response: Response[R, E]): HttpApp[R, E] = Http.succeed(response)
 
   /**
    * Creates an HTTP app which always responds with the same status code and empty data.
    */
-  def empty(code: Status): HttpApp[Any, Nothing] = HttpApp(Http.succeed(Response.http(code)))
+  def empty(code: Status): HttpApp[Any, Nothing] = Http.succeed(Response.http(code))
 
   /**
    * Creates an HTTP app which always fails with the same error type.
    */
-  def error(error: HttpError): HttpApp[Any, HttpError] = HttpApp(Http.fail(error))
+  def error(error: HttpError): HttpApp[Any, HttpError] = Http.fail(error)
 
   /**
    * Creates an HTTP app that fails with a NotFound exception.
    */
   def notFound: HttpApp[Any, HttpError] =
-    HttpApp(Http.fromFunction[Request](req => Http.fail(HttpError.NotFound(req.url.path))).flatten)
+    Http.fromFunction[Request](req => Http.fail(HttpError.NotFound(req.url.path))).flatten
 
   /**
    * Creates an HTTP app which always responds with a 200 status code.
@@ -81,11 +36,11 @@ object HttpApp {
   /**
    * Creates an HTTP app that responds with 403 - Forbidden status code
    */
-  def forbidden(msg: String): UHttpApp = HttpApp(Http.succeed(HttpError.Forbidden(msg).toResponse))
+  def forbidden(msg: String): UHttpApp = Http.succeed(HttpError.Forbidden(msg).toResponse)
 
   /**
    * Creates a Http app from a function from Request to HttpApp
    */
-  def fromFunction[R, E, B](f: Request => HttpApp[R, E]) = HttpApp(Http.flatten(Http.fromFunction(f).map(_.asHttp)))
+  def fromFunction[R, E, B](f: Request => HttpApp[R, E]) = Http.fromFunction[Request](f)
 
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -67,4 +67,20 @@ object HttpApp {
    * Creates a Http app from a function from Request to HttpApp
    */
   def fromFunction[R, E, B](f: Request => HttpApp[R, E]) = Http.fromFunction[Request](f)
+
+}
+
+private[zhttp] trait HttpAppSyntax {
+  import scala.language.implicitConversions
+
+  implicit final def httpAppSyntax[R, E](self: HttpApp[R, E]): HttpAppOps[R, E] = new HttpAppOps(self)
+}
+
+private[zhttp] final class HttpAppOps[R, E](val self: HttpApp[R, E]) extends AnyVal {
+
+  /**
+   * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
+   */
+  def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
+    self.catchAll(e => Http.succeed(s.silent(e)))
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -1,6 +1,31 @@
 package zhttp.http
 
+import zio.ZIO
+
 object HttpApp {
+
+  /**
+   * Creates an Http app from a function that returns a ZIO
+   */
+  def fromEffectFunction[R, E](f: Request => ZIO[R, E, Response[R, E]]): HttpApp[R, E] =
+    Http.fromEffectFunction(f)
+
+  /**
+   * Converts a ZIO to an Http type
+   */
+  def responseM[R, E](res: ResponseM[R, E]): HttpApp[R, E] = Http.fromEffect(res)
+
+  /**
+   * Creates an HTTP app which accepts a request and produces response.
+   */
+  def collect[R, E](pf: PartialFunction[Request, Response[R, E]]): HttpApp[R, E] =
+    Http.collect[Request](pf)
+
+  /**
+   * Creates an HTTP app which accepts a requests and produces another Http app as response.
+   */
+  def collectM[R, E](pf: PartialFunction[Request, ResponseM[R, E]]): HttpApp[R, E] =
+    Http.collectM[Request](pf)
 
   /**
    * Creates an HTTP app which always responds with the same plain text.
@@ -42,5 +67,4 @@ object HttpApp {
    * Creates a Http app from a function from Request to HttpApp
    */
   def fromFunction[R, E, B](f: Request => HttpApp[R, E]) = Http.fromFunction[Request](f)
-
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -3,6 +3,7 @@ package zhttp.http
 import zio.ZIO
 
 object HttpApp {
+  def apply[R, E](self: HttpApp[R, E]): HttpApp[R, E] = self
 
   /**
    * Creates an Http app from a function that returns a ZIO
@@ -77,6 +78,8 @@ private[zhttp] trait HttpAppSyntax {
 }
 
 private[zhttp] final class HttpAppOps[R, E](val self: HttpApp[R, E]) extends AnyVal {
+  @deprecated("you no longer need to unwrap an HttpApp", "zio-http 1.0.0.0-RC18")
+  def asHttp: HttpApp[R, E] = self
 
   /**
    * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.

--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -70,20 +70,3 @@ object HttpApp {
   def fromFunction[R, E, B](f: Request => HttpApp[R, E]) = Http.fromFunction[Request](f)
 
 }
-
-private[zhttp] trait HttpAppSyntax {
-  import scala.language.implicitConversions
-
-  implicit final def httpAppSyntax[R, E](self: HttpApp[R, E]): HttpAppOps[R, E] = new HttpAppOps(self)
-}
-
-private[zhttp] final class HttpAppOps[R, E](val self: HttpApp[R, E]) extends AnyVal {
-  @deprecated("you no longer need to unwrap an HttpApp", "zio-http 1.0.0.0-RC18")
-  def asHttp: HttpApp[R, E] = self
-
-  /**
-   * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
-   */
-  def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
-    self.catchAll(e => Http.succeed(s.silent(e)))
-}

--- a/zio-http/src/main/scala/zhttp/http/HttpAppSyntax.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpAppSyntax.scala
@@ -1,0 +1,18 @@
+package zhttp.http
+
+private[zhttp] trait HttpAppSyntax {
+  import scala.language.implicitConversions
+
+  implicit final def httpAppSyntax[R, E](self: HttpApp[R, E]): HttpAppOps[R, E] = new HttpAppOps(self)
+}
+
+private[zhttp] final class HttpAppOps[R, E](val self: HttpApp[R, E]) extends AnyVal {
+  @deprecated("you no longer need to unwrap an HttpApp", "zio-http 1.0.0.0-RC18")
+  def asHttp: HttpApp[R, E] = self
+
+  /**
+   * Converts a failing Http into a non-failing one by handling the failure and converting it to a result if possible.
+   */
+  def silent[R1 <: R, E1 >: E](implicit s: CanBeSilenced[E1, Response[R1, E1]]) =
+    self.catchAll(e => Http.succeed(s.silent(e)))
+}

--- a/zio-http/src/main/scala/zhttp/http/package.scala
+++ b/zio-http/src/main/scala/zhttp/http/package.scala
@@ -5,7 +5,7 @@ import zio.ZIO
 
 import java.nio.charset.Charset
 
-package object http extends PathModule with RequestSyntax {
+package object http extends PathModule with RequestSyntax with HttpAppSyntax {
   type HttpApp[-R, +E]    = Http[R, E, Request, Response[R, E]]
   type UHttpApp           = HttpApp[Any, Nothing]
   type RHttpApp[-R]       = HttpApp[R, Throwable]

--- a/zio-http/src/main/scala/zhttp/http/package.scala
+++ b/zio-http/src/main/scala/zhttp/http/package.scala
@@ -6,6 +6,7 @@ import zio.ZIO
 import java.nio.charset.Charset
 
 package object http extends PathModule with RequestSyntax {
+  type HttpApp[-R, +E]    = Http[R, E, Request, Response[R, E]]
   type UHttpApp           = HttpApp[Any, Nothing]
   type RHttpApp[-R]       = HttpApp[R, Throwable]
   type Endpoint           = (Method, URL)


### PR DESCRIPTION
This is a WIP of using the same [implicit trick used by Has](https://github.com/zio/zio/blob/a53fb07d9bb78629e9564b8da92a824b9e2f6d09/core/shared/src/main/scala/zio/Has.scala#L160) to provide the specialized `HttpApp` syntax. I believe this is the best of both worlds since it can provide specialized combinators while being zero allocation. It also allows us to keep all existing combinators from `Http` without having to reimplement them.

Let me know if you think it's worthwhile and I'll continue the work!