### PR TITLE
Refactor: Remove error type from SocketApp

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -170,13 +170,13 @@ object Response {
   /**
    * Creates a socket response using an app
    */
-  def socket[R, E](app: SocketApp[R, E]): Response[R, E] =
+  def socket[R, E](app: SocketApp[R]): Response[R, E] =
     Response(Status.SWITCHING_PROTOCOLS, Headers.empty, HttpData.empty, Attribute(socketApp = Option(app)))
 
   /**
    * Creates a new WebSocket Response
    */
-  def socket[R, E](ss: Socket[R, E, WebSocketFrame, WebSocketFrame]): Response[R, E] =
+  def socket[R](ss: Socket[R, Throwable, WebSocketFrame, WebSocketFrame]): Response[R, Nothing] =
     SocketApp(ss).asResponse
 
   /**
@@ -198,7 +198,7 @@ object Response {
    */
 
   private[zhttp] final case class Attribute[-R, +E](
-    socketApp: Option[SocketApp[R, E]] = None,
+    socketApp: Option[SocketApp[R]] = None,
     memoize: Boolean = false,
     serverTime: Boolean = false,
     encoded: Option[(Response[R, E], HttpResponse)] = None,
@@ -210,7 +210,7 @@ object Response {
 
     def withServerTime: Attribute[R, E] = self.copy(serverTime = true)
 
-    def withSocketApp[R1 <: R, E1 >: E](app: SocketApp[R1, E1]): Attribute[R1, E1] = self.copy(socketApp = Option(app))
+    def withSocketApp[R1 <: R](app: SocketApp[R1]): Attribute[R1, E] = self.copy(socketApp = Option(app))
   }
 
   object Attribute {

--- a/zio-http/src/main/scala/zhttp/service/server/ServerSocketHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerSocketHandler.scala
@@ -16,7 +16,7 @@ import zio.stream.ZStream
  */
 final case class ServerSocketHandler[R](
   zExec: HttpRuntime[R],
-  ss: SocketApp[R, Throwable],
+  ss: SocketApp[R],
 ) extends SimpleChannelInboundHandler[JWebSocketFrame] {
 
   /**

--- a/zio-http/src/main/scala/zhttp/socket/Conversion.scala
+++ b/zio-http/src/main/scala/zhttp/socket/Conversion.scala
@@ -5,5 +5,5 @@ import zhttp.http.Response
 trait Conversion {
   import scala.language.implicitConversions
 
-  implicit def asResponse[R, E](app: SocketApp[R, E]): Response[R, E] = app.asResponse
+  implicit def asResponse[R, E](app: SocketApp[R]): Response[R, E] = app.asResponse
 }


### PR DESCRIPTION
SocketApp doesn't provide a way  to `catch` errors. So adding an additional type-param for error doesn't add much value.