### PR TITLE
Lift in PartialCollect

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -772,11 +772,9 @@ object Http {
 
   final case class PartialCollect[A](unit: Unit) extends AnyVal {
     def apply[B](pf: PartialFunction[A, B]): Http[Any, Nothing, A, B] = {
-      FromFunctionHExit(a => {
-        pf.lift(a) match {
-          case Some(value) => HExit.succeed(value)
-          case None        => HExit.Empty
-        }
+      FromFunctionHExit(pf.lift(_) match {
+        case Some(value) => HExit.succeed(value)
+        case None        => HExit.Empty
       })
     }
   }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -771,8 +771,14 @@ object Http {
   }
 
   final case class PartialCollect[A](unit: Unit) extends AnyVal {
-    def apply[B](pf: PartialFunction[A, B]): Http[Any, Nothing, A, B] =
-      FromFunctionHExit(a => if (pf.isDefinedAt(a)) HExit.succeed(pf(a)) else HExit.Empty)
+    def apply[B](pf: PartialFunction[A, B]): Http[Any, Nothing, A, B] = {
+      FromFunctionHExit(a => {
+        pf.lift(a) match {
+          case Some(value) => HExit.succeed(value)
+          case None        => HExit.Empty
+        }
+      })
+    }
   }
 
   final case class PartialCollectHttp[A](unit: Unit) extends AnyVal {


### PR DESCRIPTION
Benchmark code:
``` scala
 // Create HTTP route
  val app: HttpApp[Any, Nothing] = Http.collect[Request] {
    case Method.GET -> !! / "text" => Response.text("Hello World!")
    case Method.GET -> !! / "plain" => Response.json("""{"greetings": "Hello World!"}""")
  }

  private val req: Request = Request(Method.GET, URL(!! / "text"))

  @Benchmark
  def benchmarkHttpProgram(): Unit = {
    val _ = app.execute(req)
    ()
  }
  ```
  
  Current main benchmark results:
  ```
  [info] Benchmark                                Mode  Cnt        Score          Error  Units
[info] HttpRouteTextPerf.benchmarkHttpProgram  thrpt    3  9613595.681 ? 28197425.311  ops/s
```

After using `Lift` :

```
[info] Benchmark                                Mode  Cnt         Score         Error  Units
[info] HttpRouteTextPerf.benchmarkHttpProgram  thrpt    3  15027343.935 ? 1966261.876  ops/s
```






  