### PR TITLE
Fix/WebSocket

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/server/WebSocketUpgrade.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/WebSocketUpgrade.scala
@@ -24,7 +24,6 @@ trait WebSocketUpgrade[R] { self: ChannelHandler =>
       .pipeline()
       .addLast(new WebSocketServerProtocolHandler(app.config.protocol.javaConfig))
       .addLast(WEB_SOCKET_HANDLER, ServerSocketHandler(runtime, app.config))
-      .remove(self)
     ctx.channel().eventLoop().submit(() => ctx.fireChannelRead(jReq)): Unit
 
   }


### PR DESCRIPTION
fixes #623 
No need to do `remove(self)` explicitly, `WebSocketServerProtocolHandler` removes handlers that are not required for WebSocket connections. 
From Netty in Action:
```To maximize performance WebSocketServerProtocolHandler will then remove any ChannelHandlers that aren’t required for WebSocket connections.```