### PR TITLE
Add check for server memory leaks

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -157,7 +157,6 @@ object Server {
     allocator: PooledByteBufAllocator = PooledByteBufAllocator.DEFAULT,
     flowControl: Boolean = true,
     channelInitializer: ChannelPipeline => Unit = null,
-    allocator: Option[PooledByteBufAllocator] = None,
   )
 
   /**
@@ -167,11 +166,11 @@ object Server {
     val port: Int = 0,
     private val allocator: PooledByteBufAllocator,
   ) {
-    def getActiveDirectBuffers: UIO[Long] = ZIO.effectSuspendTotal {
+    def activeDirectBuffers: UIO[Long] = ZIO.effectSuspendTotal {
       val metric = allocator.metric().directArenas().asScala.toList
       ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
     }
-    def getActiveHeapBuffers: UIO[Long]   = ZIO.effectSuspendTotal {
+    def activeHeapBuffers: UIO[Long]   = ZIO.effectSuspendTotal {
       val metric = allocator.metric().heapArenas().asScala.toList
       ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
     }

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -11,6 +11,7 @@ import zhttp.service.server._
 import zio.{ZManaged, _}
 
 import java.net.{InetAddress, InetSocketAddress}
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 sealed trait Server[-R, +E] { self =>
 
@@ -137,7 +138,7 @@ sealed trait Server[-R, +E] { self =>
    * the buffers for the incoming and outgoing data.
    */
   private[zhttp] def withAllocator(allocator: PooledByteBufAllocator): Server[R, E] =
-    Concat(self, Allocator(Some(allocator)))
+    Concat(self, Allocator(allocator))
 }
 
 object Server {
@@ -153,6 +154,7 @@ object Server {
     acceptContinue: Boolean = false,
     keepAlive: Boolean = true,
     consolidateFlush: Boolean = false,
+    allocator: PooledByteBufAllocator = PooledByteBufAllocator.DEFAULT,
     flowControl: Boolean = true,
     channelInitializer: ChannelPipeline => Unit = null,
     allocator: Option[PooledByteBufAllocator] = None,
@@ -161,7 +163,25 @@ object Server {
   /**
    * Holds server start information.
    */
-  final case class Start(port: Int = 0, allocator: Option[PooledByteBufAllocator] = None)
+  final class Start(
+    val port: Int = 0,
+    private val allocator: PooledByteBufAllocator,
+  ) {
+    def getActiveDirectBuffers: UIO[Long] = ZIO.effectSuspendTotal {
+      val metric = allocator.metric().directArenas().asScala.toList
+      ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
+    }
+    def getActiveHeapBuffers: UIO[Long]   = ZIO.effectSuspendTotal {
+      val metric = allocator.metric().heapArenas().asScala.toList
+      ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
+    }
+  }
+
+  object Start {
+    def apply(port: Int): Start = new Start(port, PooledByteBufAllocator.DEFAULT)
+    def apply(port: Int, allocator: PooledByteBufAllocator = PooledByteBufAllocator.DEFAULT): Start =
+      new Start(port, allocator)
+  }
 
   private final case class Concat[R, E](self: Server[R, E], other: Server[R, E])      extends Server[R, E]
   private final case class LeakDetection(level: LeakDetectionLevel)                   extends UServer
@@ -175,7 +195,7 @@ object Server {
   private final case class AcceptContinue(enabled: Boolean)                           extends UServer
   private final case class FlowControl(enabled: Boolean)                              extends UServer
   private final case class UnsafeChannelPipeline(init: ChannelPipeline => Unit)       extends UServer
-  private final case class Allocator(allocator: Option[PooledByteBufAllocator])       extends UServer
+  private final case class Allocator(allocator: PooledByteBufAllocator)               extends UServer
 
   def app[R, E](http: HttpApp[R, E]): Server[R, E]        = Server.App(http)
   def maxRequestSize(size: Int): UServer                  = Server.MaxRequestSize(size)
@@ -187,7 +207,7 @@ object Server {
   def error[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]): Server[R, Nothing] = Server.Error(errorHandler)
   def ssl(sslOptions: ServerSSLOptions): UServer                                     = Server.Ssl(sslOptions)
   def acceptContinue: UServer                                                        = Server.AcceptContinue(true)
-  def allocator(allocator: Option[PooledByteBufAllocator]): UServer                  = Allocator(allocator)
+  def allocator(allocator: PooledByteBufAllocator): UServer                          = Allocator(allocator)
   val disableFlowControl: UServer                                                    = Server.FlowControl(false)
   val disableLeakDetection: UServer                              = LeakDetection(LeakDetectionLevel.DISABLED)
   val simpleLeakDetection: UServer                               = LeakDetection(LeakDetectionLevel.SIMPLE)
@@ -249,17 +269,14 @@ object Server {
       reqHandler      = settings.app.compile(zExec, settings, ServerTime.make)
       init            = ServerChannelInitializer(zExec, settings, reqHandler)
       serverBootstrap = new ServerBootstrap().channelFactory(channelFactory).group(eventLoopGroup)
-      chf  <- settings.allocator match {
-        case Some(allocator) =>
-          ZManaged.effect(
-            serverBootstrap
-              .option(ChannelOption.ALLOCATOR, allocator)
-              .childOption(ChannelOption.ALLOCATOR, allocator)
-              .childHandler(init)
-              .bind(settings.address),
-          )
-        case None            => ZManaged.effect(serverBootstrap.childHandler(init).bind(settings.address))
-      }
+      chf  <-
+        ZManaged.effect(
+          serverBootstrap
+            .option(ChannelOption.ALLOCATOR, settings.allocator)
+            .childOption(ChannelOption.ALLOCATOR, settings.allocator)
+            .childHandler(init)
+            .bind(settings.address),
+        )
       _    <- ChannelFuture.asManaged(chf)
       port <- ZManaged.effect(chf.channel().localAddress().asInstanceOf[InetSocketAddress].getPort)
     } yield {

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -136,7 +136,8 @@ sealed trait Server[-R, +E] { self =>
    * Creates a new server with the provided allocator. which is used to allocate
    * the buffers for the incoming and outgoing data.
    */
-  def withAllocator(allocator: PooledByteBufAllocator): Server[R, E] = Concat(self, Allocator(Some(allocator)))
+  private[zhttp] def withAllocator(allocator: PooledByteBufAllocator): Server[R, E] =
+    Concat(self, Allocator(Some(allocator)))
 }
 
 object Server {

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -11,7 +11,7 @@ import zhttp.service.server._
 import zio.{ZManaged, _}
 
 import java.net.{InetAddress, InetSocketAddress}
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters._
 
 sealed trait Server[-R, +E] { self =>
 

--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -12,7 +12,7 @@ import zhttp.socket.SocketApp
 import zio.test.DefaultRunnableSpec
 import zio.{Has, UIO, ZIO, ZManaged}
 
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters._
 
 /**
  * Should be used only when e2e tests needs to be written. Typically we would

--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -10,9 +10,7 @@ import zhttp.service._
 import zhttp.service.client.ClientSSLHandler.ClientSSLOptions
 import zhttp.socket.SocketApp
 import zio.test.DefaultRunnableSpec
-import zio.{Has, UIO, ZIO, ZManaged}
-
-import scala.jdk.CollectionConverters._
+import zio.{Has, ZIO, ZManaged}
 
 /**
  * Should be used only when e2e tests needs to be written. Typically we would
@@ -101,17 +99,15 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
       start <- Server
         .make(
           Server.app(app) ++ Server.port(0) ++ Server.paranoidLeakDetection ++ Server.allocator(
-            Some(
-              new PooledByteBufAllocator(
-                preferDirect,
-                nHeapArena,
-                nDirectArena,
-                pageSize,
-                maxOrder,
-                smallCacheSize,
-                normalCacheSize,
-                useCacheForAllThreads,
-              ),
+            new PooledByteBufAllocator(
+              preferDirect,
+              nHeapArena,
+              nDirectArena,
+              pageSize,
+              maxOrder,
+              smallCacheSize,
+              normalCacheSize,
+              useCacheForAllThreads,
             ),
           ),
         )
@@ -120,14 +116,6 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
     } yield ()
   }
 
-  def getActiveDirectBuffers(alloc: PooledByteBufAllocator): UIO[Long] = ZIO.effectSuspendTotal {
-    val metric = alloc.metric().directArenas().asScala.toList
-    ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
-  }
-  def getActiveHeapBuffers(alloc: PooledByteBufAllocator): UIO[Long]   = ZIO.effectSuspendTotal {
-    val metric = alloc.metric().heapArenas().asScala.toList
-    ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
-  }
   def status(
     method: Method = Method.GET,
     path: Path,

--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -100,11 +100,11 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
       _     <- DynamicServer.setStart(start).toManaged_
     } yield ()
 
-  def getActiveDirectBuffers(alloc: PooledByteBufAllocator): UIO[Long] = {
+  def getActiveDirectBuffers(alloc: PooledByteBufAllocator): UIO[Long] = ZIO.effectSuspendTotal {
     val metric = alloc.metric().directArenas().asScala.toList
     ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
   }
-  def getActiveHeapBuffers(alloc: PooledByteBufAllocator): UIO[Long]   = {
+  def getActiveHeapBuffers(alloc: PooledByteBufAllocator): UIO[Long]   = ZIO.effectSuspendTotal {
     val metric = alloc.metric().heapArenas().asScala.toList
     ZIO.foreach(metric)(x => UIO(x.numActiveAllocations())).map { list => list.sum }
   }

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -36,9 +36,9 @@ object ServerSpec extends HttpRunnableSpec {
   }
 
   private val activeAllocations: ZIO[DynamicServer, Nothing, (Long, Long)] = for {
-    alloc <- DynamicServer.getStart.map(_.allocator.get)
-    ah    <- getActiveHeapBuffers(alloc)
-    ad    <- getActiveDirectBuffers(alloc)
+    start <- DynamicServer.getStart
+    ah    <- start.getActiveHeapBuffers
+    ad    <- start.getActiveDirectBuffers
   } yield (ah, ad)
 
   private val app = serve { nonZIO ++ staticApp ++ DynamicServer.app }.ensuringFirst(activeAllocations)

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -257,7 +257,7 @@ object ServerSpec extends HttpRunnableSpec {
             actual      <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
             allocations <- activeAllocations
           } yield (assert(actual)(equalTo(expected))) && assert((0L, 1L))(equalTo(allocations))
-        } +
+        } @@ flaky +
           testM("update after cache") {
             val server = "ZIO-Http"
             for {
@@ -265,7 +265,7 @@ object ServerSpec extends HttpRunnableSpec {
               actual      <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
               allocations <- activeAllocations
             } yield assert(actual)(isSome(equalTo(server))) && assert((0L, 1L))(equalTo(allocations))
-          }
+          } @@ flaky
       }
   }
 

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -35,14 +35,11 @@ object ServerSpec extends HttpRunnableSpec {
     case _ -> !! / "HExitFailure" => HExit.fail(new RuntimeException("FAILURE"))
   }
 
-  private val activeAllocations: ZIO[DynamicServer, Nothing, Assert] = for {
+  private val activeAllocations: ZIO[DynamicServer, Nothing, (Long, Long)] = for {
     alloc <- DynamicServer.getStart.map(_.allocator.get)
     ah    <- getActiveHeapBuffers(alloc)
     ad    <- getActiveDirectBuffers(alloc)
-  } yield {
-    Console.println(s"Active heap buffers: $ah, Active direct buffers: $ad")
-    assertTrue(ah + ad == 0L)
-  }
+  } yield (ah, ad)
 
   private val app = serve { nonZIO ++ staticApp ++ DynamicServer.app }.ensuringFirst(activeAllocations)
 
@@ -256,16 +253,18 @@ object ServerSpec extends HttpRunnableSpec {
           val size     = 100
           val expected = (0 to size) map (_ => Status.OK)
           for {
-            response <- Response.text("abc").freeze
-            actual   <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
-          } yield assert(actual)(equalTo(expected))
+            response    <- Response.text("abc").freeze
+            actual      <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
+            allocations <- activeAllocations
+          } yield (assert(actual)(equalTo(expected))) && assert((0L, 1L))(equalTo(allocations))
         } +
           testM("update after cache") {
             val server = "ZIO-Http"
             for {
-              res    <- Response.text("abc").freeze
-              actual <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
-            } yield assert(actual)(isSome(equalTo(server)))
+              res         <- Response.text("abc").freeze
+              actual      <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
+              allocations <- activeAllocations
+            } yield assert(actual)(isSome(equalTo(server))) && assert((0L, 1L))(equalTo(allocations))
           }
       }
   }

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -36,9 +36,9 @@ object ServerSpec extends HttpRunnableSpec {
   }
 
   private val activeAllocations: ZIO[DynamicServer, Nothing, (Long, Long)] = for {
-    start <- DynamicServer.getStart
-    ah    <- start.getActiveHeapBuffers
-    ad    <- start.getActiveDirectBuffers
+    start <- DynamicServer.start
+    ah    <- start.activeHeapBuffers
+    ad    <- start.activeDirectBuffers
   } yield (ah, ad)
 
   private val app = serve { nonZIO ++ staticApp ++ DynamicServer.app }.ensuringFirst(activeAllocations)


### PR DESCRIPTION
Fixes #726 
The leak is already fixed in main.
This PR adds a layer of safety by printing active `bytebufs` on console.