### PR TITLE
Fix: do not ignore query params when url path is empty

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
@@ -11,7 +11,7 @@ trait EncodeRequest {
   def encodeRequest(jVersion: HttpVersion, req: Request): FullHttpRequest = {
     val method      = req.method.asHttpMethod
     val uri         = req.url.path match {
-      case Path.End => "/"
+      case Path.End => "/" + req.url.relative.asString
       case _        => req.url.relative.asString
     }
     val content     = req.getBodyAsString match {

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -20,6 +20,28 @@ object EncodeRequestSpec extends DefaultRunnableSpec with EncodeRequest {
         val encoded = encodeRequest(jVersion = HttpVersion.HTTP_1_1, req = request)
         assert(encoded.uri())(equalTo("/"))
       },
+      testM("should encode a request with query parameters and root url") {
+        val queryParamsGen =
+          Gen.mapOfBounded(1, 5)(
+            Gen.alphaNumericStringBounded(1, 5),
+            Gen.listOfBounded(1, 5)(Gen.alphaNumericStringBounded(1, 5)),
+          )
+
+        check(queryParamsGen) { queryParams =>
+          val queryString                     = queryParamsAsString(queryParams)
+          val requestWithQueryParams: Request =
+            Request(
+              Method.GET -> URL(
+                Path(""),
+                Location.Absolute(Scheme.HTTP, "localhost", 8000),
+                queryParams,
+              ),
+            )
+
+          val encoded = encodeRequest(jVersion = HttpVersion.HTTP_1_1, req = requestWithQueryParams)
+          assert(encoded.uri())(equalTo(s"/?$queryString"))
+        }
+      },
       testM("should encode a request with query parameters") {
         val queryParamsGen =
           Gen.mapOfBounded(1, 5)(


### PR DESCRIPTION
When we are trying to send request without url path with query parameters, they are just ignored