### PR TITLE
added helper for text/html and text/yaml

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Header.scala
+++ b/zio-http/src/main/scala/zhttp/http/Header.scala
@@ -37,6 +37,8 @@ object Header {
   val contentTypeXml: Header            = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML)
   val contentTypeXhtmlXml: Header       = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML)
   val contentTypeTextPlain: Header      = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
+  val contentTypeHtml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
+  val contentTypeYaml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
   val transferEncodingChunked: Header   = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
   def contentLength(size: Long): Header = Header(HttpHeaderNames.CONTENT_LENGTH, size.toString)
   val contentTypeFormUrlEncoded: Header =


### PR DESCRIPTION
Added a couple 'helper' Vals to `Header` object for `text\html` and `text\yaml`.

`HttpHeaderValues` is from Netty and doesn't seem to be extended here to add the 'text/yaml'.