### PR TITLE
Enhancement: Added combine operator

### DIFF
--- a/example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -12,8 +12,18 @@ import zio.{App, ExitCode, UIO, URIO}
 object Main extends App {
 
   private val message: String = "Hello, World!"
+  private val json: String    = """{"greetings": "Hello World!"}"""
+
+  val path1 = "/plaintext"
+  val path2 = "/json"
 
   private val STATIC_SERVER_NAME = AsciiString.cached("zio-http")
+
+  private val frozenJsonResponse = Response
+    .json(json)
+    .withServerTime
+    .withServer(STATIC_SERVER_NAME)
+    .freeze
 
   private val frozenResponse = Response
     .text(message)
@@ -22,16 +32,20 @@ object Main extends App {
     .freeze
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {
-    frozenResponse
-      .flatMap(server(_).make.useForever)
-      .provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))
-      .exitCode
+    val s = for {
+      res1 <- frozenResponse
+      res2 <- frozenJsonResponse
+    } yield server(res1, res2)
+    s.flatMap(_.make.useForever.provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))).exitCode
   }
-  private val path                                               = "/plaintext"
-  private def app(response: Response) = Http.fromHExit(HExit.succeed(response)).whenPathEq(path)
 
-  private def server(response: Response) =
-    Server.app(app(response)) ++
+  private def app(response: Response, json: Response) =
+    Http.fromHExit(HExit.succeed(response)).whenPathEq(path1) ++ Http
+      .fromHExit(HExit.succeed(json))
+      .whenPathEq(path2)
+
+  private def server(response: Response, json: Response) =
+    Server.app(app(response, json)) ++
       Server.port(8080) ++
       Server.error(_ => UIO.unit) ++
       Server.disableLeakDetection ++

--- a/example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -1,7 +1,7 @@
 package example
 
 import io.netty.util.AsciiString
-import zhttp.http._
+import zhttp.http.{Http, _}
 import zhttp.service.server.ServerChannelFactory
 import zhttp.service.{EventLoopGroup, Server}
 import zio.{App, ExitCode, UIO, URIO}
@@ -11,41 +11,43 @@ import zio.{App, ExitCode, UIO, URIO}
  */
 object Main extends App {
 
-  private val message: String = "Hello, World!"
-  private val json: String    = """{"greetings": "Hello World!"}"""
+  private val plainTextMessage: String = "Hello, World!"
+  private val jsonMessage: String      = """{"greetings": "Hello World!"}"""
 
-  val path1 = "/plaintext"
-  val path2 = "/json"
+  private val plaintextPath = "/plaintext"
+  private val jsonPath      = "/json"
 
   private val STATIC_SERVER_NAME = AsciiString.cached("zio-http")
 
   private val frozenJsonResponse = Response
-    .json(json)
+    .json(jsonMessage)
     .withServerTime
     .withServer(STATIC_SERVER_NAME)
     .freeze
 
-  private val frozenResponse = Response
-    .text(message)
+  private val frozenPlainTextResponse = Response
+    .text(plainTextMessage)
     .withServerTime
     .withServer(STATIC_SERVER_NAME)
     .freeze
 
-  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] = {
-    val s = for {
-      res1 <- frozenResponse
-      res2 <- frozenJsonResponse
-    } yield server(res1, res2)
-    s.flatMap(_.make.useForever.provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))).exitCode
-  }
+  private def plainTextApp(response: Response) = Http.fromHExit(HExit.succeed(response)).whenPathEq(plaintextPath)
 
-  private def app(response: Response, json: Response) =
-    Http.fromHExit(HExit.succeed(response)).whenPathEq(path1) ++ Http
-      .fromHExit(HExit.succeed(json))
-      .whenPathEq(path2)
+  private def jsonApp(json: Response) = Http.fromHExit(HExit.succeed(json)).whenPathEq(jsonPath)
 
-  private def server(response: Response, json: Response) =
-    Server.app(app(response, json)) ++
+  private def app = for {
+    plainTextResponse <- frozenPlainTextResponse
+    jsonResponse      <- frozenJsonResponse
+  } yield plainTextApp(plainTextResponse) ++ jsonApp(jsonResponse)
+
+  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+    app
+      .flatMap(server(_).make.useForever)
+      .provideCustomLayer(ServerChannelFactory.auto ++ EventLoopGroup.auto(8))
+      .exitCode
+
+  private def server(app: HttpApp[Any, Nothing]) =
+    Server.app(app) ++
       Server.port(8080) ++
       Server.error(_ => UIO.unit) ++
       Server.disableLeakDetection ++

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCombineEval.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpCombineEval.scala
@@ -14,13 +14,13 @@ class HttpCombineEval {
   private val spec = (0 to MAX).foldLeft(app)((a, _) => a ++ app)
 
   @Benchmark
-  def benchmarkNotFound(): Unit = {
+  def empty(): Unit = {
     spec.execute(-1)
     ()
   }
 
   @Benchmark
-  def benchmarkOk(): Unit = {
+  def ok(): Unit = {
     spec.execute(0)
     ()
   }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -4,7 +4,6 @@ import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.channel.ChannelHandler
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.html._
-import zhttp.http.HExit.Effect
 import zhttp.http.headers.HeaderModifier
 import zhttp.service.server.ServerTime
 import zhttp.service.{Handler, HttpRuntime, Server}
@@ -600,19 +599,8 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
 
       case Combine(self, other) => {
         self.execute(a) match {
-          case HExit.Effect(zio) => {
-            Effect(
-              zio.foldM(
-                {
-                  case Some(error) => ZIO.fail(Option(error.asInstanceOf[E]))
-                  case None        => other.execute(a).toZIO
-                },
-                b => ZIO.succeed(b.asInstanceOf[B]),
-              ),
-            )
-          }
-          case HExit.Empty       => other.execute(a)
-          case u                 => u.asInstanceOf[HExit[R, E, B]]
+          case HExit.Empty => other.execute(a)
+          case u           => u.asInstanceOf[HExit[R, E, B]]
         }
       }
     }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -4,7 +4,6 @@ import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.channel.ChannelHandler
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.html._
-import zhttp.http.HExit.Effect
 import zhttp.http.headers.HeaderModifier
 import zhttp.service.server.ServerTime
 import zhttp.service.{Handler, HttpRuntime, Server}
@@ -600,19 +599,11 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
 
       case Combine(self, other) => {
         self.execute(a) match {
-          case HExit.Effect(zio) => {
-            Effect(
-              zio.foldM(
-                {
-                  case Some(error) => ZIO.fail(Option(error.asInstanceOf[E]))
-                  case None        => other.execute(a).toZIO
-                },
-                b => ZIO.succeed(b.asInstanceOf[B]),
-              ),
-            )
-          }
-          case HExit.Empty       => other.execute(a)
-          case u                 => u.asInstanceOf[HExit[R, E, B]]
+          case HExit.Empty            => other.execute(a)
+          case exit: HExit.Success[_] => exit.asInstanceOf[HExit[R, E, B]]
+          case exit: HExit.Failure[_] => exit.asInstanceOf[HExit[R, E, B]]
+          case exit: HExit.Die        => exit
+          case exit @ HExit.Effect(_) => exit.defaultWith(other.execute(a)).asInstanceOf[HExit[R, E, B]]
         }
       }
     }

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -4,6 +4,7 @@ import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.channel.ChannelHandler
 import io.netty.handler.codec.http.HttpHeaderNames
 import zhttp.html._
+import zhttp.http.HExit.Effect
 import zhttp.http.headers.HeaderModifier
 import zhttp.service.server.ServerTime
 import zhttp.service.{Handler, HttpRuntime, Server}
@@ -599,8 +600,19 @@ sealed trait Http[-R, +E, -A, +B] extends (A => ZIO[R, Option[E], B]) { self =>
 
       case Combine(self, other) => {
         self.execute(a) match {
-          case HExit.Empty => other.execute(a)
-          case u           => u.asInstanceOf[HExit[R, E, B]]
+          case HExit.Effect(zio) => {
+            Effect(
+              zio.foldM(
+                {
+                  case Some(error) => ZIO.fail(Option(error.asInstanceOf[E]))
+                  case None        => other.execute(a).toZIO
+                },
+                b => ZIO.succeed(b.asInstanceOf[B]),
+              ),
+            )
+          }
+          case HExit.Empty       => other.execute(a)
+          case u                 => u.asInstanceOf[HExit[R, E, B]]
         }
       }
     }

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -164,47 +164,32 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             val actual = (a ++ b).execute(2)
             assert(actual)(isSuccess(equalTo("B")))
           } +
-          test("should resolve third") {
-            val a      = Http.collect[Int] { case 1 => "A" }
-            val b      = Http.collect[Int] { case 2 => "B" }
-            val c      = Http.collect[Int] { case 3 => "C" }
-            val actual = (a ++ b ++ c).execute(3)
-            assert(actual)(isSuccess(equalTo("C")))
-          } +
-          test("should resolve third") {
-            val a      = Http.collect[Int] { case 1 => "A" }
-            val b      = Http.collect[Int] { case 2 => "B" }
-            val c      = Http.collectZIO[Int] { case 3 => UIO("C") }
-            val actual = (a ++ b ++ c).execute(3)
-            assert(actual)(isEffect)
-          } +
           test("should not resolve") {
             val a      = Http.collect[Int] { case 1 => "A" }
             val b      = Http.collect[Int] { case 2 => "B" }
-            val c      = Http.collect[Int] { case 3 => "C" }
-            val actual = (a ++ b ++ c).execute(4)
+            val actual = (a ++ b).execute(3)
             assert(actual)(isEmpty)
           } +
           test("should not resolve") {
-            val a      = Http.collectZIO[Int] { case 1 => UIO("A") }
-            val b      = Http.collectZIO[Int] { case 2 => UIO("B") }
-            val c      = Http.collectZIO[Int] { case 3 => UIO("C") }
-            val actual = (a ++ b ++ c).execute(4)
+            val a      = Http.empty
+            val b      = Http.empty
+            val c      = Http.empty
+            val actual = (a ++ b ++ c).execute(())
             assert(actual)(isEmpty)
           } +
           test("should fail with second") {
-            val a      = Http.collect[Int] { case 1 => "A" }
+            val a      = Http.empty
             val b      = Http.fail(100)
-            val c      = Http.collect[Int] { case 3 => "C" }
-            val actual = (a ++ b ++ c).execute(3)
+            val c      = Http.succeed("A")
+            val actual = (a ++ b ++ c).execute(())
             assert(actual)(isFailure(equalTo(100)))
           } +
-          test("should fail with second") {
-            val a      = Http.collectHttp[Int] { case 1 => Http.succeed("A") }
-            val b      = Http.collectHttp[Int] { case 2 => Http.fail(100) }
-            val c      = Http.collectHttp[Int] { case 3 => Http.succeed("C") }
-            val actual = (a ++ b ++ c).execute(2)
-            assert(actual)(isFailure(equalTo(100)))
+          test("should resolve third") {
+            val a      = Http.empty
+            val b      = Http.empty
+            val c      = Http.succeed("C")
+            val actual = (a ++ b ++ c).execute(())
+            assert(actual)(isSuccess(equalTo("C")))
           },
       ) +
       suite("asEffect")(
@@ -240,13 +225,6 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             val b      = Http.succeed("B")
             val actual = (a ++ b).execute(2)
             assert(actual)(isSuccess(equalTo("B")))
-          } +
-          test("should resolve third") {
-            val a      = Http.empty
-            val b      = Http.empty
-            val c      = Http.succeed("C")
-            val actual = (a ++ b ++ c).execute(3)
-            assert(actual)(isSuccess(equalTo("C")))
           },
       ) +
       suite("route")(

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -235,8 +235,8 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             assert(actual)(isSuccess(equalTo("B")))
           } +
           test("should resolve third") {
-            val a      = Http.empty.flatten
-            val b      = Http.empty.flatten
+            val a      = Http.empty
+            val b      = Http.empty
             val c      = Http.succeed("C")
             val actual = (a ++ b ++ c).execute(3)
             assert(actual)(isSuccess(equalTo("C")))

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -190,6 +190,12 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             val c      = Http.succeed("C")
             val actual = (a ++ b ++ c).execute(())
             assert(actual)(isSuccess(equalTo("C")))
+          } +
+          testM("should resolve second") {
+            val a      = Http.fromHExit(HExit.Effect(ZIO.fail(None)))
+            val b      = Http.succeed(2)
+            val actual = (a ++ b).execute(()).toZIO.either
+            assertM(actual)(isRight)
           },
       ) +
       suite("asEffect")(

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -198,6 +198,13 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             val c      = Http.collect[Int] { case 3 => "C" }
             val actual = (a ++ b ++ c).execute(3)
             assert(actual)(isFailure(equalTo(100)))
+          } +
+          test("should fail with second") {
+            val a      = Http.collectHttp[Int] { case 1 => Http.succeed("A") }
+            val b      = Http.collectHttp[Int] { case 2 => Http.fail(100) }
+            val c      = Http.collectHttp[Int] { case 3 => Http.succeed("C") }
+            val actual = (a ++ b ++ c).execute(2)
+            assert(actual)(isFailure(equalTo(100)))
           },
       ) +
       suite("asEffect")(

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -194,9 +194,9 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
           } +
           test("should fail with second") {
             val a      = Http.collect[Int] { case 1 => "A" }
-            val b      = Http.collectHttp[Int] { case 2 => Http.fail(100) }
+            val b      = Http.fail(100)
             val c      = Http.collect[Int] { case 3 => "C" }
-            val actual = (a ++ b ++ c).execute(2)
+            val actual = (a ++ b ++ c).execute(3)
             assert(actual)(isFailure(equalTo(100)))
           },
       ) +

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -172,8 +172,8 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
             assert(actual)(isSuccess(equalTo("C")))
           } +
           test("should resolve third") {
-            val a      = Http.collectZIO[Int] { case 1 => UIO("A") }
-            val b      = Http.collectZIO[Int] { case 2 => UIO("B") }
+            val a      = Http.collect[Int] { case 1 => "A" }
+            val b      = Http.collect[Int] { case 2 => "B" }
             val c      = Http.collectZIO[Int] { case 3 => UIO("C") }
             val actual = (a ++ b ++ c).execute(3)
             assert(actual)(isEffect)


### PR DESCRIPTION
Currently, ++ is implemented using `FoldHttp` primitive, I've added `Combine` primitive which improves performance(as mentioned below)
HttpCombineEval Benchmark results:

Main branch:
```
[info] Benchmark                           Mode  Cnt      Score       Error  Units
[info] HttpCombineEval.benchmarkNotFound  thrpt    3  70211.931 ? 18985.369  ops/s
[info] HttpCombineEval.benchmarkOk        thrpt    3  39266.153 ? 96066.575  ops/s
```

Current Branch:
```
[info] Benchmark                           Mode  Cnt      Score       Error  Units
[info] HttpCombineEval.benchmarkNotFound  thrpt    3  81206.263 ? 11267.440  ops/s
[info] HttpCombineEval.benchmarkOk        thrpt    3  91960.203 ? 43519.961  ops/s
```