### PR TITLE
fix: for websocket onClose

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
@@ -15,8 +15,8 @@ import scala.jdk.CollectionConverters._
  * channel closes.
  */
 final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
-  def unsafeRun(ctx: ChannelHandlerContext)(program: ZIO[R, Throwable, Any]): Unit = {
 
+  def unsafeRun(ctx: ChannelHandlerContext)(program: ZIO[R, Throwable, Any]): Unit = {
     val rtm = strategy.runtime(ctx)
 
     // Close the connection if the program fails
@@ -34,13 +34,27 @@ final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
         _     <- UIO(ctx.channel().closeFuture().removeListener(close))
       } yield ()) {
         case Exit.Success(_)     => ()
-        case Exit.Failure(cause) =>
-          cause.failureOption.orElse(cause.dieOption) match {
-            case None    => ()
-            case Some(_) => System.err.println(cause.prettyPrint)
-          }
-          if (ctx.channel().isOpen) ctx.close()
+        case Exit.Failure(cause) => onFailure(ctx, cause)
       }
+  }
+
+  def unsafeRunUninterruptible(ctx: ChannelHandlerContext)(program: ZIO[R, Throwable, Any]): Unit = {
+    val rtm = strategy.runtime(ctx)
+
+    rtm
+      .unsafeRunAsync(program) {
+        case Exit.Success(_)     => ()
+        case Exit.Failure(cause) => onFailure(ctx, cause)
+
+      }
+  }
+
+  private def onFailure(ctx: ChannelHandlerContext, cause: Cause[Throwable]) = {
+    cause.failureOption.orElse(cause.dieOption) match {
+      case None    => ()
+      case Some(_) => System.err.println(cause.prettyPrint)
+    }
+    if (ctx.channel().isOpen) ctx.close()
   }
 
   private def closeListener(rtm: Runtime[Any], fiber: Fiber.Runtime[_, _]): GenericFutureListener[Future[_ >: Void]] =

--- a/zio-http/src/main/scala/zhttp/service/WebSocketAppHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/WebSocketAppHandler.scala
@@ -29,7 +29,7 @@ final class WebSocketAppHandler[R](
 
   override def channelUnregistered(ctx: ChannelHandlerContext): Unit = {
     app.close match {
-      case Some(v) => zExec.unsafeRun(ctx)(v(ctx.channel().remoteAddress()).uninterruptible)
+      case Some(v) => zExec.unsafeRunUninterruptible(ctx)(v(ctx.channel().remoteAddress()).uninterruptible)
       case None    => ctx.fireChannelUnregistered()
     }
     ()


### PR DESCRIPTION
TODO: unit tests:
- find a way to provide an instance of ChannelHandlerContext 
- refactor functions to return something else than Unit as in current implementation are not testable.

fixes #1147 