### PR TITLE
Draft: Fix provide Method and Add Unit tests for `provide` in `HttpApp`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/HttpApp.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpApp.scala
@@ -45,7 +45,8 @@ case class HttpApp[-R, +E](asHttp: Http[R, E, Request, Response[R, E]]) { self =
   /**
    * Provides the environment to Http.
    */
-  def provide(r: R)(implicit ev: NeedsEnv[R]) = self.asHttp.provide(r)
+  def provide(r: R)(implicit ev: NeedsEnv[R]) =
+    self.copy(self.asHttp.provide(r).map(_.provide(r)))
 
   /**
    * Provides some of the environment to Http.

--- a/zio-http/src/main/scala/zhttp/http/HttpAttribute.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpAttribute.scala
@@ -1,16 +1,15 @@
 package zhttp.http
 
 import zhttp.socket.SocketApp
-import zio.NeedsEnv
 
 /**
  * Attribute holder for and Responses
  */
 private[zhttp] sealed trait HttpAttribute[-R, +E] extends Product with Serializable { self =>
 
-  def provide(r: R)(implicit ev: NeedsEnv[R]): HttpAttribute[Any, E] = self match {
-    case HttpAttribute.Empty       => HttpAttribute.empty
-//    case HttpAttribute.Socket(app) => HttpAttribute.Socket(app.provide(r))
+  // TODO: fix .provide to handle exhaustive cases
+  def provide: HttpAttribute[Any, Nothing] = self match {
+    case _ => HttpAttribute.empty
   }
 
 }

--- a/zio-http/src/main/scala/zhttp/http/HttpAttribute.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpAttribute.scala
@@ -1,11 +1,19 @@
 package zhttp.http
 
 import zhttp.socket.SocketApp
+import zio.NeedsEnv
 
 /**
  * Attribute holder for and Responses
  */
-private[zhttp] sealed trait HttpAttribute[-R, +E] extends Product with Serializable
+private[zhttp] sealed trait HttpAttribute[-R, +E] extends Product with Serializable { self =>
+
+  def provide(r: R)(implicit ev: NeedsEnv[R]): HttpAttribute[Any, E] = self match {
+    case HttpAttribute.Empty       => HttpAttribute.empty
+//    case HttpAttribute.Socket(app) => HttpAttribute.Socket(app.provide(r))
+  }
+
+}
 
 object HttpAttribute {
   private[zhttp] case object Empty                                   extends HttpAttribute[Any, Nothing]

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -43,8 +43,9 @@ case class Response[-R, +E] private (
   def addHeaders(headers: List[Header]): Response[R, E] =
     self.copy(headers = self.headers ++ headers)
 
+  // TODO Fix here: HttpAttribute's provide
   def provide(r: R)(implicit ev: NeedsEnv[R]): Response[Any, E] =
-    self.copy(data = self.data.provide(r), attribute = self.attribute.provide(r))
+    self.copy(data = self.data.provide(r), attribute = self.attribute.provide)
 }
 
 object Response {

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -3,7 +3,7 @@ package zhttp.http
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.http.HttpError.HTTPErrorWithCause
 import zhttp.socket.{Socket, SocketApp, WebSocketFrame}
-import zio.Chunk
+import zio.{Chunk, NeedsEnv}
 
 import java.io.{PrintWriter, StringWriter}
 
@@ -42,6 +42,9 @@ case class Response[-R, +E] private (
    */
   def addHeaders(headers: List[Header]): Response[R, E] =
     self.copy(headers = self.headers ++ headers)
+
+  def provide(r: R)(implicit ev: NeedsEnv[R]): Response[Any, E] =
+    self.copy(data = self.data.provide(r), attribute = self.attribute.provide(r))
 }
 
 object Response {

--- a/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
+++ b/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
@@ -12,6 +12,8 @@ sealed trait SocketApp[-R, +E] { self =>
 
   def asResponse: Response[R, E] = Response(Status.OK, Nil, HttpData.empty, HttpAttribute.fromSocket(self))
 
+//  def provide(r: R)(implicit ev: NeedsEnv[R]): SocketApp[Any, E] = SocketApp.Provide(self, r)
+
   def config: SocketApp.SocketConfig[R, E] = {
     def loop(config: SocketApp[R, E], s: SocketConfig[R, E]): SocketConfig[R, E] =
       config match {
@@ -44,6 +46,20 @@ sealed trait SocketApp[-R, +E] { self =>
 
         case Concat(a, b) =>
           loop(b, loop(a, s))
+//
+//        case Provide(app, r: R) =>
+//          self match {
+//            case a: Open[_, _]        => ???
+//            case Concat(a, b)         => ???
+//            case OnMessage(onMessage) => ???
+//            case OnError(onError)     => s.copy(onError = s.onError.map(f => f(_).provide(r)))
+//            case OnClose(onClose)     => s.copy(onClose = s.onClose.map(f => f(_).provide(r)))
+//            case OnTimeout(onTimeout) => s.copy(onTimeout = s.onTimeout.map(f => f.provide(r)))
+//            case Protocol(protocol)   => s
+//            case Decoder(decoder)     => s
+//            case SocketApp.Empty      => s
+//            case Provide(app, r)      => ???
+//          }
       }
 
     loop(self, SocketConfig[R, E]())
@@ -84,6 +100,7 @@ object SocketApp {
   private final case class Protocol(protocol: SocketProtocol)                      extends SocketApp[Any, Nothing]
   private final case class Decoder(decoder: SocketDecoder)                         extends SocketApp[Any, Nothing]
   private case object Empty                                                        extends SocketApp[Any, Nothing]
+//  private case class Provide[R, E](app: SocketApp[R, E], r: R)                     extends SocketApp[Any, E]
 
   /**
    * Called when the connection is successfully upgrade to a websocket one. In case of a failure on the returned stream,

--- a/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
+++ b/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
@@ -12,8 +12,6 @@ sealed trait SocketApp[-R, +E] { self =>
 
   def asResponse: Response[R, E] = Response(Status.OK, Nil, HttpData.empty, HttpAttribute.fromSocket(self))
 
-//  def provide(r: R)(implicit ev: NeedsEnv[R]): SocketApp[Any, E] = SocketApp.Provide(self, r)
-
   def config: SocketApp.SocketConfig[R, E] = {
     def loop(config: SocketApp[R, E], s: SocketConfig[R, E]): SocketConfig[R, E] =
       config match {
@@ -46,20 +44,6 @@ sealed trait SocketApp[-R, +E] { self =>
 
         case Concat(a, b) =>
           loop(b, loop(a, s))
-//
-//        case Provide(app, r: R) =>
-//          self match {
-//            case a: Open[_, _]        => ???
-//            case Concat(a, b)         => ???
-//            case OnMessage(onMessage) => ???
-//            case OnError(onError)     => s.copy(onError = s.onError.map(f => f(_).provide(r)))
-//            case OnClose(onClose)     => s.copy(onClose = s.onClose.map(f => f(_).provide(r)))
-//            case OnTimeout(onTimeout) => s.copy(onTimeout = s.onTimeout.map(f => f.provide(r)))
-//            case Protocol(protocol)   => s
-//            case Decoder(decoder)     => s
-//            case SocketApp.Empty      => s
-//            case Provide(app, r)      => ???
-//          }
       }
 
     loop(self, SocketConfig[R, E]())
@@ -100,7 +84,6 @@ object SocketApp {
   private final case class Protocol(protocol: SocketProtocol)                      extends SocketApp[Any, Nothing]
   private final case class Decoder(decoder: SocketDecoder)                         extends SocketApp[Any, Nothing]
   private case object Empty                                                        extends SocketApp[Any, Nothing]
-//  private case class Provide[R, E](app: SocketApp[R, E], r: R)                     extends SocketApp[Any, E]
 
   /**
    * Called when the connection is successfully upgrade to a websocket one. In case of a failure on the returned stream,


### PR DESCRIPTION
# Changelog
* test(provide): test case written for provide in HttpApp
* refactor(HttpApp): implementation for .provide fixed in HttpApp
* refactor(Response): implementation for .provide added in Response
* refactor(HttpAttribute): limited implementation for .provide added in HttpAttribute
* wip(SocketApp): .provide for SocketApp
* wip(Socket): .provide for Socket

# Work In Progress
* Implementation for .provide in SocketApp
* implementation for .provide in Socket
* Unit test cases for methods written
