### PR TITLE
Performance: Cookie decoder improvements

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
@@ -1,0 +1,19 @@
+package zhttp.benchmarks
+
+import org.openjdk.jmh.annotations._
+import zhttp.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class CookieDecodeBenchmark {
+  private val cookie = "SUID=123;httponly=true;expires=2007-12-03T10:15:30.00Z"
+
+  @Benchmark
+  def benchmarkApp(): Unit = {
+    val _ = Cookie.decodeResponseCookie(cookie)
+    ()
+  }
+}

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
@@ -10,15 +10,22 @@ import java.util.concurrent.TimeUnit
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class CookieDecodeBenchmark {
+  val random = new scala.util.Random()
+  val name   = random.alphanumeric.take(100).mkString("")
+  val value  = random.alphanumeric.take(100).mkString("")
+  val domain = random.alphanumeric.take(100).mkString("")
+  val path   = Path((0 to 10).map { _ => random.alphanumeric.take(10).mkString("") }.mkString(""))
+  val maxAge = random.nextLong()
+
   private val cookie    = Cookie(
-    "CookiesName",
-    "CookiesValue",
+    name,
+    value,
     Some(Instant.now()),
-    Some("domainValue"),
-    Some(Path("Some", "Path")),
+    Some(domain),
+    Some(path),
     true,
     true,
-    Some(1200),
+    Some(maxAge),
     Some(Cookie.SameSite.Strict),
   )
   private val cookieStr = cookie.encode

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
@@ -32,7 +32,7 @@ class CookieDecodeBenchmark {
 
   @Benchmark
   def benchmarkApp(): Unit = {
-    val _ = Cookie.decodeResponseCookie(cookieStr)
+    val _ = Cookie.unsafeDecodeResponseCookie(cookieStr)
     ()
   }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CookieDecodeBenchmark.scala
@@ -3,17 +3,29 @@ package zhttp.benchmarks
 import org.openjdk.jmh.annotations._
 import zhttp.http._
 
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class CookieDecodeBenchmark {
-  private val cookie = "SUID=123;httponly=true;expires=2007-12-03T10:15:30.00Z"
+  private val cookie    = Cookie(
+    "CookiesName",
+    "CookiesValue",
+    Some(Instant.now()),
+    Some("domainValue"),
+    Some(Path("Some", "Path")),
+    true,
+    true,
+    Some(1200),
+    Some(Cookie.SameSite.Strict),
+  )
+  private val cookieStr = cookie.encode
 
   @Benchmark
   def benchmarkApp(): Unit = {
-    val _ = Cookie.decodeResponseCookie(cookie)
+    val _ = Cookie.decodeResponseCookie(cookieStr)
     ()
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -156,7 +156,7 @@ object Cookie {
   def decodeResponseCookie(headerValue: String): Option[Cookie] =
     Try(unsafeDecodeResponseCookie(headerValue)).toOption
 
-  private[http] def unsafeDecodeResponseCookie(headerValue: String): Cookie = {
+  private[zhttp] def unsafeDecodeResponseCookie(headerValue: String): Cookie = {
     var name: String              = null
     var content: String           = null
     var expires: Instant          = null

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -243,7 +243,7 @@ object Cookie {
    * Decodes from `Cookie` header value inside of Request into a cookie
    */
   def decodeRequestCookie(headerValue: String): Option[List[Cookie]] = {
-    val cookies: Array[String]  = headerValue.split(";").map(_.trim)
+    val cookies: Array[String]  = headerValue.split(';').map(_.trim)
     val x: List[Option[Cookie]] = cookies.toList.map(a => {
       val (name, content) = splitNameContent(a)
       if (name == "" && content.isEmpty) None

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -154,10 +154,10 @@ object Cookie {
     var sameSite: Cookie.SameSite = null
 
     var prev = 0
-    var i    = headerValue.indexOf(';')
-    do {
+    var i    = 0
+    while (i >= 0) {
       i = headerValue.indexOf(';', prev)
-      val c       = if (i < 0) headerValue.substring(prev) else headerValue.substring(prev, i)
+      val c       = if (i <= 0) headerValue.substring(prev) else headerValue.substring(prev, i)
       val (n, ct) = splitNameContent(c)
 
       (n.toLowerCase, ct) match {
@@ -180,7 +180,7 @@ object Cookie {
         case (_, _)                        => ()
       }
       prev = i + 1
-    } while (i >= 0)
+    }
 
     if (!name.isBlank || !content.isBlank)
       Some(

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -182,7 +182,7 @@ object Cookie {
       prev = i + 1
     }
 
-    if (!name.isBlank || !content.isBlank)
+    if (name != "" || content != "")
       Some(
         Cookie(
           name = name,

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -154,7 +154,7 @@ object Cookie {
    * Decodes from Set-Cookie header value inside of Response into a cookie
    */
   def decodeResponseCookie(headerValue: String): Option[Cookie] =
-    Option(unsafeDecodeResponseCookie(headerValue))
+    Try(unsafeDecodeResponseCookie(headerValue)).toOption
 
   private[http] def unsafeDecodeResponseCookie(headerValue: String): Cookie = {
     var name: String              = null
@@ -193,11 +193,9 @@ object Cookie {
             name = headerValue.substring(0, next)
           }
         } else if (headerValue.regionMatches(true, curr, fieldExpires, 0, fieldExpires.length)) {
-          expires =
-            try { Instant.parse(headerValue.substring(curr + 8, next)) }
-            catch { case _: Throwable => null }
+          expires = Instant.parse(headerValue.substring(curr + 8, next))
         } else if (headerValue.regionMatches(true, curr, fieldMaxAge, 0, fieldMaxAge.length)) {
-          maxAge = Try(headerValue.substring(curr + 8, next).toLong).toOption
+          maxAge = Some(headerValue.substring(curr + 8, next).toLong)
         } else if (headerValue.regionMatches(true, curr, fieldDomain, 0, fieldDomain.length)) {
           domain = headerValue.substring(curr + 7, next)
         } else if (headerValue.regionMatches(true, curr, fieldPath, 0, fieldPath.length)) {

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -182,7 +182,7 @@ object Cookie {
       prev = i + 1
     }
 
-    if (name != "" || content != "")
+    if (!name.isEmpty || !content.isEmpty)
       Some(
         Cookie(
           name = name,

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -153,7 +153,10 @@ object Cookie {
   /**
    * Decodes from Set-Cookie header value inside of Response into a cookie
    */
-  def decodeResponseCookie(headerValue: String): Option[Cookie] = {
+  def decodeResponseCookie(headerValue: String): Option[Cookie] =
+    Option(unsafeDecodeResponseCookie(headerValue))
+
+  private[http] def unsafeDecodeResponseCookie(headerValue: String): Cookie = {
     var name: String              = null
     var content: String           = null
     var expires: Instant          = null
@@ -221,21 +224,19 @@ object Cookie {
     }
 
     if ((name != null && !name.isEmpty) || (content != null && !content.isEmpty))
-      Some(
-        Cookie(
-          name = name,
-          content = content,
-          expires = Option(expires),
-          maxAge = maxAge,
-          domain = Option(domain),
-          path = Option(path),
-          isSecure = secure,
-          isHttpOnly = httpOnly,
-          sameSite = Option(sameSite),
-        ),
+      Cookie(
+        name = name,
+        content = content,
+        expires = Option(expires),
+        maxAge = maxAge,
+        domain = Option(domain),
+        path = Option(path),
+        isSecure = secure,
+        isHttpOnly = httpOnly,
+        sameSite = Option(sameSite),
       )
     else
-      None
+      null
   }
 
   /**

--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -246,7 +246,7 @@ object Cookie {
     val cookies: Array[String]  = headerValue.split(';').map(_.trim)
     val x: List[Option[Cookie]] = cookies.toList.map(a => {
       val (name, content) = splitNameContent(a)
-      if (name == "" && content.isEmpty) None
+      if (name.isEmpty && content.isEmpty) None
       else Some(Cookie(name, content))
     })
 


### PR DESCRIPTION
See #571.

Reduce Cookie case class allocations in Cookie.decodeResponseCookie.
Right now, it allocates a new Cookie instance with each field (using Cookie.copy through several methods).
For example,
it allocates 3 instances for ```"SUID=123;httponly=true;expires=2007-12-03T10:15:30.00Z"```.

This change parses each field separately and then creates one single Cookie instance.

This simple jhm benchmark show the two approaches
```scala
package sample

import java.util.concurrent.TimeUnit
import org.openjdk.jmh.annotations._
import zhttp.http.Cookie

@State(Scope.Thread)
@BenchmarkMode(Array(Mode.Throughput))
@OutputTimeUnit(TimeUnit.MICROSECONDS)
class CookieDecode {
  @Benchmark
  def benchmarkDecode(): Unit = {
    val value="SUID=123;httponly=true;expires=2007-12-03T10:15:30.00Z"
    val _ = Cookie.decodeResponseCookie(value)
    ()
  }
}
```

Parsing and copying Cookie case class
```

# Warmup Iteration   1: 0,141 ops/us
[info] # Warmup Iteration   2: 0,151 ops/us
[info] # Warmup Iteration   3: 0,206 ops/us
[info] Iteration   1: 0,217 ops/us
[info] Iteration   2: 0,168 ops/us
[info] Iteration   3: 0,147 ops/us
[info] Result "sample.CookieDecode.benchmarkDecode":
[info]   0,177 ┬▒(99.9%) 0,653 ops/us [Average]
[info]   (min, avg, max) = (0,147, 0,177, 0,217), stdev = 0,036
[info]   CI (99.9%): [? 0, 0,831] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:01
```

Parsing fields with mutable vars
```
[info] # Warmup Iteration   1: 0,340 ops/us
[info] # Warmup Iteration   2: 0,375 ops/us
[info] # Warmup Iteration   3: 0,354 ops/us
[info] Iteration   1: 0,369 ops/us
[info] Iteration   2: 0,375 ops/us
[info] Iteration   3: 0,349 ops/us
[info] Result "sample.CookieDecode.benchmarkDecode":
[info]   0,364 ┬▒(99.9%) 0,244 ops/us [Average]
[info]   (min, avg, max) = (0,349, 0,364, 0,375), stdev = 0,013
[info]   CI (99.9%): [0,120, 0,608] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:00
```
