### PR TITLE
feat: Add remoteAddress to Request

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -5,6 +5,7 @@ final case class Request(
   endpoint: Endpoint,
   headers: List[Header] = List.empty,
   content: HttpData[Any, Nothing] = HttpData.empty,
+  remoteAddress: String = "",
 ) extends HasHeaders
     with HeadersHelpers { self =>
   val method: Method = endpoint._1

--- a/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/DecodeJRequest.scala
@@ -8,11 +8,11 @@ trait DecodeJRequest {
   /**
    * Tries to decode the [io.netty.handler.codec.http.FullHttpRequest] to [Request].
    */
-  def decodeJRequest(jReq: JFullHttpRequest): Either[HttpError, Request] = for {
+  def decodeJRequest(jReq: JFullHttpRequest, remoteAddress: String): Either[HttpError, Request] = for {
     url <- URL.fromString(jReq.uri())
     method   = Method.fromJHttpMethod(jReq.method())
     headers  = Header.make(jReq.headers())
     endpoint = method -> url
     data     = HttpData.fromByteBuf(jReq.content())
-  } yield Request(endpoint, headers, data)
+  } yield Request(endpoint, headers, data, remoteAddress)
 }

--- a/zio-http/src/main/scala/zhttp/service/server/ServerRequestHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerRequestHandler.scala
@@ -8,6 +8,7 @@ import zhttp.http._
 import zhttp.service.Server.Settings
 import zhttp.service._
 import zio.Exit
+
 import java.net.InetSocketAddress
 
 /**


### PR DESCRIPTION
Needed this to implement rate limiting per requesting IP. Usually, you'll want to use `X-Forwarded-For` or something similar, but if you aren't running behind a loadbalancer/ingress (such as locally) it's handy to get the raw remote IP from the underlying socket.