### PR TITLE
File handler improvements

### DIFF
--- a/example/src/main/scala/example/FileStreaming.scala
+++ b/example/src/main/scala/example/FileStreaming.scala
@@ -1,6 +1,6 @@
 package example
 
-import zhttp.http.{HttpData, Method, Response, _}
+import zhttp.http.{HttpData, Method, _}
 import zhttp.service.Server
 import zio.stream.ZStream
 import zio.{App, ExitCode, URIO}
@@ -16,16 +16,19 @@ object FileStreaming extends App {
 
   // Uses netty's capability to write file content to the Channel
   // Content-type response headers are automatically identified and added
-  // Does not use Chunked transfer encoding
-  val videoFileContent = HttpData.fromFile(new File("src/main/resources/TestVideoFile.mp4"))
-  val textFileContent  = HttpData.fromFile(new File("src/main/resources/TestFile.txt"))
+  // Does not use chunked transfer encoding
+
+  val videoFileHttp       = Http.fromFile(new File("src/main/resources/TestVideoFile.mp4"))
+  val textFileHttp        = Http.fromFile(new File("src/main/resources/TestFile.txt"))
+  val nonExistentFilePath = Http.fromFile(new File("src/main/resources/NonExistent.txt"))
 
   // Create HTTP route
-  val app = Http.collect[Request] {
-    case Method.GET -> !! / "health" => Response.ok
-    case Method.GET -> !! / "file"   => Response(data = content)
-    case Method.GET -> !! / "video"  => Response(data = videoFileContent)
-    case Method.GET -> !! / "text"   => Response(data = textFileContent)
+  val app = Http.collectHttp[Request] {
+    case Method.GET -> !! / "health" => Http.ok
+    case Method.GET -> !! / "file"   => Http.fromData(content)
+    case Method.GET -> !! / "video"  => videoFileHttp
+    case Method.GET -> !! / "text"   => textFileHttp
+    case Method.GET -> !! / "error"  => nonExistentFilePath
   }
 
   // Run it like any simple app

--- a/zio-http/src/main/scala/zhttp/http/HttpData.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpData.scala
@@ -47,6 +47,7 @@ sealed trait HttpData[-R, +E] { self =>
           .fold(Unpooled.compositeBuffer())((c, b) => c.addComponent(b))
       case HttpData.File(file)           =>
         effectBlocking {
+          // The method ensures that the file is closed when all bytes have been read or an I/O error, or other runtime exception, is thrown.
           val fileContent = Files.readAllBytes(file.toPath)
           Unpooled.copiedBuffer(fileContent)
         }

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -78,6 +78,7 @@ final case class Response[-R, +E] private (
       case HttpData.Empty               => Unpooled.EMPTY_BUFFER
       case HttpData.File(file)          =>
         jHeaders.set(HttpHeaderNames.CONTENT_TYPE, Files.probeContentType(file.toPath))
+        jHeaders.set(HttpHeaderNames.CONTENT_LENGTH, file.length())
         null
     }
 

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -145,6 +145,15 @@ object ServerSpec extends HttpRunnableSpec(8088) {
             .map(_.getOrElse("Content type header not found."))
         assertM(res)(equalTo("text/plain"))
       } +
+      testM("content-length header on file response") {
+        val file = new File(getClass.getResource("/TestFile.txt").getPath)
+        val res  =
+          Http
+            .fromFile(file)
+            .requestHeaderValueByName()(HttpHeaderNames.CONTENT_LENGTH)
+            .map(_.getOrElse(-1))
+        assertM(res)(equalTo(32))
+      } +
       testM("status") {
         checkAllM(HttpGen.status) { case (status) =>
           val res = Http.status(status).requestStatus()

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -155,7 +155,7 @@ object ServerSpec extends HttpRunnableSpec(8088) {
         assertM(res)(equalTo(32))
       } +
       testM("Internal Server Error on non-existent file") {
-        val file = new File(getClass.getResource("/NonExistentFile.txt").getPath)
+        val file = new File("NonExistentFile.txt")
         val res  = Http
           .fromFile(file)
           .requestStatus()

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -154,6 +154,13 @@ object ServerSpec extends HttpRunnableSpec(8088) {
             .map(_.getOrElse(-1))
         assertM(res)(equalTo(32))
       } +
+      testM("Internal Server Error on non-existent file") {
+        val file = new File(getClass.getResource("/NonExistentFile.txt").getPath)
+        val res  = Http
+          .fromFile(file)
+          .requestStatus()
+        assertM(res)(equalTo(Status.INTERNAL_SERVER_ERROR))
+      } +
       testM("status") {
         checkAllM(HttpGen.status) { case (status) =>
           val res = Http.status(status).requestStatus()


### PR DESCRIPTION
This is a follow-up to [#706](https://github.com/dream11/zio-http/pull/706) 
The `RandomAccessFile` created as part of [unsafeWriteFileContent](https://github.com/dream11/zio-http/blob/main/zio-http/src/main/scala/zhttp/service/Handler.scala#L221) was not properly closed.

