### PR TITLE
Fix: HasHeader bug

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
@@ -18,7 +18,7 @@ trait HeaderChecks[+A] { self: HeaderExtension[A] with A =>
 
   final def hasHeader(name: CharSequence, value: CharSequence): Boolean =
     getHeaderValue(name) match {
-      case Some(v1) => v1 == value.toString
+      case Some(v1) => v1.contentEquals(value)
       case None     => false
     }
 

--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
@@ -18,7 +18,7 @@ trait HeaderChecks[+A] { self: HeaderExtension[A] with A =>
 
   final def hasHeader(name: CharSequence, value: CharSequence): Boolean =
     getHeaderValue(name) match {
-      case Some(v1) => v1 == value
+      case Some(v1) => v1 == value.toString
       case None     => false
     }
 

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -61,6 +61,12 @@ object HeaderSpec extends DefaultRunnableSpec {
             assert(actual)(isNone)
           },
       ) +
+      suite("hasHeader")(
+        test("should return true if content-type is application/json") {
+          val actual = contentTypeJson.hasHeader(HeaderNames.contentType, HeaderValues.applicationJson)
+          assert(actual)(isTrue)
+        },
+      ) +
       suite("hasJsonContentType")(
         test("should return true if content-type is application/json") {
           val actual = contentTypeJson.hasJsonContentType


### PR DESCRIPTION
Reason of the issue: 
CharSequence interface does not refine the general contracts of the equals and hashCode methods. The result of testing two objects that implement CharSequence for equality is therefore, in general, undefined. Each object may be implemented by a different class, and there is no guarantee that each class will be capable of testing its instances for equality with those of the other. It is therefore inappropriate to use arbitrary CharSequence instances as elements in a set or as keys in a map.
(from JDK doc)

fixes #834 