### PR TITLE
BenchMarks: Disable flow Control

### DIFF
--- a/example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -36,6 +36,7 @@ object Main extends App {
       Server.error(_ => UIO.unit) ++
       Server.keepAlive ++
       Server.disableLeakDetection ++
-      Server.consolidateFlush
+      Server.consolidateFlush ++
+      Server.disableFlowControl
 
 }

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -129,7 +129,7 @@ object Server {
     acceptContinue: Boolean = false,
     keepAlive: Boolean = false,
     consolidateFlush: Boolean = false,
-    flowControl: Boolean = false,
+    flowControl: Boolean = true,
   )
 
   /**


### PR DESCRIPTION
Currently flow control is always set to false, there is no way to enable it.