### PR TITLE
Jmh Benchmark comparison

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpExecuteBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpExecuteBenchmark.scala
@@ -1,0 +1,22 @@
+package zhttp.benchmarks
+
+import org.openjdk.jmh.annotations._
+import zhttp.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class HttpExecuteBenchmark {
+
+  private val msg          = "HELLO WORLD"
+  private val app          = Http.succeed(msg)
+  private val req: Request = Request(Method.GET, URL(!!))
+
+  @Benchmark
+  def benchmarkHttpProgram(): Unit = {
+    app.execute(req)
+    ()
+  }
+}

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpExecuteBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpExecuteBenchmark.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 class HttpExecuteBenchmark {
 
   private val msg          = "HELLO WORLD"
-  private val app          = Http.succeed(msg)
+  private val app          = Http.fromHExit(HExit.succeed(msg))
   private val req: Request = Request(Method.GET, URL(!!))
 
   @Benchmark


### PR DESCRIPTION
Main without optimisation
```
[info] Benchmark                                   Mode  Cnt          Score          Error  Units
[info] HttpExecuteBenchmark.benchmarkHttpProgram  thrpt    3  246985859.821 ? 75279200.251  ops/s
```