### PR TITLE
Scaladoc Doc generation failing

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
+++ b/zio-http/src/main/scala/zhttp/http/RouteDecoderModule.scala
@@ -9,8 +9,8 @@ import java.util.UUID
  *
  * ```scala
  * Http.collect[Request] {
- *   case GET -> !! / "user" / int(id) => Response.text("User id requested: ${id}")
- *   case GET -> !! / "user" / name    => Response.text("User name requested: ${name}")
+ *   case GET -> !! / "user" / int(id) => Response.text("User id requested: \${id}")
+ *   case GET -> !! / "user" / name    => Response.text("User name requested: \${name}")
  * }
  * ```
  *


### PR DESCRIPTION
Due to syntax conflict if string interpolation and define scaladoc generation was failing
Please refer: 
https://github.com/scala/bug/issues/10333