### PR TITLE
Feature: Add implicit conversion from `Unit` to `Html`

### DIFF
--- a/zio-http/src/main/scala/zhttp/html/Html.scala
+++ b/zio-http/src/main/scala/zhttp/html/Html.scala
@@ -1,5 +1,6 @@
 package zhttp.html
 
+import scala.annotation.nowarn
 import scala.language.implicitConversions
 
 /**
@@ -21,6 +22,8 @@ object Html {
   implicit def fromSeq(elements: Seq[Dom]): Html = Html.Multiple(elements)
 
   implicit def fromDomElement(element: Dom): Html = Html.Single(element)
+
+  implicit def fromUnit(@nowarn unit: Unit): Html = Html.Empty
 
   private[zhttp] case class Single(element: Dom) extends Html
 

--- a/zio-http/src/test/scala/zhttp/html/HtmlSpec.scala
+++ b/zio-http/src/test/scala/zhttp/html/HtmlSpec.scala
@@ -44,7 +44,13 @@ case object HtmlSpec extends DefaultRunnableSpec {
           val view     = div("Hello!", css := "container" :: Nil)
           val expected = """<div class="container">Hello!</div>"""
           assert(view.encode)(equalTo(expected.stripMargin))
-        },
+        } +
+        suite("implicit conversions")(
+          test("from unit") {
+            val view: Html = {}
+            assert(view.encode)(equalTo(""))
+          },
+        ),
     )
   }
 }


### PR DESCRIPTION
The conversion is useful in cases when we don't want to construct any `Html` but want to leave it empty. It is is expected by users of `scalatags` or similar libraries.