### PR TITLE
Refactor: Make `Http.getResource` consistent with `ZStream.fromResource`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -8,7 +8,7 @@ import zhttp.http.headers.HeaderModifier
 import zhttp.service.server.ServerTime
 import zhttp.service.{Handler, HttpRuntime, Server}
 import zio._
-import zio.blocking.{Blocking, effectBlockingIO}
+import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.stream.ZStream
@@ -859,7 +859,7 @@ object Http {
   /**
    * Creates an Http app from a resource path
    */
-  def fromResource(path: String): HttpApp[Blocking, Throwable] =
+  def fromResource(path: String): HttpApp[Any, Throwable] =
     Http.getResource(path).flatMap(url => Http.fromFile(new File(url.getPath)))
 
   /**
@@ -886,13 +886,13 @@ object Http {
    */
   def getResource(path: String): Http[Any, Throwable, Any, net.URL] =
     Http
-      .fromZIO(effectBlockingIO(getClass.getClassLoader.getResource(path)))
+      .fromZIO(Blocking.Service.live.effectBlockingIO(getClass.getClassLoader.getResource(path)))
       .flatMap { resource => if (resource == null) Http.empty else Http.succeed(resource) }
 
   /**
    * Attempts to retrieve files from the classpath.
    */
-  def getResourceAsFile(path: String): Http[Blocking, Throwable, Any, File] =
+  def getResourceAsFile(path: String): Http[Any, Throwable, Any, File] =
     Http.getResource(path).map(url => new File(url.getPath))
 
   /**

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -860,7 +860,7 @@ object Http {
    * Creates an Http app from a resource path
    */
   def fromResource(path: String): HttpApp[Blocking, Throwable] =
-    Http.getResourceAsFile(path) >>= { Http.fromFile(_) }
+    Http.getResource(path).flatMap(url => Http.fromFile(new File(url.getPath)))
 
   /**
    * Creates a Http that always succeeds with a 200 status code and the provided

--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -884,7 +884,7 @@ object Http {
   /**
    * Attempts to retrieve files from the classpath.
    */
-  def getResource(path: String): Http[Blocking, Throwable, Any, net.URL] =
+  def getResource(path: String): Http[Any, Throwable, Any, net.URL] =
     Http
       .fromZIO(effectBlockingIO(getClass.getClassLoader.getResource(path)))
       .flatMap { resource => if (resource == null) Http.empty else Http.succeed(resource) }

--- a/zio-http/src/test/scala/zhttp/http/ContentTypeSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/ContentTypeSpec.scala
@@ -12,32 +12,32 @@ object ContentTypeSpec extends HttpRunnableSpec {
 
   val contentSpec = suite("Content type header on file response") {
     testM("mp4") {
-      val res = Http.fromResource("/TestFile2.mp4").deploy.contentType.run()
+      val res = Http.fromResource("TestFile2.mp4").deploy.contentType.run()
       assertM(res)(isSome(equalTo("video/mp4")))
     } +
       testM("js") {
-        val res = Http.fromResource("/TestFile3.js").deploy.contentType.run()
+        val res = Http.fromResource("TestFile3.js").deploy.contentType.run()
         assertM(res)(isSome(equalTo("application/javascript")))
       } +
       testM("no extension") {
-        val res = Http.fromResource("/TestFile4").deploy.contentType.run()
+        val res = Http.fromResource("TestFile4").deploy.contentType.run()
         assertM(res)(isNone)
       } +
       testM("css") {
-        val res = Http.fromResource("/TestFile5.css").deploy.contentType.run()
+        val res = Http.fromResource("TestFile5.css").deploy.contentType.run()
         assertM(res)(isSome(equalTo("text/css")))
       } +
       testM("mp3") {
-        val res = Http.fromResource("/TestFile6.mp3").deploy.contentType.run()
+        val res = Http.fromResource("TestFile6.mp3").deploy.contentType.run()
         assertM(res)(isSome(equalTo("audio/mpeg")))
       } +
       testM("unidentified extension") {
-        val res = Http.fromResource("/truststore.jks").deploy.contentType.run()
+        val res = Http.fromResource("truststore.jks").deploy.contentType.run()
         assertM(res)(isNone)
       } +
       testM("already set content-type") {
         val expected = MediaType.application.`json`
-        val res      = Http.fromResource("/TestFile6.mp3").map(_.withMediaType(expected)).deploy.contentType.run()
+        val res      = Http.fromResource("TestFile6.mp3").map(_.withMediaType(expected)).deploy.contentType.run()
         assertM(res)(isSome(equalTo(expected.fullType)))
       }
   }

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -171,13 +171,13 @@ object ServerSpec extends HttpRunnableSpec {
       }
     } +
       testM("data from file") {
-        val res = Http.fromResource("/TestFile.txt").deploy.bodyAsString.run()
+        val res = Http.fromResource("TestFile.txt").deploy.bodyAsString.run()
         assertM(res)(equalTo("abc\nfoo"))
       } +
       testM("content-type header on file response") {
         val res =
           Http
-            .fromResource("/TestFile2.mp4")
+            .fromResource("TestFile2.mp4")
             .deploy
             .headerValue(HeaderNames.contentType)
             .run()

--- a/zio-http/src/test/scala/zhttp/service/StaticFileServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/StaticFileServerSpec.scala
@@ -22,8 +22,8 @@ object StaticFileServerSpec extends HttpRunnableSpec {
   private def staticSpec = suite("Static RandomAccessFile Server") {
     suite("fromResource") {
       suite("file") {
-        val fileOk       = Http.fromResource("/TestFile.txt").deploy
-        val fileNotFound = Http.fromResource("/Nothing").deploy
+        val fileOk       = Http.fromResource("TestFile.txt").deploy
+        val fileNotFound = Http.fromResource("Nothing").deploy
         testM("should have 200 status code") {
           val res = fileOk.run().map(_.status)
           assertM(res)(equalTo(Status.Ok))


### PR DESCRIPTION
Code based on https://github.com/zio/zio/blob/v1.0.13/streams/jvm/src/main/scala/zio/stream/platform.scala#L385-L398

I debugged a request trying to access a `index.html` file present in the `resources` folder:

<img width="1346" alt="Screen Shot 2022-03-03 at 9 08 35 pm" src="https://user-images.githubusercontent.com/1193670/156574804-d885a372-ee72-4cd0-a6db-43d688c3a79d.png">

As you can see in this debug evaludation window, when I execute `getClass.getResource(path)`, it returns me `null`:
<img width="888" alt="Screen Shot 2022-03-03 at 9 08 47 pm" src="https://user-images.githubusercontent.com/1193670/156574914-eaa4f06d-98c4-4eb0-b030-0d2097f8432a.png">
While when I execute `getClass.getClassLoader.getResource(path)` I get the file:
<img width="888" alt="Screen Shot 2022-03-03 at 9 08 59 pm" src="https://user-images.githubusercontent.com/1193670/156575030-372262d4-fd4c-4d8c-a945-2b3d3ba35a85.png">

