### PR TITLE
Refactor: Remove `get` prefix from Public APIs

### DIFF
--- a/example/src/main/scala/example/Authentication.scala
+++ b/example/src/main/scala/example/Authentication.scala
@@ -32,7 +32,7 @@ object Authentication extends App {
   def authenticate[R, E](fail: HttpApp[R, E], success: JwtClaim => HttpApp[R, E]): HttpApp[R, E] =
     Http
       .fromFunction[Request] {
-        _.getHeader("X-ACCESS-TOKEN")
+        _.header("X-ACCESS-TOKEN")
           .flatMap(header => jwtDecode(header._2.toString))
           .fold[HttpApp[R, E]](fail)(success)
       }

--- a/example/src/main/scala/example/HttpsClient.scala
+++ b/example/src/main/scala/example/HttpsClient.scala
@@ -30,7 +30,7 @@ object HttpsClient extends App {
 
   val program = for {
     res  <- Client.request(url, headers = headers, ssl = sslOption)
-    data <- res.getBodyAsString
+    data <- res.bodyAsString
     _    <- console.putStrLn { data }
   } yield ()
 

--- a/example/src/main/scala/example/SimpleClient.scala
+++ b/example/src/main/scala/example/SimpleClient.scala
@@ -9,7 +9,7 @@ object SimpleClient extends App {
 
   val program = for {
     res  <- Client.request(url)
-    data <- res.getBodyAsString
+    data <- res.bodyAsString
     _    <- console.putStrLn { data }
   } yield ()
 

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -22,7 +22,7 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
 
   def combineIf(cond: Boolean)(other: Headers): Headers = if (cond) Headers(self.toChunk ++ other.toChunk) else self
 
-  override def getHeaders: Headers = self
+  override def headers: Headers = self
 
   def toList: List[(String, String)] = toChunk.map { case (name, value) => (name.toString, value.toString) }.toList
 

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -179,36 +179,36 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
   /**
    * Extracts body
    */
-  final def getBody(implicit eb: IsResponse[B], ee: E <:< Throwable): Http[R, Throwable, A, Chunk[Byte]] =
-    self.getBodyAsByteBuf.mapZIO(buf => Task(Chunk.fromArray(ByteBufUtil.getBytes(buf))))
+  final def body(implicit eb: IsResponse[B], ee: E <:< Throwable): Http[R, Throwable, A, Chunk[Byte]] =
+    self.bodyAsByteBuf.mapZIO(buf => Task(Chunk.fromArray(ByteBufUtil.getBytes(buf))))
 
   /**
    * Extracts body as a string
    */
-  final def getBodyAsString(implicit eb: IsResponse[B], ee: E <:< Throwable): Http[R, Throwable, A, String] =
-    self.getBodyAsByteBuf.mapZIO(bytes => Task(bytes.toString(HTTP_CHARSET)))
+  final def bodyAsString(implicit eb: IsResponse[B], ee: E <:< Throwable): Http[R, Throwable, A, String] =
+    self.bodyAsByteBuf.mapZIO(bytes => Task(bytes.toString(HTTP_CHARSET)))
 
   /**
    * Extracts content-length from the response if available
    */
-  final def getContentLength(implicit eb: IsResponse[B]): Http[R, E, A, Option[Long]] =
-    getHeaders.map(_.getContentLength)
+  final def contentLength(implicit eb: IsResponse[B]): Http[R, E, A, Option[Long]] =
+    headers.map(_.contentLength)
 
   /**
    * Extracts the value of the provided header name.
    */
-  final def getHeaderValue(name: CharSequence)(implicit eb: IsResponse[B]): Http[R, E, A, Option[CharSequence]] =
-    getHeaders.map(_.getHeaderValue(name))
+  final def headerValue(name: CharSequence)(implicit eb: IsResponse[B]): Http[R, E, A, Option[CharSequence]] =
+    headers.map(_.headerValue(name))
 
   /**
    * Extracts the `Headers` from the type `B` if possible
    */
-  final def getHeaders(implicit eb: IsResponse[B]): Http[R, E, A, Headers] = self.map(eb.getHeaders)
+  final def headers(implicit eb: IsResponse[B]): Http[R, E, A, Headers] = self.map(eb.headers)
 
   /**
    * Extracts `Status` from the type `B` is possible.
    */
-  final def getStatus(implicit ev: IsResponse[B]): Http[R, E, A, Status] = self.map(ev.getStatus)
+  final def status(implicit ev: IsResponse[B]): Http[R, E, A, Status] = self.map(ev.status)
 
   /**
    * Transforms the output of the http app
@@ -395,11 +395,11 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
   /**
    * Extracts body as a ByteBuf
    */
-  private[zhttp] final def getBodyAsByteBuf(implicit
+  private[zhttp] final def bodyAsByteBuf(implicit
     eb: IsResponse[B],
     ee: E <:< Throwable,
   ): Http[R, Throwable, A, ByteBuf] =
-    self.widen[Throwable, B].mapZIO(eb.getBodyAsByteBuf)
+    self.widen[Throwable, B].mapZIO(eb.bodyAsByteBuf)
 }
 
 object Http {

--- a/zio-http/src/main/scala/zhttp/http/IsResponse.scala
+++ b/zio-http/src/main/scala/zhttp/http/IsResponse.scala
@@ -5,21 +5,21 @@ import zhttp.service.Client.ClientResponse
 import zio.Task
 
 sealed trait IsResponse[-A] {
-  def getBodyAsByteBuf(a: A): Task[ByteBuf]
-  def getHeaders(a: A): Headers
-  def getStatus(a: A): Status
+  def bodyAsByteBuf(a: A): Task[ByteBuf]
+  def headers(a: A): Headers
+  def status(a: A): Status
 }
 
 object IsResponse {
   implicit object serverResponse extends IsResponse[Response] {
-    def getBodyAsByteBuf(a: Response): Task[ByteBuf] = a.getBodyAsByteBuf
-    def getHeaders(a: Response): Headers             = a.headers
-    def getStatus(a: Response): Status               = a.status
+    def bodyAsByteBuf(a: Response): Task[ByteBuf] = a.bodyAsByteBuf
+    def headers(a: Response): Headers             = a.headers
+    def status(a: Response): Status               = a.status
   }
 
   implicit object clientResponse extends IsResponse[ClientResponse] {
-    def getBodyAsByteBuf(a: ClientResponse): Task[ByteBuf] = a.getBodyAsByteBuf
-    def getHeaders(a: ClientResponse): Headers             = a.headers
-    def getStatus(a: ClientResponse): Status               = a.status
+    def bodyAsByteBuf(a: ClientResponse): Task[ByteBuf] = a.bodyAsByteBuf
+    def headers(a: ClientResponse): Headers             = a.headers
+    def status(a: ClientResponse): Status               = a.status
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -11,37 +11,37 @@ trait Request extends HeaderExtension[Request] { self =>
   /**
    * Updates the headers using the provided function
    */
-  final override def updateHeaders(update: Headers => Headers): Request = self.copy(headers = update(self.getHeaders))
+  final override def updateHeaders(update: Headers => Headers): Request = self.copy(headers = update(self.headers))
 
-  def copy(method: Method = self.method, url: URL = self.url, headers: Headers = self.getHeaders): Request = {
+  def copy(method: Method = self.method, url: URL = self.url, headers: Headers = self.headers): Request = {
     val m = method
     val u = url
     val h = headers
     new Request {
       override def method: Method                     = m
       override def url: URL                           = u
-      override def getHeaders: Headers                = h
+      override def headers: Headers                   = h
       override def remoteAddress: Option[InetAddress] = self.remoteAddress
-      override private[zhttp] def getBodyAsByteBuf    = self.getBodyAsByteBuf
+      override private[zhttp] def bodyAsByteBuf       = self.bodyAsByteBuf
     }
   }
 
   /**
    * Decodes the content of request as a Chunk of Bytes
    */
-  def getBody: Task[Chunk[Byte]] =
-    getBodyAsByteBuf.flatMap(buf => Task(Chunk.fromArray(ByteBufUtil.getBytes(buf))))
+  def body: Task[Chunk[Byte]] =
+    bodyAsByteBuf.flatMap(buf => Task(Chunk.fromArray(ByteBufUtil.getBytes(buf))))
 
   /**
    * Decodes the content of request as string
    */
-  def getBodyAsString: Task[String] =
-    getBodyAsByteBuf.flatMap(buf => Task(buf.toString(getCharset)))
+  def bodyAsString: Task[String] =
+    bodyAsByteBuf.flatMap(buf => Task(buf.toString(charset)))
 
   /**
    * Gets all the headers in the Request
    */
-  def getHeaders: Headers
+  def headers: Headers
 
   /**
    * Checks is the request is a pre-flight request or not
@@ -83,7 +83,7 @@ trait Request extends HeaderExtension[Request] { self =>
    */
   def url: URL
 
-  private[zhttp] def getBodyAsByteBuf: Task[ByteBuf]
+  private[zhttp] def bodyAsByteBuf: Task[ByteBuf]
 }
 
 object Request {
@@ -103,11 +103,11 @@ object Request {
     val h  = headers
     val ra = remoteAddress
     new Request {
-      override def method: Method                                 = m
-      override def url: URL                                       = u
-      override def getHeaders: Headers                            = h
-      override def remoteAddress: Option[InetAddress]             = ra
-      override private[zhttp] def getBodyAsByteBuf: Task[ByteBuf] = data.toByteBuf
+      override def method: Method                              = m
+      override def url: URL                                    = u
+      override def headers: Headers                            = h
+      override def remoteAddress: Option[InetAddress]          = ra
+      override private[zhttp] def bodyAsByteBuf: Task[ByteBuf] = data.toByteBuf
     }
   }
 
@@ -127,11 +127,11 @@ object Request {
    * Lift request to TypedRequest with option to extract params
    */
   final class ParameterizedRequest[A](req: Request, val params: A) extends Request {
-    override def getHeaders: Headers                            = req.getHeaders
-    override def method: Method                                 = req.method
-    override def remoteAddress: Option[InetAddress]             = req.remoteAddress
-    override def url: URL                                       = req.url
-    override private[zhttp] def getBodyAsByteBuf: Task[ByteBuf] = req.getBodyAsByteBuf
+    override def headers: Headers                            = req.headers
+    override def method: Method                              = req.method
+    override def remoteAddress: Option[InetAddress]          = req.remoteAddress
+    override def url: URL                                    = req.url
+    override private[zhttp] def bodyAsByteBuf: Task[ByteBuf] = req.bodyAsByteBuf
   }
 
   object ParameterizedRequest {

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -24,7 +24,7 @@ final case class Response private (
    * Adds cookies in the response headers.
    */
   def addCookie(cookie: Cookie): Response =
-    self.copy(headers = self.getHeaders ++ Headers(HttpHeaderNames.SET_COOKIE.toString, cookie.encode))
+    self.copy(headers = self.headers ++ Headers(HttpHeaderNames.SET_COOKIE.toString, cookie.encode))
 
   /**
    * A micro-optimizations that ignores all further modifications to the response and encodes the current version into a
@@ -35,8 +35,6 @@ final case class Response private (
    */
   def freeze: UIO[Response] =
     UIO(self.copy(attribute = self.attribute.withEncodedResponse(unsafeEncode(), self)))
-
-  override def getHeaders: Headers = headers
 
   /**
    * Sets the response attributes
@@ -54,7 +52,7 @@ final case class Response private (
    * Updates the headers using the provided function
    */
   override def updateHeaders(update: Headers => Headers): Response =
-    self.copy(headers = update(self.getHeaders))
+    self.copy(headers = update(self.headers))
 
   /**
    * A more efficient way to append server-time to the response headers.
@@ -64,7 +62,7 @@ final case class Response private (
   /**
    * Extracts the body as ByteBuf
    */
-  private[zhttp] def getBodyAsByteBuf: Task[ByteBuf] = self.data.toByteBuf
+  private[zhttp] def bodyAsByteBuf: Task[ByteBuf] = self.data.toByteBuf
 
   /**
    * Encodes the Response into a Netty HttpResponse. Sets default headers such as `content-length`. For performance
@@ -74,7 +72,7 @@ final case class Response private (
   private[zhttp] def unsafeEncode(): HttpResponse = {
     import io.netty.handler.codec.http._
 
-    val jHeaders = self.getHeaders.encode
+    val jHeaders = self.headers.encode
     val jContent = self.data match {
       case HttpData.Text(text, charset) => Unpooled.wrappedBuffer(text.getBytes(charset))
       case HttpData.BinaryChunk(data)   => Unpooled.copiedBuffer(data.toArray)

--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderChecks.scala
@@ -11,19 +11,19 @@ import zhttp.http.HeaderValues
  */
 trait HeaderChecks[+A] { self: HeaderExtension[A] with A =>
   final def hasContentType(value: CharSequence): Boolean =
-    getContentType.exists(contentEqualsIgnoreCase(value, _))
+    contentType.exists(contentEqualsIgnoreCase(value, _))
 
   final def hasFormUrlencodedContentType: Boolean =
     hasContentType(HeaderValues.applicationXWWWFormUrlencoded)
 
   final def hasHeader(name: CharSequence, value: CharSequence): Boolean =
-    getHeaderValue(name) match {
+    headerValue(name) match {
       case Some(v1) => v1.contentEquals(value)
       case None     => false
     }
 
   final def hasHeader(name: CharSequence): Boolean =
-    getHeaderValue(name).nonEmpty
+    headerValue(name).nonEmpty
 
   final def hasJsonContentType: Boolean =
     hasContentType(HeaderValues.applicationJson)

--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderGetters.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderGetters.scala
@@ -3,7 +3,7 @@ package zhttp.http.headers
 import io.netty.handler.codec.http.HttpUtil
 import io.netty.util.AsciiString.contentEqualsIgnoreCase
 import zhttp.http.Headers.{BasicSchemeName, BearerSchemeName}
-import zhttp.http.{Cookie, HTTP_CHARSET, Header, HeaderNames, Headers}
+import zhttp.http._
 
 import java.nio.charset.Charset
 import java.util.Base64
@@ -16,64 +16,64 @@ import scala.util.control.NonFatal
  */
 trait HeaderGetters[+A] { self =>
 
-  final def getAccept: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accept)
+  final def accept: Option[CharSequence] =
+    headerValue(HeaderNames.accept)
 
-  final def getAcceptCharset: Option[CharSequence] =
-    getHeaderValue(HeaderNames.acceptCharset)
+  final def acceptCharset: Option[CharSequence] =
+    headerValue(HeaderNames.acceptCharset)
 
-  final def getAcceptEncoding: Option[CharSequence] =
-    getHeaderValue(HeaderNames.acceptEncoding)
+  final def acceptEncoding: Option[CharSequence] =
+    headerValue(HeaderNames.acceptEncoding)
 
-  final def getAcceptLanguage: Option[CharSequence] =
-    getHeaderValue(HeaderNames.acceptLanguage)
+  final def acceptLanguage: Option[CharSequence] =
+    headerValue(HeaderNames.acceptLanguage)
 
-  final def getAcceptPatch: Option[CharSequence] =
-    getHeaderValue(HeaderNames.acceptPatch)
+  final def acceptPatch: Option[CharSequence] =
+    headerValue(HeaderNames.acceptPatch)
 
-  final def getAcceptRanges: Option[CharSequence] =
-    getHeaderValue(HeaderNames.acceptRanges)
+  final def acceptRanges: Option[CharSequence] =
+    headerValue(HeaderNames.acceptRanges)
 
-  final def getAccessControlAllowCredentials: Option[Boolean] =
-    getHeaderValue(HeaderNames.accessControlAllowCredentials) match {
+  final def accessControlAllowCredentials: Option[Boolean] =
+    headerValue(HeaderNames.accessControlAllowCredentials) match {
       case Some(string) =>
         try Some(string.toBoolean)
         catch { case _: Throwable => None }
       case None         => None
     }
 
-  final def getAccessControlAllowHeaders: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlAllowHeaders)
+  final def accessControlAllowHeaders: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlAllowHeaders)
 
-  final def getAccessControlAllowMethods: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlAllowMethods)
+  final def accessControlAllowMethods: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlAllowMethods)
 
-  final def getAccessControlAllowOrigin: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlAllowOrigin)
+  final def accessControlAllowOrigin: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlAllowOrigin)
 
-  final def getAccessControlExposeHeaders: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlExposeHeaders)
+  final def accessControlExposeHeaders: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlExposeHeaders)
 
-  final def getAccessControlMaxAge: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlMaxAge)
+  final def accessControlMaxAge: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlMaxAge)
 
-  final def getAccessControlRequestHeaders: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlRequestHeaders)
+  final def accessControlRequestHeaders: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlRequestHeaders)
 
-  final def getAccessControlRequestMethod: Option[CharSequence] =
-    getHeaderValue(HeaderNames.accessControlRequestMethod)
+  final def accessControlRequestMethod: Option[CharSequence] =
+    headerValue(HeaderNames.accessControlRequestMethod)
 
-  final def getAge: Option[CharSequence] =
-    getHeaderValue(HeaderNames.age)
+  final def age: Option[CharSequence] =
+    headerValue(HeaderNames.age)
 
-  final def getAllow: Option[CharSequence] =
-    getHeaderValue(HeaderNames.allow)
+  final def allow: Option[CharSequence] =
+    headerValue(HeaderNames.allow)
 
-  final def getAuthorization: Option[CharSequence] =
-    getHeaderValue(HeaderNames.authorization)
+  final def authorization: Option[CharSequence] =
+    headerValue(HeaderNames.authorization)
 
-  final def getBasicAuthorizationCredentials: Option[Header] = {
-    getAuthorization
+  final def basicAuthorizationCredentials: Option[Header] = {
+    authorization
       .map(_.toString)
       .flatMap(v => {
         val indexOfBasic = v.indexOf(BasicSchemeName)
@@ -90,7 +90,7 @@ trait HeaderGetters[+A] { self =>
       })
   }
 
-  final def getBearerToken: Option[String] = getAuthorization
+  final def bearerToken: Option[String] = authorization
     .map(_.toString)
     .flatMap(v => {
       val indexOfBearer = v.indexOf(BearerSchemeName)
@@ -100,32 +100,32 @@ trait HeaderGetters[+A] { self =>
         Some(v.substring(BearerSchemeName.length + 1))
     })
 
-  final def getCacheControl: Option[CharSequence] =
-    getHeaderValue(HeaderNames.cacheControl)
+  final def cacheControl: Option[CharSequence] =
+    headerValue(HeaderNames.cacheControl)
 
-  final def getCharset: Charset =
-    getHeaderValue(HeaderNames.contentType) match {
+  final def charset: Charset =
+    headerValue(HeaderNames.contentType) match {
       case Some(value) => HttpUtil.getCharset(value, HTTP_CHARSET)
       case None        => HTTP_CHARSET
     }
 
-  final def getConnection: Option[CharSequence] =
-    getHeaderValue(HeaderNames.connection)
+  final def connection: Option[CharSequence] =
+    headerValue(HeaderNames.connection)
 
-  final def getContentBase: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentBase)
+  final def contentBase: Option[CharSequence] =
+    headerValue(HeaderNames.contentBase)
 
-  final def getContentDisposition: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentDisposition)
+  final def contentDisposition: Option[CharSequence] =
+    headerValue(HeaderNames.contentDisposition)
 
-  final def getContentEncoding: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentEncoding)
+  final def contentEncoding: Option[CharSequence] =
+    headerValue(HeaderNames.contentEncoding)
 
-  final def getContentLanguage: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentLanguage)
+  final def contentLanguage: Option[CharSequence] =
+    headerValue(HeaderNames.contentLanguage)
 
-  final def getContentLength: Option[Long] =
-    getHeaderValue(HeaderNames.contentLength) match {
+  final def contentLength: Option[Long] =
+    headerValue(HeaderNames.contentLength) match {
       case Some(str) =>
         try Some(str.toString.toLong)
         catch {
@@ -134,197 +134,197 @@ trait HeaderGetters[+A] { self =>
       case None      => None
     }
 
-  final def getContentLocation: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentLocation)
+  final def contentLocation: Option[CharSequence] =
+    headerValue(HeaderNames.contentLocation)
 
-  final def getContentMd5: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentMd5)
+  final def contentMd5: Option[CharSequence] =
+    headerValue(HeaderNames.contentMd5)
 
-  final def getContentRange: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentRange)
+  final def contentRange: Option[CharSequence] =
+    headerValue(HeaderNames.contentRange)
 
-  final def getContentSecurityPolicy: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentSecurityPolicy)
+  final def contentSecurityPolicy: Option[CharSequence] =
+    headerValue(HeaderNames.contentSecurityPolicy)
 
-  final def getContentTransferEncoding: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentTransferEncoding)
+  final def contentTransferEncoding: Option[CharSequence] =
+    headerValue(HeaderNames.contentTransferEncoding)
 
-  final def getContentType: Option[CharSequence] =
-    getHeaderValue(HeaderNames.contentType)
+  final def contentType: Option[CharSequence] =
+    headerValue(HeaderNames.contentType)
 
-  final def getCookie: Option[CharSequence] =
-    getHeaderValue(HeaderNames.cookie)
+  final def cookie: Option[CharSequence] =
+    headerValue(HeaderNames.cookie)
 
-  final def getCookiesDecoded: List[Cookie] =
-    getHeaderValues(HeaderNames.cookie).flatMap { header =>
+  final def cookieValue(name: CharSequence): Option[CharSequence] =
+    cookiesDecoded.find(_.name == name).map(_.content)
+
+  final def cookiesDecoded: List[Cookie] =
+    headerValues(HeaderNames.cookie).flatMap { header =>
       Cookie.decodeRequestCookie(header) match {
         case None       => Nil
         case Some(list) => list
       }
     }
 
-  final def getCookieValue(name: CharSequence): Option[CharSequence] =
-    getCookiesDecoded.find(_.name == name).map(_.content)
+  final def date: Option[CharSequence] =
+    headerValue(HeaderNames.date)
 
-  final def getDate: Option[CharSequence] =
-    getHeaderValue(HeaderNames.date)
+  final def dnt: Option[CharSequence] =
+    headerValue(HeaderNames.dnt)
 
-  final def getDnt: Option[CharSequence] =
-    getHeaderValue(HeaderNames.dnt)
+  final def etag: Option[CharSequence] =
+    headerValue(HeaderNames.etag)
 
-  final def getEtag: Option[CharSequence] =
-    getHeaderValue(HeaderNames.etag)
+  final def expect: Option[CharSequence] =
+    headerValue(HeaderNames.expect)
 
-  final def getExpect: Option[CharSequence] =
-    getHeaderValue(HeaderNames.expect)
+  final def expires: Option[CharSequence] =
+    headerValue(HeaderNames.expires)
 
-  final def getExpires: Option[CharSequence] =
-    getHeaderValue(HeaderNames.expires)
+  final def from: Option[CharSequence] =
+    headerValue(HeaderNames.from)
 
-  final def getFrom: Option[CharSequence] =
-    getHeaderValue(HeaderNames.from)
-
-  final def getHeader(headerName: CharSequence): Option[Header] =
-    getHeaders.toList
+  final def header(headerName: CharSequence): Option[Header] =
+    headers.toList
       .find(h => contentEqualsIgnoreCase(h._1, headerName))
 
-  final def getHeaderValue(headerName: CharSequence): Option[String] =
-    getHeader(headerName).map(_._2.toString)
+  final def headerValue(headerName: CharSequence): Option[String] =
+    header(headerName).map(_._2.toString)
 
-  final def getHeaderValues(headerName: CharSequence): List[String] =
-    getHeaders.toList.collect { case h if contentEqualsIgnoreCase(h._1, headerName) => h._2.toString }
+  final def headerValues(headerName: CharSequence): List[String] =
+    headers.toList.collect { case h if contentEqualsIgnoreCase(h._1, headerName) => h._2.toString }
 
   /**
    * Returns the Headers object on the current type A
    */
-  def getHeaders: Headers
+  def headers: Headers
 
-  final def getHeadersAsList: List[(String, String)] = self.getHeaders.toList
+  final def headersAsList: List[(String, String)] = self.headers.toList
 
-  final def getHost: Option[CharSequence] =
-    getHeaderValue(HeaderNames.host)
+  final def host: Option[CharSequence] =
+    headerValue(HeaderNames.host)
 
-  final def getIfMatch: Option[CharSequence] =
-    getHeaderValue(HeaderNames.ifMatch)
+  final def ifMatch: Option[CharSequence] =
+    headerValue(HeaderNames.ifMatch)
 
-  final def getIfModifiedSince: Option[CharSequence] =
-    getHeaderValue(HeaderNames.ifModifiedSince)
+  final def ifModifiedSince: Option[CharSequence] =
+    headerValue(HeaderNames.ifModifiedSince)
 
-  final def getIfNoneMatch: Option[CharSequence] =
-    getHeaderValue(HeaderNames.ifNoneMatch)
+  final def ifNoneMatch: Option[CharSequence] =
+    headerValue(HeaderNames.ifNoneMatch)
 
-  final def getIfRange: Option[CharSequence] =
-    getHeaderValue(HeaderNames.ifRange)
+  final def ifRange: Option[CharSequence] =
+    headerValue(HeaderNames.ifRange)
 
-  final def getIfUnmodifiedSince: Option[CharSequence] =
-    getHeaderValue(HeaderNames.ifUnmodifiedSince)
+  final def ifUnmodifiedSince: Option[CharSequence] =
+    headerValue(HeaderNames.ifUnmodifiedSince)
 
-  final def getLastModified: Option[CharSequence] =
-    getHeaderValue(HeaderNames.lastModified)
+  final def lastModified: Option[CharSequence] =
+    headerValue(HeaderNames.lastModified)
 
-  final def getLocation: Option[CharSequence] =
-    getHeaderValue(HeaderNames.location)
+  final def location: Option[CharSequence] =
+    headerValue(HeaderNames.location)
 
-  final def getMaxForwards: Option[CharSequence] =
-    getHeaderValue(HeaderNames.maxForwards)
+  final def maxForwards: Option[CharSequence] =
+    headerValue(HeaderNames.maxForwards)
 
-  final def getOrigin: Option[CharSequence] =
-    getHeaderValue(HeaderNames.origin)
+  final def origin: Option[CharSequence] =
+    headerValue(HeaderNames.origin)
 
-  final def getPragma: Option[CharSequence] =
-    getHeaderValue(HeaderNames.pragma)
+  final def pragma: Option[CharSequence] =
+    headerValue(HeaderNames.pragma)
 
-  final def getProxyAuthenticate: Option[CharSequence] =
-    getHeaderValue(HeaderNames.proxyAuthenticate)
+  final def proxyAuthenticate: Option[CharSequence] =
+    headerValue(HeaderNames.proxyAuthenticate)
 
-  final def getProxyAuthorization: Option[CharSequence] =
-    getHeaderValue(HeaderNames.proxyAuthorization)
+  final def proxyAuthorization: Option[CharSequence] =
+    headerValue(HeaderNames.proxyAuthorization)
 
-  final def getRange: Option[CharSequence] =
-    getHeaderValue(HeaderNames.range)
+  final def range: Option[CharSequence] =
+    headerValue(HeaderNames.range)
 
-  final def getReferer: Option[CharSequence] =
-    getHeaderValue(HeaderNames.referer)
+  final def referer: Option[CharSequence] =
+    headerValue(HeaderNames.referer)
 
-  final def getRetryAfter: Option[CharSequence] =
-    getHeaderValue(HeaderNames.retryAfter)
+  final def retryAfter: Option[CharSequence] =
+    headerValue(HeaderNames.retryAfter)
 
-  final def getSecWebSocketAccept: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketAccept)
+  final def secWebSocketAccept: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketAccept)
 
-  final def getSecWebSocketExtensions: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketExtensions)
+  final def secWebSocketExtensions: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketExtensions)
 
-  final def getSecWebSocketKey: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketKey)
+  final def secWebSocketKey: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketKey)
 
-  final def getSecWebSocketLocation: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketLocation)
+  final def secWebSocketLocation: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketLocation)
 
-  final def getSecWebSocketOrigin: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketOrigin)
+  final def secWebSocketOrigin: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketOrigin)
 
-  final def getSecWebSocketProtocol: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketProtocol)
+  final def secWebSocketProtocol: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketProtocol)
 
-  final def getSecWebSocketVersion: Option[CharSequence] =
-    getHeaderValue(HeaderNames.secWebSocketVersion)
+  final def secWebSocketVersion: Option[CharSequence] =
+    headerValue(HeaderNames.secWebSocketVersion)
 
-  final def getServer: Option[CharSequence] =
-    getHeaderValue(HeaderNames.server)
+  final def server: Option[CharSequence] =
+    headerValue(HeaderNames.server)
 
-  final def getSetCookie: Option[CharSequence] =
-    getHeaderValue(HeaderNames.setCookie)
+  final def setCookie: Option[CharSequence] =
+    headerValue(HeaderNames.setCookie)
 
-  final def getSetCookiesDecoded(secret: Option[String] = None): List[Cookie] =
-    getHeaderValues(HeaderNames.setCookie)
+  final def setCookiesDecoded(secret: Option[String] = None): List[Cookie] =
+    headerValues(HeaderNames.setCookie)
       .map(Cookie.decodeResponseCookie(_, secret))
       .collect { case Some(cookie) => cookie }
 
-  final def getTe: Option[CharSequence] =
-    getHeaderValue(HeaderNames.te)
+  final def te: Option[CharSequence] =
+    headerValue(HeaderNames.te)
 
-  final def getTrailer: Option[CharSequence] =
-    getHeaderValue(HeaderNames.trailer)
+  final def trailer: Option[CharSequence] =
+    headerValue(HeaderNames.trailer)
 
-  final def getTransferEncoding: Option[CharSequence] =
-    getHeaderValue(HeaderNames.transferEncoding)
+  final def transferEncoding: Option[CharSequence] =
+    headerValue(HeaderNames.transferEncoding)
 
-  final def getUpgrade: Option[CharSequence] =
-    getHeaderValue(HeaderNames.upgrade)
+  final def upgrade: Option[CharSequence] =
+    headerValue(HeaderNames.upgrade)
 
-  final def getUpgradeInsecureRequests: Option[CharSequence] =
-    getHeaderValue(HeaderNames.upgradeInsecureRequests)
+  final def upgradeInsecureRequests: Option[CharSequence] =
+    headerValue(HeaderNames.upgradeInsecureRequests)
 
-  final def getUserAgent: Option[CharSequence] =
-    getHeaderValue(HeaderNames.userAgent)
+  final def userAgent: Option[CharSequence] =
+    headerValue(HeaderNames.userAgent)
 
-  final def getVary: Option[CharSequence] =
-    getHeaderValue(HeaderNames.vary)
+  final def vary: Option[CharSequence] =
+    headerValue(HeaderNames.vary)
 
-  final def getVia: Option[CharSequence] =
-    getHeaderValue(HeaderNames.via)
+  final def via: Option[CharSequence] =
+    headerValue(HeaderNames.via)
 
-  final def getWarning: Option[CharSequence] =
-    getHeaderValue(HeaderNames.warning)
+  final def warning: Option[CharSequence] =
+    headerValue(HeaderNames.warning)
 
-  final def getWebSocketLocation: Option[CharSequence] =
-    getHeaderValue(HeaderNames.webSocketLocation)
+  final def webSocketLocation: Option[CharSequence] =
+    headerValue(HeaderNames.webSocketLocation)
 
-  final def getWebSocketOrigin: Option[CharSequence] =
-    getHeaderValue(HeaderNames.webSocketOrigin)
+  final def webSocketOrigin: Option[CharSequence] =
+    headerValue(HeaderNames.webSocketOrigin)
 
-  final def getWebSocketProtocol: Option[CharSequence] =
-    getHeaderValue(HeaderNames.webSocketProtocol)
+  final def webSocketProtocol: Option[CharSequence] =
+    headerValue(HeaderNames.webSocketProtocol)
 
-  final def getWwwAuthenticate: Option[CharSequence] =
-    getHeaderValue(HeaderNames.wwwAuthenticate)
+  final def wwwAuthenticate: Option[CharSequence] =
+    headerValue(HeaderNames.wwwAuthenticate)
 
-  final def getXFrameOptions: Option[CharSequence] =
-    getHeaderValue(HeaderNames.xFrameOptions)
+  final def xFrameOptions: Option[CharSequence] =
+    headerValue(HeaderNames.xFrameOptions)
 
-  final def getXRequestedWith: Option[CharSequence] =
-    getHeaderValue(HeaderNames.xRequestedWith)
+  final def xRequestedWith: Option[CharSequence] =
+    headerValue(HeaderNames.xRequestedWith)
 
   private def decodeHttpBasic(encoded: String): Option[Header] = {
     val decoded    = new String(Base64.getDecoder.decode(encoded))

--- a/zio-http/src/main/scala/zhttp/http/middleware/Auth.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/Auth.scala
@@ -11,7 +11,7 @@ private[zhttp] trait Auth {
    */
   final def basicAuth(f: Header => Boolean): HttpMiddleware[Any, Nothing] =
     customAuth(
-      _.getBasicAuthorizationCredentials match {
+      _.basicAuthorizationCredentials match {
         case Some(header) => f(header)
         case None         => false
       },
@@ -31,7 +31,7 @@ private[zhttp] trait Auth {
     verify: Headers => Boolean,
     responseHeaders: Headers = Headers.empty,
   ): HttpMiddleware[Any, Nothing] =
-    Middleware.ifThenElse[Request](req => verify(req.getHeaders))(
+    Middleware.ifThenElse[Request](req => verify(req.headers))(
       _ => Middleware.identity,
       _ => Middleware.fromHttp(Http.status(Status.FORBIDDEN).addHeaders(responseHeaders)),
     )

--- a/zio-http/src/main/scala/zhttp/http/middleware/Cors.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/Cors.scala
@@ -43,8 +43,8 @@ private[zhttp] trait Cors {
     Middleware.collect[Request] { case req =>
       (
         req.method,
-        req.getHeaders.getHeader(HttpHeaderNames.ORIGIN),
-        req.getHeaders.getHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD),
+        req.headers.header(HttpHeaderNames.ORIGIN),
+        req.headers.header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD),
       ) match {
         case (Method.OPTIONS, Some(origin), Some(acrm)) if allowCORS(origin, Method.fromString(acrm._2.toString)) =>
           Middleware.succeed(

--- a/zio-http/src/main/scala/zhttp/http/middleware/Csrf.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/Csrf.scala
@@ -33,7 +33,7 @@ private[zhttp] trait Csrf {
   def csrfValidate(tokenName: String = "x-csrf-token"): HttpMiddleware[Any, Nothing] = {
     Middleware.whenHeader(
       headers => {
-        (headers.getHeaderValue(tokenName), headers.getCookieValue(tokenName)) match {
+        (headers.headerValue(tokenName), headers.cookieValue(tokenName)) match {
           case (Some(headerValue), Some(cookieValue)) => headerValue != cookieValue
           case _                                      => true
         }

--- a/zio-http/src/main/scala/zhttp/http/middleware/Web.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/Web.scala
@@ -51,7 +51,7 @@ private[zhttp] trait Web extends Cors with Csrf with Auth with HeaderModifier[Ht
   final def ifHeaderThenElse[R, E](
     cond: Headers => Boolean,
   )(left: HttpMiddleware[R, E], right: HttpMiddleware[R, E]): HttpMiddleware[R, E] =
-    Middleware.ifThenElse[Request](req => cond(req.getHeaders))(_ => left, _ => right)
+    Middleware.ifThenElse[Request](req => cond(req.headers))(_ => left, _ => right)
 
   /**
    * Logical operator to decide which middleware to select based on the method.
@@ -122,12 +122,12 @@ private[zhttp] trait Web extends Cors with Csrf with Auth with HeaderModifier[Ht
    */
   final def signCookies(secret: String): HttpMiddleware[Any, Nothing] =
     updateHeaders {
-      case h if h.getHeader(HeaderNames.setCookie).isDefined =>
+      case h if h.header(HeaderNames.setCookie).isDefined =>
         Headers(
           HeaderNames.setCookie,
-          Cookie.decodeResponseCookie(h.getHeader(HeaderNames.setCookie).get._2.toString).get.sign(secret).encode,
+          Cookie.decodeResponseCookie(h.header(HeaderNames.setCookie).get._2.toString).get.sign(secret).encode,
         )
-      case h                                                 => h
+      case h                                              => h
     }
 
   /**
@@ -146,7 +146,7 @@ private[zhttp] trait Web extends Cors with Csrf with Auth with HeaderModifier[Ht
    * Applies the middleware only when the condition for the headers are true
    */
   final def whenHeader[R, E](cond: Headers => Boolean, middleware: HttpMiddleware[R, E]): HttpMiddleware[R, E] =
-    middleware.when[Request](req => cond(req.getHeaders))
+    middleware.when[Request](req => cond(req.headers))
 
   /**
    * Applies the middleware only if the condition function evaluates to true

--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -94,7 +94,7 @@ final case class Client[R](rtm: HttpRuntime[R], cf: JChannelFactory[Channel], el
 
           // Add WebSocketHandlers if it's a `ws` or `wss` request
           if (isWebSocket) {
-            val headers = req.getHeaders.encode
+            val headers = req.headers.encode
             val app     = req.attribute.socketApp.getOrElse(Socket.empty.toSocketApp)
             val config  = app.protocol.clientBuilder
               .customHeaders(headers)
@@ -175,9 +175,7 @@ object Client {
   ) extends HeaderExtension[ClientRequest] {
     self =>
 
-    def getBodyAsString: Task[String] = getBodyAsByteBuf.map(_.toString(getHeaders.getCharset))
-
-    def getHeaders: Headers = headers
+    def bodyAsString: Task[String] = getBodyAsByteBuf.map(_.toString(headers.charset))
 
     def remoteAddress: Option[InetAddress] = {
       if (channelContext != null && channelContext.channel().remoteAddress().isInstanceOf[InetSocketAddress])
@@ -190,7 +188,7 @@ object Client {
      * Updates the headers using the provided function
      */
     override def updateHeaders(update: Headers => Headers): ClientRequest =
-      self.copy(headers = update(self.getHeaders))
+      self.copy(headers = update(self.headers))
 
     private[zhttp] def getBodyAsByteBuf: Task[ByteBuf] = data.toByteBuf
   }
@@ -199,13 +197,11 @@ object Client {
       extends HeaderExtension[ClientResponse] {
     self =>
 
-    def getBody: Task[Chunk[Byte]] = Task(Chunk.fromArray(ByteBufUtil.getBytes(buffer)))
+    def body: Task[Chunk[Byte]] = Task(Chunk.fromArray(ByteBufUtil.getBytes(buffer)))
 
-    def getBodyAsByteBuf: Task[ByteBuf] = Task(buffer)
+    def bodyAsByteBuf: Task[ByteBuf] = Task(buffer)
 
-    def getBodyAsString: Task[String] = Task(buffer.toString(self.getCharset))
-
-    override def getHeaders: Headers = headers
+    def bodyAsString: Task[String] = Task(buffer.toString(self.charset))
 
     override def updateHeaders(update: Headers => Headers): ClientResponse = self.copy(headers = update(headers))
   }

--- a/zio-http/src/main/scala/zhttp/service/EncodeClientRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeClientRequest.scala
@@ -17,7 +17,7 @@ trait EncodeClientRequest {
       // Host and port information should be in the headers.
       val path = req.url.relative.encode
 
-      val encodedReqHeaders = req.getHeaders.encode
+      val encodedReqHeaders = req.headers.encode
 
       val headers = req.url.host match {
         case Some(value) => encodedReqHeaders.set(HttpHeaderNames.HOST, value)

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -31,9 +31,9 @@ private[zhttp] final case class Handler[R](
 
         override def url: URL = URL.fromString(jReq.uri()).getOrElse(null)
 
-        override def getHeaders: Headers = Headers.make(jReq.headers())
+        override def headers: Headers = Headers.make(jReq.headers())
 
-        override private[zhttp] def getBodyAsByteBuf: Task[ByteBuf] = Task(jReq.content())
+        override private[zhttp] def bodyAsByteBuf: Task[ByteBuf] = Task(jReq.content())
 
         override def remoteAddress: Option[InetAddress] = {
           ctx.channel().remoteAddress() match {

--- a/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
@@ -16,7 +16,7 @@ import scala.jdk.CollectionConverters._
 final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
   def unsafeRun(ctx: ChannelHandlerContext)(program: ZIO[R, Throwable, Any]): Unit = {
 
-    val rtm = strategy.getRuntime(ctx)
+    val rtm = strategy.runtime(ctx)
 
     // Close the connection if the program fails
     // When connection closes, interrupt the program
@@ -57,7 +57,7 @@ object HttpRuntime {
     Strategy.sticky(group).map(runtime => new HttpRuntime[R](runtime))
 
   sealed trait Strategy[R] {
-    def getRuntime(ctx: ChannelHandlerContext): Runtime[R]
+    def runtime(ctx: ChannelHandlerContext): Runtime[R]
   }
 
   object Strategy {
@@ -72,7 +72,7 @@ object HttpRuntime {
       ZIO.runtime[R].map(runtime => Group(runtime, group))
 
     case class Default[R](runtime: Runtime[R]) extends Strategy[R] {
-      override def getRuntime(ctx: ChannelHandlerContext): Runtime[R] = runtime
+      override def runtime(ctx: ChannelHandlerContext): Runtime[R] = runtime
     }
 
     case class Dedicated[R](runtime: Runtime[R], group: JEventLoopGroup) extends Strategy[R] {
@@ -82,7 +82,7 @@ object HttpRuntime {
         }
       }
 
-      override def getRuntime(ctx: ChannelHandlerContext): Runtime[R] = localRuntime
+      override def runtime(ctx: ChannelHandlerContext): Runtime[R] = localRuntime
     }
 
     case class Group[R](runtime: Runtime[R], group: JEventLoopGroup) extends Strategy[R] {
@@ -98,7 +98,7 @@ object HttpRuntime {
         map
       }
 
-      override def getRuntime(ctx: ChannelHandlerContext): Runtime[R] =
+      override def runtime(ctx: ChannelHandlerContext): Runtime[R] =
         localRuntime.getOrElse(ctx.executor(), runtime)
     }
   }

--- a/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
@@ -25,14 +25,14 @@ object GetBodyAsStringSpec extends DefaultRunnableSpec {
               data = HttpData.BinaryChunk(Chunk.fromArray("abc".getBytes(charset))),
             )
 
-          val encoded  = request.getBodyAsString
+          val encoded  = request.bodyAsString
           val expected = new String(Chunk.fromArray("abc".getBytes(charset)).toArray, charset)
           assertM(encoded)(equalTo(expected))
         }
       } +
         testM("should map bytes to default utf-8 if no charset given") {
           val request  = Client.ClientRequest(URL(!!), data = HttpData.BinaryChunk(Chunk.fromArray("abc".getBytes())))
-          val encoded  = request.getBodyAsString
+          val encoded  = request.bodyAsString
           val expected = new String(Chunk.fromArray("abc".getBytes()).toArray, HTTP_CHARSET)
           assertM(encoded)(equalTo(expected))
         }

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -10,54 +10,54 @@ object HeaderSpec extends DefaultRunnableSpec {
   def spec = suite("Header") {
     suite("getHeader")(
       test("should not return header that doesn't exist in list") {
-        val actual = predefinedHeaders.getHeader("dummyHeaderName")
+        val actual = predefinedHeaders.header("dummyHeaderName")
         assert(actual)(isNone)
       } +
         test("should return header from predefined headers list by String") {
-          val actual = predefinedHeaders.getHeaderValue(HttpHeaderNames.CONTENT_TYPE)
+          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
           assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
         } +
         test("should return header from predefined headers list by String of another case") {
-          val actual = predefinedHeaders.getHeaderValue("Content-Type")
+          val actual = predefinedHeaders.headerValue("Content-Type")
           assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
         } +
         test("should return header from predefined headers list by AsciiString") {
-          val actual = predefinedHeaders.getHeaderValue(HttpHeaderNames.CONTENT_TYPE)
+          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
           assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
         } +
         test("should return header from custom headers list by String") {
-          val actual = customHeaders.getHeader(HttpHeaderNames.CONTENT_TYPE)
+          val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
           assert(actual)(isSome(equalTo(customContentJsonHeader)))
         } +
         test("should return header from custom headers list by AsciiString") {
-          val actual = customHeaders.getHeader(HttpHeaderNames.CONTENT_TYPE)
+          val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
           assert(actual)(isSome(equalTo(customContentJsonHeader)))
         },
     ) +
       suite("getHeaderValue") {
         test("should return header value") {
-          val actual = predefinedHeaders.getHeaderValue(HttpHeaderNames.CONTENT_TYPE)
+          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
           assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
         }
       } +
       suite("getContentType")(
         test("should return content-type value") {
-          val actual = predefinedHeaders.getContentType
+          val actual = predefinedHeaders.contentType
           assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
         } +
           test("should not return content-type value if it doesn't exist") {
-            val actual = acceptJson.getContentType
+            val actual = acceptJson.contentType
             assert(actual)(isNone)
           },
       ) +
       suite("getAuthorizationHeader")(
         test("should return authorization value") {
           val authorizationValue = "dummyValue"
-          val actual             = Headers.authorization(authorizationValue).getAuthorization
+          val actual             = Headers.authorization(authorizationValue).authorization
           assert(actual)(isSome(equalTo(authorizationValue)))
         } +
           test("should not return authorization value if it doesn't exist") {
-            val actual = acceptJson.getContentType
+            val actual = acceptJson.contentType
             assert(actual)(isNone)
           },
       ) +
@@ -142,33 +142,33 @@ object HeaderSpec extends DefaultRunnableSpec {
       ) +
       suite("getBasicAuthorizationCredentials")(
         test("should decode proper basic http authorization header") {
-          val actual = Headers.authorization("Basic dXNlcjpwYXNzd29yZCAxMQ==").getBasicAuthorizationCredentials
+          val actual = Headers.authorization("Basic dXNlcjpwYXNzd29yZCAxMQ==").basicAuthorizationCredentials
           assert(actual)(isSome(equalTo(("user", "password 11"))))
         } +
           test("should decode basic http authorization header with empty name and password") {
-            val actual = Headers.authorization("Basic Og==").getBasicAuthorizationCredentials
+            val actual = Headers.authorization("Basic Og==").basicAuthorizationCredentials
             assert(actual)(isSome(equalTo(("", ""))))
           } +
           test("should not decode improper base64") {
-            val actual = Headers.authorization("Basic Og=").getBasicAuthorizationCredentials
+            val actual = Headers.authorization("Basic Og=").basicAuthorizationCredentials
             assert(actual)(isNone)
           } +
           test("should not decode only basic") {
-            val actual = Headers.authorization("Basic").getBasicAuthorizationCredentials
+            val actual = Headers.authorization("Basic").basicAuthorizationCredentials
             assert(actual)(isNone)
           } +
           test("should not decode basic contained header value") {
-            val actual = Headers.authorization("wrongBasic Og==").getBasicAuthorizationCredentials
+            val actual = Headers.authorization("wrongBasic Og==").basicAuthorizationCredentials
             assert(actual)(isNone)
           } +
           test("should get credentials for nonbasic schema") {
-            val actual = Headers.authorization("DummySchema Og==").getBasicAuthorizationCredentials
+            val actual = Headers.authorization("DummySchema Og==").basicAuthorizationCredentials
             assert(actual)(isNone)
           } +
           test("should decode header from Header.basicHttpAuthorization") {
             val username = "username"
             val password = "password"
-            val actual   = Headers.basicAuthorizationHeader(username, password).getBasicAuthorizationCredentials
+            val actual   = Headers.basicAuthorizationHeader(username, password).basicAuthorizationCredentials
             assert(actual)(isSome(equalTo((username, password))))
           } +
           test("should decode value from Header.basicHttpAuthorization") {
@@ -176,7 +176,7 @@ object HeaderSpec extends DefaultRunnableSpec {
             val password = "password"
             val actual   = Headers
               .basicAuthorizationHeader(username, password)
-              .getHeaderValue(HeaderNames.authorization)
+              .headerValue(HeaderNames.authorization)
             val expected = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
             assert(actual)(isSome(equalTo(expected)))
           },
@@ -184,36 +184,36 @@ object HeaderSpec extends DefaultRunnableSpec {
       suite("getBearerToken")(
         test("should get bearer token") {
           val token  = "token"
-          val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, token)).getBearerToken
+          val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, token)).bearerToken
           assert(actual)(isSome(equalTo(token)))
         } +
           test("should get empty bearer token") {
-            val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, "")).getBearerToken
+            val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, "")).bearerToken
             assert(actual)(isSome(equalTo("")))
           } +
           test("should not get bearer token for nonbearer schema") {
-            val actual = Headers.authorization("DummySchema token").getBearerToken
+            val actual = Headers.authorization("DummySchema token").bearerToken
             assert(actual)(isNone)
           } +
           test("should not get bearer token for bearer contained header") {
-            val actual = Headers.authorization("wrongBearer token").getBearerToken
+            val actual = Headers.authorization("wrongBearer token").bearerToken
             assert(actual)(isNone)
           },
       ) +
       suite("getContentLength") {
         testM("should get content-length") {
           check(Gen.anyLong) { c =>
-            val actual = Headers.contentLength(c).getContentLength
+            val actual = Headers.contentLength(c).contentLength
             assert(actual)(isSome(equalTo(c)))
           }
         } +
           test("should not return content-length value if it doesn't exist") {
-            val actual = Headers.empty.getContentType
+            val actual = Headers.empty.contentType
             assert(actual)(isNone)
           } +
           testM("should get content-length") {
             check(Gen.anyChar) { c =>
-              val actual = Headers(HttpHeaderNames.CONTENT_LENGTH, c.toString).getContentLength
+              val actual = Headers(HttpHeaderNames.CONTENT_LENGTH, c.toString).contentLength
               assert(actual)(isNone)
             }
           }

--- a/zio-http/src/test/scala/zhttp/http/ResponseSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/ResponseSpec.scala
@@ -10,11 +10,11 @@ object ResponseSpec extends DefaultRunnableSpec {
       test("Temporary redirect should produce a response with a TEMPORARY_REDIRECT") {
         val x = Response.redirect(location)
         assertTrue(x.status == Status.TEMPORARY_REDIRECT) &&
-        assertTrue(x.getHeaderValue(HeaderNames.location).contains(location))
+        assertTrue(x.headerValue(HeaderNames.location).contains(location))
       } +
         test("Temporary redirect should produce a response with a location") {
           val x = Response.redirect(location)
-          assertTrue(x.getHeaderValue(HeaderNames.location).contains(location))
+          assertTrue(x.headerValue(HeaderNames.location).contains(location))
         } +
         test("Permanent redirect should produce a response with a PERMANENT_REDIRECT") {
           val x = Response.redirect(location, true)
@@ -22,13 +22,13 @@ object ResponseSpec extends DefaultRunnableSpec {
         } +
         test("Permanent redirect should produce a response with a location") {
           val x = Response.redirect(location, true)
-          assertTrue(x.getHeaderValue(HeaderNames.location).contains(location))
+          assertTrue(x.headerValue(HeaderNames.location).contains(location))
         }
     } +
       suite("json")(
         test("Json should set content type to ApplicationJson") {
           val x = Response.json("""{"message": "Hello"}""")
-          assertTrue(x.getHeaderValue(HeaderNames.contentType).contains(HeaderValues.applicationJson.toString))
+          assertTrue(x.headerValue(HeaderNames.contentType).contains(HeaderValues.applicationJson.toString))
         },
       ) +
       suite("toHttp")(

--- a/zio-http/src/test/scala/zhttp/http/middleware/AuthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/AuthSpec.scala
@@ -13,15 +13,15 @@ object AuthSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
   def spec = suite("AuthSpec") {
     suite("basicAuth") {
       testM("HttpApp is accepted if the basic authentication succeeds") {
-        val app = (Http.ok @@ basicAuthM).getStatus
+        val app = (Http.ok @@ basicAuthM).status
         assertM(app(Request().addHeaders(basicHS)))(equalTo(Status.OK))
       } +
         testM("Uses forbidden app if the basic authentication fails") {
-          val app = (Http.ok @@ basicAuthM).getStatus
+          val app = (Http.ok @@ basicAuthM).status
           assertM(app(Request().addHeaders(basicHF)))(equalTo(Status.FORBIDDEN))
         } +
         testM("Responses should have WWW-Authentication header if Basic Auth failed") {
-          val app = Http.ok @@ basicAuthM getHeader "WWW-AUTHENTICATE"
+          val app = Http.ok @@ basicAuthM header "WWW-AUTHENTICATE"
           assertM(app(Request().addHeaders(basicHF)))(isSome)
         }
     }

--- a/zio-http/src/test/scala/zhttp/http/middleware/CorsSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/CorsSpec.scala
@@ -28,7 +28,7 @@ object CorsSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
 
       for {
         res <- app(request)
-      } yield assert(res.getHeadersAsList)(hasSubset(expected)) &&
+      } yield assert(res.headersAsList)(hasSubset(expected)) &&
         assertTrue(res.status == Status.NO_CONTENT)
     } +
       testM("GET request") {
@@ -48,7 +48,7 @@ object CorsSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
 
         for {
           res <- app(request)
-        } yield assert(res.getHeadersAsList)(hasSubset(expected))
+        } yield assert(res.headersAsList)(hasSubset(expected))
       }
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/middleware/CsrfSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/CsrfSpec.scala
@@ -9,7 +9,7 @@ import zio.test._
 
 object CsrfSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
   override def spec = suite("CSRF Middlewares") {
-    val app           = (Http.ok @@ csrfValidate("x-token")).getStatus
+    val app           = (Http.ok @@ csrfValidate("x-token")).status
     val setCookie     = Headers.cookie(Cookie("x-token", "secret"))
     val invalidXToken = Headers("x-token", "secret1")
     val validXToken   = Headers("x-token", "secret")

--- a/zio-http/src/test/scala/zhttp/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/WebSpec.scala
@@ -20,22 +20,22 @@ object WebSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
     suite("headers suite") {
       testM("addHeaders") {
         val middleware = addHeaders(Headers("KeyA", "ValueA") ++ Headers("KeyB", "ValueB"))
-        val headers    = (Http.ok @@ middleware).getHeaderValues
+        val headers    = (Http.ok @@ middleware).headerValues
         assertM(headers(Request()))(contains("ValueA") && contains("ValueB"))
       } +
         testM("addHeader") {
           val middleware = addHeader("KeyA", "ValueA")
-          val headers    = (Http.ok @@ middleware).getHeaderValues
+          val headers    = (Http.ok @@ middleware).headerValues
           assertM(headers(Request()))(contains("ValueA"))
         } +
         testM("updateHeaders") {
           val middleware = updateHeaders(_ => Headers("KeyA", "ValueA"))
-          val headers    = (Http.ok @@ middleware).getHeaderValues
+          val headers    = (Http.ok @@ middleware).headerValues
           assertM(headers(Request()))(contains("ValueA"))
         } +
         testM("removeHeader") {
           val middleware = removeHeader("KeyA")
-          val headers = (Http.succeed(Response.ok.setHeaders(Headers("KeyA", "ValueA"))) @@ middleware) getHeader "KeyA"
+          val headers    = (Http.succeed(Response.ok.setHeaders(Headers("KeyA", "ValueA"))) @@ middleware) header "KeyA"
           assertM(headers(Request()))(isNone)
         }
     } +
@@ -87,60 +87,60 @@ object WebSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
         } +
           testM("add headers twice") {
             val middleware = addHeader("KeyA", "ValueA") ++ addHeader("KeyB", "ValueB")
-            val headers    = (Http.ok @@ middleware).getHeaderValues
+            val headers    = (Http.ok @@ middleware).headerValues
             assertM(headers(Request()))(contains("ValueA") && contains("ValueB"))
           } +
           testM("add and remove header") {
             val middleware = addHeader("KeyA", "ValueA") ++ removeHeader("KeyA")
-            val program    = (Http.ok @@ middleware) getHeader "KeyA"
+            val program    = (Http.ok @@ middleware) header "KeyA"
             assertM(program(Request()))(isNone)
           }
       } +
       suite("ifRequestThenElseZIO") {
         testM("if the condition is true take first") {
-          val app = (Http.ok @@ ifRequestThenElseZIO(condM(true))(midA, midB)) getHeader "X-Custom"
+          val app = (Http.ok @@ ifRequestThenElseZIO(condM(true))(midA, midB)) header "X-Custom"
           assertM(app(Request()))(isSome(equalTo("A")))
         } +
           testM("if the condition is false take 2nd") {
             val app =
-              (Http.ok @@ ifRequestThenElseZIO(condM(false))(midA, midB)) getHeader "X-Custom"
+              (Http.ok @@ ifRequestThenElseZIO(condM(false))(midA, midB)) header "X-Custom"
             assertM(app(Request()))(isSome(equalTo("B")))
           }
       } +
       suite("ifRequestThenElse") {
         testM("if the condition is true take first") {
-          val app = Http.ok @@ ifRequestThenElse(cond(true))(midA, midB) getHeader "X-Custom"
+          val app = Http.ok @@ ifRequestThenElse(cond(true))(midA, midB) header "X-Custom"
           assertM(app(Request()))(isSome(equalTo("A")))
         } +
           testM("if the condition is false take 2nd") {
-            val app = Http.ok @@ ifRequestThenElse(cond(false))(midA, midB) getHeader "X-Custom"
+            val app = Http.ok @@ ifRequestThenElse(cond(false))(midA, midB) header "X-Custom"
             assertM(app(Request()))(isSome(equalTo("B")))
           }
       } +
       suite("whenRequestZIO") {
         testM("if the condition is true apply middleware") {
-          val app = (Http.ok @@ whenRequestZIO(condM(true))(midA)) getHeader "X-Custom"
+          val app = (Http.ok @@ whenRequestZIO(condM(true))(midA)) header "X-Custom"
           assertM(app(Request()))(isSome(equalTo("A")))
         } +
           testM("if the condition is false don't apply any middleware") {
-            val app = (Http.ok @@ whenRequestZIO(condM(false))(midA)) getHeader "X-Custom"
+            val app = (Http.ok @@ whenRequestZIO(condM(false))(midA)) header "X-Custom"
             assertM(app(Request()))(isNone)
           }
       } +
       suite("whenRequest") {
         testM("if the condition is true apple middleware") {
-          val app = Http.ok @@ Middleware.whenRequest(cond(true))(midA) getHeader "X-Custom"
+          val app = Http.ok @@ Middleware.whenRequest(cond(true))(midA) header "X-Custom"
           assertM(app(Request()))(isSome(equalTo("A")))
         } +
           testM("if the condition is false don't apply the middleware") {
-            val app = Http.ok @@ Middleware.whenRequest(cond(false))(midA) getHeader "X-Custom"
+            val app = Http.ok @@ Middleware.whenRequest(cond(false))(midA) header "X-Custom"
             assertM(app(Request()))(isNone)
           }
       } +
       suite("cookie") {
         testM("addCookie") {
           val cookie = Cookie("test", "testValue")
-          val app    = (Http.ok @@ addCookie(cookie)).getHeader("set-cookie")
+          val app    = (Http.ok @@ addCookie(cookie)).header("set-cookie")
           assertM(app(Request()))(
             equalTo(Some(cookie.encode)),
           )
@@ -148,7 +148,7 @@ object WebSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
           testM("addCookieM") {
             val cookie = Cookie("test", "testValue")
             val app    =
-              (Http.ok @@ addCookieZIO(UIO(cookie))).getHeader("set-cookie")
+              (Http.ok @@ addCookieZIO(UIO(cookie))).header("set-cookie")
             assertM(app(Request()))(
               equalTo(Some(cookie.encode)),
             )
@@ -157,11 +157,11 @@ object WebSpec extends DefaultRunnableSpec with HttpAppTestExtensions {
       suite("signCookies") {
         testM("should sign cookies") {
           val cookie = Cookie("key", "value").withHttpOnly
-          val app    = Http.ok.withSetCookie(cookie) @@ signCookies("secret") getHeader "set-cookie"
+          val app    = Http.ok.withSetCookie(cookie) @@ signCookies("secret") header "set-cookie"
           assertM(app(Request()))(isSome(equalTo(cookie.sign("secret").encode)))
         } +
           testM("sign cookies no cookie header") {
-            val app = (Http.ok.addHeader("keyA", "ValueA") @@ signCookies("secret")).getHeaderValues
+            val app = (Http.ok.addHeader("keyA", "ValueA") @@ signCookies("secret")).headerValues
             assertM(app(Request()))(contains("ValueA"))
           }
       }

--- a/zio-http/src/test/scala/zhttp/internal/HttpAppTestExtensions.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpAppTestExtensions.scala
@@ -4,16 +4,16 @@ import zhttp.http._
 
 trait HttpAppTestExtensions {
   implicit class HttpAppSyntax[R, E](app: HttpApp[R, E]) {
-    def getHeader(name: String): Http[R, E, Request, Option[String]] =
-      app.map(res => res.getHeaderValue(name))
+    def header(name: String): Http[R, E, Request, Option[String]] =
+      app.map(res => res.headerValue(name))
 
-    def getHeaders: Http[R, E, Request, Headers] =
-      app.map(res => res.getHeaders)
+    def headerValues: Http[R, E, Request, List[String]] =
+      app.map(res => res.headers.toList.map(_._2.toString))
 
-    def getHeaderValues: Http[R, E, Request, List[String]] =
-      app.map(res => res.getHeaders.toList.map(_._2.toString))
+    def headers: Http[R, E, Request, Headers] =
+      app.map(res => res.headers)
 
-    def getStatus: Http[R, E, Request, Status] =
+    def status: Http[R, E, Request, Status] =
       app.map(res => res.status)
   }
 }

--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -56,7 +56,7 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
      */
     def deploy: HttpTestClient[Any, ClientRequest, ClientResponse] =
       for {
-        port     <- Http.fromZIO(DynamicServer.getPort)
+        port     <- Http.fromZIO(DynamicServer.port)
         id       <- Http.fromZIO(DynamicServer.deploy(app))
         response <- Http.fromFunctionZIO[Client.ClientRequest] { params =>
           Client.request(
@@ -94,7 +94,7 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
     path: Path,
   ): ZIO[EventLoopGroup with ChannelFactory with DynamicServer, Throwable, Status] = {
     for {
-      port   <- DynamicServer.getPort
+      port   <- DynamicServer.port
       status <- Client
         .request(
           "http://localhost:%d/%s".format(port, path),

--- a/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
@@ -17,27 +17,27 @@ object ClientSpec extends HttpRunnableSpec {
 
   def clientSpec = suite("ClientSpec") {
     testM("respond Ok") {
-      val app = Http.ok.deploy.getStatus.run()
+      val app = Http.ok.deploy.status.run()
       assertM(app)(equalTo(Status.OK))
     } +
       testM("non empty content") {
         val app             = Http.text("abc")
-        val responseContent = app.deploy.getBody.run()
+        val responseContent = app.deploy.body.run()
         assertM(responseContent)(isNonEmpty)
       } +
       testM("echo POST request content") {
-        val app = Http.collectZIO[Request] { case req => req.getBodyAsString.map(Response.text(_)) }
-        val res = app.deploy.getBodyAsString.run(method = Method.POST, content = "ZIO user")
+        val app = Http.collectZIO[Request] { case req => req.bodyAsString.map(Response.text(_)) }
+        val res = app.deploy.bodyAsString.run(method = Method.POST, content = "ZIO user")
         assertM(res)(equalTo("ZIO user"))
       } +
       testM("empty content") {
         val app             = Http.empty
-        val responseContent = app.deploy.getBody.run()
+        val responseContent = app.deploy.body.run()
         assertM(responseContent)(isEmpty)
       } +
       testM("text content") {
         val app             = Http.text("zio user does not exist")
-        val responseContent = app.deploy.getBodyAsString.run()
+        val responseContent = app.deploy.bodyAsString.run()
         assertM(responseContent)(containsString("user"))
       } +
       testM("handle connection failure") {

--- a/zio-http/src/test/scala/zhttp/service/KeepAliveSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/KeepAliveSpec.scala
@@ -18,22 +18,22 @@ object KeepAliveSpec extends HttpRunnableSpec {
   def keepAliveSpec = suite("KeepAlive") {
     suite("Http 1.1") {
       testM("without connection close") {
-        val res = app.deploy.getHeaderValue(HeaderNames.connection).run()
+        val res = app.deploy.headerValue(HeaderNames.connection).run()
         assertM(res)(isNone)
       } +
         testM("with connection close") {
-          val res = app.deploy.getHeaderValue(HeaderNames.connection).run(headers = connectionCloseHeader)
+          val res = app.deploy.headerValue(HeaderNames.connection).run(headers = connectionCloseHeader)
           assertM(res)(isSome(equalTo("close")))
         }
     } +
       suite("Http 1.0") {
         testM("without keep-alive") {
-          val res = app.deploy.getHeaderValue(HeaderNames.connection).run(version = HttpVersion.HTTP_1_0)
+          val res = app.deploy.headerValue(HeaderNames.connection).run(version = HttpVersion.HTTP_1_0)
           assertM(res)(isSome(equalTo("close")))
         } +
           testM("with keep-alive") {
             val res = app.deploy
-              .getHeaderValue(HeaderNames.connection)
+              .headerValue(HeaderNames.connection)
               .run(version = HttpVersion.HTTP_1_0, headers = keepAliveHeader)
             assertM(res)(isNone)
           }

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -41,76 +41,76 @@ object ServerSpec extends HttpRunnableSpec {
   def dynamicAppSpec = suite("DynamicAppSpec") {
     suite("success") {
       testM("status is 200") {
-        val status = Http.ok.deploy.getStatus.run()
+        val status = Http.ok.deploy.status.run()
         assertM(status)(equalTo(Status.OK))
       } +
         testM("status is 200") {
-          val res = Http.text("ABC").deploy.getStatus.run()
+          val res = Http.text("ABC").deploy.status.run()
           assertM(res)(equalTo(Status.OK))
         } +
         testM("content is set") {
-          val res = Http.text("ABC").deploy.getBodyAsString.run()
+          val res = Http.text("ABC").deploy.bodyAsString.run()
           assertM(res)(containsString("ABC"))
         }
     } +
       suite("not found") {
         val app = Http.empty
         testM("status is 404") {
-          val res = app.deploy.getStatus.run()
+          val res = app.deploy.status.run()
           assertM(res)(equalTo(Status.NOT_FOUND))
         } +
           testM("header is set") {
-            val res = app.deploy.getHeaderValue(HeaderNames.contentLength).run()
+            val res = app.deploy.headerValue(HeaderNames.contentLength).run()
             assertM(res)(isSome(equalTo("0")))
           }
       } +
       suite("error") {
         val app = Http.fail(new Error("SERVER_ERROR"))
         testM("status is 500") {
-          val res = app.deploy.getStatus.run()
+          val res = app.deploy.status.run()
           assertM(res)(equalTo(Status.INTERNAL_SERVER_ERROR))
         } +
           testM("content is set") {
-            val res = app.deploy.getBodyAsString.run()
+            val res = app.deploy.bodyAsString.run()
             assertM(res)(containsString("SERVER_ERROR"))
           } +
           testM("header is set") {
-            val res = app.deploy.getHeaderValue(HeaderNames.contentLength).run()
+            val res = app.deploy.headerValue(HeaderNames.contentLength).run()
             assertM(res)(isSome(anything))
           }
       } +
       suite("echo content") {
         val app = Http.collectZIO[Request] { case req =>
-          req.getBodyAsString.map(text => Response.text(text))
+          req.bodyAsString.map(text => Response.text(text))
         }
 
         testM("status is 200") {
-          val res = app.deploy.getStatus.run()
+          val res = app.deploy.status.run()
           assertM(res)(equalTo(Status.OK))
         } +
           testM("body is ok") {
-            val res = app.deploy.getBodyAsString.run(content = "ABC")
+            val res = app.deploy.bodyAsString.run(content = "ABC")
             assertM(res)(equalTo("ABC"))
           } +
           testM("empty string") {
-            val res = app.deploy.getBodyAsString.run(content = "")
+            val res = app.deploy.bodyAsString.run(content = "")
             assertM(res)(equalTo(""))
           } +
           testM("one char") {
-            val res = app.deploy.getBodyAsString.run(content = "1")
+            val res = app.deploy.bodyAsString.run(content = "1")
             assertM(res)(equalTo("1"))
           }
       } +
       suite("headers") {
         val app = Http.ok.addHeader("Foo", "Bar")
         testM("headers are set") {
-          val res = app.deploy.getHeaderValue("Foo").run()
+          val res = app.deploy.headerValue("Foo").run()
           assertM(res)(isSome(equalTo("Bar")))
         }
       } + suite("response") {
         val app = Http.response(Response(status = Status.OK, data = HttpData.fromString("abc")))
         testM("body is set") {
-          val res = app.deploy.getBodyAsString.run()
+          val res = app.deploy.bodyAsString.run()
           assertM(res)(equalTo("abc"))
         }
       }
@@ -118,17 +118,17 @@ object ServerSpec extends HttpRunnableSpec {
 
   def requestSpec = suite("RequestSpec") {
     val app: HttpApp[Any, Nothing] = Http.collect[Request] { case req =>
-      Response.text(req.getContentLength.getOrElse(-1).toString)
+      Response.text(req.contentLength.getOrElse(-1).toString)
     }
     testM("has content-length") {
       checkAllM(Gen.alphaNumericString) { string =>
-        val res = app.deploy.getBodyAsString.run(content = string)
+        val res = app.deploy.bodyAsString.run(content = string)
         assertM(res)(equalTo(string.length.toString))
       }
     } +
       testM("POST Request.getBody") {
-        val app = Http.collectZIO[Request] { case req => req.getBody.as(Response.ok) }
-        val res = app.deploy.getStatus.run(path = !!, method = Method.POST, content = "some text")
+        val app = Http.collectZIO[Request] { case req => req.body.as(Response.ok) }
+        val res = app.deploy.status.run(path = !!, method = Method.POST, content = "some text")
         assertM(res)(equalTo(Status.OK))
       }
   }
@@ -136,13 +136,13 @@ object ServerSpec extends HttpRunnableSpec {
   def responseSpec = suite("ResponseSpec") {
     testM("data") {
       checkAllM(nonEmptyContent) { case (string, data) =>
-        val res = Http.fromData(data).deploy.getBodyAsString.run()
+        val res = Http.fromData(data).deploy.bodyAsString.run()
         assertM(res)(equalTo(string))
       }
     } +
       testM("data from file") {
         val file = new File(getClass.getResource("/TestFile.txt").getPath)
-        val res  = Http.fromFile(file).deploy.getBodyAsString.run()
+        val res  = Http.fromFile(file).deploy.bodyAsString.run()
         assertM(res)(equalTo("abc\nfoo"))
       } +
       testM("content-type header on file response") {
@@ -151,61 +151,61 @@ object ServerSpec extends HttpRunnableSpec {
           Http
             .fromFile(file)
             .deploy
-            .getHeaderValue(HeaderNames.contentType)
+            .headerValue(HeaderNames.contentType)
             .run()
             .map(_.getOrElse("Content type header not found."))
         assertM(res)(equalTo("text/plain"))
       } +
       testM("status") {
         checkAllM(HttpGen.status) { case status =>
-          val res = Http.status(status).deploy.getStatus.run()
+          val res = Http.status(status).deploy.status.run()
           assertM(res)(equalTo(status))
         }
       } +
       testM("header") {
         checkAllM(HttpGen.header) { case header @ (name, value) =>
-          val res = Http.ok.addHeader(header).deploy.getHeaderValue(name).run()
+          val res = Http.ok.addHeader(header).deploy.headerValue(name).run()
           assertM(res)(isSome(equalTo(value)))
         }
       } +
       testM("text streaming") {
-        val res = Http.fromStream(ZStream("a", "b", "c")).deploy.getBodyAsString.run()
+        val res = Http.fromStream(ZStream("a", "b", "c")).deploy.bodyAsString.run()
         assertM(res)(equalTo("abc"))
       } +
       testM("echo streaming") {
         val res = Http
           .collectHttp[Request] { case req =>
-            Http.fromStream(ZStream.fromEffect(req.getBody).flattenChunks)
+            Http.fromStream(ZStream.fromEffect(req.body).flattenChunks)
           }
           .deploy
-          .getBodyAsString
+          .bodyAsString
           .run(content = "abc")
         assertM(res)(equalTo("abc"))
       } +
       testM("file-streaming") {
         val path = getClass.getResource("/TestFile.txt").getPath
-        val res  = Http.fromStream(ZStream.fromFile(Paths.get(path))).deploy.getBodyAsString.run()
+        val res  = Http.fromStream(ZStream.fromFile(Paths.get(path))).deploy.bodyAsString.run()
         assertM(res)(equalTo("abc\nfoo"))
       } +
       suite("html") {
         testM("body") {
-          val res = Http.html(html(body(div(id := "foo", "bar")))).deploy.getBodyAsString.run()
+          val res = Http.html(html(body(div(id := "foo", "bar")))).deploy.bodyAsString.run()
           assertM(res)(equalTo("""<!DOCTYPE html><html><body><div id="foo">bar</div></body></html>"""))
         } +
           testM("content-type") {
             val app = Http.html(html(body(div(id := "foo", "bar"))))
-            val res = app.deploy.getHeaderValue(HeaderNames.contentType).run()
+            val res = app.deploy.headerValue(HeaderNames.contentType).run()
             assertM(res)(isSome(equalTo(HeaderValues.textHtml.toString)))
           }
       } +
       suite("content-length") {
         suite("string") {
           testM("unicode text") {
-            val res = Http.text("äöü").deploy.getContentLength.run()
+            val res = Http.text("äöü").deploy.contentLength.run()
             assertM(res)(isSome(equalTo(6L)))
           } +
             testM("already set") {
-              val res = Http.text("1234567890").withContentLength(4L).deploy.getContentLength.run()
+              val res = Http.text("1234567890").withContentLength(4L).deploy.contentLength.run()
               assertM(res)(isSome(equalTo(4L)))
             }
         }
@@ -216,14 +216,14 @@ object ServerSpec extends HttpRunnableSpec {
           val expected = (0 to size) map (_ => Status.OK)
           for {
             response <- Response.text("abc").freeze
-            actual   <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.getStatus.run())
+            actual   <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
           } yield assert(actual)(equalTo(expected))
         } +
           testM("update after cache") {
             val server = "ZIO-Http"
             for {
               res    <- Response.text("abc").freeze
-              actual <- Http.response(res).withServer(server).deploy.getHeaderValue(HeaderNames.server).run()
+              actual <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
             } yield assert(actual)(isSome(equalTo(server)))
           }
       }


### PR DESCRIPTION
If one want's to access something we should simply access it via the field name and not have to type `get` unnecessarily.