### PR TITLE
Feature: Add method for creating text/html response

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -92,6 +92,15 @@ object Response {
     }
   }
 
+  /**
+   * Creates a response with content-type set to text/html
+   */
+  def html(data: String): UResponse =
+    Response(
+      data = HttpData.fromChunk(Chunk.fromArray(data.getBytes(HTTP_CHARSET))),
+      headers = List(Header.contentTypeHtml),
+    )
+
   @deprecated("Use `Response(status, headers, data)` constructor instead.", "22-Sep-2021")
   def http[R, E](
     status: Status = Status.OK,

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -97,7 +97,7 @@ object Response {
    */
   def html(data: String): UResponse =
     Response(
-      data = HttpData.fromChunk(Chunk.fromArray(data.getBytes(HTTP_CHARSET))),
+      data = HttpData.fromText(data),
       headers = List(Header.contentTypeHtml),
     )
 


### PR DESCRIPTION
I'm doing some experiments with serving static content and though this could be useful  in addition to `jsonString` and `text` methods on `Response`.