### PR TITLE
Fix: `toByteBuf` for streamed HttpData

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/HttpData.scala
+++ b/zio-http/src/main/scala/zhttp/http/HttpData.scala
@@ -95,7 +95,7 @@ object HttpData {
         case HttpData.BinaryStream(stream)  =>
           stream
             .asInstanceOf[ZStream[Any, Throwable, ByteBuf]]
-            .fold(Unpooled.compositeBuffer())((c, b) => c.addComponent(b))
+            .fold(Unpooled.compositeBuffer())((c, b) => c.addComponent(true, b))
         case HttpData.RandomAccessFile(raf) =>
           effectBlocking {
             val fis                      = new FileInputStream(raf().getFD)

--- a/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
@@ -19,7 +19,6 @@ object HttpDataSpec extends DefaultRunnableSpec {
         },
         testM("HttpData.fromStream") {
           checkAllM(Gen.anyString) { payload =>
-            println(payload)
             val stringBuffer    = payload.toString.getBytes(HTTP_CHARSET)
             val responseContent = ZStream.fromIterable(stringBuffer)
             val res             = HttpData.fromStream(responseContent).toByteBuf.map(_.toString(HTTP_CHARSET))

--- a/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
@@ -1,11 +1,10 @@
 package zhttp.http
 
+import zio.stream.ZStream
 import zio.test.Assertion.equalTo
-import zio.test.{DefaultRunnableSpec, assertM, checkAllM}
+import zio.test.{DefaultRunnableSpec, Gen, assertM, checkAllM}
 
 import java.io.File
-import zio.stream.ZStream
-import zio.test.Gen
 
 object HttpDataSpec extends DefaultRunnableSpec {
   // TODO : Add tests for othe HttpData types

--- a/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
@@ -1,16 +1,31 @@
 package zhttp.http
 
 import zio.test.Assertion.equalTo
-import zio.test.{DefaultRunnableSpec, assertM}
+import zio.test.{DefaultRunnableSpec, assertM, checkAllM}
 
 import java.io.File
+import zio.stream.ZStream
+import zio.test.Gen
 
 object HttpDataSpec extends DefaultRunnableSpec {
   // TODO : Add tests for othe HttpData types
   override def spec =
-    suite("HttpDataSpec")(suite("Test toByteBuf")(testM("HttpData.fromFile") {
-      val file = new File(getClass.getResource("/TestFile.txt").getPath)
-      val res  = HttpData.fromFile(file).toByteBuf.map(_.toString(HTTP_CHARSET))
-      assertM(res)(equalTo("abc\nfoo"))
-    }))
+    suite("HttpDataSpec")(
+      suite("Test toByteBuf")(
+        testM("HttpData.fromFile") {
+          val file = new File(getClass.getResource("/TestFile.txt").getPath)
+          val res  = HttpData.fromFile(file).toByteBuf.map(_.toString(HTTP_CHARSET))
+          assertM(res)(equalTo("abc\nfoo"))
+        },
+        testM("HttpData.fromStream") {
+          checkAllM(Gen.anyString) { payload =>
+            println(payload)
+            val stringBuffer    = payload.toString.getBytes(HTTP_CHARSET)
+            val responseContent = ZStream.fromIterable(stringBuffer)
+            val res             = HttpData.fromStream(responseContent).toByteBuf.map(_.toString(HTTP_CHARSET))
+            assertM(res)(equalTo(payload))
+          }
+        },
+      ),
+    )
 }


### PR DESCRIPTION
This is related to https://github.com/softwaremill/tapir/issues/1914

I've noticed that the following code was returning an empty body:
```scala
val stringBuffer    = """{"number": 5}""".toString.getBytes(CharsetUtil.UTF_8)
val responseContent = ZStream.fromIterable(stringBuffer)
val response        = Response.apply(data = HttpData.fromStream(responseContent))
val content         = response.data.toByteBuf.map(_.toString(CharsetUtil.UTF_8))
println(zio.Runtime.default.unsafeRun(content))
```

After isolating the issue, it seems that setting `increaseWriterIndex` to true inside the `addComponent` method is mandatory to correctly decode our payload.