### PR TITLE
Disable benchmarks comment on fork pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
 
   runBenchMarks:
     name: Benchmarks
-    if: ${{ github.event_name == 'pull_request'}}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}
     strategy:
       matrix:
         os: [centos]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
 
   runBenchMarks:
     name: Benchmarks
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}
+    if: ${{ github.event_name == 'pull_request'}}
     strategy:
       matrix:
         os: [centos]
@@ -259,15 +259,15 @@ jobs:
         run: |
           cp ./zio-http/example/src/main/scala/example/PlainTextBenchmarkServer.scala ./FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
           cd ./FrameworkBenchMarks
-          echo ${{github.event.pull_request.head.sha}}
-          sed -i "s/---COMMIT_SHA---/${{github.event.pull_request.head.sha}}/g" frameworks/Scala/zio-http/build.sbt
+          sed -i "s/---COMMIT_SHA---/${{github.event.pull_request.head.repo.owner.login}}\/zio-http.git#${{github.event.pull_request.head.sha}}/g" frameworks/Scala/zio-http/build.sbt
           ./tfb  --test zio-http | tee result
           RESULT_REQUEST=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "requests/sec: [0-9]+.[0-9]+")
           RESULT_CONCURRENCY=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "concurrency: [0-9]+")
           echo ::set-output name=request_result::$(echo $RESULT_REQUEST)
           echo ::set-output name=concurrency_result::$(echo $RESULT_CONCURRENCY)
 
-      - uses: peter-evans/commit-comment@v1
+      - if: ${{github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}
+        uses: peter-evans/commit-comment@v1
         with:
           sha: ${{github.event.pull_request.head.sha}}
           body: |

--- a/project/BenchmarkWorkFlow.scala
+++ b/project/BenchmarkWorkFlow.scala
@@ -7,7 +7,9 @@ object BenchmarkWorkFlow {
       id = "runBenchMarks",
       name = "Benchmarks",
       oses = List("centos"),
-      cond = Some("${{ github.event_name == 'pull_request'}}"),
+      cond = Some(
+        "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}",
+      ),
       steps = List(
         WorkflowStep.Run(
           env = Map("GITHUB_TOKEN" -> "${{secrets.ACTIONS_PAT}}"),

--- a/project/BenchmarkWorkFlow.scala
+++ b/project/BenchmarkWorkFlow.scala
@@ -8,7 +8,7 @@ object BenchmarkWorkFlow {
       name = "Benchmarks",
       oses = List("centos"),
       cond = Some(
-        "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}",
+        "${{ github.event_name == 'pull_request'}}",
       ),
       steps = List(
         WorkflowStep.Run(
@@ -36,8 +36,7 @@ object BenchmarkWorkFlow {
           commands = List(
             "cp ./zio-http/example/src/main/scala/example/PlainTextBenchmarkServer.scala ./FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala",
             "cd ./FrameworkBenchMarks",
-            "echo ${{github.event.pull_request.head.sha}}",
-            """sed -i "s/---COMMIT_SHA---/${{github.event.pull_request.head.sha}}/g" frameworks/Scala/zio-http/build.sbt""",
+            """sed -i "s/---COMMIT_SHA---/${{github.event.pull_request.head.repo.owner.login}}\/zio-http.git#${{github.event.pull_request.head.sha}}/g" frameworks/Scala/zio-http/build.sbt""",
             "./tfb  --test zio-http | tee result",
             """RESULT_REQUEST=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "requests/sec: [0-9]+.[0-9]+")""",
             """RESULT_CONCURRENCY=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "concurrency: [0-9]+")""",
@@ -47,6 +46,9 @@ object BenchmarkWorkFlow {
         ),
         WorkflowStep.Use(
           ref = UseRef.Public("peter-evans", "commit-comment", "v1"),
+          cond = Some(
+            "${{github.event.pull_request.head.repo.full_name == 'dream11/zio-http'}}",
+          ),
           params = Map(
             "sha"  -> "${{github.event.pull_request.head.sha}}",
             "body" ->


### PR DESCRIPTION
### This workflow will run the benchmarks on forks also, but will skip commenting on PR. For forks You can still see the benchmark results in the job logs.
This PR will protect, Benchmark results to be published on fork PR.

*This is done to make sure the fork PR's doesn't show failure due to benchmark step*
Fixes #619 