### PR TITLE
#508: Use Option instead of Either in Cookies

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/HasCookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/HasCookie.scala
@@ -18,8 +18,8 @@ object HasCookie {
     override def decode(a: Request): List[Cookie] =
       headers(a).flatMap { header =>
         Cookie.decodeRequestCookie(header) match {
-          case Left(_)     => Nil
-          case Right(list) => list
+          case None       => Nil
+          case Some(list) => list
         }
       }
   }
@@ -29,6 +29,6 @@ object HasCookie {
       a.getHeaderValues(HttpHeaderNames.SET_COOKIE)
 
     override def decode(a: Response[Any, Nothing]): List[Cookie] =
-      headers(a).map(Cookie.decodeResponseCookie).collect { case Right(cookie) => cookie }
+      headers(a).map(Cookie.decodeResponseCookie).collect { case Some(cookie) => cookie }
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
@@ -1,7 +1,7 @@
 package zhttp.http
 
 import zhttp.internal.HttpGen
-import zio.test.Assertion.{equalTo, isRight}
+import zio.test.Assertion.{equalTo, isSome}
 import zio.test._
 
 object CookieSpec extends DefaultRunnableSpec {
@@ -10,8 +10,8 @@ object CookieSpec extends DefaultRunnableSpec {
       testM("encode/decode cookies with ZIO Test Gen") {
         checkAll(HttpGen.cookies) { cookie =>
           val cookieString = cookie.encode
-          assert(Cookie.decodeResponseCookie(cookieString))(isRight(equalTo(cookie))) &&
-          assert(Cookie.decodeResponseCookie(cookieString).map(_.encode))(isRight(equalTo(cookieString)))
+          assert(Cookie.decodeResponseCookie(cookieString))(isSome(equalTo(cookie))) &&
+          assert(Cookie.decodeResponseCookie(cookieString).map(_.encode))(isSome(equalTo(cookieString)))
         }
       }
     } +
@@ -23,7 +23,7 @@ object CookieSpec extends DefaultRunnableSpec {
             cookieList   <- Gen.listOf(Gen.const(Cookie(name, content)))
             cookieString <- Gen.const(cookieList.map(x => s"${x.name}=${x.content}").mkString(";"))
           } yield (cookieList, cookieString)) { case (cookies, message) =>
-            assert(Cookie.decodeRequestCookie(message))(isRight(equalTo(cookies)))
+            assert(Cookie.decodeRequestCookie(message))(isSome(equalTo(cookies)))
           }
         }
       }


### PR DESCRIPTION
See #508.

Use Option instead of Either in Cookie.decodeResponseCookie and Cookie.decodeRequestCookie