### PR TITLE
Added json response in benchmark

### DIFF
--- a/example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -12,8 +12,18 @@ import zio.{App, ExitCode, UIO, URIO}
 object Main extends App {
 
   private val message: String = "Hello, World!"
+  private val json: String    = """{"greetings": "Hello World!"}"""
+
+  val path1 = "/plaintext"
+  val path2 = "/json"
 
   private val STATIC_SERVER_NAME = AsciiString.cached("zio-http")
+
+  private val frozenJsonResponse = Response
+    .json(json)
+    .withServerTime
+    .withServer(STATIC_SERVER_NAME)
+    .freeze
 
   private val frozenResponse = Response
     .text(message)
@@ -22,16 +32,18 @@ object Main extends App {
     .freeze
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {
-    frozenResponse
-      .flatMap(server(_).make.useForever)
-      .provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))
-      .exitCode
+    val s = for {
+      res1 <- frozenResponse
+      res2 <- frozenJsonResponse
+    } yield server(res1, res2)
+    s.flatMap(_.make.useForever.provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))).exitCode
   }
-  private val path                                               = "/plaintext"
-  private def app(response: Response) = Http.fromHExit(HExit.succeed(response)).whenPathEq(path)
 
-  private def server(response: Response) =
-    Server.app(app(response)) ++
+  private def app(response: Response, json: Response) =
+    Http.fromHExit(HExit.succeed(response)).whenPathEq(path1) ++ Http.fromHExit(HExit.succeed(json)).whenPathEq(path2)
+
+  private def server(response: Response, json: Response) =
+    Server.app(app(response, json)) ++
       Server.port(8080) ++
       Server.error(_ => UIO.unit) ++
       Server.disableLeakDetection ++

--- a/example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -40,7 +40,9 @@ object Main extends App {
   }
 
   private def app(response: Response, json: Response) =
-    Http.fromHExit(HExit.succeed(response)).whenPathEq(path1) ++ Http.fromHExit(HExit.succeed(json)).whenPathEq(path2)
+    Http.fromHExit(HExit.succeed(response)).whenPathEq(path1) composeHttp Http
+      .fromHExit(HExit.succeed(json))
+      .whenPathEq(path2)
 
   private def server(response: Response, json: Response) =
     Server.app(app(response, json)) ++

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpComposeHttpEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpComposeHttpEval.scala
@@ -1,0 +1,27 @@
+package zhttp.benchmarks
+
+import org.openjdk.jmh.annotations._
+import zhttp.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class HttpComposeHttpEval {
+  private val MAX  = 1000
+  private val app  = Http.collect[Int] { case 0 => 1 }
+  private val spec = (0 to MAX).foldLeft(app)((a, _) => a composeHttp app)
+
+  @Benchmark
+  def benchmarkNotFound(): Unit = {
+    spec.execute(-1)
+    ()
+  }
+
+  @Benchmark
+  def benchmarkOk(): Unit = {
+    spec.execute(0)
+    ()
+  }
+}

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
@@ -2,6 +2,7 @@ package zhttp.benchmarks
 
 import org.openjdk.jmh.annotations._
 import zhttp.http._
+import zio._
 
 import java.util.concurrent.TimeUnit
 
@@ -10,16 +11,23 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpRouteTextPerf {
 
+  private val runtime = Runtime.default
+
   private val res          = Response.text("HELLO WORLD")
-  private val app          = Http.fromHExit(HExit.succeed(res)).whenPathEq("/text") composeHttp Http
-    .fromHExit(HExit.succeed(res))
-    .whenPathEq("/plain")
-  private val req: Request = Request(Method.GET, URL(!! / "text"))
+  private val app          = Http.succeed(res)
+  private val req: Request = Request(Method.GET, URL(!!))
+  private val httpProgram  = ZIO.foreach_(0 to 1000) { _ => app.execute(req).toZIO }
+  private val UIOProgram   = ZIO.foreach_(0 to 1000) { _ => UIO(res) }
 
   @Benchmark
   def benchmarkHttpProgram(): Unit = {
-    val _ = app.execute(req)
+    runtime.unsafeRun(httpProgram)
     ()
   }
 
+  @Benchmark
+  def benchmarkUIOProgram(): Unit = {
+    runtime.unsafeRun(UIOProgram)
+    ()
+  }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
@@ -2,7 +2,6 @@ package zhttp.benchmarks
 
 import org.openjdk.jmh.annotations._
 import zhttp.http._
-import zio._
 
 import java.util.concurrent.TimeUnit
 
@@ -11,23 +10,19 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpRouteTextPerf {
 
-  private val runtime = Runtime.default
+  private val res  = Response.text("HELLO WORLD")
+  private val res2 = Response.text("HELLO WORLD2")
 
-  private val res          = Response.text("HELLO WORLD")
-  private val app          = Http.succeed(res)
-  private val req: Request = Request(Method.GET, URL(!!))
-  private val httpProgram  = ZIO.foreach_(0 to 1000) { _ => app.execute(req).toZIO }
-  private val UIOProgram   = ZIO.foreach_(0 to 1000) { _ => UIO(res) }
+  private val app          =
+    Http.fromHExit(HExit.succeed(res)).whenPathEq("/text") composeHttp Http
+      .fromHExit(HExit.succeed(res2))
+      .whenPathEq("/plain")
+  private val req: Request = Request(Method.GET, URL(!! / "text"))
 
   @Benchmark
   def benchmarkHttpProgram(): Unit = {
-    runtime.unsafeRun(httpProgram)
+    val _ = app.execute(req)
     ()
   }
 
-  @Benchmark
-  def benchmarkUIOProgram(): Unit = {
-    runtime.unsafeRun(UIOProgram)
-    ()
-  }
 }

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpRouteTextPerf.scala
@@ -2,7 +2,6 @@ package zhttp.benchmarks
 
 import org.openjdk.jmh.annotations._
 import zhttp.http._
-import zio._
 
 import java.util.concurrent.TimeUnit
 
@@ -11,23 +10,16 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpRouteTextPerf {
 
-  private val runtime = Runtime.default
-
   private val res          = Response.text("HELLO WORLD")
-  private val app          = Http.succeed(res)
-  private val req: Request = Request(Method.GET, URL(!!))
-  private val httpProgram  = ZIO.foreach_(0 to 1000) { _ => app.execute(req).toZIO }
-  private val UIOProgram   = ZIO.foreach_(0 to 1000) { _ => UIO(res) }
+  private val app          = Http.fromHExit(HExit.succeed(res)).whenPathEq("/text") composeHttp Http
+    .fromHExit(HExit.succeed(res))
+    .whenPathEq("/plain")
+  private val req: Request = Request(Method.GET, URL(!! / "text"))
 
   @Benchmark
   def benchmarkHttpProgram(): Unit = {
-    runtime.unsafeRun(httpProgram)
+    val _ = app.execute(req)
     ()
   }
 
-  @Benchmark
-  def benchmarkUIOProgram(): Unit = {
-    runtime.unsafeRun(UIOProgram)
-    ()
-  }
 }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -209,7 +209,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
     dd: Http[R1, E1, A1, B1],
   ): Http[R1, E1, A1, B1] = Http.FoldHttp(self, ee, bb, dd)
 
-  final def composeHttp[R1 <: R, A1 <: A, E1, B1](other: Http[R1, E1, A1, B1]): Http[R1, E1, A1, B1] =
+  final def composeHttp[R1 <: R, A1 <: A, E1 >: E, B1 >: B](other: Http[R1, E1, A1, B1]): Http[R1, E1, A1, B1] =
     Http.Compose(self, other)
 
   /**

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -210,7 +210,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
   ): Http[R1, E1, A1, B1] = Http.FoldHttp(self, ee, bb, dd)
 
   final def composeHttp[R1 <: R, A1 <: A, E1 >: E, B1 >: B](other: Http[R1, E1, A1, B1]): Http[R1, E1, A1, B1] =
-    Http.Compose(self, other)
+    Http.Combine(self, other)
 
   /**
    * Extracts the value of the provided header name.
@@ -422,7 +422,7 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
       case FoldHttp(self, ee, bb, dd) =>
         self.execute(a).foldExit(ee(_).execute(a), bb(_).execute(a), dd.execute(a))
 
-      case Compose(self, other) => {
+      case Combine(self, other) => {
         self.execute(a) match {
           case HExit.Effect(zio) => {
             Effect(
@@ -865,7 +865,7 @@ object Http {
 
   private case class Attempt[A](a: () => A) extends Http[Any, Nothing, Any, A]
 
-  private final case class Compose[R, E, EE, A, B, BB](
+  private final case class Combine[R, E, EE, A, B, BB](
     self: Http[R, E, A, B],
     other: Http[R, EE, A, BB],
   ) extends Http[R, EE, A, BB]


### PR DESCRIPTION
Benchmark code:
```scala
package zhttp.benchmarks

import org.openjdk.jmh.annotations._
import zhttp.http._

import java.util.concurrent.TimeUnit

@State(Scope.Thread)
@BenchmarkMode(Array(Mode.Throughput))
@OutputTimeUnit(TimeUnit.SECONDS)
class HttpRouteTextPerf {

  private val res          = Response.text("HELLO WORLD")
  private val app          = Http.fromHExit(HExit.succeed(res)).whenPathEq("/text") ++ Http
    .fromHExit(HExit.succeed(res))
    .whenPathEq("/plain")
  private val req: Request = Request(Method.GET, URL(!! / "text"))

  @Benchmark
  def benchmarkHttpProgram(): Unit = {
    val _ = app.execute(req)
    ()
  }

}
```



jmh benchmark results
```
[info] Benchmark                                Mode  Cnt        Score         Error  Units
[info] HttpRouteTextPerf.benchmarkHttpProgram  thrpt    3  4052918.714 ? 1315668.386  ops/s
```