### PR TITLE
Refactor: Use builder pattern for SocketApp

### DIFF
--- a/example/src/main/scala/example/WebSocketAdvanced.scala
+++ b/example/src/main/scala/example/WebSocketAdvanced.scala
@@ -27,15 +27,25 @@ object WebSocketAdvanced extends App {
   private val decoder = SocketDecoder.allowExtensions
 
   // Combine all channel handlers together
-  private val socketApp =
-    SocketApp.open(open) ++                   // Called after the request is successfully upgraded to websocket
-      SocketApp.message(echo merge fooBar) ++ // Called after each message being received on the channel
-      SocketApp.close(_ => console.putStrLn("Closed!").ignore) ++ // Called after the connection is closed
-      SocketApp.error(_ =>
-        console.putStrLn("Error!").ignore,
-      ) ++ // Called whenever there is an error on the socket channel
-      SocketApp.decoder(decoder) ++
-      SocketApp.protocol(protocol)
+  private val socketApp = {
+
+    SocketApp(echo merge fooBar) // Called after each message being received on the channel
+
+      // Called after the request is successfully upgraded to websocket
+      .onOpen(open)
+
+      // Called after the connection is closed
+      .onClose(_ => console.putStrLn("Closed!").ignore)
+
+      // Called whenever there is an error on the socket channel
+      .onError(_ => console.putStrLn("Error!").ignore)
+
+      // Setup websocket decoder config
+      .withDecoder(decoder)
+
+      // Setup websocket protocol config
+      .withProtocol(protocol)
+  }
 
   private val app =
     Http.collect[Request] {

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -171,13 +171,13 @@ object Response {
    * Creates a socket response using an app
    */
   def socket[R, E](app: SocketApp[R, E]): Response[R, E] =
-    Response(Status.SWITCHING_PROTOCOLS, Headers.empty, HttpData.empty, Attribute(socketApp = app))
+    Response(Status.SWITCHING_PROTOCOLS, Headers.empty, HttpData.empty, Attribute(socketApp = Option(app)))
 
   /**
    * Creates a new WebSocket Response
    */
   def socket[R, E](ss: Socket[R, E, WebSocketFrame, WebSocketFrame]): Response[R, E] =
-    SocketApp.message(ss).asResponse
+    SocketApp(ss).asResponse
 
   /**
    * Creates an empty response with the provided Status
@@ -198,7 +198,7 @@ object Response {
    */
 
   private[zhttp] final case class Attribute[-R, +E](
-    socketApp: SocketApp[R, E] = SocketApp.empty,
+    socketApp: Option[SocketApp[R, E]] = None,
     memoize: Boolean = false,
     serverTime: Boolean = false,
     encoded: Option[(Response[R, E], HttpResponse)] = None,
@@ -210,7 +210,7 @@ object Response {
 
     def withServerTime: Attribute[R, E] = self.copy(serverTime = true)
 
-    def withSocketApp[R1 <: R, E1 >: E](app: SocketApp[R1, E1]): Attribute[R1, E1] = self.copy(socketApp = app)
+    def withSocketApp[R1 <: R, E1 >: E](app: SocketApp[R1, E1]): Attribute[R1, E1] = self.copy(socketApp = Option(app))
   }
 
   object Attribute {

--- a/zio-http/src/main/scala/zhttp/service/server/WebSocketUpgrade.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/WebSocketUpgrade.scala
@@ -22,8 +22,8 @@ trait WebSocketUpgrade[R] { self: ChannelHandler =>
     ctx
       .channel()
       .pipeline()
-      .addLast(new WebSocketServerProtocolHandler(app.config.protocol.javaConfig))
-      .addLast(WEB_SOCKET_HANDLER, ServerSocketHandler(runtime, app.config))
+      .addLast(new WebSocketServerProtocolHandler(app.get.protocol.javaConfig))
+      .addLast(WEB_SOCKET_HANDLER, ServerSocketHandler(runtime, app.get))
     ctx.channel().eventLoop().submit(() => ctx.fireChannelRead(jReq)): Unit
 
   }

--- a/zio-http/src/main/scala/zhttp/socket/IsWebSocket.scala
+++ b/zio-http/src/main/scala/zhttp/socket/IsWebSocket.scala
@@ -1,0 +1,12 @@
+package zhttp.socket
+
+sealed trait IsWebSocket[+R, -E, +A, -B] {
+  def apply[R1 >: R, E1 <: E, A1 >: A, B1 <: B](
+    socket: Socket[R1, E1, A1, B1],
+  ): Socket[R1, E1, WebSocketFrame, WebSocketFrame] =
+    socket.asInstanceOf[Socket[R1, E1, WebSocketFrame, WebSocketFrame]]
+}
+
+object IsWebSocket extends IsWebSocket[Nothing, Any, WebSocketFrame, WebSocketFrame] {
+  implicit def webSocketFrame[R, E]: IsWebSocket[R, E, WebSocketFrame, WebSocketFrame] = IsWebSocket
+}

--- a/zio-http/src/main/scala/zhttp/socket/Socket.scala
+++ b/zio-http/src/main/scala/zhttp/socket/Socket.scala
@@ -5,6 +5,9 @@ import zio.{Cause, NeedsEnv, ZIO}
 
 sealed trait Socket[-R, +E, -A, +B] { self =>
   import Socket._
+  def <>[R1 <: R, E1, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
+    self orElse other
+
   def apply(a: A): ZStream[R, E, B] = self match {
     case End                         => ZStream.halt(Cause.empty)
     case FromStreamingFunction(func) => func(a)
@@ -19,7 +22,19 @@ sealed trait Socket[-R, +E, -A, +B] { self =>
     case Provide(s, r)               => s(a).asInstanceOf[ZStream[R, E, B]].provide(r.asInstanceOf[R])
   }
 
-  private[zhttp] def execute(a: A): ZStream[R, E, B] = self(a)
+  def contramap[Z](za: Z => A): Socket[R, E, Z, B] = Socket.FCMap(self, za)
+
+  def contramapZIO[R1 <: R, E1 >: E, Z](za: Z => ZIO[R1, E1, A]): Socket[R1, E1, Z, B] = Socket.FCMapZIO(self, za)
+
+  def map[C](bc: B => C): Socket[R, E, A, C] = Socket.FMap(self, bc)
+
+  def mapZIO[R1 <: R, E1 >: E, C](bc: B => ZIO[R1, E1, C]): Socket[R1, E1, A, C] = Socket.FMapZIO(self, bc)
+
+  def merge[R1 <: R, E1 >: E, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
+    Socket.FMerge(self, other)
+
+  def orElse[R1 <: R, E1, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
+    Socket.FOrElse(self, other)
 
   /**
    * Provides the socket with its required environment, which eliminates its dependency on R. This operation assumes
@@ -27,50 +42,19 @@ sealed trait Socket[-R, +E, -A, +B] { self =>
    */
   def provide(r: R)(implicit env: NeedsEnv[R]): Socket[Any, E, A, B] = Provide(self, r)
 
-  def map[C](bc: B => C): Socket[R, E, A, C] = Socket.FMap(self, bc)
-
-  def mapZIO[R1 <: R, E1 >: E, C](bc: B => ZIO[R1, E1, C]): Socket[R1, E1, A, C] = Socket.FMapZIO(self, bc)
-
-  def contramap[Z](za: Z => A): Socket[R, E, Z, B] = Socket.FCMap(self, za)
-
-  def contramapZIO[R1 <: R, E1 >: E, Z](za: Z => ZIO[R1, E1, A]): Socket[R1, E1, Z, B] = Socket.FCMapZIO(self, za)
-
-  def <>[R1 <: R, E1, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
-    self orElse other
-
-  def orElse[R1 <: R, E1, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
-    Socket.FOrElse(self, other)
-
-  def merge[R1 <: R, E1 >: E, A1 <: A, B1 >: B](other: Socket[R1, E1, A1, B1]): Socket[R1, E1, A1, B1] =
-    Socket.FMerge(self, other)
+  private[zhttp] def execute(a: A): ZStream[R, E, B] = self(a)
 }
 
 object Socket {
-  private final case class FromStreamingFunction[R, E, A, B](func: A => ZStream[R, E, B]) extends Socket[R, E, A, B]
-  private final case class FromStream[R, E, B](stream: ZStream[R, E, B])                  extends Socket[R, E, Any, B]
-  private final case class Succeed[A](a: A)                                        extends Socket[Any, Nothing, Any, A]
-  private final case class FMap[R, E, A, B, C](m: Socket[R, E, A, B], bc: B => C)  extends Socket[R, E, A, C]
-  private final case class FMapZIO[R, E, A, B, C](m: Socket[R, E, A, B], bc: B => ZIO[R, E, C])
-      extends Socket[R, E, A, C]
-  private final case class FCMap[R, E, X, A, B](m: Socket[R, E, A, B], xa: X => A) extends Socket[R, E, X, B]
-  private final case class FCMapZIO[R, E, X, A, B](m: Socket[R, E, A, B], xa: X => ZIO[R, E, A])
-      extends Socket[R, E, X, B]
-  private case object End extends Socket[Any, Nothing, Any, Nothing]
-  private final case class FOrElse[R, E, E1, A, B](a: Socket[R, E, A, B], b: Socket[R, E1, A, B])
-      extends Socket[R, E1, A, B]
-
-  private final case class FMerge[R, E, A, B](a: Socket[R, E, A, B], b: Socket[R, E, A, B]) extends Socket[R, E, A, B]
-  private final case class Provide[R, E, A, B](s: Socket[R, E, A, B], r: R)                 extends Socket[Any, E, A, B]
-
   def collect[A]: MkCollect[A] = new MkCollect[A](())
-
-  def succeed[A](a: A): Socket[Any, Nothing, Any, A] = Succeed(a)
-
-  def fromStream[R, E, B](stream: ZStream[R, E, B]): Socket[R, E, Any, B] = FromStream(stream)
 
   def end: ZStream[Any, Nothing, Nothing] = ZStream.halt(Cause.empty)
 
   def fromFunction[A]: MkFromFunction[A] = new MkFromFunction[A](())
+
+  def fromStream[R, E, B](stream: ZStream[R, E, B]): Socket[R, E, Any, B] = FromStream(stream)
+
+  def succeed[A](a: A): Socket[Any, Nothing, Any, A] = Succeed(a)
 
   final class MkFromFunction[A](val unit: Unit) extends AnyVal {
     def apply[R, E, B](f: A => ZStream[R, E, B]): Socket[R, E, A, B] = FromStreamingFunction(f)
@@ -82,4 +66,29 @@ object Socket {
         if (pf.isDefinedAt(a)) pf(a) else ZStream.empty
     }
   }
+
+  private final case class FromStreamingFunction[R, E, A, B](func: A => ZStream[R, E, B]) extends Socket[R, E, A, B]
+
+  private final case class FromStream[R, E, B](stream: ZStream[R, E, B]) extends Socket[R, E, Any, B]
+
+  private final case class Succeed[A](a: A) extends Socket[Any, Nothing, Any, A]
+
+  private final case class FMap[R, E, A, B, C](m: Socket[R, E, A, B], bc: B => C) extends Socket[R, E, A, C]
+
+  private final case class FMapZIO[R, E, A, B, C](m: Socket[R, E, A, B], bc: B => ZIO[R, E, C])
+      extends Socket[R, E, A, C]
+
+  private final case class FCMap[R, E, X, A, B](m: Socket[R, E, A, B], xa: X => A) extends Socket[R, E, X, B]
+
+  private final case class FCMapZIO[R, E, X, A, B](m: Socket[R, E, A, B], xa: X => ZIO[R, E, A])
+      extends Socket[R, E, X, B]
+
+  private final case class FOrElse[R, E, E1, A, B](a: Socket[R, E, A, B], b: Socket[R, E1, A, B])
+      extends Socket[R, E1, A, B]
+
+  private final case class FMerge[R, E, A, B](a: Socket[R, E, A, B], b: Socket[R, E, A, B]) extends Socket[R, E, A, B]
+
+  private final case class Provide[R, E, A, B](s: Socket[R, E, A, B], r: R) extends Socket[Any, E, A, B]
+
+  private case object End extends Socket[Any, Nothing, Any, Nothing]
 }

--- a/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
+++ b/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
@@ -1,163 +1,127 @@
 package zhttp.socket
 
-import zhttp.http._
-import zio._
+import zhttp.http.Response
+import zhttp.socket.SocketApp.Handle.{WithEffect, WithSocket}
+import zhttp.socket.SocketApp.{Connection, Handle}
+import zio.ZIO
 import zio.stream.ZStream
 
 import java.net.SocketAddress
 
-sealed trait SocketApp[-R, +E] { self =>
-  import SocketApp._
-  def ++[R1 <: R, E1 >: E](other: SocketApp[R1, E1]): SocketApp[R1, E1] = SocketApp.Concat(self, other)
+final case class SocketApp[-R, +E](
+  timeout: Option[ZIO[R, Nothing, Any]] = None,
+  open: Option[Handle[R, E]] = None,
+  message: Option[Socket[R, E, WebSocketFrame, WebSocketFrame]] = None,
+  error: Option[Throwable => ZIO[R, Nothing, Any]] = None,
+  close: Option[Connection => ZIO[R, Nothing, Any]] = None,
+  decoder: SocketDecoder = SocketDecoder.default,
+  protocol: SocketProtocol = SocketProtocol.default,
+) { self =>
 
+  /**
+   * Creates a new WebSocket Response
+   */
   def asResponse: Response[R, E] = Response.socket(self)
 
-  def config: SocketApp.SocketConfig[R, E] = {
-    def loop(config: SocketApp[R, E], s: SocketConfig[R, E]): SocketConfig[R, E] =
-      config match {
-        case Empty => s
+  /**
+   * Called when the websocket connection is closed successfully.
+   */
+  def onClose[R1 <: R](close: Connection => ZIO[R1, Nothing, Any]): SocketApp[R1, E] =
+    copy(close = self.close match {
+      case Some(value) => Some(connection => value(connection) *> close(connection))
+      case None        => Some(close)
+    })
 
-        case Decoder(decoder) => s.copy(decoder = s.decoder ++ decoder)
+  /**
+   * Called whenever there is an error on the channel after a successful upgrade to websocket.
+   */
+  def onError[R1 <: R](error: Throwable => ZIO[R1, Nothing, Any]): SocketApp[R1, E] =
+    copy(error = self.error match {
+      case Some(value) => Some(cause => value(cause) *> error(cause))
+      case None        => Some(error)
+    })
 
-        case Protocol(protocol) => s.copy(protocol = s.protocol ++ protocol)
+  /**
+   * Called on every incoming WebSocketFrame. In case of a failure on the returned stream, the socket is forcefully
+   * closed.
+   */
+  def onMessage[R1 <: R, E1 >: E](message: Socket[R1, E1, WebSocketFrame, WebSocketFrame]): SocketApp[R1, E1] =
+    copy(message = self.message match {
+      case Some(other) => Some(other merge message)
+      case None        => Some(message)
+    })
 
-        case OnTimeout(onTimeout) =>
-          s.copy(onTimeout = s.onTimeout.fold(Option(onTimeout))(v => Option(v &> onTimeout)))
+  /**
+   * Called when the connection is successfully upgraded to a websocket one. In case of a failure, the socket is
+   * forcefully closed.
+   */
+  def onOpen[R1 <: R, E1 >: E](open: Socket[R1, E1, Connection, WebSocketFrame]): SocketApp[R1, E1] =
+    onOpen(Handle(open))
 
-        case a: Open[_, _] =>
-          s.copy(onOpen = s.onOpen match {
-            case Some(b) => Option(b merge a)
-            case None    => Option(a)
-          })
+  /**
+   * Called when the connection is successfully upgraded to a websocket one. In case of a failure, the socket is
+   * forcefully closed.
+   */
+  def onOpen[R1 <: R, E1 >: E](open: Connection => ZIO[R1, E1, Any]): SocketApp[R1, E1] =
+    onOpen(Handle(open))
 
-        case OnMessage(a) =>
-          s.copy(onMessage = s.onMessage match {
-            case Some(b) => Option(b merge a)
-            case None    => Option(a)
-          })
+  /**
+   * Called when the websocket handshake gets timeout.
+   */
+  def onTimeout[R1 <: R](timeout: ZIO[R1, Nothing, Any]): SocketApp[R1, E] =
+    copy(timeout = self.timeout match {
+      case Some(other) => Some(timeout *> other)
+      case None        => Some(timeout)
+    })
 
-        case OnError(onError) =>
-          s.copy(onError = s.onError.fold(Option(onError))(v => Option(c => v(c) &> onError(c))))
+  /**
+   * Frame decoder configuration
+   */
+  def withDecoder(decoder: SocketDecoder): SocketApp[R, E] =
+    copy(decoder = self.decoder ++ decoder)
 
-        case OnClose(onClose) =>
-          s.copy(onClose = s.onClose.fold(Option(onClose))(v => Option(c => v(c) &> onClose(c))))
+  /**
+   * Server side websocket configuration
+   */
+  def withProtocol(protocol: SocketProtocol): SocketApp[R, E] =
+    copy(protocol = self.protocol ++ protocol)
 
-        case Concat(a, b) =>
-          loop(b, loop(a, s))
-      }
-
-    loop(self, SocketConfig[R, E]())
-  }
-
-  def isEmpty: Boolean = self match {
-    case Empty => true
-    case _     => false
-  }
-
-  def nonEmpty: Boolean = !isEmpty
+  /**
+   * Called when the connection is successfully upgraded to a websocket one. In case of a failure, the socket is
+   * forcefully closed.
+   */
+  private def onOpen[R1 <: R, E1 >: E](open: Handle[R1, E1]): SocketApp[R1, E1] =
+    copy(open = self.open.fold(Some(open))(other => Some(other merge open)))
 }
 
 object SocketApp {
   type Connection = SocketAddress
-  type Cause      = Option[Throwable]
 
-  private[zhttp] sealed trait Open[-R, +E] extends SocketApp[R, E] { self =>
-    import Open._
-    private def sock: Open[R, E] = self match {
-      case WithEffect(f)     => WithSocket(Socket.fromFunction(c => ZStream.fromEffect(f(c)) *> ZStream.empty))
-      case s @ WithSocket(_) => s
-    }
+  def apply[R, E](socket: Socket[R, E, WebSocketFrame, WebSocketFrame]): SocketApp[R, E] =
+    SocketApp(message = Some(socket))
 
-    def merge[R1 <: R, E1 >: E](other: Open[R1, E1]): Open[R1, E1] = {
+  private[zhttp] sealed trait Handle[-R, +E] { self =>
+    def merge[R1 <: R, E1 >: E](other: Handle[R1, E1]): Handle[R1, E1] = {
       (self, other) match {
         case (WithSocket(s0), WithSocket(s1)) => WithSocket(s0 merge s1)
         case (WithEffect(f0), WithEffect(f1)) => WithEffect(c => f0(c) <&> f1(c))
         case (a, b)                           => a.sock merge b.sock
       }
     }
+
+    private def sock: Handle[R, E] = self match {
+      case WithEffect(f)     => WithSocket(Socket.fromFunction(c => ZStream.fromEffect(f(c)) *> ZStream.empty))
+      case s @ WithSocket(_) => s
+    }
   }
 
-  private[zhttp] object Open {
-    final case class WithEffect[R, E](f: Connection => ZIO[R, E, Any])             extends Open[R, E]
-    final case class WithSocket[R, E](s: Socket[R, E, Connection, WebSocketFrame]) extends Open[R, E]
+  private[zhttp] object Handle {
+    def apply[R, E](onOpen: Socket[R, E, Connection, WebSocketFrame]): Handle[R, E] = WithSocket(onOpen)
+
+    def apply[R, E](onOpen: Connection => ZIO[R, E, Any]): Handle[R, E] = WithEffect(onOpen)
+
+    final case class WithEffect[R, E](f: Connection => ZIO[R, E, Any]) extends Handle[R, E]
+
+    final case class WithSocket[R, E](s: Socket[R, E, Connection, WebSocketFrame]) extends Handle[R, E]
   }
-  private final case class Concat[R, E](a: SocketApp[R, E], b: SocketApp[R, E]) extends SocketApp[R, E]
-  private final case class OnMessage[R, E](onMessage: Socket[R, E, WebSocketFrame, WebSocketFrame])
-      extends SocketApp[R, E]
-  private final case class OnError[R](onError: Throwable => ZIO[R, Nothing, Any])  extends SocketApp[R, Nothing]
-  private final case class OnClose[R](onClose: Connection => ZIO[R, Nothing, Any]) extends SocketApp[R, Nothing]
-  private final case class OnTimeout[R](onTimeout: ZIO[R, Nothing, Any])           extends SocketApp[R, Nothing]
-  private final case class Protocol(protocol: SocketProtocol)                      extends SocketApp[Any, Nothing]
-  private final case class Decoder(decoder: SocketDecoder)                         extends SocketApp[Any, Nothing]
-  private case object Empty                                                        extends SocketApp[Any, Nothing]
-
-  /**
-   * Called when the connection is successfully upgrade to a websocket one. In case of a failure on the returned stream,
-   * the socket is forcefully closed.
-   */
-  def open[R, E](onOpen: Socket[R, E, Connection, WebSocketFrame]): SocketApp[R, E] =
-    SocketApp.Open.WithSocket(onOpen)
-
-  /**
-   * Called when the connection is successfully upgrade to a websocket one. In case of a failure on the returned stream,
-   * the socket is forcefully closed.
-   */
-  def open[R, E](onOpen: Connection => ZIO[R, E, Any]): SocketApp[R, E] =
-    SocketApp.Open.WithEffect(onOpen)
-
-  /**
-   * Called when the handshake gets timeout.
-   */
-  def timeout[R](onTimeout: ZIO[R, Nothing, Any]): SocketApp[R, Nothing] = SocketApp.OnTimeout(onTimeout)
-
-  /**
-   * Called on every incoming WebSocketFrame. In case of a failure on the returned stream, the socket is forcefully
-   * closed.
-   */
-  def message[R, E](onMessage: Socket[R, E, WebSocketFrame, WebSocketFrame]): SocketApp[R, E] =
-    SocketApp.OnMessage(onMessage)
-
-  /**
-   * Called whenever there is an error on the channel after a successful upgrade to websocket.
-   */
-  def error[R](onError: Throwable => ZIO[R, Nothing, Any]): SocketApp[R, Nothing] = SocketApp.OnError(onError)
-
-  /**
-   * Called when the websocket connection is closed successfully.
-   */
-  def close[R](onClose: (Connection) => ZIO[R, Nothing, Any]): SocketApp[R, Nothing] =
-    SocketApp.OnClose(onClose)
-
-  /**
-   * Frame decoder configuration
-   */
-  def decoder(decoder: SocketDecoder): SocketApp[Any, Nothing] = Decoder(decoder)
-
-  /**
-   * Server side websocket configuration
-   */
-  def protocol(protocol: SocketProtocol): SocketApp[Any, Nothing] = Protocol(protocol)
-
-  def protocol(name: String): SocketApp[Any, Nothing] = Protocol(SocketProtocol.subProtocol(name))
-
-  /**
-   * Creates a new empty socket handler
-   */
-  def empty: SocketApp[Any, Nothing] = Empty
-
-  /**
-   * Echos the message back to the client
-   */
-  def echo: SocketApp[Any, Nothing] = SocketApp.message(Socket.collect { case msg => ZStream.succeed(msg) })
-
-  // TODO: rename to HandlerConfig
-  final case class SocketConfig[-R, +E](
-    onTimeout: Option[ZIO[R, Nothing, Any]] = None,
-    onOpen: Option[Open[R, E]] = None,
-    onMessage: Option[Socket[R, E, WebSocketFrame, WebSocketFrame]] = None,
-    onError: Option[Throwable => ZIO[R, Nothing, Any]] = None,
-    onClose: Option[Connection => ZIO[R, Nothing, Any]] = None,
-    decoder: SocketDecoder = SocketDecoder.default,
-    protocol: SocketProtocol = SocketProtocol.default,
-  )
 }

--- a/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
+++ b/zio-http/src/main/scala/zhttp/socket/SocketApp.scala
@@ -28,7 +28,7 @@ final case class SocketApp[-R, +E](
    */
   def onClose[R1 <: R](close: Connection => ZIO[R1, Nothing, Any]): SocketApp[R1, E] =
     copy(close = self.close match {
-      case Some(value) => Some(connection => value(connection) *> close(connection))
+      case Some(value) => Some((connection: Connection) => value(connection) *> close(connection))
       case None        => Some(close)
     })
 
@@ -37,7 +37,7 @@ final case class SocketApp[-R, +E](
    */
   def onError[R1 <: R](error: Throwable => ZIO[R1, Nothing, Any]): SocketApp[R1, E] =
     copy(error = self.error match {
-      case Some(value) => Some(cause => value(cause) *> error(cause))
+      case Some(value) => Some((cause: Throwable) => value(cause) *> error(cause))
       case None        => Some(error)
     })
 

--- a/zio-http/src/test/scala/zhttp/service/WebSocketServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/WebSocketServerSpec.scala
@@ -20,7 +20,7 @@ object WebSocketServerSpec extends HttpRunnableSpec(8011) {
   def websocketSpec = suite("WebSocket Server") {
     suite("connections") {
       testM("Multiple websocket upgrades") {
-        val socketApp = SocketApp.message(Socket.succeed(WebSocketFrame.text("BAR")))
+        val socketApp = SocketApp(Socket.succeed(WebSocketFrame.text("BAR")))
         val app       = Http.fromEffect(ZIO(Response.socket(socketApp)))
         assertM(app.webSocketStatusCode(!! / "subscriptions").repeatN(1024))(equalTo(101))
       }


### PR DESCRIPTION
- Using the `++` operator for configuring SocketApp is quite verbose.
- The builder pattern seems a lot more natural for such use-cases.
- Adding `provide` operator is much harder (though not impossible).