### PR TITLE
Reorganize methods in Header and HeaderExtension alphabetically and r…

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Header.scala
+++ b/zio-http/src/main/scala/zhttp/http/Header.scala
@@ -30,12 +30,12 @@ object Header {
   /**
    * Creates a [[HttpHeaderNames.AUTHORIZATION]] [[Header]].
    */
-  def authorization(value: String): Header = Header(HttpHeaderNames.AUTHORIZATION, value)
+  def authorization(value: CharSequence): Header = Header(HttpHeaderNames.AUTHORIZATION, value)
 
   /**
    * Creates a basic http authorization header.
    */
-  def basicHttpAuthorization(username: String, password: String): Header = {
+  def basicHttpAuthorization(username: CharSequence, password: CharSequence): Header = {
     val authString    = String.format("%s:%s", username, password)
     val authCB        = Unpooled.wrappedBuffer(authString.getBytes(CharsetUtil.UTF_8))
     val encodedAuthCB = Base64.encode(authCB)
@@ -51,7 +51,7 @@ object Header {
   /**
    * Use built-in header methods for better performance.
    */
-  def custom(name: String, value: CharSequence): Header = Header(name, value)
+  def custom(name: CharSequence, value: CharSequence): Header = Header(name, value)
 
   /**
    * Converts a [[List]] of [[Header]] to [[io.netty.handler.codec.http.HttpHeaders]]
@@ -74,15 +74,15 @@ object Header {
   /**
    * Creates a [[HttpHeaderNames.HOST]] [[Header]].
    */
-  def host(name: String): Header = Header(HttpHeaderNames.HOST, name)
+  def host(name: CharSequence): Header = Header(HttpHeaderNames.HOST, name)
 
   /**
    * Creates a [[HttpHeaderNames.LOCATION]] [[Header]].
    */
-  def location(value: String): Header = Header(HttpHeaderNames.LOCATION, value)
+  def location(value: CharSequence): Header = Header(HttpHeaderNames.LOCATION, value)
 
   /**
    * Creates a [[HttpHeaderNames.USER_AGENT]] [[Header]].
    */
-  def userAgent(name: String): Header = Header(HttpHeaderNames.USER_AGENT, name)
+  def userAgent(name: CharSequence): Header = Header(HttpHeaderNames.USER_AGENT, name)
 }

--- a/zio-http/src/main/scala/zhttp/http/Header.scala
+++ b/zio-http/src/main/scala/zhttp/http/Header.scala
@@ -12,41 +12,21 @@ final case class Header(name: CharSequence, value: CharSequence)
 
 object Header {
 
-  /**
-   * Converts a List[Header] to [io.netty.handler.codec.http.HttpHeaders]
-   */
-  def disassemble(headers: List[Header]): HttpHeaders =
-    headers.foldLeft[HttpHeaders](new DefaultHttpHeaders()) { case (headers, entry) =>
-      headers.set(entry.name, entry.value)
-    }
-
-  def make(headers: HttpHeaders): List[Header] =
-    headers
-      .iteratorCharSequence()
-      .asScala
-      .map(h => Header(h.getKey, h.getValue))
-      .toList
-
   // Helper utils to create Header instances
-  val acceptJson: Header     = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON)
-  val acceptXhtmlXml: Header = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XHTML)
-  val acceptXml: Header      = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XML)
-  val acceptAll: Header      = Header(HttpHeaderNames.ACCEPT, "*/*")
-
-  val contentTypeJson: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
-  val contentTypeXml: Header            = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML)
-  val contentTypeXhtmlXml: Header       = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML)
-  val contentTypeTextPlain: Header      = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
-  val contentTypeHtml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
-  val contentTypeYaml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
-  val transferEncodingChunked: Header   = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
-  def contentLength(size: Long): Header = Header(HttpHeaderNames.CONTENT_LENGTH, size.toString)
+  val acceptAll: Header                 = Header(HttpHeaderNames.ACCEPT, "*/*")
+  val acceptJson: Header                = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON)
+  val acceptXhtmlXml: Header            = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XHTML)
+  val acceptXml: Header                 = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XML)
   val contentTypeFormUrlEncoded: Header =
     Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED)
+  val contentTypeHtml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
+  val contentTypeJson: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
+  val contentTypeTextPlain: Header      = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
+  val contentTypeXml: Header            = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML)
+  val contentTypeXhtmlXml: Header       = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML)
+  val contentTypeYaml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
+  val transferEncodingChunked: Header   = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
 
-  def host(name: String): Header           = Header(HttpHeaderNames.HOST, name)
-  def userAgent(name: String): Header      = Header(HttpHeaderNames.USER_AGENT, name)
-  def location(value: String): Header      = Header(HttpHeaderNames.LOCATION, value)
   def authorization(value: String): Header = Header(HttpHeaderNames.AUTHORIZATION, value)
 
   def basicHttpAuthorization(username: String, password: String): Header = {
@@ -54,16 +34,37 @@ object Header {
     val authCB        = Unpooled.wrappedBuffer(authString.getBytes(CharsetUtil.UTF_8))
     val encodedAuthCB = Base64.encode(authCB)
     val value         = String.format("%s %s", BasicSchemeName, encodedAuthCB.toString(CharsetUtil.UTF_8))
-    Header(HttpHeaderNames.AUTHORIZATION, value)
+    authorization(value)
   }
 
-  def createAuthorizationHeader(value: String): Header = Header(HttpHeaderNames.AUTHORIZATION, value)
+  def contentLength(size: Long): Header = Header(HttpHeaderNames.CONTENT_LENGTH, size.toString)
 
   /**
    * Use built-in header methods for better performance.
    */
   def custom(name: String, value: CharSequence): Header = Header(name, value)
 
-  def parse(headers: HttpHeaders): List[Header] =
-    headers.entries().asScala.toList.map(entry => Header(entry.getKey, entry.getValue))
+  /**
+   * Converts a [[List]] of [[Header]] to [[io.netty.handler.codec.http.HttpHeaders]]
+   */
+  def disassemble(headers: List[Header]): HttpHeaders =
+    headers.foldLeft[HttpHeaders](new DefaultHttpHeaders()) { case (headers, entry) =>
+      headers.set(entry.name, entry.value)
+    }
+
+  /**
+   * Builds a [[List]] of [[Header]] from [[io.netty.handler.codec.http.HttpHeaders]]
+   */
+  def fromHttpHeaders(headers: HttpHeaders): List[Header] =
+    headers
+      .iteratorCharSequence()
+      .asScala
+      .map(h => Header(h.getKey, h.getValue))
+      .toList
+
+  def host(name: String): Header = Header(HttpHeaderNames.HOST, name)
+
+  def location(value: String): Header = Header(HttpHeaderNames.LOCATION, value)
+
+  def userAgent(name: String): Header = Header(HttpHeaderNames.USER_AGENT, name)
 }

--- a/zio-http/src/main/scala/zhttp/http/Header.scala
+++ b/zio-http/src/main/scala/zhttp/http/Header.scala
@@ -27,8 +27,14 @@ object Header {
   val contentTypeYaml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
   val transferEncodingChunked: Header   = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
 
+  /**
+   * Creates a [[HttpHeaderNames.AUTHORIZATION]] [[Header]].
+   */
   def authorization(value: String): Header = Header(HttpHeaderNames.AUTHORIZATION, value)
 
+  /**
+   * Creates a basic http authorization header.
+   */
   def basicHttpAuthorization(username: String, password: String): Header = {
     val authString    = String.format("%s:%s", username, password)
     val authCB        = Unpooled.wrappedBuffer(authString.getBytes(CharsetUtil.UTF_8))
@@ -37,6 +43,9 @@ object Header {
     authorization(value)
   }
 
+  /**
+   * Creates a [[HttpHeaderNames.CONTENT_LENGTH]] [[Header]].
+   */
   def contentLength(size: Long): Header = Header(HttpHeaderNames.CONTENT_LENGTH, size.toString)
 
   /**
@@ -62,9 +71,18 @@ object Header {
       .map(h => Header(h.getKey, h.getValue))
       .toList
 
+  /**
+   * Creates a [[HttpHeaderNames.HOST]] [[Header]].
+   */
   def host(name: String): Header = Header(HttpHeaderNames.HOST, name)
 
+  /**
+   * Creates a [[HttpHeaderNames.LOCATION]] [[Header]].
+   */
   def location(value: String): Header = Header(HttpHeaderNames.LOCATION, value)
 
+  /**
+   * Creates a [[HttpHeaderNames.USER_AGENT]] [[Header]].
+   */
   def userAgent(name: String): Header = Header(HttpHeaderNames.USER_AGENT, name)
 }

--- a/zio-http/src/main/scala/zhttp/http/Header.scala
+++ b/zio-http/src/main/scala/zhttp/http/Header.scala
@@ -13,19 +13,21 @@ final case class Header(name: CharSequence, value: CharSequence)
 object Header {
 
   // Helper utils to create Header instances
-  val acceptAll: Header                 = Header(HttpHeaderNames.ACCEPT, "*/*")
-  val acceptJson: Header                = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON)
-  val acceptXhtmlXml: Header            = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XHTML)
-  val acceptXml: Header                 = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XML)
-  val contentTypeFormUrlEncoded: Header =
+  val acceptAll: Header                    = Header(HttpHeaderNames.ACCEPT, "*/*")
+  val acceptJson: Header                   = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_JSON)
+  val acceptXhtmlXml: Header               = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XHTML)
+  val acceptXml: Header                    = Header(HttpHeaderNames.ACCEPT, HttpHeaderValues.APPLICATION_XML)
+  val contentTypeFormUrlEncoded: Header    =
     Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED)
-  val contentTypeHtml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
-  val contentTypeJson: Header           = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
-  val contentTypeTextPlain: Header      = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
-  val contentTypeXml: Header            = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML)
-  val contentTypeXhtmlXml: Header       = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML)
-  val contentTypeYaml: Header           = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
-  val transferEncodingChunked: Header   = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
+  val contentTypeHtml: Header              = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_HTML)
+  val contentTypeJson: Header              = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_JSON)
+  val contentTypeMultiPartFormData: Header = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.MULTIPART_FORM_DATA)
+  val contentTypeMultiPartMixed: Header    = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.MULTIPART_MIXED)
+  val contentTypeTextPlain: Header         = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN)
+  val contentTypeXml: Header               = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XML)
+  val contentTypeXhtmlXml: Header          = Header(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.APPLICATION_XHTML)
+  val contentTypeYaml: Header              = Header(HttpHeaderNames.CONTENT_TYPE, "text/yaml")
+  val transferEncodingChunked: Header      = Header(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED)
 
   /**
    * Creates a [[HttpHeaderNames.AUTHORIZATION]] [[Header]].

--- a/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
+++ b/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
@@ -156,6 +156,18 @@ private[zhttp] trait HeaderExtension[+A] { self =>
   def isXhtmlXmlContentType: Boolean =
     checkContentType(HttpHeaderValues.APPLICATION_XHTML)
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.MULTIPART_FORM_DATA]]
+   */
+  def isMultiPartFormDataContentType: Boolean =
+    checkContentType(HttpHeaderValues.MULTIPART_FORM_DATA)
+
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.MULTIPART_MIXED]]
+   */
+  def isMultiPartMixedContentType: Boolean =
+    checkContentType(HttpHeaderValues.MULTIPART_MIXED)
+
   def removeHeader(name: String): A = removeHeaders(List(name))
 
   def removeHeaders(headers: List[String]): A

--- a/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
+++ b/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
@@ -16,10 +16,16 @@ private[zhttp] trait HeaderExtension[+A] { self =>
 
   def addHeaders(headers: List[Header]): A
 
-  def getAuthorization: Option[String] = getHeaderValue(HttpHeaderNames.AUTHORIZATION)
+  /**
+   * Gets the [[HttpHeaderNames.AUTHORIZATION]] header value if present.
+   */
+  def getAuthorizationValue: Option[String] = getHeaderValue(HttpHeaderNames.AUTHORIZATION)
 
+  /**
+   * Gets the Basic Authorization Credentials if present.
+   */
   def getBasicAuthorizationCredentials: Option[(String, String)] = {
-    getAuthorization.flatMap(v => {
+    getAuthorizationValue.flatMap(v => {
       val indexOfBasic = v.indexOf(BasicSchemeName)
       if (indexOfBasic != 0 || v.length == BasicSchemeName.length)
         None
@@ -34,7 +40,10 @@ private[zhttp] trait HeaderExtension[+A] { self =>
     })
   }
 
-  def getBearerToken: Option[String] = getAuthorization.flatMap(v => {
+  /**
+   * Gets the Bearer Token from the [[HttpHeaderNames.AUTHORIZATION]] [[Header]], if present.
+   */
+  def getBearerToken: Option[String] = getAuthorizationValue.flatMap(v => {
     val indexOfBearer = v.indexOf(BearerSchemeName)
     if (indexOfBearer != 0 || v.length == BearerSchemeName.length)
       None
@@ -42,48 +51,108 @@ private[zhttp] trait HeaderExtension[+A] { self =>
       Some(v.substring(BearerSchemeName.length + 1))
   })
 
+  /**
+   * Gets the [[Charset]] of the content type from the [[HttpHeaderNames.CONTENT_TYPE]] [[Header]], if present.
+   */
   def getCharset: Option[Charset] =
     getHeaderValue(HttpHeaderNames.CONTENT_TYPE).map(HttpUtil.getCharset(_, HTTP_CHARSET))
 
+  /**
+   * Gets the value of [[HttpHeaderNames.CONTENT_TYPE]], if present.
+   */
   def getContentType: Option[String] = getHeaderValue(HttpHeaderNames.CONTENT_TYPE)
 
+  /**
+   * @param headerName
+   *   the cookie header name.
+   * @return
+   *   A [[List]] of [[Cookie]] for the given headerName.
+   */
   def getCookieFromHeader(headerName: AsciiString): List[Cookie] =
     getHeaderValues(headerName).flatMap(Cookie.decode(_) match {
       case Left(_)      => Nil
       case Right(value) => List(value)
     })
 
+  /**
+   * Gets the [[Header]] for this headerName, if present.
+   */
   def getHeader(headerName: CharSequence): Option[Header] =
     headers.find(h => contentEqualsIgnoreCase(h.name, headerName))
 
+  /**
+   * Gets the header value for this headerName, if present.
+   */
   def getHeaderValue(headerName: CharSequence): Option[String] =
     getHeader(headerName).map(_.value.toString)
 
+  /**
+   * Gets the header values for this headerName.
+   *
+   * @param headerName
+   *   the name of the header.
+   * @return
+   *   the matched header values.
+   */
   def getHeaderValues(headerName: CharSequence): List[String] =
     headers.filter(h => contentEqualsIgnoreCase(h.name, headerName)).map(_.value.toString)
 
+  /**
+   * Checks if a header is present with the given name and value.
+   *
+   * @param name
+   *   the name of the header.
+   * @param value
+   *   the value of the header.
+   * @return
+   *   true if a matching header found.
+   */
   def hasHeader(name: CharSequence, value: CharSequence): Boolean =
     getHeaderValue(name) match {
       case Some(v1) => v1 == value
       case None     => false
     }
 
+  /**
+   * Checks if a header is present with the given name.
+   *
+   * @param name
+   *   the name of the header.
+   * @return
+   *   true if a matching header found.
+   */
   def hasHeader(name: CharSequence): Boolean = getHeaderValue(name).nonEmpty
 
   def headers: List[Header]
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is
+   * [[HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED]]
+   */
   def isFormUrlencodedContentType: Boolean =
     checkContentType(HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED)
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.APPLICATION_JSON]]
+   */
   def isJsonContentType: Boolean =
     checkContentType(HttpHeaderValues.APPLICATION_JSON)
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.TEXT_PLAIN]]
+   */
   def isTextPlainContentType: Boolean =
     checkContentType(HttpHeaderValues.TEXT_PLAIN)
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.APPLICATION_XML]]
+   */
   def isXmlContentType: Boolean =
     checkContentType(HttpHeaderValues.APPLICATION_XML)
 
+  /**
+   * Checks if the [[Header]]'s [[HttpHeaderNames.CONTENT_TYPE]] is [[HttpHeaderValues.APPLICATION_XHTML]]
+   */
   def isXhtmlXmlContentType: Boolean =
     checkContentType(HttpHeaderValues.APPLICATION_XHTML)
 
@@ -91,8 +160,14 @@ private[zhttp] trait HeaderExtension[+A] { self =>
 
   def removeHeaders(headers: List[String]): A
 
+  /**
+   * Sets the [[HttpHeaderNames.CONTENT_LENGTH]] [[Header]]
+   */
   def setContentLength(value: Long): A = addHeader(Header.contentLength(value))
 
+  /**
+   * Sets the [[HttpHeaderNames.TRANSFER_ENCODING]] [[Header]] as [[HttpHeaderValues.CHUNKED]]
+   */
   def setTransferEncodingChunked: A = addHeader(Header.transferEncodingChunked)
 
   private def contentEqualsIgnoreCase(a: CharSequence, b: CharSequence): Boolean = {

--- a/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
+++ b/zio-http/src/main/scala/zhttp/http/HeaderExtension.scala
@@ -17,6 +17,11 @@ private[zhttp] trait HeaderExtension[+A] { self =>
   def addHeaders(headers: List[Header]): A
 
   /**
+   * Gets [[Cookie]]s from the [[HttpHeaderNames.COOKIE]] [[Header]] .
+   */
+  def cookies: List[Cookie] = getCookieFromHeader(HttpHeaderNames.COOKIE)
+
+  /**
    * Gets the [[HttpHeaderNames.AUTHORIZATION]] header value if present.
    */
   def getAuthorizationValue: Option[String] = getHeaderValue(HttpHeaderNames.AUTHORIZATION)

--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -1,36 +1,20 @@
 package zhttp.http
 
-import io.netty.handler.codec.http.HttpHeaderNames
 import zio.{Chunk, ZIO}
 
 import java.net.InetAddress
 
 trait Request extends HeaderExtension[Request] { self =>
-  def isPreflight: Boolean = method == Method.OPTIONS
 
-  def method: Method
-
-  def url: URL
-
-  def headers: List[Header]
-
-  def path: Path = url.path
-
-  def decodeContent[R, B](decoder: ContentDecoder[R, Throwable, Chunk[Byte], B]): ZIO[R, Throwable, B]
-
-  def remoteAddress: Option[InetAddress]
-
+  /**
+   * Adds headers to the [[Request]]
+   */
   override def addHeaders(headers: List[Header]): Request =
     self.copy(headers = self.headers ++ headers)
 
-  override def removeHeaders(headers: List[String]): Request =
-    self.copy(headers = self.headers.filterNot(h => headers.contains(h)))
-
   /**
-   * Get cookies from request
+   * Creates a copy of the [[Request]]
    */
-  def cookies: List[Cookie] = getCookieFromHeader(HttpHeaderNames.COOKIE)
-
   def copy(method: Method = self.method, url: URL = self.url, headers: List[Header] = self.headers): Request = {
     val m = method
     val u = url
@@ -49,6 +33,23 @@ trait Request extends HeaderExtension[Request] { self =>
         self.decodeContent(decoder)
     }
   }
+
+  def decodeContent[R, B](decoder: ContentDecoder[R, Throwable, Chunk[Byte], B]): ZIO[R, Throwable, B]
+
+  def headers: List[Header]
+
+  def isPreflight: Boolean = method == Method.OPTIONS
+
+  def method: Method
+
+  def path: Path = url.path
+
+  def remoteAddress: Option[InetAddress]
+
+  override def removeHeaders(headers: List[String]): Request =
+    self.copy(headers = self.headers.filterNot(h => headers.contains(h)))
+
+  def url: URL
 }
 
 object Request {

--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -46,7 +46,7 @@ trait Request extends HeaderExtension[Request] { self =>
 
   def remoteAddress: Option[InetAddress]
 
-  override def removeHeaders(headers: List[String]): Request =
+  override def removeHeaders(headers: List[CharSequence]): Request =
     self.copy(headers = self.headers.filterNot(h => headers.contains(h)))
 
   def url: URL

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -51,7 +51,7 @@ case class Response[-R, +E] private (
   def setPayloadHeaders: Response[R, E] = {
     getContentLength match {
       case Some(value) => setContentLength(value)
-      case None        => setChunkedEncoding
+      case None        => setTransferEncodingChunked
     }
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -37,7 +37,7 @@ case class Response[-R, +E] private (
   /**
    * Removes headers by name from the response
    */
-  override def removeHeaders(headers: List[String]): Response[R, E] =
+  override def removeHeaders(headers: List[CharSequence]): Response[R, E] =
     self.copy(headers = self.headers.filterNot(h => headers.contains(h.name)))
 
   /**

--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -165,7 +165,7 @@ object Client {
     override def addHeaders(headers: List[Header]): ClientParams =
       self.copy(headers = self.headers ++ headers)
 
-    override def removeHeaders(headers: List[String]): ClientParams =
+    override def removeHeaders(headers: List[CharSequence]): ClientParams =
       self.copy(headers = self.headers.filterNot(h => headers.contains(h)))
   }
 

--- a/zio-http/src/main/scala/zhttp/service/DecodeJResponse.scala
+++ b/zio-http/src/main/scala/zhttp/service/DecodeJResponse.scala
@@ -14,7 +14,7 @@ trait DecodeJResponse {
    */
   def decodeJResponse(jRes: FullHttpResponse): Either[Throwable, Client.ClientResponse] = Try {
     val status  = Status.fromHttpResponseStatus(jRes.status())
-    val headers = Header.parse(jRes.headers())
+    val headers = Header.fromHttpHeaders(jRes.headers())
     val content = Chunk.fromArray(ByteBufUtil.getBytes(jRes.content()))
     Client.ClientResponse(status, headers, content)
   }.toEither

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -240,7 +240,7 @@ final case class Handler[R, E] private[zhttp] (app: HttpApp[R, E], runtime: Http
 
             override def method: Method                     = Method.fromHttpMethod(jRequest.method())
             override def url: URL                           = URL.fromString(jRequest.uri()).getOrElse(null)
-            override def headers: List[Header]              = Header.make(jRequest.headers())
+            override def headers: List[Header]              = Header.fromHttpHeaders(jRequest.headers())
             override def remoteAddress: Option[InetAddress] = {
               ctx.channel().remoteAddress() match {
                 case m: InetSocketAddress => Some(m.getAddress())

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -77,7 +77,7 @@ object HeaderSpec extends DefaultRunnableSpec {
         test("should return authorization value") {
           val authorizationValue = "dummyValue"
           val headersHolder      = HeadersHolder(List(Header.authorization(authorizationValue)))
-          val found              = headersHolder.getAuthorization
+          val found              = headersHolder.getAuthorizationValue
           assert(found)(isSome(equalTo(authorizationValue)))
         } +
           test("should not return authorization value if it doesn't exist") {

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -171,6 +171,40 @@ object HeaderSpec extends DefaultRunnableSpec {
             assert(found)(isFalse)
           },
       ) +
+      suite("isMultiPartFormDataContentType")(
+        test("should return true if content-type is multipart/form-data") {
+          val headersHolder = HeadersHolder(List(contentTypeMultiPartFormData))
+          val found         = headersHolder.isMultiPartFormDataContentType
+          assert(found)(isTrue)
+        } +
+          test("should return false if content-type is not multipart/form-data") {
+            val headersHolder = HeadersHolder(List(acceptJson))
+            val found         = headersHolder.isMultiPartFormDataContentType
+            assert(found)(isFalse)
+          } +
+          test("should return false if content-type doesn't exist") {
+            val headersHolder = HeadersHolder(List())
+            val found         = headersHolder.isMultiPartFormDataContentType
+            assert(found)(isFalse)
+          },
+      ) +
+      suite("isMultiPartMixedContentType")(
+        test("should return true if content-type is multipart/mixed") {
+          val headersHolder = HeadersHolder(List(contentTypeMultiPartMixed))
+          val found         = headersHolder.isMultiPartMixedContentType
+          assert(found)(isTrue)
+        } +
+          test("should return false if content-type is not multipart/mixed") {
+            val headersHolder = HeadersHolder(List(acceptJson))
+            val found         = headersHolder.isMultiPartMixedContentType
+            assert(found)(isFalse)
+          } +
+          test("should return false if content-type doesn't exist") {
+            val headersHolder = HeadersHolder(List())
+            val found         = headersHolder.isMultiPartMixedContentType
+            assert(found)(isFalse)
+          },
+      ) +
       suite("getBasicAuthorizationCredentials")(
         test("should decode proper basic http authorization header") {
           val headerHolder = HeadersHolder(List(Header.authorization("Basic dXNlcjpwYXNzd29yZCAxMQ==")))

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -76,7 +76,7 @@ object HeaderSpec extends DefaultRunnableSpec {
       suite("getAuthorizationHeader")(
         test("should return authorization value") {
           val authorizationValue = "dummyValue"
-          val headersHolder      = HeadersHolder(List(createAuthorizationHeader(authorizationValue)))
+          val headersHolder      = HeadersHolder(List(Header.authorization(authorizationValue)))
           val found              = headersHolder.getAuthorization
           assert(found)(isSome(equalTo(authorizationValue)))
         } +

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -17,7 +17,7 @@ object HeaderSpec extends DefaultRunnableSpec {
     override def addHeaders(headers: List[Header]): HeadersHolder =
       HeadersHolder(self.headers ++ headers)
 
-    override def removeHeaders(headers: List[String]): HeadersHolder =
+    override def removeHeaders(headers: List[CharSequence]): HeadersHolder =
       HeadersHolder(self.headers.filterNot(h => headers.contains(h.name)))
   }
 


### PR DESCRIPTION
partially fixes #442

* alphabetical reodering of methods in `Header`  `HeaderExtension` `Request` and `Response` 
* some minor clean up of redundant methods

> 1. -  removed duplicate method createAuthorizationHeader , using authorization instead.
> 2. -  Removed `Header` duplicate functionality in parse/make  and renamed to `fromHttpHeaders`
> 3. - moved duplicated`cookies` method to `HeaderExtension`