### PR TITLE
Documentation fix for `defaultWith`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -115,7 +115,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
     Http.fromEffectFunction[X](xa) >>> self
 
   /**
-   * Named alias for `+++`
+   * Named alias for `++`
    */
   final def defaultWith[R1 <: R, E1 >: E, A1 <: A, B1 >: B](other: Http[R1, E1, A1, B1]): Http[R1, E1, A1, B1] =
     self.foldM(Http.fail, Http.succeed, other)


### PR DESCRIPTION
Hi, thank you for creating such a lovely library! I noticed in the description of `defaultWith` function, just a small typo.