### PR TITLE
Refactor: Server Settings Support in `HttpRunnableSpec#serve`

### DIFF
--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -85,10 +85,13 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
 
   def serve[R <: Has[_]](
     app: HttpApp[R, Throwable],
+    serverSettings: Server[R, Nothing]*,
   ): ZManaged[R with EventLoopGroup with ServerChannelFactory with DynamicServer, Nothing, Unit] =
     for {
-      start <- Server.make(Server.app(app) ++ Server.port(0) ++ Server.paranoidLeakDetection).orDie
-      _     <- DynamicServer.setStart(start).toManaged_
+      settings <- ZManaged
+        .succeed(serverSettings.foldLeft(Server.app(app) ++ Server.port(0) ++ Server.paranoidLeakDetection)(_ ++ _))
+      start    <- Server.make(settings).orDie
+      _        <- DynamicServer.setStart(start).toManaged_
     } yield ()
 
   def status(

--- a/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpRunnableSpec.scala
@@ -85,11 +85,11 @@ abstract class HttpRunnableSpec extends DefaultRunnableSpec { self =>
 
   def serve[R <: Has[_]](
     app: HttpApp[R, Throwable],
-    serverSettings: Server[R, Nothing]*,
+    server: Option[Server[R, Throwable]] = None,
   ): ZManaged[R with EventLoopGroup with ServerChannelFactory with DynamicServer, Nothing, Unit] =
     for {
       settings <- ZManaged
-        .succeed(serverSettings.foldLeft(Server.app(app) ++ Server.port(0) ++ Server.paranoidLeakDetection)(_ ++ _))
+        .succeed(server.foldLeft(Server.app(app) ++ Server.port(0) ++ Server.paranoidLeakDetection)(_ ++ _))
       start    <- Server.make(settings).orDie
       _        <- DynamicServer.setStart(start).toManaged_
     } yield ()


### PR DESCRIPTION
Adds in support to set arbitrary server settings while using HttpRunnableSpec#serve.