### PR TITLE
making test case robust by using HttpGen.method

### DIFF
--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -134,10 +134,12 @@ object ServerSpec extends HttpRunnableSpec(8088) {
         assertM(res)(equalTo(string.length.toString))
       }
     } +
-      testM("POST Request.getBody") {
+      testM("Request.getBody All Http Methods") {
         val app = Http.collectM[Request] { case req => req.getBody.as(Response.ok) }
-        val res = app.requestStatus(!!, Method.POST, "some text")
-        assertM(res)(equalTo(Status.OK))
+        checkM(HttpGen.method, nonEmptyContent) { (mtd, nec) =>
+          val res = app.requestStatus(!!, mtd, nec._1)
+          assertM(res)(equalTo(Status.OK))
+        }
       }
 
   }


### PR DESCRIPTION
More natural way of making tests robust is by using check / checkM along with HttpGen 