### PR TITLE
Performance: remove stack safety from Http.execute

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCollectEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCollectEval.scala
@@ -15,7 +15,7 @@ class HttpCollectEval {
 
   @Benchmark
   def benchmarkApp(): Unit = {
-    (0 to MAX).foreach(_ => app.execute(0).evaluate)
+    (0 to MAX).foreach(_ => app.execute(0))
     ()
   }
 

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCombineEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCombineEval.scala
@@ -15,13 +15,13 @@ class HttpCombineEval {
 
   @Benchmark
   def benchmarkNotFound(): Unit = {
-    spec.execute(-1).evaluate
+    spec.execute(-1)
     ()
   }
 
   @Benchmark
   def benchmarkOk(): Unit = {
-    spec.execute(0).evaluate
+    spec.execute(0)
     ()
   }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpNestedFlatMapEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpNestedFlatMapEval.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpNestedFlatMapEval {
 
-  private val MAX = 10000
+  private val MAX = 1000
 
   val programFlatMap: Http[Any, Nothing, Int, Int] =
     (0 to MAX).foldLeft(Http.identity[Int])((a, _) => a.flatMap(i => Http.succeed(i + 1)))

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpNestedFlatMapEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpNestedFlatMapEval.scala
@@ -17,7 +17,7 @@ class HttpNestedFlatMapEval {
 
   @Benchmark
   def benchmarkHttpFlatMap(): Unit = {
-    programFlatMap.execute(0).evaluate
+    programFlatMap.execute(0)
     ()
   }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
@@ -16,7 +16,7 @@ class HttpRouteTextPerf {
   private val res          = Response.text("HELLO WORLD")
   private val app          = Http.succeed(res)
   private val req: Request = Request(Method.GET, URL(!!))
-  private val httpProgram  = ZIO.foreach_(0 to 1000) { _ => app.execute(req).evaluate.asEffect }
+  private val httpProgram  = ZIO.foreach_(0 to 1000) { _ => app.execute(req).toEffect }
   private val UIOProgram   = ZIO.foreach_(0 to 1000) { _ => UIO(res) }
 
   @Benchmark

--- a/zio-http-test/src/main/scala/zhttp/test/test.scala
+++ b/zio-http-test/src/main/scala/zhttp/test/test.scala
@@ -5,6 +5,6 @@ import zio.ZIO
 
 package object test {
   implicit class HttpWithTest[R, E, A, B](http: Http[R, E, A, B]) {
-    def apply(req: A): ZIO[R, Option[E], B] = http.execute(req).evaluate.asEffect
+    def apply(req: A): ZIO[R, Option[E], B] = http.execute(req).toEffect
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/HExit.scala
+++ b/zio-http/src/main/scala/zhttp/http/HExit.scala
@@ -1,146 +1,83 @@
 package zhttp.http
 
-import zio.{CanFail, ZIO}
-
-import scala.annotation.{tailrec, unused}
+import zhttp.http.HExit.Effect
+import zio.ZIO
 
 private[zhttp] sealed trait HExit[-R, +E, +A] { self =>
-
-  def map[B](ab: A => B): HExit[R, E, B] = self.flatMap(a => HExit.succeed(ab(a)))
-
-  def as[B](b: B): HExit[R, E, B] = self.map(_ => b)
 
   def >>=[R1 <: R, E1 >: E, B](ab: A => HExit[R1, E1, B]): HExit[R1, E1, B] =
     self.flatMap(ab)
 
-  def *>[R1 <: R, E1 >: E, B](other: HExit[R1, E1, B]): HExit[R1, E1, B] =
-    self.flatMap(_ => other)
-
   def <>[R1 <: R, E1, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
     self orElse other
-
-  def orElse[R1 <: R, E1, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
-    self.flatMapError(_ => other)
-
-  def flatMap[R1 <: R, E1 >: E, B](ab: A => HExit[R1, E1, B]): HExit[R1, E1, B] =
-    HExit.flatMap(self, ab)
-
-  def flatten[R1 <: R, E1 >: E, A1](implicit ev: A <:< HExit[R1, E1, A1]): HExit[R1, E1, A1] =
-    self.flatMap(identity(_))
-
-  def defaultWith[R1 <: R, E1 >: E, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
-    self.foldM(HExit.fail, HExit.succeed, other)
 
   def <+>[R1 <: R, E1 >: E, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
     this defaultWith other
 
-  def flatMapError[R1 <: R, E1, A1 >: A](h: E => HExit[R1, E1, A1])(implicit
-    @unused ev: CanFail[E],
-  ): HExit[R1, E1, A1] = HExit.flatMapError(self, h)
+  def *>[R1 <: R, E1 >: E, B](other: HExit[R1, E1, B]): HExit[R1, E1, B] =
+    self.flatMap(_ => other)
+
+  def as[B](b: B): HExit[R, E, B] = self.map(_ => b)
+
+  def defaultWith[R1 <: R, E1 >: E, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
+    self.foldM(HExit.fail, HExit.succeed, other)
+
+  def flatMap[R1 <: R, E1 >: E, B](ab: A => HExit[R1, E1, B]): HExit[R1, E1, B] =
+    self.foldM(HExit.fail, ab, HExit.empty)
+
+  def flatten[R1 <: R, E1 >: E, A1](implicit ev: A <:< HExit[R1, E1, A1]): HExit[R1, E1, A1] =
+    self.flatMap(identity(_))
 
   def foldM[R1 <: R, E1, B1](
     ee: E => HExit[R1, E1, B1],
     aa: A => HExit[R1, E1, B1],
     dd: HExit[R1, E1, B1],
   ): HExit[R1, E1, B1] =
-    HExit.foldM(self, ee, aa, dd)
+    self match {
+      case HExit.Success(a)  => aa(a)
+      case HExit.Failure(e)  => ee(e)
+      case HExit.Effect(zio) =>
+        Effect(
+          zio.foldM(
+            {
+              case Some(error) => ee(error).toEffect
+              case None        => dd.toEffect
+            },
+            a => aa(a).toEffect,
+          ),
+        )
+      case HExit.Empty       => dd
+    }
 
-  def fold[E1, B1](ee: E => E1, aa: A => B1): HExit[R, E1, B1] =
-    self.foldM(e => HExit.fail(ee(e)), a => HExit.succeed(aa(a)), HExit.empty)
+  def map[B](ab: A => B): HExit[R, E, B] = self.flatMap(a => HExit.succeed(ab(a)))
 
-  def mapError[E1](ee: E => E1): HExit[R, E1, A] =
-    self.fold(ee, identity(_))
+  def orElse[R1 <: R, E1, A1 >: A](other: HExit[R1, E1, A1]): HExit[R1, E1, A1] =
+    self.foldM(_ => other, HExit.succeed, HExit.empty)
 
-  final private[zhttp] def evaluate: HExit.Out[R, E, A] = HExit.evaluate(self)
+  def toEffect: ZIO[R, Option[E], A] = self match {
+    case HExit.Success(a)  => ZIO.succeed(a)
+    case HExit.Failure(e)  => ZIO.fail(Option(e))
+    case HExit.Empty       => ZIO.fail(None)
+    case HExit.Effect(zio) => zio
+  }
 }
 
 object HExit {
-  sealed trait Out[-R, +E, +A] extends HExit[R, E, A] { self =>
-    def asEffect: ZIO[R, Option[E], A] = self match {
-      case Empty      => ZIO.fail(None)
-      case Success(a) => ZIO.succeed(a)
-      case Failure(e) => ZIO.fail(Option(e))
-      case Effect(z)  => z
-    }
+  def effect[R, E, A](z: ZIO[R, E, A]): HExit[R, E, A] = Effect(z.mapError(Option(_)))
 
-    def isEmpty: Boolean = self match {
-      case HExit.Empty => true
-      case _           => false
-    }
-  }
+  def empty: HExit[Any, Nothing, Nothing] = Empty
 
-  // CTOR
-  final case class Success[A](a: A)                         extends Out[Any, Nothing, A]
-  final case class Failure[E](e: E)                         extends Out[Any, E, Nothing]
-  final case class Effect[R, E, A](z: ZIO[R, Option[E], A]) extends Out[R, E, A]
-  case object Empty                                         extends Out[Any, Nothing, Nothing]
+  def fail[E](e: E): HExit[Any, E, Nothing] = Failure(e)
 
-  // OPR
-  private final case class EffectTotal[A](f: () => A)                extends HExit[Any, Nothing, A]
-  private final case class Suspend[R, E, A](r: () => HExit[R, E, A]) extends HExit[R, E, A]
-  private final case class FoldM[R, E, EE, A, AA](
-    rr: HExit[R, E, A],
-    ee: E => HExit[R, EE, AA],
-    aa: A => HExit[R, EE, AA],
-    dd: HExit[R, EE, AA],
-  ) extends HExit[R, EE, AA]
+  def succeed[A](a: A): HExit[Any, Nothing, A] = Success(a)
 
-  // Help
-  def succeed[A](a: A): HExit.Out[Any, Nothing, A] = Success(a)
-  def fail[E](e: E): HExit.Out[Any, E, Nothing]    = Failure(e)
-  def empty: HExit.Out[Any, Nothing, Nothing]      = Empty
+  def unit: HExit[Any, Nothing, Unit] = HExit.succeed(())
 
-  def effect[R, E, A](z: ZIO[R, E, A]): HExit.Out[R, E, A] = Effect(z.mapError(Option(_)))
-  def effectTotal[A](z: => A): HExit[Any, Nothing, A]      = EffectTotal(() => z)
-  def unit: HExit[Any, Nothing, Unit]                      = HExit.succeed(())
+  final case class Success[A](a: A) extends HExit[Any, Nothing, A]
 
-  def flatMap[R, E, A, B](r: HExit[R, E, A], aa: A => HExit[R, E, B]): HExit[R, E, B] =
-    HExit.foldM(r, HExit.fail[E], aa, HExit.empty)
+  final case class Failure[E](e: E) extends HExit[Any, E, Nothing]
 
-  def suspend[R, E, A](r: => HExit[R, E, A]): HExit[R, E, A] = HExit.Suspend(() => r)
+  final case class Effect[R, E, A](z: ZIO[R, Option[E], A]) extends HExit[R, E, A]
 
-  def foldM[R, E, EE, A, AA](
-    r: HExit[R, E, A],
-    ee: E => HExit[R, EE, AA],
-    aa: A => HExit[R, EE, AA],
-    dd: HExit[R, EE, AA],
-  ): HExit[R, EE, AA] =
-    HExit.FoldM(r, ee, aa, dd)
-
-  def flatMapError[R, E, E1, A](r: HExit[R, E, A], ee: E => HExit[R, E1, A]): HExit[R, E1, A] =
-    HExit.foldM(r, ee, HExit.succeed[A], HExit.empty)
-
-  // EVAL
-  @tailrec
-  private[zhttp] def evaluate[R, E, A](result: HExit[R, E, A]): Out[R, E, A] = {
-    result match {
-      case m: Out[_, _, _]         => m
-      case Suspend(r)              => evaluate(r())
-      case EffectTotal(f)          => HExit.succeed(f())
-      case FoldM(self, ee, aa, dd) =>
-        evaluate(self match {
-          case Empty                      => dd
-          case Success(a)                 => aa(a)
-          case Failure(e)                 => ee(e)
-          case Suspend(r)                 => r().foldM(ee, aa, dd)
-          case EffectTotal(f)             => aa(f())
-          case Effect(z)                  =>
-            Effect(
-              z.foldM(
-                {
-                  case None    => ZIO.fail(None)
-                  case Some(e) => ee(e).evaluate.asEffect
-                },
-                aa(_).evaluate.asEffect,
-              ),
-            )
-          case FoldM(self, ee0, aa0, dd0) =>
-            self.foldM(
-              e => ee0(e).foldM(ee, aa, dd),
-              a => aa0(a).foldM(ee, aa, dd),
-              dd0.foldM(ee, aa, dd),
-            )
-        })
-    }
-  }
+  case object Empty extends HExit[Any, Nothing, Nothing]
 }

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -99,7 +99,7 @@ private[zhttp] final case class Handler[R](
     http: Http[R, Throwable, A, Response[R, Throwable]],
     a: A,
   )(implicit ctx: ChannelHandlerContext): Unit = {
-    http.execute(a).evaluate match {
+    http.execute(a) match {
       case HExit.Effect(resM) =>
         unsafeRunZIO {
           resM.foldM(

--- a/zio-http/src/test/scala/zhttp/http/HExitAssertion.scala
+++ b/zio-http/src/test/scala/zhttp/http/HExitAssertion.scala
@@ -28,6 +28,6 @@ private[zhttp] trait HExitAssertion {
     }
 
   private[zhttp] implicit class HExitSyntax[R, E, A](result: HExit[R, E, A]) {
-    def ===(assertion: Assertion[HExit[R, E, A]]): TestResult = assert(result.evaluate)(assertion)
+    def ===(assertion: Assertion[HExit[R, E, A]]): TestResult = assert(result)(assertion)
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -3,7 +3,7 @@ package zhttp.http
 import zio._
 import zio.duration.durationInt
 import zio.test.Assertion._
-import zio.test.TestAspect.{ignore, sequential, timeout}
+import zio.test.TestAspect.{ignore, timeout}
 import zio.test._
 
 object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
@@ -244,5 +244,5 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             } yield assert(res)(equalTo(1))
           },
       ),
-  ) @@ timeout(10 seconds) @@ sequential
+  ) @@ timeout(10 seconds)
 }

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -5,6 +5,7 @@ import zio.duration.durationInt
 import zio.test.Assertion._
 import zio.test.TestAspect.{ignore, timeout}
 import zio.test._
+import zio.test.environment.TestClock
 
 object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
   def spec = suite("Http")(
@@ -243,6 +244,25 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
               res <- r.get
             } yield assert(res)(equalTo(1))
           },
-      ),
+      ) +
+      suite("race") {
+        testM("left wins") {
+          val http = Http.succeed(1) race Http.succeed(2)
+          assertM(http(()))(equalTo(1))
+        } +
+          testM("sync right wins") {
+            val http = Http.fromEffect(UIO(1)) race Http.succeed(2)
+            assertM(http(()))(equalTo(2))
+          } +
+          testM("sync left wins") {
+            val http = Http.succeed(1) race Http.fromEffect(UIO(2))
+            assertM(http(()))(equalTo(1))
+          } +
+          testM("async fast wins") {
+            val http    = Http.succeed(1).delay(1 second) race Http.succeed(2).delay(2 second)
+            val program = http(()) <& TestClock.adjust(5 second)
+            assertM(program)(equalTo(1))
+          }
+      },
   ) @@ timeout(10 seconds)
 }

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -3,70 +3,70 @@ package zhttp.http
 import zio._
 import zio.duration.durationInt
 import zio.test.Assertion._
-import zio.test.TestAspect.timeout
+import zio.test.TestAspect.{ignore, sequential, timeout}
 import zio.test._
 
 object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
   def spec = suite("Http")(
     suite("flatMap")(
       test("should flatten") {
-        val app    = Http.identity[Int].flatMap(i => Http.succeed(i + 1))
-        val actual = app.execute(0).evaluate
-        assert(actual)(isSuccess(equalTo(1)))
+        val app    = Http.succeed(1).flatMap(i => Http.succeed(i + 1))
+        val actual = app.execute(0)
+        assert(actual)(isSuccess(equalTo(2)))
       } +
         test("should be stack-safe") {
           val i      = 100000
           val app    = (0 until i).foldLeft(Http.identity[Int])((i, _) => i.flatMap(c => Http.succeed(c + 1)))
-          val actual = app.execute(0).evaluate
+          val actual = app.execute(0)
           assert(actual)(isSuccess(equalTo(i)))
-        },
+        } @@ ignore,
     ) +
       suite("orElse")(
         test("should succeed") {
           val a1     = Http.succeed(1)
           val a2     = Http.succeed(2)
           val a      = a1 <> a2
-          val actual = a.execute(()).evaluate
+          val actual = a.execute(())
           assert(actual)(isSuccess(equalTo(1)))
         } +
           test("should fail with first") {
             val a1     = Http.fail("A")
             val a2     = Http.succeed("B")
             val a      = a1 <> a2
-            val actual = a.execute(()).evaluate
+            val actual = a.execute(())
             assert(actual)(isSuccess(equalTo("B")))
           },
       ) +
       suite("fail")(
         test("should fail") {
           val a      = Http.fail(100)
-          val actual = a.execute(()).evaluate
+          val actual = a.execute(())
           assert(actual)(isFailure(equalTo(100)))
         },
       ) +
       suite("foldM")(
         test("should catch") {
           val a      = Http.fail(100).catchAll(e => Http.succeed(e + 1))
-          val actual = a.execute(0).evaluate
+          val actual = a.execute(0)
           assert(actual)(isSuccess(equalTo(101)))
         },
       ) +
       suite("identity")(
         test("should passthru") {
           val a      = Http.identity[Int]
-          val actual = a.execute(0).evaluate
+          val actual = a.execute(0)
           assert(actual)(isSuccess(equalTo(0)))
         },
       ) +
       suite("collect")(
         test("should succeed") {
           val a      = Http.collect[Int] { case 1 => "OK" }
-          val actual = a.execute(1).evaluate
+          val actual = a.execute(1)
           assert(actual)(isSuccess(equalTo("OK")))
         } +
           test("should fail") {
             val a      = Http.collect[Int] { case 1 => "OK" }
-            val actual = a.execute(0).evaluate
+            val actual = a.execute(0)
             assert(actual)(isEmpty)
           },
       ) +
@@ -74,62 +74,62 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
         test("should resolve first") {
           val a      = Http.collect[Int] { case 1 => "A" }
           val b      = Http.collect[Int] { case 2 => "B" }
-          val actual = (a ++ b).execute(1).evaluate
+          val actual = (a ++ b).execute(1)
           assert(actual)(isSuccess(equalTo("A")))
         } +
           test("should resolve second") {
             val a      = Http.empty
             val b      = Http.succeed("A")
-            val actual = (a ++ b).execute(()).evaluate
+            val actual = (a ++ b).execute(())
             assert(actual)(isSuccess(equalTo("A")))
           } +
           test("should resolve second") {
             val a      = Http.collect[Int] { case 1 => "A" }
             val b      = Http.collect[Int] { case 2 => "B" }
-            val actual = (a ++ b).execute(2).evaluate
+            val actual = (a ++ b).execute(2)
             assert(actual)(isSuccess(equalTo("B")))
           } +
           test("should not resolve") {
             val a      = Http.collect[Int] { case 1 => "A" }
             val b      = Http.collect[Int] { case 2 => "B" }
-            val actual = (a ++ b).execute(3).evaluate
+            val actual = (a ++ b).execute(3)
             assert(actual)(isEmpty)
           } +
           test("should be stack-safe") {
             val i      = 100000
             val a      = Http.collect[Int] { case i => i + 1 }
             val app    = (0 until i).foldLeft(a)((i, _) => i ++ a)
-            val actual = app.execute(0).evaluate
+            val actual = app.execute(0)
             assert(actual)(isSuccess(equalTo(1)))
-          },
+          } @@ ignore,
       ) +
       suite("asEffect")(
         testM("should resolve") {
           val a      = Http.collect[Int] { case 1 => "A" }
-          val actual = a.execute(1).evaluate.asEffect
+          val actual = a.execute(1).toEffect
           assertM(actual)(equalTo("A"))
         } +
           testM("should complete") {
             val a      = Http.collect[Int] { case 1 => "A" }
-            val actual = a.execute(2).evaluate.asEffect.either
+            val actual = a.execute(2).toEffect.either
             assertM(actual)(isLeft(isNone))
           },
       ) +
       suite("collectM")(
         test("should be empty") {
           val a      = Http.collectM[Int] { case 1 => UIO("A") }
-          val actual = a.execute(2).evaluate
+          val actual = a.execute(2)
           assert(actual)(isEmpty)
         } +
           test("should resolve") {
             val a      = Http.collectM[Int] { case 1 => UIO("A") }
-            val actual = a.execute(1).evaluate
+            val actual = a.execute(1)
             assert(actual)(isEffect)
           } +
           test("should resolve second effect") {
             val a      = Http.empty.flatten
             val b      = Http.succeed("B")
-            val actual = (a ++ b).execute(2).evaluate
+            val actual = (a ++ b).execute(2)
             assert(actual)(isSuccess(equalTo("B")))
           },
       ) +
@@ -139,12 +139,12 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             case 1 => Http.succeed(1)
             case 2 => Http.succeed(2)
           }
-          val actual = app.execute(2).evaluate
+          val actual = app.execute(2)
           assert(actual)(isSuccess(equalTo(2)))
         } +
           test("should be empty if no matches") {
             val app    = Http.route[Int](Map.empty)
-            val actual = app.execute(1).evaluate
+            val actual = app.execute(1)
             assert(actual)(isEmpty)
           },
       ) +
@@ -153,7 +153,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           for {
             r <- Ref.make(0)
             app = Http.succeed(1).tap(v => Http.fromEffect(r.set(v)))
-            _   <- app.execute(()).evaluate.asEffect
+            _   <- app.execute(()).toEffect
             res <- r.get
           } yield assert(res)(equalTo(1))
         },
@@ -163,7 +163,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           for {
             r <- Ref.make(0)
             app = Http.succeed(1).tapM(r.set)
-            _   <- app.execute(()).evaluate.asEffect
+            _   <- app.execute(()).toEffect
             res <- r.get
           } yield assert(res)(equalTo(1))
         },
@@ -173,7 +173,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           for {
             r <- Ref.make(0)
             app = Http.fail(1).tapError(v => Http.fromEffect(r.set(v)))
-            _   <- app.execute(()).evaluate.asEffect.ignore
+            _   <- app.execute(()).toEffect.ignore
             res <- r.get
           } yield assert(res)(equalTo(1))
         },
@@ -183,7 +183,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           for {
             r <- Ref.make(0)
             app = Http.fail(1).tapErrorM(r.set)
-            _   <- app.execute(()).evaluate.asEffect.ignore
+            _   <- app.execute(()).toEffect.ignore
             res <- r.get
           } yield assert(res)(equalTo(1))
         },
@@ -194,7 +194,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             r <- Ref.make(0)
             app = (Http.succeed(1): Http[Any, Any, Any, Int])
               .tapAll(_ => Http.empty, v => Http.fromEffect(r.set(v)), Http.empty)
-            _   <- app.execute(()).evaluate.asEffect
+            _   <- app.execute(()).toEffect
             res <- r.get
           } yield assert(res)(equalTo(1))
         } +
@@ -203,7 +203,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
               r <- Ref.make(0)
               app = (Http.fail(1): Http[Any, Int, Any, Any])
                 .tapAll(v => Http.fromEffect(r.set(v)), _ => Http.empty, Http.empty)
-              _   <- app.execute(()).evaluate.asEffect.ignore
+              _   <- app.execute(()).toEffect.ignore
               res <- r.get
             } yield assert(res)(equalTo(1))
           } +
@@ -212,7 +212,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
               r <- Ref.make(0)
               app = (Http.empty: Http[Any, Any, Any, Any])
                 .tapAll(_ => Http.empty, _ => Http.empty, Http.fromEffect(r.set(1)))
-              _   <- app.execute(()).evaluate.asEffect.ignore
+              _   <- app.execute(()).toEffect.ignore
               res <- r.get
             } yield assert(res)(equalTo(1))
           },
@@ -222,7 +222,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           for {
             r <- Ref.make(0)
             app = (Http.succeed(1): Http[Any, Any, Any, Int]).tapAllM(_ => ZIO.unit, r.set, ZIO.unit)
-            _   <- app.execute(()).evaluate.asEffect
+            _   <- app.execute(()).toEffect
             res <- r.get
           } yield assert(res)(equalTo(1))
         } +
@@ -230,7 +230,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             for {
               r <- Ref.make(0)
               app = (Http.fail(1): Http[Any, Int, Any, Any]).tapAllM(r.set, _ => ZIO.unit, ZIO.unit)
-              _   <- app.execute(()).evaluate.asEffect.ignore
+              _   <- app.execute(()).toEffect.ignore
               res <- r.get
             } yield assert(res)(equalTo(1))
           } +
@@ -239,10 +239,10 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
               r <- Ref.make(0)
               app = (Http.empty: Http[Any, Any, Any, Any])
                 .tapAllM(_ => ZIO.unit, _ => ZIO.unit, r.set(1))
-              _   <- app.execute(()).evaluate.asEffect.ignore
+              _   <- app.execute(()).toEffect.ignore
               res <- r.get
             } yield assert(res)(equalTo(1))
           },
       ),
-  ) @@ timeout(10 seconds)
+  ) @@ timeout(10 seconds) @@ sequential
 }

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -3,7 +3,7 @@ package zhttp.http
 import zio._
 import zio.duration.durationInt
 import zio.test.Assertion._
-import zio.test.TestAspect.{ignore, timeout}
+import zio.test.TestAspect.timeout
 import zio.test._
 import zio.test.environment.TestClock
 
@@ -14,13 +14,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
         val app    = Http.succeed(1).flatMap(i => Http.succeed(i + 1))
         val actual = app.execute(0)
         assert(actual)(isSuccess(equalTo(2)))
-      } +
-        test("should be stack-safe") {
-          val i      = 100000
-          val app    = (0 until i).foldLeft(Http.identity[Int])((i, _) => i.flatMap(c => Http.succeed(c + 1)))
-          val actual = app.execute(0)
-          assert(actual)(isSuccess(equalTo(i)))
-        } @@ ignore,
+      },
     ) +
       suite("orElse")(
         test("should succeed") {
@@ -95,14 +89,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             val b      = Http.collect[Int] { case 2 => "B" }
             val actual = (a ++ b).execute(3)
             assert(actual)(isEmpty)
-          } +
-          test("should be stack-safe") {
-            val i      = 100000
-            val a      = Http.collect[Int] { case i => i + 1 }
-            val app    = (0 until i).foldLeft(a)((i, _) => i ++ a)
-            val actual = app.execute(0)
-            assert(actual)(isSuccess(equalTo(1)))
-          } @@ ignore,
+          },
       ) +
       suite("asEffect")(
         testM("should resolve") {


### PR DESCRIPTION
There are two optimizations done here — 
1. Operators on `HExit` now are using final encoding. This reduces allocations and improves performances dramatically in certain use-cases.
2. Remove stack safety from `Http`. This is done because there are no "real" use-cases where you would need to recursively create `Http`. Moreover adding stack safety by using the heap, slows down the evaluation of the domain.

# Benchmarks

**NOTE:**

- Iteration count was reduced to `1000` from `10,000` because we are losing out on stack safety.

**Before**
```
[info] Benchmark                                         Mode   Cnt       Score       Error  Units
[info] HttpNestedFlatMapEval.benchmarkHttpFlatMap        thrpt    3   12335.029 ± 13513.481  ops/s
```

**After**
```
[info] Benchmark                                         Mode   Cnt        Score      Error  Units
[info] HttpNestedFlatMapEval.benchmarkHttpFlatMap        thrpt    3   113165.055 ± 9829.742  ops/s
```



**Before**
```
[info] Benchmark                           Mode  Cnt      Score       Error  Units
[info] HttpCombineEval.benchmarkNotFound  thrpt    3  16582.192 ±  5952.810  ops/s
[info] HttpCombineEval.benchmarkOk        thrpt    3  13392.093 ± 35982.678  ops/s
```

**After**
```
[info] Benchmark                           Mode  Cnt       Score       Error  Units
[info] HttpCombineEval.benchmarkNotFound  thrpt    3  121755.257 ± 56679.664  ops/s
[info] HttpCombineEval.benchmarkOk        thrpt    3   49160.038 ± 39910.239  ops/s
````
