### PR TITLE
Rewrite CORS to use new middleware API

### DIFF
--- a/example/src/main/scala/HelloWorldWithCORS.scala
+++ b/example/src/main/scala/HelloWorldWithCORS.scala
@@ -1,16 +1,20 @@
 import zhttp.http._
+import zhttp.http.middleware.HttpMiddleware.cors
 import zhttp.service.Server
 import zio._
 
 object HelloWorldWithCORS extends App {
+
+  // Create CORS configuration
+  val config: CORSConfig =
+    CORSConfig(allowedOrigins = _ == "dev", allowedMethods = Some(Set(Method.PUT, Method.DELETE)))
+
   // Create HTTP route with CORS enabled
-  val app: HttpApp[Any, Nothing] = CORS(
+  val app: HttpApp[Any, Nothing] =
     HttpApp.collect {
       case Method.GET -> !! / "text" => Response.text("Hello World!")
       case Method.GET -> !! / "json" => Response.jsonString("""{"greetings": "Hello World!"}""")
-    },
-    config = CORSConfig(anyOrigin = true),
-  )
+    } @@ cors(config)
 
   // Run it like any simple app
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =

--- a/zio-http/src/main/scala/zhttp/http/CORS.scala
+++ b/zio-http/src/main/scala/zhttp/http/CORS.scala
@@ -1,7 +1,5 @@
 package zhttp.http
 
-import io.netty.handler.codec.http.HttpHeaderNames
-
 final case class CORSConfig(
   anyOrigin: Boolean = false,
   anyMethod: Boolean = true,
@@ -13,78 +11,5 @@ final case class CORSConfig(
 )
 
 object CORS {
-  def DefaultCORSConfig =
-    CORSConfig(anyOrigin = true, allowCredentials = true)
-
-  def apply[R, E](httpApp: HttpApp[R, E], config: CORSConfig = DefaultCORSConfig): HttpApp[R, E] = {
-    def allowCORS(origin: Header, acrm: Method): Boolean =
-      (config.anyOrigin, config.anyMethod, origin.value.toString, acrm) match {
-        case (true, true, _, _)           => true
-        case (true, false, _, acrm)       =>
-          config.allowedMethods.exists(_.contains(acrm))
-        case (false, true, origin, _)     => config.allowedOrigins(origin)
-        case (false, false, origin, acrm) =>
-          config.allowedMethods.exists(_.contains(acrm)) &&
-            config.allowedOrigins(origin)
-      }
-
-    def corsHeaders(origin: Header, method: Method, isPreflight: Boolean = false): List[Header] = {
-      (method match {
-        case _ if isPreflight =>
-          config.allowedHeaders.fold(List.empty[Header])(h => {
-            List(
-              Header.custom(
-                HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
-                h.mkString(","),
-              ),
-            )
-          })
-        case _                =>
-          config.exposedHeaders.fold(List.empty[Header])(h => {
-            List(
-              Header.custom(
-                HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(),
-                h.mkString(","),
-              ),
-            )
-          })
-      }) ++
-        List(
-          Header.custom(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), origin.value),
-          Header.custom(
-            HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
-            config.allowedMethods.fold(method.toString())(m => m.map(m => m.toString()).mkString(",")),
-          ),
-        ) ++
-        (if (config.allowCredentials)
-           List(
-             Header
-               .custom(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), config.allowCredentials.toString()),
-           )
-         else List.empty[Header])
-    }
-
-    Http.flatten {
-      Http.fromFunction[Request](req => {
-        (
-          req.method,
-          req.getHeader(HttpHeaderNames.ORIGIN),
-          req.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD),
-        ) match {
-          case (Method.OPTIONS, Some(origin), Some(acrm))
-              if allowCORS(origin, Method.fromString(acrm.value.toString())) =>
-            Http.succeed(
-              Response(
-                Status.NO_CONTENT,
-                headers = corsHeaders(origin, Method.fromString(acrm.value.toString()), isPreflight = true),
-              ),
-            )
-          case (_, Some(origin), _) if allowCORS(origin, req.method) =>
-            httpApp.asHttp >>>
-              Http.fromFunction[Response[R, E]](r => r.copy(headers = r.headers ++ corsHeaders(origin, req.method)))
-          case _                                                     => httpApp.asHttp
-        }
-      })
-    }.toApp
-  }
+  def DefaultCORSConfig = CORSConfig(anyOrigin = true, allowCredentials = true)
 }

--- a/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
+++ b/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
@@ -10,9 +10,9 @@ import zhttp.http.HeaderExtension.{BasicSchemeName, BearerSchemeName}
 import java.nio.charset.Charset
 import scala.util.control.NonFatal
 
-case class HeadersList(val headers: List[Header]) extends ReadHeaderExtension[HeadersList]
+private[zhttp] trait HeaderExtension[+A] { self =>
+  def headers: List[Header]
 
-private[zhttp] trait HeaderExtension[+A] extends ReadHeaderExtension[A] { self =>
   def addHeaders(headers: List[Header]): A
 
   def removeHeaders(headers: List[String]): A
@@ -26,15 +26,6 @@ private[zhttp] trait HeaderExtension[+A] extends ReadHeaderExtension[A] { self =
 
   def setChunkedEncoding: A =
     addHeader(Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED))
-}
-
-object HeaderExtension {
-  val BasicSchemeName  = "Basic"
-  val BearerSchemeName = "Bearer"
-}
-
-private[zhttp] trait ReadHeaderExtension[+A] { self =>
-  def headers: List[Header]
 
   private def equalsIgnoreCase(a: Char, b: Char) = a == b || toLowerCase(a) == toLowerCase(b)
 
@@ -143,4 +134,9 @@ private[zhttp] trait ReadHeaderExtension[+A] { self =>
 
   def hasHeader(name: CharSequence): Boolean =
     getHeaderValue(name).nonEmpty
+}
+
+object HeaderExtension {
+  val BasicSchemeName  = "Basic"
+  val BearerSchemeName = "Bearer"
 }

--- a/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
+++ b/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
@@ -10,9 +10,9 @@ import zhttp.http.HeaderExtension.{BasicSchemeName, BearerSchemeName}
 import java.nio.charset.Charset
 import scala.util.control.NonFatal
 
-private[zhttp] trait HeaderExtension[+A] { self =>
-  def headers: List[Header]
+case class HeadersList(val headers: List[Header]) extends ReadHeaderExtension[HeadersList]
 
+private[zhttp] trait HeaderExtension[+A] extends ReadHeaderExtension[A] { self =>
   def addHeaders(headers: List[Header]): A
 
   def removeHeaders(headers: List[String]): A
@@ -26,6 +26,15 @@ private[zhttp] trait HeaderExtension[+A] { self =>
 
   def setChunkedEncoding: A =
     addHeader(Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED))
+}
+
+object HeaderExtension {
+  val BasicSchemeName  = "Basic"
+  val BearerSchemeName = "Bearer"
+}
+
+private[zhttp] trait ReadHeaderExtension[+A] { self =>
+  def headers: List[Header]
 
   private def equalsIgnoreCase(a: Char, b: Char) = a == b || toLowerCase(a) == toLowerCase(b)
 
@@ -134,9 +143,4 @@ private[zhttp] trait HeaderExtension[+A] { self =>
 
   def hasHeader(name: CharSequence): Boolean =
     getHeaderValue(name).nonEmpty
-}
-
-object HeaderExtension {
-  val BasicSchemeName  = "Basic"
-  val BearerSchemeName = "Bearer"
 }

--- a/zio-http/src/main/scala/zhttp/http/middleware/HttpMiddleware.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/HttpMiddleware.scala
@@ -1,5 +1,7 @@
 package zhttp.http.middleware
 
+import io.netty.handler.codec.http.HttpHeaderNames
+import zhttp.http.CORS.DefaultCORSConfig
 import zhttp.http._
 import zhttp.http.middleware.HttpMiddleware.RequestP
 import zio.clock.Clock
@@ -177,6 +179,100 @@ object HttpMiddleware {
    */
   def removeHeader(name: String): HttpMiddleware[Any, Nothing] =
     patch((_, _) => Patch.removeHeaders(List(name)))
+
+  /**
+   * Creates a middleware for Cross-Origin Resource Sharing (CORS).
+   * @see
+   *   https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+   */
+  def cors[R, E](config: CORSConfig = DefaultCORSConfig): HttpMiddleware[R, E] = {
+    def allowCORS(origin: Header, acrm: Method): Boolean                                =
+      (config.anyOrigin, config.anyMethod, origin.value.toString, acrm) match {
+        case (true, true, _, _)           => true
+        case (true, false, _, acrm)       =>
+          config.allowedMethods.exists(_.contains(acrm))
+        case (false, true, origin, _)     => config.allowedOrigins(origin)
+        case (false, false, origin, acrm) =>
+          config.allowedMethods.exists(_.contains(acrm)) &&
+            config.allowedOrigins(origin)
+      }
+    def corsHeaders(origin: Header, method: Method, isPreflight: Boolean): List[Header] = {
+      (method match {
+        case _ if isPreflight =>
+          config.allowedHeaders.fold(List.empty[Header])((h: Set[String]) => {
+            List(
+              Header.custom(
+                HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(),
+                h.mkString(","),
+              ),
+            )
+          })
+        case _                =>
+          config.exposedHeaders.fold(List.empty[Header])(h => {
+            List(
+              Header.custom(
+                HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(),
+                h.mkString(","),
+              ),
+            )
+          })
+      }) ++
+        List(
+          Header.custom(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), origin.value),
+          Header.custom(
+            HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+            config.allowedMethods.fold(method.toString())(m => m.map(m => m.toString()).mkString(",")),
+          ),
+        ) ++
+        (if (config.allowCredentials)
+           List(
+             Header
+               .custom(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), config.allowCredentials.toString),
+           )
+         else List.empty[Header])
+    }
+
+    val existingRoutesWithHeaders = HttpMiddleware.make((method, _, headers) => {
+      val headersList = HeadersList(headers)
+      (
+        method,
+        headersList.getHeader(HttpHeaderNames.ORIGIN),
+      ) match {
+        case (_, Some(origin)) if allowCORS(origin, method) => (Some(origin), method)
+        case _                                              => (None, method)
+      }
+    })((_, _, s) => {
+      s match {
+        case (Some(origin), method) =>
+          Patch.addHeaders(corsHeaders(origin, method, isPreflight = false))
+        case _                      => Patch.empty
+      }
+    })
+
+    val optionsHeaders = fromMiddlewareFunction { case (method, _, headers) =>
+      val headersList = HeadersList(headers)
+      (
+        method,
+        headersList.getHeader(HttpHeaderNames.ORIGIN),
+        headersList.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD),
+      ) match {
+        case (Method.OPTIONS, Some(origin), Some(acrm)) if allowCORS(origin, Method.fromString(acrm.value.toString)) =>
+          fromApp(
+            HttpApp.fromHttp(
+              Http.succeed(
+                Response(
+                  Status.NO_CONTENT,
+                  headers = corsHeaders(origin, Method.fromString(acrm.value.toString), isPreflight = true),
+                ),
+              ),
+            ),
+          )
+        case _ => identity
+      }
+    }
+
+    existingRoutesWithHeaders orElse optionsHeaders
+  }
 
   /**
    * Applies the middleware on an HttpApp

--- a/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
@@ -2,7 +2,7 @@ package zhttp.service
 
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.http._
-import zhttp.http.middleware.HttpMiddleware
+import zhttp.http.middleware.HttpMiddleware.cors
 import zhttp.service.server._
 import zio.ZManaged
 import zio.test.Assertion._
@@ -14,7 +14,7 @@ object CORSSpec extends HttpRunnableSpec(8089) {
   val app: ZManaged[EventLoopGroup with ServerChannelFactory, Nothing, Unit] = serve {
     HttpApp.collect { case Method.GET -> !! / "success" =>
       Response.ok
-    } @@ HttpMiddleware.cors()
+    } @@ cors()
   }
 
   override def spec = suiteM("CORS")(

--- a/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/CORSSpec.scala
@@ -2,6 +2,7 @@ package zhttp.service
 
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.http._
+import zhttp.http.middleware.HttpMiddleware
 import zhttp.service.server._
 import zio.ZManaged
 import zio.test.Assertion._
@@ -11,9 +12,9 @@ object CORSSpec extends HttpRunnableSpec(8089) {
   val env = EventLoopGroup.auto() ++ ChannelFactory.auto ++ ServerChannelFactory.auto
 
   val app: ZManaged[EventLoopGroup with ServerChannelFactory, Nothing, Unit] = serve {
-    CORS(HttpApp.collect { case Method.GET -> !! / "success" =>
+    HttpApp.collect { case Method.GET -> !! / "success" =>
       Response.ok
-    })
+    } @@ HttpMiddleware.cors()
   }
 
   override def spec = suiteM("CORS")(


### PR DESCRIPTION
I think it works in the same way as in current implementation.

Not sure if OPTIONS are handled correctly (in the current and new implementation). Http status 204 and CORS headers and returned for OPTIONS for any path (not only for paths that are defined in routes, but for all). Unfortunately I do not know how to return CORS headers only for paths defined in routes.

@amitksingh1490 @tusharmath 

Fix #427