### PR TITLE
Make path extraction right associative

### DIFF
--- a/example/src/main/scala/Authentication.scala
+++ b/example/src/main/scala/Authentication.scala
@@ -37,13 +37,13 @@ object Authentication extends App {
 
   // Http app that requires a JWT claim
   def user(claim: JwtClaim): UHttpApp = Http.collect {
-    case Method.GET -> "user" /: name /: "greet" /: _ => Response.text(s"Welcome to the ZIO party! ${name}")
-    case Method.GET -> "user" /: "expiration" /: _ => Response.text(s"Expires in: ${claim.expiration.getOrElse(-1L)}")
+    case Method.GET -> !! / "user" / name / "greet" => Response.text(s"Welcome to the ZIO party! ${name}")
+    case Method.GET -> !! / "user" / "expiration"   => Response.text(s"Expires in: ${claim.expiration.getOrElse(-1L)}")
   }
 
   // App that let's the user login
   // Login is successful only if the password is the reverse of the username
-  def login: UHttpApp = Http.collect { case Method.GET -> "login" /: username /: password /: _ =>
+  def login: UHttpApp = Http.collect { case Method.GET -> !! / "login" / username / password =>
     if (password.reverse == username) Response.text(jwtEncode(username))
     else Response.fromHttpError(HttpError.Unauthorized("Invalid username of password\n"))
   }

--- a/example/src/main/scala/Authentication.scala
+++ b/example/src/main/scala/Authentication.scala
@@ -37,13 +37,13 @@ object Authentication extends App {
 
   // Http app that requires a JWT claim
   def user(claim: JwtClaim): UHttpApp = Http.collect {
-    case Method.GET -> Root / "user" / name / "greet" => Response.text(s"Welcome to the ZIO party! ${name}")
-    case Method.GET -> Root / "user" / "expiration" => Response.text(s"Expires in: ${claim.expiration.getOrElse(-1L)}")
+    case Method.GET -> "user" /: name /: "greet" /: _ => Response.text(s"Welcome to the ZIO party! ${name}")
+    case Method.GET -> "user" /: "expiration" /: _ => Response.text(s"Expires in: ${claim.expiration.getOrElse(-1L)}")
   }
 
   // App that let's the user login
   // Login is successful only if the password is the reverse of the username
-  def login: UHttpApp = Http.collect { case Method.GET -> Root / "login" / username / password =>
+  def login: UHttpApp = Http.collect { case Method.GET -> "login" /: username /: password /: _ =>
     if (password.reverse == username) Response.text(jwtEncode(username))
     else Response.fromHttpError(HttpError.Unauthorized("Invalid username of password\n"))
   }

--- a/example/src/main/scala/FileStreaming.scala
+++ b/example/src/main/scala/FileStreaming.scala
@@ -13,8 +13,8 @@ object FileStreaming extends App {
 
   // Create HTTP route
   val app = HttpApp.collect {
-    case Method.GET -> Root / "health" => Response.ok
-    case Method.GET -> Root / "file"   => Response.http(content = content)
+    case Method.GET -> "health" /: _ => Response.ok
+    case Method.GET -> "file" /: _   => Response.http(content = content)
   }
 
   // Run it like any simple app

--- a/example/src/main/scala/FileStreaming.scala
+++ b/example/src/main/scala/FileStreaming.scala
@@ -13,8 +13,8 @@ object FileStreaming extends App {
 
   // Create HTTP route
   val app = HttpApp.collect {
-    case Method.GET -> "health" /: _ => Response.ok
-    case Method.GET -> "file" /: _   => Response.http(content = content)
+    case Method.GET -> !! / "health" => Response.ok
+    case Method.GET -> !! / "file"   => Response.http(content = content)
   }
 
   // Run it like any simple app

--- a/example/src/main/scala/HelloWorld.scala
+++ b/example/src/main/scala/HelloWorld.scala
@@ -6,8 +6,8 @@ object HelloWorld extends App {
 
   // Create HTTP route
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> Root / "text" => Response.text("Hello World!")
-    case Method.GET -> Root / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
+    case Method.GET -> "text" /: _ => Response.text("Hello World!")
+    case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
   }
 
   // Run it like any simple app

--- a/example/src/main/scala/HelloWorld.scala
+++ b/example/src/main/scala/HelloWorld.scala
@@ -6,8 +6,8 @@ object HelloWorld extends App {
 
   // Create HTTP route
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> "text" /: _ => Response.text("Hello World!")
-    case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
+    case Method.GET -> !! / "text" => Response.text("Hello World!")
+    case Method.GET -> !! / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
   }
 
   // Run it like any simple app

--- a/example/src/main/scala/HelloWorldAdvanced.scala
+++ b/example/src/main/scala/HelloWorldAdvanced.scala
@@ -10,13 +10,13 @@ object HelloWorldAdvanced extends App {
   private val PORT = 8090
 
   private val fooBar: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> Root / "foo" => Response.text("bar")
-    case Method.GET -> Root / "bar" => Response.text("foo")
+    case Method.GET -> "foo" /: _ => Response.text("bar")
+    case Method.GET -> "bar" /: _ => Response.text("foo")
   }
 
   private val app = HttpApp.collectM {
-    case Method.GET -> Root / "random" => random.nextString(10).map(Response.text)
-    case Method.GET -> Root / "utc"    => clock.currentDateTime.map(s => Response.text(s.toString))
+    case Method.GET -> "random" /: _ => random.nextString(10).map(Response.text)
+    case Method.GET -> "utc" /: _    => clock.currentDateTime.map(s => Response.text(s.toString))
   }
 
   private val server =

--- a/example/src/main/scala/HelloWorldAdvanced.scala
+++ b/example/src/main/scala/HelloWorldAdvanced.scala
@@ -10,13 +10,13 @@ object HelloWorldAdvanced extends App {
   private val PORT = 8090
 
   private val fooBar: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> "foo" /: _ => Response.text("bar")
-    case Method.GET -> "bar" /: _ => Response.text("foo")
+    case Method.GET -> !! / "foo" => Response.text("bar")
+    case Method.GET -> !! / "bar" => Response.text("foo")
   }
 
   private val app = HttpApp.collectM {
-    case Method.GET -> "random" /: _ => random.nextString(10).map(Response.text)
-    case Method.GET -> "utc" /: _    => clock.currentDateTime.map(s => Response.text(s.toString))
+    case Method.GET -> !! / "random" => random.nextString(10).map(Response.text)
+    case Method.GET -> !! / "utc"    => clock.currentDateTime.map(s => Response.text(s.toString))
   }
 
   private val server =

--- a/example/src/main/scala/HelloWorldWithCORS.scala
+++ b/example/src/main/scala/HelloWorldWithCORS.scala
@@ -6,8 +6,8 @@ object HelloWorldWithCORS extends App {
   // Create HTTP route with CORS enabled
   val app: HttpApp[Any, Nothing] = CORS(
     HttpApp.collect {
-      case Method.GET -> "text" /: _ => Response.text("Hello World!")
-      case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
+      case Method.GET -> !! / "text" => Response.text("Hello World!")
+      case Method.GET -> !! / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
     },
     config = CORSConfig(anyOrigin = true),
   )

--- a/example/src/main/scala/HelloWorldWithCORS.scala
+++ b/example/src/main/scala/HelloWorldWithCORS.scala
@@ -6,8 +6,8 @@ object HelloWorldWithCORS extends App {
   // Create HTTP route with CORS enabled
   val app: HttpApp[Any, Nothing] = CORS(
     HttpApp.collect {
-      case Method.GET -> Root / "text" => Response.text("Hello World!")
-      case Method.GET -> Root / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
+      case Method.GET -> "text" /: _ => Response.text("Hello World!")
+      case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
     },
     config = CORSConfig(anyOrigin = true),
   )

--- a/example/src/main/scala/HttpsHelloWorld.scala
+++ b/example/src/main/scala/HttpsHelloWorld.scala
@@ -8,8 +8,8 @@ object HttpsHelloWorld extends App {
 
   // Create HTTP route
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> Root / "text" => Response.text("Hello World!")
-    case Method.GET -> Root / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
+    case Method.GET -> "text" /: _ => Response.text("Hello World!")
+    case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
   }
 
   /**

--- a/example/src/main/scala/HttpsHelloWorld.scala
+++ b/example/src/main/scala/HttpsHelloWorld.scala
@@ -8,8 +8,8 @@ object HttpsHelloWorld extends App {
 
   // Create HTTP route
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
-    case Method.GET -> "text" /: _ => Response.text("Hello World!")
-    case Method.GET -> "json" /: _ => Response.jsonString("""{"greetings": "Hello World!"}""")
+    case Method.GET -> !! / "text" => Response.text("Hello World!")
+    case Method.GET -> !! / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
   }
 
   /**

--- a/example/src/main/scala/StickyThread.scala
+++ b/example/src/main/scala/StickyThread.scala
@@ -24,7 +24,7 @@ object StickyThread extends App {
   /**
    * The expected behaviour is that all the `printThread` output different fiber ids with the same thread name.
    */
-  val app = HttpApp.collectM { case Method.GET -> "text" /: _ =>
+  val app = HttpApp.collectM { case Method.GET -> !! / "text" =>
     for {
 
       _  <- printThread("Start")

--- a/example/src/main/scala/StickyThread.scala
+++ b/example/src/main/scala/StickyThread.scala
@@ -24,7 +24,7 @@ object StickyThread extends App {
   /**
    * The expected behaviour is that all the `printThread` output different fiber ids with the same thread name.
    */
-  val app = HttpApp.collectM { case Method.GET -> Root / "text" =>
+  val app = HttpApp.collectM { case Method.GET -> "text" /: _ =>
     for {
 
       _  <- printThread("Start")

--- a/example/src/main/scala/StreamingResponse.scala
+++ b/example/src/main/scala/StreamingResponse.scala
@@ -14,10 +14,10 @@ object StreamingResponse extends App {
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
 
     // Simple (non-stream) based route
-    case Method.GET -> "health" /: _ => Response.ok
+    case Method.GET -> !! / "health" => Response.ok
 
     // ZStream powered response
-    case Method.GET -> "stream" /: _ =>
+    case Method.GET -> !! / "stream" =>
       Response.http(
         status = Status.OK,
         headers = List(Header.contentLength(message.length.toLong)),

--- a/example/src/main/scala/StreamingResponse.scala
+++ b/example/src/main/scala/StreamingResponse.scala
@@ -14,10 +14,10 @@ object StreamingResponse extends App {
   val app: HttpApp[Any, Nothing] = HttpApp.collect {
 
     // Simple (non-stream) based route
-    case Method.GET -> Root / "health" => Response.ok
+    case Method.GET -> "health" /: _ => Response.ok
 
     // ZStream powered response
-    case Method.GET -> Root / "stream" =>
+    case Method.GET -> "stream" /: _ =>
       Response.http(
         status = Status.OK,
         headers = List(Header.contentLength(message.length.toLong)),

--- a/example/src/main/scala/WebSocketAdvanced.scala
+++ b/example/src/main/scala/WebSocketAdvanced.scala
@@ -37,8 +37,8 @@ object WebSocketAdvanced extends App {
 
   private val app =
     HttpApp.collect {
-      case Method.GET -> Root / "greet" / name  => Response.text(s"Greetings ${name}!")
-      case Method.GET -> Root / "subscriptions" => socketApp
+      case Method.GET -> "greet" /: name /: _ => Response.text(s"Greetings ${name}!")
+      case Method.GET -> "subscriptions" /: _ => socketApp
     }
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/example/src/main/scala/WebSocketAdvanced.scala
+++ b/example/src/main/scala/WebSocketAdvanced.scala
@@ -37,8 +37,8 @@ object WebSocketAdvanced extends App {
 
   private val app =
     HttpApp.collect {
-      case Method.GET -> "greet" /: name /: _ => Response.text(s"Greetings ${name}!")
-      case Method.GET -> "subscriptions" /: _ => socketApp
+      case Method.GET -> !! / "greet" / name  => Response.text(s"Greetings ${name}!")
+      case Method.GET -> !! / "subscriptions" => socketApp
     }
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/example/src/main/scala/WebSocketEcho.scala
+++ b/example/src/main/scala/WebSocketEcho.scala
@@ -17,8 +17,8 @@ object WebSocketEcho extends App {
 
   private val app =
     HttpApp.collect {
-      case Method.GET -> Root / "greet" / name  => Response.text(s"Greetings {$name}!")
-      case Method.GET -> Root / "subscriptions" => Response.socket(socket)
+      case Method.GET -> "greet" /: name /: _ => Response.text(s"Greetings {$name}!")
+      case Method.GET -> "subscriptions" /: _ => Response.socket(socket)
     }
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/example/src/main/scala/WebSocketEcho.scala
+++ b/example/src/main/scala/WebSocketEcho.scala
@@ -17,8 +17,8 @@ object WebSocketEcho extends App {
 
   private val app =
     HttpApp.collect {
-      case Method.GET -> "greet" /: name /: _ => Response.text(s"Greetings {$name}!")
-      case Method.GET -> "subscriptions" /: _ => Response.socket(socket)
+      case Method.GET -> !! / "greet" / name  => Response.text(s"Greetings {$name}!")
+      case Method.GET -> !! / "subscriptions" => Response.socket(socket)
     }
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
@@ -15,7 +15,7 @@ class HttpRouteTextPerf {
 
   private val res                        = Response.text("HELLO WORLD")
   private val app: HttpApp[Any, Nothing] = HttpApp.text("HELLO WORLD")
-  private val req: Request               = Request(Method.GET -> URL(Root))
+  private val req: Request               = Request(Method.GET -> URL(!!))
   private val httpProgram                = ZIO.foreach_(0 to 1000) { _ => app.execute(req).evaluate.asEffect }
   private val UIOProgram                 = ZIO.foreach_(0 to 1000) { _ => UIO(res) }
 

--- a/zio-http/src/main/scala/zhttp/http/PathModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/PathModule.scala
@@ -1,35 +1,52 @@
 package zhttp.http
 
 private[zhttp] trait PathModule { module =>
-  sealed trait Path {
-    self =>
+  sealed trait Path { self =>
     def asString: String
-
-    def /(name: String): Path = append(name)
-
-    def append(name: String): Path = if (name.isEmpty) this else module./(this, name)
-
+    def /:(name: String): Path     = append(name)
+    def append(name: String): Path = if (name.isEmpty) self else Path.Default(name, self)
     def toList: List[String]
-
-    override def toString: String = this.asString
+    override def toString: String  = this.asString
   }
 
   object Path {
-    def apply(): Path                               = Root
-    def apply(string: String): Path                 = if (string.trim.isEmpty) Root else Path(string.split("/").toList)
+    def apply(): Path                               = End
+    def apply(string: String): Path                 = if (string.trim.isEmpty) End else Path(string.split("/").toList)
     def apply(seqString: String*): Path             = Path(seqString.toList)
-    def apply(list: List[String]): Path             = list.foldLeft[Path](Root)((a, s) => a.append(s))
+    def apply(list: List[String]): Path             = list.foldRight[Path](End)((s, a) => a.append(s))
     def unapplySeq(arg: Path): Option[List[String]] = Option(arg.toList)
-    def empty: Path                                 = Root
+    def empty: Path                                 = End
+
+    case object End extends Path {
+      override def asString: String     = ""
+      override def toList: List[String] = Nil
+    }
+
+    case class Default(name: String, path: Path) extends Path {
+      override def asString: String     = s"/${name}${path.asString}"
+      override def toList: List[String] = name :: path.toList
+    }
   }
 
-  case class /(path: Path, name: String) extends Path {
-    override lazy val asString: String = s"${path.asString}/${name}"
-    override def toList: List[String]  = path.toList ::: List(name)
+  object /: {
+    def unapply(path: Path): Option[(String, Path)] =
+      path match {
+        case Path.End                 => None
+        case Path.Default(name, path) => Option(name -> path)
+      }
   }
 
-  case object Root extends Path {
-    override lazy val asString: String = ""
-    override def toList: List[String]  = Nil
+  val !! = Path.End
+
+  abstract class Decode[A](f: String => Option[A]) {
+    def unapply(a: String): Option[A] = f(a)
   }
+
+  object boolean extends Decode(_.toBooleanOption)
+  object byte    extends Decode(_.toByteOption)
+  object short   extends Decode(_.toShortOption)
+  object int     extends Decode(_.toIntOption)
+  object long    extends Decode(_.toLongOption)
+  object float   extends Decode(_.toFloatOption)
+  object double  extends Decode(_.toDoubleOption)
 }

--- a/zio-http/src/main/scala/zhttp/http/PathModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/PathModule.scala
@@ -37,16 +37,4 @@ private[zhttp] trait PathModule { module =>
   }
 
   val !! = Path.End
-
-  abstract class Decode[A](f: String => Option[A]) {
-    def unapply(a: String): Option[A] = f(a)
-  }
-
-  object boolean extends Decode(_.toBooleanOption)
-  object byte    extends Decode(_.toByteOption)
-  object short   extends Decode(_.toShortOption)
-  object int     extends Decode(_.toIntOption)
-  object long    extends Decode(_.toLongOption)
-  object float   extends Decode(_.toFloatOption)
-  object double  extends Decode(_.toDoubleOption)
 }

--- a/zio-http/src/main/scala/zhttp/http/PathModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/PathModule.scala
@@ -3,10 +3,11 @@ package zhttp.http
 private[zhttp] trait PathModule { module =>
   sealed trait Path { self =>
     def asString: String
+    def /(name: String): Path      = Path(self.toList :+ name)
     def /:(name: String): Path     = append(name)
-    def append(name: String): Path = if (name.isEmpty) self else Path.Default(name, self)
+    def append(name: String): Path = if (name.isEmpty) self else Path.Cons(name, self)
     def toList: List[String]
-    override def toString: String  = this.asString
+    def reverse: Path              = Path(toList.reverse)
   }
 
   object Path {
@@ -22,7 +23,7 @@ private[zhttp] trait PathModule { module =>
       override def toList: List[String] = Nil
     }
 
-    case class Default(name: String, path: Path) extends Path {
+    case class Cons(name: String, path: Path) extends Path {
       override def asString: String     = s"/${name}${path.asString}"
       override def toList: List[String] = name :: path.toList
     }
@@ -31,10 +32,22 @@ private[zhttp] trait PathModule { module =>
   object /: {
     def unapply(path: Path): Option[(String, Path)] =
       path match {
-        case Path.End                 => None
-        case Path.Default(name, path) => Option(name -> path)
+        case Path.End              => None
+        case Path.Cons(name, path) => Option(name -> path)
       }
   }
 
+  object / {
+    def unapply(path: Path): Option[(Path, String)] = {
+      path.toList.reverse match {
+        case Nil          => None
+        case head :: next => Option((Path(next.reverse), head))
+      }
+    }
+  }
+
   val !! = Path.End
+
+  @deprecated("Use `!!` operator instead.", "23-Aug-2021")
+  val Root = !!
 }

--- a/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
@@ -1,0 +1,15 @@
+package zhttp.http
+
+trait RouteDecoderModule {
+  abstract class RouteDecode[A](f: String => Option[A]) {
+    def unapply(a: String): Option[A] = f(a)
+  }
+
+  object boolean extends RouteDecode(_.toBooleanOption)
+  object byte    extends RouteDecode(_.toByteOption)
+  object short   extends RouteDecode(_.toShortOption)
+  object int     extends RouteDecode(_.toIntOption)
+  object long    extends RouteDecode(_.toLongOption)
+  object float   extends RouteDecode(_.toFloatOption)
+  object double  extends RouteDecode(_.toDoubleOption)
+}

--- a/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
@@ -1,15 +1,23 @@
 package zhttp.http
 
+import java.util.UUID
+
 trait RouteDecoderModule {
-  abstract class RouteDecode[A](f: String => Option[A]) {
-    def unapply(a: String): Option[A] = f(a)
+  abstract class RouteDecode[A](f: String => A) {
+    def unapply(a: String): Option[A] =
+      try {
+        Option(f(a))
+      } catch {
+        case _: Throwable => None
+      }
   }
 
-  object boolean extends RouteDecode(_.toBooleanOption)
-  object byte    extends RouteDecode(_.toByteOption)
-  object short   extends RouteDecode(_.toShortOption)
-  object int     extends RouteDecode(_.toIntOption)
-  object long    extends RouteDecode(_.toLongOption)
-  object float   extends RouteDecode(_.toFloatOption)
-  object double  extends RouteDecode(_.toDoubleOption)
+  object boolean extends RouteDecode(_.toBoolean)
+  object byte    extends RouteDecode(_.toByte)
+  object short   extends RouteDecode(_.toShort)
+  object int     extends RouteDecode(_.toInt)
+  object long    extends RouteDecode(_.toLong)
+  object float   extends RouteDecode(_.toFloat)
+  object double  extends RouteDecode(_.toDouble)
+  object uuid    extends RouteDecode(str => UUID.fromString(str))
 }

--- a/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
@@ -3,6 +3,22 @@ package zhttp.http
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 
+/**
+ * Instead of using just `String` as path params, using the RouteDecoderModule we can extract and converted params into
+ * a specific type also.
+ *
+ * ```scala
+ * Http.collect[Request] {
+ *   case GET -> !! / "user" / int(id) => Response.text("User id requested: ${id}")
+ *   case GET -> !! / "user" / name    => Response.text("User name requested: ${name}")
+ * }
+ * ```
+ *
+ * If the request looks like `GET /user/100` then it would match the first case. This is because internally the `id`
+ * param can be decoded into an `Int`. If a request of the form `GET /user/zio` is made, in that case the second case is
+ * matched.
+ */
+
 trait RouteDecoderModule {
   abstract class RouteDecode[A](f: String => A) {
     def unapply(a: String): Option[A] =

--- a/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
@@ -1,5 +1,6 @@
 package zhttp.http
 
+import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 
 trait RouteDecoderModule {
@@ -20,4 +21,6 @@ trait RouteDecoderModule {
   object float   extends RouteDecode(_.toFloat)
   object double  extends RouteDecode(_.toDouble)
   object uuid    extends RouteDecode(str => UUID.fromString(str))
+  object date    extends RouteDecode(str => LocalDate.parse(str))
+  object time    extends RouteDecode(str => LocalDateTime.parse(str))
 }

--- a/zio-http/src/main/scala/zhttp/http/package.scala
+++ b/zio-http/src/main/scala/zhttp/http/package.scala
@@ -5,7 +5,7 @@ import zio.ZIO
 
 import java.nio.charset.Charset
 
-package object http extends PathModule with RequestSyntax with HttpAppSyntax {
+package object http extends PathModule with RequestSyntax with HttpAppSyntax with RouteDecoderModule {
   type UHttp[-A, +B]      = Http[Any, Nothing, A, B]
   type HttpApp[-R, +E]    = Http[R, E, Request, Response[R, E]]
   type UHttpApp           = HttpApp[Any, Nothing]

--- a/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
@@ -2,7 +2,7 @@ package zhttp.service
 
 import io.netty.buffer.Unpooled
 import io.netty.handler.codec.http.{DefaultFullHttpRequest, FullHttpRequest, HttpHeaderNames, HttpVersion}
-import zhttp.http.{HTTP_CHARSET, Header, Request, Root}
+import zhttp.http.{HTTP_CHARSET, Header, Path, Request}
 trait EncodeRequest {
 
   /**
@@ -11,8 +11,8 @@ trait EncodeRequest {
   def encodeRequest(jVersion: HttpVersion, req: Request): FullHttpRequest = {
     val method      = req.method.asHttpMethod
     val uri         = req.url.path match {
-      case Root => "/"
-      case _    => req.url.relative.asString
+      case Path.End => "/"
+      case _        => req.url.relative.asString
     }
     val content     = req.getBodyAsString match {
       case Some(text) => Unpooled.copiedBuffer(text, HTTP_CHARSET)

--- a/zio-http/src/test/scala/zhttp/http/PathSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/PathSpec.scala
@@ -1,33 +1,78 @@
 package zhttp.http
 
-import zio.test.Assertion.equalTo
+import zio.test.Assertion.{equalTo, isFalse, isNone, isSome, isTrue}
 import zio.test._
 
-object PathSpec extends DefaultRunnableSpec {
-  def spec =
+object PathSpec extends DefaultRunnableSpec with HttpResultAssertion {
+  def collect[A](pf: PartialFunction[Path, A]): Path => Option[A] = path => pf.lift(path)
+  def spec                                                        =
     suite("Path")(
       suite("toList")(
-        test("/")(assert(Path("").toList)(equalTo(Nil))),
-        test("/A")(assert(Path("A").toList)(equalTo(List("A")))),
-        test("/A/B%2FC")(assert(Path("A", "B%2FC").toList)(equalTo(List("A", "B%2FC")))),
-        test("/A/B/C")(assert(Path("A", "B", "C").toList)(equalTo(List("A", "B", "C")))),
+        test("empty")(assert(Path().toList)(equalTo(Nil))),
+        test("empty string")(assert(Path("").toList)(equalTo(Nil))),
+        test("just /")(assert(Path("/").toList)(equalTo(Nil))),
+        test("un-prefixed")(assert(Path("A").toList)(equalTo(List("A")))),
+        test("prefixed")(assert(Path("/A").toList)(equalTo(List("A")))),
+        test("encoding string")(assert(Path("A", "B%2FC").toList)(equalTo(List("A", "B%2FC")))),
+        test("nested paths")(assert(Path("A", "B", "C").toList)(equalTo(List("A", "B", "C")))),
       ),
-      suite("apply")(
-        test("/")(assert(Path("/"))(equalTo(Root))),
-        test("/A")(assert(Path("/A"))(equalTo(Path("A")))),
-        test("/A/B%2FC")(assert(Path("/A/B%2FC"))(equalTo(Path("A", "B%2FC")))),
-        test("/A/B/C")(assert(Path("/A/B/C"))(equalTo(Path("A", "B", "C")))),
+      suite("apply()")(
+        test("empty")(assert(Path())(equalTo(!!))),
+        test("empty string")(assert(Path(""))(equalTo(!!))),
+        test("just /")(assert(Path("/"))(equalTo(!!))),
+        test("prefixed path")(assert(Path("/A"))(equalTo(Path("A")))),
+        test("encoded paths")(assert(Path("/A/B%2FC"))(equalTo(Path("A", "B%2FC")))),
+        test("nested paths")(assert(Path("/A/B/C"))(equalTo(Path("A", "B", "C")))),
       ),
-      suite("unapplySeq")(
-        test("/")((Path(): @unchecked) match { case Root => assertCompletes }),
-        test("/")((Path(""): @unchecked) match { case Root => assertCompletes }),
-        test("/A/B")((Path("A", "B"): @unchecked) match { case Root / x / y => assert((x, y))(equalTo(("A", "B"))) }),
-        test("/A/B%2FC")((Path("A", "B%2FC"): @unchecked) match {
-          case Root / x / y => assert((x, y))(equalTo(("A", "B%2FC")))
-        }),
-        test("/A/B/C") {
-          (Path("A", "B", "C"): @unchecked) match { case Path(x, y, z) => assert((x, y, z))(equalTo(("A", "B", "C"))) }
+      suite("asString")(
+        test("a, b, c") {
+          val path = Path("a", "b", "c").asString
+          assert(path)(equalTo("/a/b/c"))
         },
+        test("Path()") {
+          val path = Path().asString
+          assert(path)(equalTo(""))
+        },
+      ),
+      suite("PathSyntax /:")(
+        suite("default")(
+          test("extract path 'name' /: name") {
+            val path = collect { case "name" /: name => name.asString }
+            assert(path(Path("name", "a", "b", "c")))(isSome(equalTo("/a/b/c")))
+          },
+          test("extract paths 'name' /: a /: b /: 'c' /: !!") {
+            val path = collect { case "name" /: a /: b /: "c" /: !! => (a, b) }
+            assert(path(Path("name", "a", "b", "c")))(isSome(equalTo(("a", "b"))))
+          },
+          test("extract paths 'name' /: a /: b /: _") {
+            val path = collect { case "name" /: a /: b /: _ => (a, b) }
+            assert(path(Path("name", "a", "b", "c")))(isSome(equalTo(("a", "b"))))
+          },
+          test("extract paths 'name' /: name /: 'a' /: 'b' /: 'c' /: !!") {
+            val path = collect { case "name" /: name /: "a" /: "b" /: "c" /: !! => name.toString }
+            assert(path(Path("name", "Xyz", "a", "b", "c")))(isSome(equalTo("Xyz")))
+          },
+        ),
+        suite("int()")(
+          test("extract path 'user' /: int(1)") {
+            val path = collect { case "user" /: int(age) /: !! => age }
+            assert(path(Path("user", "1")))(isSome(equalTo(1)))
+          },
+          test("extract path 'user' /: int(Xyz)") {
+            val path = collect { case "user" /: int(age) /: !! => age }
+            assert(path(Path("user", "Xyz")))(isNone)
+          },
+        ),
+        suite("boolean()")(
+          test("extract path 'user' /: boolean(true)") {
+            val path = collect { case "user" /: boolean(ok) /: !! => ok }
+            assert(path(Path("user", "True")))(isSome(isTrue))
+          },
+          test("extract path 'user' /: boolean(false)") {
+            val path = collect { case "user" /: boolean(ok) /: !! => ok }
+            assert(path(Path("user", "false")))(isSome(isFalse))
+          },
+        ),
       ),
     )
 }

--- a/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
@@ -11,7 +11,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
   val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
 
   val app: ZManaged[EventLoopGroup with ServerChannelFactory, Nothing, Unit] = serve {
-    CORS(HttpApp.collect { case Method.GET -> Root / "success" =>
+    CORS(HttpApp.collect { case Method.GET -> "success" /: _ =>
       Response.ok
     })
   }
@@ -22,7 +22,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
         List(
           testM("OPTIONS request") {
             val actual = request(
-              Root / "success",
+              "success" /: !!,
               Method.OPTIONS,
               "",
               List[Header](
@@ -51,7 +51,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
           },
           testM("GET request") {
             val actual = headers(
-              Root / "success",
+              "success" /: !!,
               Method.GET,
               "",
               HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD -> Method.GET.toString(),

--- a/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
@@ -11,7 +11,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
   val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
 
   val app: ZManaged[EventLoopGroup with ServerChannelFactory, Nothing, Unit] = serve {
-    CORS(HttpApp.collect { case Method.GET -> "success" /: _ =>
+    CORS(HttpApp.collect { case Method.GET -> !! / "success" =>
       Response.ok
     })
   }
@@ -22,7 +22,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
         List(
           testM("OPTIONS request") {
             val actual = request(
-              "success" /: !!,
+              !! / "success",
               Method.OPTIONS,
               "",
               List[Header](
@@ -51,7 +51,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
           },
           testM("GET request") {
             val actual = headers(
-              "success" /: !!,
+              !! / "success",
               Method.GET,
               "",
               HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD -> Method.GET.toString(),

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -31,7 +31,7 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
     }
 
   def getApp(state: Ref[ServerState]) = serve {
-    HttpApp.collectM { case req @ _ -> path /: !! =>
+    HttpApp.collectM { case req @ _ -> !! / path =>
       state.update(updateState(_, req.headers, path)) *> ZIO.succeed(Response.ok)
     }
   }
@@ -52,20 +52,20 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
         List(
           testM("get request without content") {
             val path   = "getWithoutContent"
-            val actual = status(path /: !!) *> getLengthForPath(state, path)
+            val actual = status(!! / path) *> getLengthForPath(state, path)
             assertM(actual)(isNone)
           } @@ ignore,
           testM("post request with nonempty content") {
             val path    = "postWithNonemptyContent"
             val content = "content"
-            val actual  = request(path /: !!, Method.POST, content) *> getLengthForPath(state, path)
+            val actual  = request(!! / path, Method.POST, content) *> getLengthForPath(state, path)
             assertM(actual)(isSome(isPositive[Int]))
           },
           testM("post request with nonempty content and set content-length") {
             val path    = "postWithNonemptyContentAndSetContentLength"
             val content = "content"
             val headers = List(Header.custom(contentLengthName, "dummy"))
-            val actual  = request(path /: !!, Method.POST, content, headers) *> getLengthForPath(state, path)
+            val actual  = request(!! / path, Method.POST, content, headers) *> getLengthForPath(state, path)
             assertM(actual)(isSome(isPositive[Int]))
           },
         ),

--- a/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientContentLengthSpec.scala
@@ -31,7 +31,7 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
     }
 
   def getApp(state: Ref[ServerState]) = serve {
-    HttpApp.collectM { case req @ _ -> Root / path =>
+    HttpApp.collectM { case req @ _ -> path /: !! =>
       state.update(updateState(_, req.headers, path)) *> ZIO.succeed(Response.ok)
     }
   }
@@ -52,20 +52,20 @@ object ClientContentLengthSpec extends HttpRunnableSpec(8083) {
         List(
           testM("get request without content") {
             val path   = "getWithoutContent"
-            val actual = status(Root / path) *> getLengthForPath(state, path)
+            val actual = status(path /: !!) *> getLengthForPath(state, path)
             assertM(actual)(isNone)
           } @@ ignore,
           testM("post request with nonempty content") {
             val path    = "postWithNonemptyContent"
             val content = "content"
-            val actual  = request(Root / path, Method.POST, content) *> getLengthForPath(state, path)
+            val actual  = request(path /: !!, Method.POST, content) *> getLengthForPath(state, path)
             assertM(actual)(isSome(isPositive[Int]))
           },
           testM("post request with nonempty content and set content-length") {
             val path    = "postWithNonemptyContentAndSetContentLength"
             val content = "content"
             val headers = List(Header.custom(contentLengthName, "dummy"))
-            val actual  = request(Root / path, Method.POST, content, headers) *> getLengthForPath(state, path)
+            val actual  = request(path /: !!, Method.POST, content, headers) *> getLengthForPath(state, path)
             assertM(actual)(isSome(isPositive[Int]))
           },
         ),

--- a/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
@@ -39,7 +39,7 @@ object SSLSpec extends HttpRunnableSpec(8073) {
   val clientssl1 = SslContextBuilder.forClient().trustManager(ssc1.cert()).build()
   val clientssl2 = SslContextBuilder.forClient().trustManager(ssc2.cert()).build()
 
-  val app = HttpApp.collectM[Any, Nothing] { case Method.GET -> Root / "success" =>
+  val app = HttpApp.collectM[Any, Nothing] { case Method.GET -> "success" /: _ =>
     ZIO.succeed(Response.ok)
   }
 

--- a/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
@@ -39,7 +39,7 @@ object SSLSpec extends HttpRunnableSpec(8073) {
   val clientssl1 = SslContextBuilder.forClient().trustManager(ssc1.cert()).build()
   val clientssl2 = SslContextBuilder.forClient().trustManager(ssc2.cert()).build()
 
-  val app = HttpApp.collectM[Any, Nothing] { case Method.GET -> "success" /: _ =>
+  val app = HttpApp.collectM[Any, Nothing] { case Method.GET -> !! / "success" =>
     ZIO.succeed(Response.ok)
   }
 

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -11,9 +11,9 @@ object ServerSpec extends HttpRunnableSpec(8081) {
 
   val app = serve {
     HttpApp.collectM {
-      case Method.GET -> Root / "success"       => ZIO.succeed(Response.ok)
-      case Method.GET -> Root / "failure"       => ZIO.fail(new RuntimeException("FAILURE"))
-      case Method.GET -> Root / "get%2Fsuccess" =>
+      case Method.GET -> "success" /: _       => ZIO.succeed(Response.ok)
+      case Method.GET -> "failure" /: _       => ZIO.fail(new RuntimeException("FAILURE"))
+      case Method.GET -> "get%2Fsuccess" /: _ =>
         ZIO.succeed(Response.ok)
     }
   }
@@ -23,19 +23,19 @@ object ServerSpec extends HttpRunnableSpec(8081) {
       .as(
         List(
           testM("200 response") {
-            val actual = status(Root / "success")
+            val actual = status("success" /: !!)
             assertM(actual)(equalTo(Status.OK))
           },
           testM("500 response") {
-            val actual = status(Root / "failure")
+            val actual = status("failure" /: !!)
             assertM(actual)(equalTo(Status.INTERNAL_SERVER_ERROR))
           },
           testM("404 response") {
-            val actual = status(Root / "random")
+            val actual = status("random" /: !!)
             assertM(actual)(equalTo(Status.NOT_FOUND))
           },
           testM("200 response with encoded path") {
-            val actual = status(Root / "get%2Fsuccess")
+            val actual = status("get%2Fsuccess" /: !!)
             assertM(actual)(equalTo(Status.OK))
           },
         ),

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -11,9 +11,9 @@ object ServerSpec extends HttpRunnableSpec(8081) {
 
   val app = serve {
     HttpApp.collectM {
-      case Method.GET -> "success" /: _       => ZIO.succeed(Response.ok)
-      case Method.GET -> "failure" /: _       => ZIO.fail(new RuntimeException("FAILURE"))
-      case Method.GET -> "get%2Fsuccess" /: _ =>
+      case Method.GET -> !! / "success"       => ZIO.succeed(Response.ok)
+      case Method.GET -> !! / "failure"       => ZIO.fail(new RuntimeException("FAILURE"))
+      case Method.GET -> !! / "get%2Fsuccess" =>
         ZIO.succeed(Response.ok)
     }
   }
@@ -23,19 +23,19 @@ object ServerSpec extends HttpRunnableSpec(8081) {
       .as(
         List(
           testM("200 response") {
-            val actual = status("success" /: !!)
+            val actual = status(!! / "success")
             assertM(actual)(equalTo(Status.OK))
           },
           testM("500 response") {
-            val actual = status("failure" /: !!)
+            val actual = status(!! / "failure")
             assertM(actual)(equalTo(Status.INTERNAL_SERVER_ERROR))
           },
           testM("404 response") {
-            val actual = status("random" /: !!)
+            val actual = status(!! / "random")
             assertM(actual)(equalTo(Status.NOT_FOUND))
           },
           testM("200 response with encoded path") {
-            val actual = status("get%2Fsuccess" /: !!)
+            val actual = status(!! / "get%2Fsuccess")
             assertM(actual)(equalTo(Status.OK))
           },
         ),


### PR DESCRIPTION
## Current Behavior
With the current API only exact match is supported and is **impossible** to match a prefix and extract the rest of the path. For eg: 

```scala
Http.collect[Path] {
  case Root / "a" / rest => rest
}
```
In the above example, the path `/a/b/c/d` will not match the route, resulting in a 404 error.


## New Behavior
The new API is now right-associative and can match paths partially, for eg: 

```scala
Http.collect[Path] {
  case "a" /: rest => rest
}
```
With this new API, instead of using `/` we use `/:`. This allows us to start the extraction from the right-hand side of the expression. 
The value of `rest` will be equal to `/b/c/d` in this new API!

## Support for Exact Match

To support an exact match use case, one needs to mark the end of the path explicitly. This is done by a new `!!` operator eg —

```scala
Http.collect[Path] {
  case "a" /: rest /: !! => rest
}
```
This route would simulate the old behavior of exact match but with a different syntax.

## Bonus!
Special route extractors have been added to pull `int` `short` `long` `date` etc.
```scala
Http.collect[Path] {
  case "user" /: int(id) /: "create" /: !! => console.putStrLn("User created!")
  case "weather" /: date(dd) /: !!         => console.putStrLn(s"Get weather for ${dd}")
}
```