### PR TITLE
#573: Add toApp, toResponse methods to status

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Status.scala
+++ b/zio-http/src/main/scala/zhttp/http/Status.scala
@@ -3,10 +3,20 @@ package zhttp.http
 import io.netty.handler.codec.http.HttpResponseStatus
 
 sealed trait Status extends Product with Serializable { self =>
+
+  /**
+   * Returns an HttpApp[Any, Nothing] that responses with this http status code.
+   */
   def toApp: UHttpApp = HttpApp.status(self)
 
+  /**
+   * Returns a Response[Any, Nothing] with empty data and no headers.
+   */
   def toResponse: UResponse = Response(self)
 
+  /**
+   * Returns self as io.netty.handler.codec.http.HttpResponseStatus.
+   */
   def asJava: HttpResponseStatus = self match {
     case Status.CONTINUE                        => HttpResponseStatus.CONTINUE                        // 100
     case Status.SWITCHING_PROTOCOLS             => HttpResponseStatus.SWITCHING_PROTOCOLS             // 101

--- a/zio-http/src/main/scala/zhttp/http/Status.scala
+++ b/zio-http/src/main/scala/zhttp/http/Status.scala
@@ -3,6 +3,10 @@ package zhttp.http
 import io.netty.handler.codec.http.HttpResponseStatus
 
 sealed trait Status extends Product with Serializable { self =>
+  def toApp: UHttpApp = HttpApp.status(self)
+
+  def toResponse: UResponse = Response(self)
+
   def asJava: HttpResponseStatus = self match {
     case Status.CONTINUE                        => HttpResponseStatus.CONTINUE                        // 100
     case Status.SWITCHING_PROTOCOLS             => HttpResponseStatus.SWITCHING_PROTOCOLS             // 101

--- a/zio-http/src/test/scala/zhttp/http/StatusSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/StatusSpec.scala
@@ -1,0 +1,29 @@
+package zhttp.http
+
+import zhttp.internal.HttpMessageAssertions
+import zhttp.service.EventLoopGroup
+import zio.test.Assertion._
+import zio.test._
+
+object StatusSpec extends DefaultRunnableSpec with HttpMessageAssertions {
+  private val env = EventLoopGroup.auto(1)
+
+  def spec = suite("Status")(
+    toAppSpec,
+    toResponseSpec,
+  ).provideCustomLayer(env)
+
+  def toResponseSpec =
+    suite("toResponse")(
+      test("ok")(assert(Status.OK.toResponse.status)(equalTo(Status.OK))),
+    )
+
+  def toAppSpec = {
+    suite("toApp")(
+      testM("ok") {
+        val res = Status.OK.toApp.getResponse
+        assertM(res)(isResponse(responseStatus(200)))
+      },
+    )
+  }
+}


### PR DESCRIPTION
Fixes #573.
Added toApp (UHttpApp) and toResponse (UResponse) to zhttp.http.Status.