### PR TITLE
refactor: rename `provide` and `provideSome`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -241,7 +241,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
   /**
    * Provides the environment to Http.
    */
-  final def provide(r: R)(implicit ev: NeedsEnv[R]): Http[Any, E, A, B] =
+  final def provideEnvironment(r: R)(implicit ev: NeedsEnv[R]): Http[Any, E, A, B] =
     Http.fromOptionFunction[A](a => self(a).provide(r))
 
   /**
@@ -263,7 +263,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
   /**
    * Provides some of the environment to Http.
    */
-  final def provideSome[R1 <: R](r: R1 => R)(implicit ev: NeedsEnv[R]): Http[R1, E, A, B] =
+  final def provideSomeEnvironment[R1 <: R](r: R1 => R)(implicit ev: NeedsEnv[R]): Http[R1, E, A, B] =
     Http.fromOptionFunction[A](a => self(a).provideSome(r))
 
   /**

--- a/zio-http/src/main/scala/zhttp/http/Response.scala
+++ b/zio-http/src/main/scala/zhttp/http/Response.scala
@@ -151,7 +151,7 @@ object Response {
         Status.SWITCHING_PROTOCOLS,
         Headers.empty,
         HttpData.empty,
-        Attribute(socketApp = Option(app.provide(env))),
+        Attribute(socketApp = Option(app.provideEnvironment(env))),
       )
     }
 

--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -48,7 +48,7 @@ final case class Client[R](rtm: HttpRuntime[R], cf: JChannelFactory[Channel], el
         url,
         Method.GET,
         headers,
-        attribute = Client.Attribute(socketApp = Some(socketApp.provide(env)), ssl = Some(sslOptions)),
+        attribute = Client.Attribute(socketApp = Some(socketApp.provideEnvironment(env)), ssl = Some(sslOptions)),
       ),
     )
   } yield res

--- a/zio-http/src/main/scala/zhttp/socket/Socket.scala
+++ b/zio-http/src/main/scala/zhttp/socket/Socket.scala
@@ -21,7 +21,7 @@ sealed trait Socket[-R, +E, -A, +B] { self =>
     case FOrElse(sa, sb)             => sa(a) <> sb(a)
     case FMerge(sa, sb)              => sa(a) merge sb(a)
     case Succeed(a)                  => ZStream.succeed(a)
-    case Provide(s, r)               => s(a).asInstanceOf[ZStream[R, E, B]].provide(r.asInstanceOf[R])
+    case ProvideEnvironment(s, r)    => s(a).asInstanceOf[ZStream[R, E, B]].provide(r.asInstanceOf[R])
     case Empty                       => ZStream.empty
   }
 
@@ -49,7 +49,7 @@ sealed trait Socket[-R, +E, -A, +B] { self =>
    * dependency on R. This operation assumes that your socket requires an
    * environment.
    */
-  def provide(r: R)(implicit env: NeedsEnv[R]): Socket[Any, E, A, B] = Provide(self, r)
+  def provideEnvironment(r: R)(implicit env: NeedsEnv[R]): Socket[Any, E, A, B] = ProvideEnvironment(self, r)
 
   /**
    * Converts the Socket into an Http
@@ -123,7 +123,7 @@ object Socket {
 
   private final case class FMerge[R, E, A, B](a: Socket[R, E, A, B], b: Socket[R, E, A, B]) extends Socket[R, E, A, B]
 
-  private final case class Provide[R, E, A, B](s: Socket[R, E, A, B], r: R) extends Socket[Any, E, A, B]
+  private final case class ProvideEnvironment[R, E, A, B](s: Socket[R, E, A, B], r: R) extends Socket[Any, E, A, B]
 
   private case object End extends Socket[Any, Nothing, Any, Nothing]
 

--- a/zio-http/src/test/scala/zhttp/socket/SocketSpec.scala
+++ b/zio-http/src/test/scala/zhttp/socket/SocketSpec.scala
@@ -20,7 +20,7 @@ object SocketSpec extends DefaultRunnableSpec {
       val environment = ZStream.environment[String]
       val socket      = Socket
         .fromStream(environment)
-        .provide(text)
+        .provideEnvironment(text)
         .execute("")
 
       assertM(socket.runCollect)(equalTo(Chunk(text)))
@@ -29,7 +29,7 @@ object SocketSpec extends DefaultRunnableSpec {
         val environmentFunction = (_: Any) => ZStream.environment[WebSocketFrame]
         val socket              = Socket
           .fromFunction(environmentFunction)
-          .provide(WebSocketFrame.text("Foo"))
+          .provideEnvironment(WebSocketFrame.text("Foo"))
           .execute(WebSocketFrame.text("Bar"))
 
         assertM(socket.runCollect)(equalTo(Chunk(WebSocketFrame.text("Foo"))))
@@ -40,7 +40,7 @@ object SocketSpec extends DefaultRunnableSpec {
           .collect[WebSocketFrame] { case WebSocketFrame.Pong =>
             environment
           }
-          .provide(WebSocketFrame.ping)
+          .provideEnvironment(WebSocketFrame.ping)
           .execute(WebSocketFrame.pong)
 
         assertM(socket.runCollect)(equalTo(Chunk(WebSocketFrame.ping)))
@@ -50,9 +50,9 @@ object SocketSpec extends DefaultRunnableSpec {
           ZStream.environment[Int]
         }
 
-        val socketA: Socket[Int, Nothing, Int, Int] = socket.provide(12)
-        val socketB: Socket[Int, Nothing, Int, Int] = socketA.provide(1)
-        val socketC: Socket[Any, Nothing, Int, Int] = socketB.provide(42)
+        val socketA: Socket[Int, Nothing, Int, Int] = socket.provideEnvironment(12)
+        val socketB: Socket[Int, Nothing, Int, Int] = socketA.provideEnvironment(1)
+        val socketC: Socket[Any, Nothing, Int, Int] = socketB.provideEnvironment(42)
 
         assertM(socketC.execute(1000).runCollect)(equalTo(Chunk(12)))
       } +


### PR DESCRIPTION
This PR renames `provide` and `provideSome` operators to their zio 2 counterparts `provideEnvironment` and `provideSomeEnvironment`

Closes #997 