### PR TITLE
Scala Steward Repo Configuration

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,25 @@
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+#
+# Possible values:
+#   @asap
+#     PRs are created without delay.
+#
+#   <timespan>
+#     PRs are created only again after the given timespan since the last PR
+#     has passed. Example values are "36 hours", "1 day", or "14 days".
+#   <CRON expression>
+#     PRs are created roughly according to the given CRON expression.
+#
+#     CRON expressions consist of five fields:
+#     minutes, hour of day, day of month, month, and day of week.
+#
+#     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
+#     more information about the CRON expressions that are supported.
+#
+#     Note that the date parts of the CRON expression are matched exactly
+#     while the time parts are only used to abide to the frequency of
+#     the given expression.
+#
+# Default: @asap
+pullRequests.frequency = "365 days"


### PR DESCRIPTION
# Description
* `.scala-steward.conf`added to control how often or when Scala Steward is allowed to create pull requests.

Reference: [Scala Steward Docs](https://github.com/scala-steward-org/scala-steward/blob/master/docs/repo-specific-configuration.md)
