### PR TITLE
Indexed fields cookie changes

### DIFF
--- a/example/src/main/scala/example/CookieServerSide.scala
+++ b/example/src/main/scala/example/CookieServerSide.scala
@@ -1,6 +1,6 @@
 package example
 
-import zhttp.http.{Cookie, Method, Response, _}
+import zhttp.http.{CookieImpl, Method, Response, _}
 import zhttp.service.Server
 import zio.duration.durationInt
 import zio.{App, ExitCode, URIO}
@@ -11,7 +11,7 @@ import zio.{App, ExitCode, URIO}
 object CookieServerSide extends App {
 
   // Setting cookies with an expiry of 5 days
-  private val cookie = Cookie("key", "value").withMaxAge(5 days)
+  private val cookie = CookieImpl("key", "value").withMaxAge(5 days)
   val res            = Response.ok.addCookie(cookie)
 
   private val app = Http.collect[Request] {

--- a/example/src/main/scala/example/SignCookies.scala
+++ b/example/src/main/scala/example/SignCookies.scala
@@ -1,6 +1,6 @@
 package example
 
-import zhttp.http.{Cookie, Method, Response, _}
+import zhttp.http.{CookieImpl, Method, Response, _}
 import zhttp.service.Server
 import zio.duration.durationInt
 import zio.{App, ExitCode, URIO}
@@ -11,7 +11,7 @@ import zio.{App, ExitCode, URIO}
 object SignCookies extends App {
 
   // Setting cookies with an expiry of 5 days
-  private val cookie = Cookie("key", "hello").withMaxAge(5 days)
+  private val cookie = CookieImpl("key", "hello").withMaxAge(5 days)
 
   private val app = Http.collect[Request] { case Method.GET -> !! / "cookie" =>
     Response.ok.addCookie(cookie.sign("secret"))

--- a/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
@@ -18,9 +18,10 @@ object CookieSpec extends DefaultRunnableSpec {
       suite("request cookies") {
         testM("encode/decode multiple cookies with ZIO Test Gen") {
           checkAll(for {
-            name         <- Gen.anyString
-            content      <- Gen.anyString
-            cookieList   <- Gen.listOf(Gen.const(Cookie(name, content)))
+            name         <- Gen.anyString.filter(s => !s.isEmpty)
+            content      <- Gen.anyString.filter(s => !s.isEmpty)
+            cookieList   <- Gen
+              .listOf(Gen.const(Cookie(name, content)))
             cookieString <- Gen.const(cookieList.map(x => s"${x.name}=${x.content}").mkString(";"))
           } yield (cookieList, cookieString)) { case (cookies, message) =>
             assert(Cookie.decodeRequestCookie(message))(isSome(equalTo(cookies)))


### PR DESCRIPTION
This PR tries to implement a fields indexed cookie view to avoid allocation memory whenever possible.
It was suggested by @tusharmath in a previous PR (#576).

* It defines a Cookie trait with the basic properties and method signatures.
* CookieImpl as a case class to instantiate a cookie with all of his fields when necessary. Cookie object `apply` method invokes this case class.
* A CookieView that takes a raw string cookie value. It postpones memory allocation (of each field) until needed.
* CookieBuilder trait to allow mutate a cookie.

I'm not really sure about naming anyway, CookieImpl does not convince me at all.

This are the CookieDecodeBenchmark results (it's not very fair to compare them ...).

Main branch:
```
[info] Result "zhttp.benchmarks.CookieDecodeBenchmark.benchmarkApp":
[info]   1910631,365 ±(99.9%) 88274,142 ops/s [Average]
[info]   (min, avg, max) = (1786687,328, 1910631,365, 2041812,681), stdev = 82571,687
[info]   CI (99.9%): [1822357,224, 1998905,507] (assumes normal distribution)
[info] # Run complete. Total time: 00:05:03
```

Indexed field cookie:
```
[info] Result "zhttp.benchmarks.CookieDecodeBenchmark.benchmarkApp":
[info]   4714328,763 ±(99.9%) 245711,977 ops/s [Average]
[info]   (min, avg, max) = (4501769,424, 4714328,763, 5239183,243), stdev = 229839,136
[info]   CI (99.9%): [4468616,786, 4960040,740] (assumes normal distribution)
[info] # Run complete. Total time: 00:05:03
```