### PR TITLE
feat: Add tap* combinators

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -202,7 +202,7 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAll[R1 <: R, E1 >: E](
     f: E => Http[R1, E1, Any, Any],
     g: B => Http[R1, E1, Any, Any],
-    h: Unit => Http[R1, E1, Any, Any],
+    h: Http[R1, E1, Any, Any],
   ): Http[R1, E1, A, B] =
     self.foldM(
       e => f(e) *> Http.fail(e),

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -216,7 +216,7 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAllM[R1 <: R, E1 >: E](
     f: E => ZIO[R1, E1, Any],
     g: B => ZIO[R1, E1, Any],
-    h: Unit => ZIO[R1, E1, Any],
+    h: ZIO[R1, E1, Any],
   ): Http[R1, E1, A, B] =
     tapAll(
       e => Http.fromEffect(f(e)),

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -202,12 +202,12 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAll[R1 <: R, E1 >: E](
     f: E => Http[R1, E1, Any, Any],
     g: B => Http[R1, E1, Any, Any],
-    h: Http[R1, E1, Any, Any],
+    h: => Http[R1, E1, Any, Any],
   ): Http[R1, E1, A, B] =
     self.foldM(
       e => f(e) *> Http.fail(e),
       x => g(x) *> Http.succeed(x),
-      h(()) *> Http.empty,
+      h *> Http.empty,
     )
 
   /**
@@ -216,12 +216,12 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAllM[R1 <: R, E1 >: E](
     f: E => ZIO[R1, E1, Any],
     g: B => ZIO[R1, E1, Any],
-    h: ZIO[R1, E1, Any],
+    h: => ZIO[R1, E1, Any],
   ): Http[R1, E1, A, B] =
     tapAll(
       e => Http.fromEffect(f(e)),
       x => Http.fromEffect(g(x)),
-      x => Http.fromEffect(h(x)),
+      Http.fromEffect(h),
     )
 
   /**

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -202,7 +202,7 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAll[R1 <: R, E1 >: E](
     f: E => Http[R1, E1, Any, Any],
     g: B => Http[R1, E1, Any, Any],
-    h: => Http[R1, E1, Any, Any],
+    h: Http[R1, E1, Any, Any],
   ): Http[R1, E1, A, B] =
     self.foldM(
       e => f(e) *> Http.fail(e),

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -169,6 +169,62 @@ sealed trait Http[-R, +E, -A, +B] { self =>
     self.flatMap(Http.fromEffect(_))
 
   /**
+   * Returns an Http that peeks at the success of this Http.
+   */
+  def tap[R1 <: R, E1 >: E, A1 <: A](f: B => Http[R1, E1, Any, Any]): Http[R1, E1, A, B] =
+    self.flatMap(v => f(v).as(v))
+
+  /**
+   * Returns an Http that effectfully peeks at the success of this Http.
+   */
+  def tapM[R1 <: R, E1 >: E](f: B => ZIO[R1, E1, Any]): Http[R1, E1, A, B] =
+    self.tap(v => Http.fromEffect(f(v)))
+
+  /**
+   * Returns an Http that peeks at the failure of this Http.
+   */
+  def tapError[R1 <: R, E1 >: E](f: E => Http[R1, E1, Any, Any]): Http[R1, E1, A, B] =
+    self.foldM(
+      e => f(e) *> Http.fail(e),
+      Http.succeed,
+      Http.empty,
+    )
+
+  /**
+   * Returns an Http that effectfully peeks at the failure of this Http.
+   */
+  def tapErrorM[R1 <: R, E1 >: E](f: E => ZIO[R1, E1, Any]): Http[R1, E1, A, B] =
+    self.tapError(e => Http.fromEffect(f(e)))
+
+  /**
+   * Returns an Http that peeks at the success, failed or empty value of this Http.
+   */
+  def tapAll[R1 <: R, E1 >: E](
+    f: E => Http[R1, E1, Any, Any],
+    g: B => Http[R1, E1, Any, Any],
+    h: Unit => Http[R1, E1, Any, Any],
+  ): Http[R1, E1, A, B] =
+    self.foldM(
+      e => f(e) *> Http.fail(e),
+      x => g(x) *> Http.succeed(x),
+      h(()) *> Http.empty,
+    )
+
+  /**
+   * Returns an Http that effectfully peeks at the success, failed or empty value of this Http.
+   */
+  def tapAllM[R1 <: R, E1 >: E](
+    f: E => ZIO[R1, E1, Any],
+    g: B => ZIO[R1, E1, Any],
+    h: Unit => ZIO[R1, E1, Any],
+  ): Http[R1, E1, A, B] =
+    tapAll(
+      e => Http.fromEffect(f(e)),
+      x => Http.fromEffect(g(x)),
+      x => Http.fromEffect(h(x)),
+    )
+
+  /**
    * Evaluates the app and returns an HttpResult that can be resolved further
    */
   final private[zhttp] def execute(a: A): HttpResult[R, E, B] = {

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -216,7 +216,7 @@ sealed trait Http[-R, +E, -A, +B] { self =>
   def tapAllM[R1 <: R, E1 >: E](
     f: E => ZIO[R1, E1, Any],
     g: B => ZIO[R1, E1, Any],
-    h: => ZIO[R1, E1, Any],
+    h: ZIO[R1, E1, Any],
   ): Http[R1, E1, A, B] =
     tapAll(
       e => Http.fromEffect(f(e)),

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -194,7 +194,7 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
       testM("taps the success") {
         for {
           r <- Ref.make(0)
-          app = Http.succeed(1).tapAll((_ => Http.empty): @nowarn, v => Http.fromEffect(r.set(v)), _ => Http.empty)
+          app = Http.succeed(1).tapAll((_ => Http.empty): @nowarn, v => Http.fromEffect(r.set(v)), Http.empty)
           _   <- app.execute(()).evaluate.asEffect
           res <- r.get
         } yield assert(res)(equalTo(1))
@@ -202,7 +202,9 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
       testM("taps the failure") {
         for {
           r <- Ref.make(0)
-          app = Http.fail(1).tapAll(v => Http.fromEffect(r.set(v)), (_ => Http.empty): @nowarn, _ => Http.empty)
+          app = Http
+            .fromEffect(ZIO.fail(1))
+            .tapAll(v => Http.fromEffect(r.set(v)), (_ => Http.empty): @nowarn, Http.empty)
           _   <- app.execute(()).evaluate.asEffect.catchAll(_ => ZIO.unit)
           res <- r.get
         } yield assert(res)(equalTo(1))
@@ -211,7 +213,7 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
         for {
           r <- Ref.make(0)
           app = Http.empty
-            .tapAll((_ => Http.empty): @nowarn, (_ => Http.empty): @nowarn, _ => Http.fromEffect(r.set(1)))
+            .tapAll((_ => Http.empty): @nowarn, (_ => Http.empty): @nowarn, Http.fromEffect(r.set(1)))
           _   <- app.execute(()).evaluate.asEffect.catchAll(_ => ZIO.unit)
           res <- r.get
         } yield assert(res)(equalTo(1))
@@ -221,7 +223,7 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
       testM("taps the success") {
         for {
           r <- Ref.make(0)
-          app = Http.succeed(1).tapAllM((_ => ZIO.unit): @nowarn, r.set, _ => ZIO.unit)
+          app = Http.succeed(1).tapAllM((_ => ZIO.unit): @nowarn, r.set, ZIO.unit)
           _   <- app.execute(()).evaluate.asEffect
           res <- r.get
         } yield assert(res)(equalTo(1))
@@ -229,7 +231,7 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
       testM("taps the failure") {
         for {
           r <- Ref.make(0)
-          app = Http.fail(1).tapAllM(r.set, (_ => ZIO.unit): @nowarn, _ => ZIO.unit)
+          app = Http.fail(1).tapAllM(r.set, (_ => ZIO.unit): @nowarn, ZIO.unit)
           _   <- app.execute(()).evaluate.asEffect.catchAll(_ => ZIO.unit)
           res <- r.get
         } yield assert(res)(equalTo(1))
@@ -237,7 +239,7 @@ object HttpSpec extends DefaultRunnableSpec with HttpResultAssertion {
       testM("taps the empty value") {
         for {
           r <- Ref.make(0)
-          app = Http.empty.tapAllM((_ => ZIO.unit): @nowarn, (_ => ZIO.unit): @nowarn, _ => r.set(1))
+          app = Http.empty.tapAllM((_ => ZIO.unit): @nowarn, (_ => ZIO.unit): @nowarn, r.set(1))
           _   <- app.execute(()).evaluate.asEffect.catchAll(_ => ZIO.unit)
           res <- r.get
         } yield assert(res)(equalTo(1))


### PR DESCRIPTION
All the `@nowarn` annotations is to suppress `dead code following this construct` warnings. `tap`, has the same error, e.g 

```
dead code following this construct
[error]         ZIO.fail(1).tap(_ => ZIO.debug("hi"))
```