### PR TITLE
chore: Ignore flaky tests

### DIFF
--- a/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
@@ -10,7 +10,7 @@ import zhttp.service.server._
 import zio.ZIO
 import zio.duration.durationInt
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.timeout
+import zio.test.TestAspect.{ignore, timeout}
 import zio.test.assertM
 
 object SSLSpec extends HttpRunnableSpec(8073) {
@@ -40,7 +40,7 @@ object SSLSpec extends HttpRunnableSpec(8073) {
               .request("https://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL1))
               .map(_.status)
             assertM(actual)(equalTo(Status.OK))
-          } +
+          } @@ ignore +
             testM("fail with DecoderException when client doesn't have the server certificate") {
               val actual = Client
                 .request("https://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL2))
@@ -48,19 +48,19 @@ object SSLSpec extends HttpRunnableSpec(8073) {
                   case _: DecoderException => ZIO.succeed("DecoderException")
                 })
               assertM(actual)(equalTo("DecoderException"))
-            } +
+            } @@ ignore +
             testM("succeed when client has default SSL") {
               val actual = Client
                 .request("https://localhost:8073/success", ClientSSLOptions.DefaultSSL)
                 .map(_.status)
               assertM(actual)(equalTo(Status.OK))
-            } +
+            } @@ ignore +
             testM("Https Redirect when client makes http request") {
               val actual = Client
                 .request("http://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL1))
                 .map(_.status)
               assertM(actual)(equalTo(Status.PERMANENT_REDIRECT))
-            },
+            } @@ ignore,
         ),
       )
       .useNow,

--- a/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
@@ -40,7 +40,7 @@ object SSLSpec extends HttpRunnableSpec(8073) {
               .request("https://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL1))
               .map(_.status)
             assertM(actual)(equalTo(Status.OK))
-          } @@ ignore +
+          } +
             testM("fail with DecoderException when client doesn't have the server certificate") {
               val actual = Client
                 .request("https://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL2))
@@ -48,21 +48,21 @@ object SSLSpec extends HttpRunnableSpec(8073) {
                   case _: DecoderException => ZIO.succeed("DecoderException")
                 })
               assertM(actual)(equalTo("DecoderException"))
-            } @@ ignore +
+            } +
             testM("succeed when client has default SSL") {
               val actual = Client
                 .request("https://localhost:8073/success", ClientSSLOptions.DefaultSSL)
                 .map(_.status)
               assertM(actual)(equalTo(Status.OK))
-            } @@ ignore +
+            } +
             testM("Https Redirect when client makes http request") {
               val actual = Client
                 .request("http://localhost:8073/success", ClientSSLOptions.CustomSSL(clientSSL1))
                 .map(_.status)
               assertM(actual)(equalTo(Status.PERMANENT_REDIRECT))
-            } @@ ignore,
+            },
         ),
       )
       .useNow,
-  ).provideCustomLayer(env) @@ timeout(5 second)
+  ).provideCustomLayer(env) @@ timeout(5 second) @@ ignore
 }


### PR DESCRIPTION
SSLSpec is flaky as it get timed out at times. Ignoring it for now.