### PR TITLE
Refactor: Remove type params from HttpData

### DIFF
--- a/example/src/main/scala/example/FileStreaming.scala
+++ b/example/src/main/scala/example/FileStreaming.scala
@@ -1,6 +1,6 @@
 package example
 
-import zhttp.http.{HttpData, Method, Response, _}
+import zhttp.http._
 import zhttp.service.Server
 import zio.stream.ZStream
 import zio.{App, ExitCode, URIO}
@@ -9,23 +9,20 @@ import java.io.File
 import java.nio.file.Paths
 
 object FileStreaming extends App {
-  // Read the file as ZStream
-  val content = HttpData.fromStream {
-    ZStream.fromFile(Paths.get("README.md"))
-  }
-
-  // Uses netty's capability to write file content to the Channel
-  // Content-type response headers are automatically identified and added
-  // Does not use Chunked transfer encoding
-  val videoFileContent = HttpData.fromFile(new File("src/main/resources/TestVideoFile.mp4"))
-  val textFileContent  = HttpData.fromFile(new File("src/main/resources/TestFile.txt"))
 
   // Create HTTP route
-  val app = Http.collect[Request] {
-    case Method.GET -> !! / "health" => Response.ok
-    case Method.GET -> !! / "file"   => Response(data = content)
-    case Method.GET -> !! / "video"  => Response(data = videoFileContent)
-    case Method.GET -> !! / "text"   => Response(data = textFileContent)
+  val app = Http.collectHttp[Request] {
+    case Method.GET -> !! / "health" => Http.ok
+
+    // Read the file as ZStream
+    // Uses the blocking version of ZStream.fromFile
+    case Method.GET -> !! / "blocking" => Http.fromStream(ZStream.fromFile(Paths.get("README.md")))
+
+    // Uses netty's capability to write file content to the Channel
+    // Content-type response headers are automatically identified and added
+    // Does not use Chunked transfer encoding
+    case Method.GET -> !! / "video" => Http.fromFile(new File("src/main/resources/TestVideoFile.mp4"))
+    case Method.GET -> !! / "text"  => Http.fromFile(new File("src/main/resources/TestFile.txt"))
   }
 
   // Run it like any simple app

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -463,7 +463,7 @@ object Http {
   /**
    * Creates an Http app which always responds the provided data and a 200 status code
    */
-  def fromData[R, E](data: HttpData) = response(Response(data = data))
+  def fromData(data: HttpData) = response(Response(data = data))
 
   /**
    * Converts a ZIO to an Http type

--- a/zio-http/src/main/scala/zhttp/http/HttpData.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpData.scala
@@ -3,7 +3,7 @@ package zhttp.http
 import io.netty.buffer.{ByteBuf, Unpooled}
 import zio.blocking.Blocking.Service.live.effectBlocking
 import zio.stream.ZStream
-import zio.{Chunk, NeedsEnv, UIO, ZIO}
+import zio.{Chunk, Task, UIO}
 
 import java.nio.charset.Charset
 import java.nio.file.Files
@@ -11,7 +11,7 @@ import java.nio.file.Files
 /**
  * Holds HttpData that needs to be written on the HttpChannel
  */
-sealed trait HttpData[-R, +E] { self =>
+sealed trait HttpData { self =>
 
   /**
    * Returns true if HttpData is a stream
@@ -29,13 +29,7 @@ sealed trait HttpData[-R, +E] { self =>
     case _              => false
   }
 
-  def provide[R1 <: R](env: R)(implicit ev: NeedsEnv[R]): HttpData[Any, E] =
-    self match {
-      case HttpData.BinaryStream(data) => HttpData.BinaryStream(data.provide(env))
-      case m                           => m.asInstanceOf[HttpData[Any, E]]
-    }
-
-  def toByteBuf: ZIO[R, Throwable, ByteBuf] = {
+  def toByteBuf: Task[ByteBuf] = {
     self match {
       case HttpData.Text(text, charset)  => UIO(Unpooled.copiedBuffer(text, charset))
       case HttpData.BinaryChunk(data)    => UIO(Unpooled.copiedBuffer(data.toArray))
@@ -43,7 +37,7 @@ sealed trait HttpData[-R, +E] { self =>
       case HttpData.Empty                => UIO(Unpooled.EMPTY_BUFFER)
       case HttpData.BinaryStream(stream) =>
         stream
-          .asInstanceOf[ZStream[R, Throwable, ByteBuf]]
+          .asInstanceOf[ZStream[Any, Throwable, ByteBuf]]
           .fold(Unpooled.compositeBuffer())((c, b) => c.addComponent(b))
       case HttpData.File(file)           =>
         effectBlocking {
@@ -59,44 +53,44 @@ object HttpData {
   /**
    * Helper to create empty HttpData
    */
-  def empty: HttpData[Any, Nothing] = Empty
+  def empty: HttpData = Empty
 
   /**
    * Helper to create HttpData from ByteBuf
    */
-  def fromByteBuf(byteBuf: ByteBuf): HttpData[Any, Nothing] = HttpData.BinaryByteBuf(byteBuf)
+  def fromByteBuf(byteBuf: ByteBuf): HttpData = HttpData.BinaryByteBuf(byteBuf)
 
   /**
    * Helper to create HttpData from chunk of bytes
    */
-  def fromChunk(data: Chunk[Byte]): HttpData[Any, Nothing] = BinaryChunk(data)
+  def fromChunk(data: Chunk[Byte]): HttpData = BinaryChunk(data)
 
   /**
    * Helper to create HttpData from Stream of bytes
    */
-  def fromStream[R, E](stream: ZStream[R, E, Byte]): HttpData[R, E] =
+  def fromStream(stream: ZStream[Any, Throwable, Byte]): HttpData =
     HttpData.BinaryStream(stream.mapChunks(chunks => Chunk(Unpooled.copiedBuffer(chunks.toArray))))
 
   /**
    * Helper to create HttpData from Stream of string
    */
-  def fromStream[R, E](stream: ZStream[R, E, String], charset: Charset = HTTP_CHARSET): HttpData[R, E] =
+  def fromStream(stream: ZStream[Any, Throwable, String], charset: Charset = HTTP_CHARSET): HttpData =
     HttpData.BinaryStream(stream.map(str => Unpooled.copiedBuffer(str, charset)))
 
   /**
    * Helper to create HttpData from String
    */
-  def fromString(text: String, charset: Charset = HTTP_CHARSET): HttpData[Any, Nothing] = Text(text, charset)
+  def fromString(text: String, charset: Charset = HTTP_CHARSET): HttpData = Text(text, charset)
 
   /**
    * Helper to create HttpData from contents of a file
    */
-  def fromFile(file: java.io.File): HttpData[Any, Nothing] = File(file)
+  def fromFile(file: java.io.File): HttpData = File(file)
 
-  private[zhttp] final case class Text(text: String, charset: Charset)               extends HttpData[Any, Nothing]
-  private[zhttp] final case class BinaryChunk(data: Chunk[Byte])                     extends HttpData[Any, Nothing]
-  private[zhttp] final case class BinaryByteBuf(data: ByteBuf)                       extends HttpData[Any, Nothing]
-  private[zhttp] final case class BinaryStream[R, E](stream: ZStream[R, E, ByteBuf]) extends HttpData[R, E]
-  private[zhttp] final case class File(file: java.io.File)                           extends HttpData[Any, Nothing]
-  private[zhttp] case object Empty                                                   extends HttpData[Any, Nothing]
+  private[zhttp] final case class Text(text: String, charset: Charset)                   extends HttpData
+  private[zhttp] final case class BinaryChunk(data: Chunk[Byte])                         extends HttpData
+  private[zhttp] final case class BinaryByteBuf(data: ByteBuf)                           extends HttpData
+  private[zhttp] final case class BinaryStream(stream: ZStream[Any, Throwable, ByteBuf]) extends HttpData
+  private[zhttp] final case class File(file: java.io.File)                               extends HttpData
+  private[zhttp] case object Empty                                                       extends HttpData
 }

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -16,7 +16,7 @@ import java.nio.file.Files
 final case class Response[-R, +E] private (
   status: Status,
   headers: Headers,
-  data: HttpData[R, E],
+  data: HttpData,
   private[zhttp] val attribute: Response.Attribute[R, E],
 ) extends HeaderExtension[Response[R, E]] { self =>
 
@@ -109,7 +109,7 @@ object Response {
   def apply[R, E](
     status: Status = Status.OK,
     headers: Headers = Headers.empty,
-    data: HttpData[R, E] = HttpData.Empty,
+    data: HttpData = HttpData.Empty,
   ): Response[R, E] =
     Response(status, headers, data, Attribute.empty)
 
@@ -142,7 +142,7 @@ object Response {
   def http[R, E](
     status: Status = Status.OK,
     headers: Headers = Headers.empty,
-    data: HttpData[R, E] = HttpData.empty,
+    data: HttpData = HttpData.empty,
   ): Response[R, E] = Response(status, headers, data)
 
   /**

--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -100,7 +100,7 @@ object Client {
   def request(
     url: String,
     headers: Headers,
-    content: HttpData[Any, Nothing],
+    content: HttpData,
   ): ZIO[EventLoopGroup with ChannelFactory, Throwable, ClientResponse] =
     for {
       url <- ZIO.fromEither(URL.fromString(url))
@@ -132,7 +132,7 @@ object Client {
     method: Method,
     url: URL,
     headers: Headers,
-    content: HttpData[Any, Nothing],
+    content: HttpData,
   ): ZIO[EventLoopGroup with ChannelFactory, Throwable, ClientResponse] =
     request(ClientParams(method, url, headers, content))
 
@@ -151,7 +151,7 @@ object Client {
     method: Method,
     url: URL,
     getHeaders: Headers = Headers.empty,
-    data: HttpData[Any, Nothing] = HttpData.empty,
+    data: HttpData = HttpData.empty,
     private val channelContext: ChannelHandlerContext = null,
   ) extends HeaderExtension[ClientParams] { self =>
 

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -206,9 +206,9 @@ private[zhttp] final case class Handler[R](
   /**
    * Writes Binary Stream data to the Channel
    */
-  private def writeStreamContent[A](
-    stream: ZStream[R, Throwable, ByteBuf],
-  )(implicit ctx: Ctx): ZIO[R, Throwable, Unit] = {
+  private def writeStreamContent(
+    stream: ZStream[Any, Throwable, ByteBuf],
+  )(implicit ctx: Ctx): ZIO[Any, Throwable, Unit] = {
     for {
       _ <- stream.foreach(c => UIO(ctx.writeAndFlush(c)))
       _ <- ChannelFuture.unit(ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT))

--- a/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
@@ -31,11 +31,11 @@ object GetBodyAsStringSpec extends DefaultRunnableSpec {
       }
     } +
       test("should map bytes to default utf-8 if no charset given") {
-        val data                            = Chunk.fromArray("abc".getBytes())
-        val content: HttpData[Any, Nothing] = HttpData.BinaryChunk(data)
-        val request                         = Client.ClientParams(Method.GET, URL(Path("/")), data = content)
-        val encoded                         = request.getBodyAsString
-        val actual                          = Option(new String(data.toArray, HTTP_CHARSET))
+        val data    = Chunk.fromArray("abc".getBytes())
+        val content = HttpData.BinaryChunk(data)
+        val request = Client.ClientParams(Method.GET, URL(Path("/")), data = content)
+        val encoded = request.getBodyAsString
+        val actual  = Option(new String(data.toArray, HTTP_CHARSET))
         assert(actual)(equalTo(encoded))
       },
   )

--- a/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
@@ -11,7 +11,7 @@ import zio.{Chunk, ZIO}
 import java.io.File
 
 object HttpGen {
-  def clientParams[R](dataGen: Gen[R, HttpData[Any, Nothing]]): Gen[Random with Sized with R, ClientParams] =
+  def clientParams[R](dataGen: Gen[R, HttpData]) =
     for {
       method  <- HttpGen.method
       url     <- HttpGen.url
@@ -45,7 +45,7 @@ object HttpGen {
     value <- Gen.alphaNumericStringBounded(1, 4)
   } yield (key, value)
 
-  def httpData[R](gen: Gen[R, List[String]]): Gen[R, HttpData[Any, Nothing]] =
+  def httpData[R](gen: Gen[R, List[String]]): Gen[R, HttpData] =
     for {
       list <- gen
       cnt  <- Gen
@@ -86,7 +86,7 @@ object HttpGen {
     ),
   )
 
-  def nonEmptyHttpData[R](gen: Gen[R, List[String]]): Gen[R, HttpData[Any, Nothing]] =
+  def nonEmptyHttpData[R](gen: Gen[R, List[String]]): Gen[R, HttpData] =
     for {
       list <- gen
       cnt  <- Gen

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -13,7 +13,6 @@ import zio.test.TestAspect._
 import zio.test._
 
 import java.io.File
-import java.nio.file.Paths
 
 object ServerSpec extends HttpRunnableSpec(8088) {
 
@@ -157,10 +156,9 @@ object ServerSpec extends HttpRunnableSpec(8088) {
           assertM(res)(isSome(equalTo(value)))
         }
       } +
-      testM("file-streaming") {
-        val path = getClass.getResource("/TestFile.txt").getPath
-        val res  = Http.fromData(HttpData.fromStream(ZStream.fromFile(Paths.get(path)))).requestBodyAsString()
-        assertM(res)(containsString("abc"))
+      testM("streaming") {
+        val res = Http.fromStream(ZStream("a", "b", "c")).requestBodyAsString()
+        assertM(res)(equalTo("abc"))
       } +
       suite("html") {
         testM("body") {

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -13,6 +13,7 @@ import zio.test.TestAspect._
 import zio.test._
 
 import java.io.File
+import java.nio.file.Paths
 
 object ServerSpec extends HttpRunnableSpec(8088) {
 
@@ -156,9 +157,14 @@ object ServerSpec extends HttpRunnableSpec(8088) {
           assertM(res)(isSome(equalTo(value)))
         }
       } +
-      testM("streaming") {
+      testM("text streaming") {
         val res = Http.fromStream(ZStream("a", "b", "c")).requestBodyAsString()
         assertM(res)(equalTo("abc"))
+      } +
+      testM("file-streaming") {
+        val path = getClass.getResource("/TestFile.txt").getPath
+        val res  = Http.fromStream(ZStream.fromFile(Paths.get(path))).requestBodyAsString()
+        assertM(res)(equalTo("abc\nfoo"))
       } +
       suite("html") {
         testM("body") {


### PR DESCRIPTION
HttpData was unnecessary complex with type-parameters. This also help in our final goal of ultimately removing type-params from Response.

**Feature**
- Added `fromStream` operator to `Http`