### PR TITLE
refactor: move java scheme generators to SchemeSpec

### DIFF
--- a/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
@@ -1,9 +1,13 @@
 package zhttp.http
 
+import io.netty.handler.codec.http.HttpScheme
+import io.netty.handler.codec.http.websocketx.WebSocketScheme
 import zhttp.internal.HttpGen
 import zio.test._
 
 object SchemeSpec extends DefaultRunnableSpec {
+  override def spec = schemeSpec
+
   def schemeSpec = suite("SchemeSpec") {
     testM("string") {
       checkAll(HttpGen.scheme) { scheme =>
@@ -11,12 +15,12 @@ object SchemeSpec extends DefaultRunnableSpec {
       }
     } +
       testM("java http scheme") {
-        checkAll(HttpGen.jHttpScheme) { jHttpScheme =>
+        checkAll(jHttpScheme) { jHttpScheme =>
           assertTrue(Scheme.fromJScheme(jHttpScheme).flatMap(_.toJHttpScheme).get == jHttpScheme)
         }
       } +
       testM("java websocket scheme") {
-        checkAll(HttpGen.jWebSocketScheme) { jWebSocketScheme =>
+        checkAll(jWebSocketScheme) { jWebSocketScheme =>
           assertTrue(
             Scheme.fromJScheme(jWebSocketScheme).flatMap(_.toWebSocketScheme).get == jWebSocketScheme,
           )
@@ -24,5 +28,7 @@ object SchemeSpec extends DefaultRunnableSpec {
       }
   }
 
-  override def spec = schemeSpec
+  def jHttpScheme: Gen[Any, HttpScheme] = Gen.fromIterable(List(HttpScheme.HTTP, HttpScheme.HTTPS))
+
+  def jWebSocketScheme: Gen[Any, WebSocketScheme] = Gen.fromIterable(List(WebSocketScheme.WS, WebSocketScheme.WSS))
 }

--- a/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
@@ -6,9 +6,7 @@ import zhttp.internal.HttpGen
 import zio.test._
 
 object SchemeSpec extends DefaultRunnableSpec {
-  override def spec = schemeSpec
-
-  def schemeSpec = suite("SchemeSpec") {
+  override def spec = suite("SchemeSpec") {
     testM("string") {
       checkAll(HttpGen.scheme) { scheme =>
         assertTrue(Scheme.decode(scheme.encode).get == scheme)
@@ -28,7 +26,8 @@ object SchemeSpec extends DefaultRunnableSpec {
       }
   }
 
-  def jHttpScheme: Gen[Any, HttpScheme] = Gen.fromIterable(List(HttpScheme.HTTP, HttpScheme.HTTPS))
+  private def jHttpScheme: Gen[Any, HttpScheme] = Gen.fromIterable(List(HttpScheme.HTTP, HttpScheme.HTTPS))
 
-  def jWebSocketScheme: Gen[Any, WebSocketScheme] = Gen.fromIterable(List(WebSocketScheme.WS, WebSocketScheme.WSS))
+  private def jWebSocketScheme: Gen[Any, WebSocketScheme] =
+    Gen.fromIterable(List(WebSocketScheme.WS, WebSocketScheme.WSS))
 }

--- a/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
@@ -1,8 +1,6 @@
 package zhttp.internal
 
 import io.netty.buffer.Unpooled
-import io.netty.handler.codec.http.HttpScheme
-import io.netty.handler.codec.http.websocketx.WebSocketScheme
 import zhttp.http.Scheme.{HTTP, HTTPS, WS, WSS}
 import zhttp.http.URL.Location
 import zhttp.http._
@@ -96,9 +94,7 @@ object HttpGen {
     ),
   )
 
-  def scheme: Gen[Any, Scheme]                    = Gen.fromIterable(List(HTTP, HTTPS, WS, WSS))
-  def jHttpScheme: Gen[Any, HttpScheme]           = Gen.fromIterable(List(HttpScheme.HTTP, HttpScheme.HTTPS))
-  def jWebSocketScheme: Gen[Any, WebSocketScheme] = Gen.fromIterable(List(WebSocketScheme.WS, WebSocketScheme.WSS))
+  def scheme: Gen[Any, Scheme] = Gen.fromIterable(List(HTTP, HTTPS, WS, WSS))
 
   def nonEmptyHttpData[R](gen: Gen[R, List[String]]): Gen[R, HttpData] =
     for {


### PR DESCRIPTION
cleans up changes for websocket client support