### PR TITLE
Fix jmh benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,7 +938,7 @@ jobs:
       - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: peter-evans/commit-comment@v1
         with:
-          sha: ${{github.sha}}
+          sha: ${{github.event.pull_request.head.sha}}
           body: |
 
             **🚀 Jmh Benchmark:**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -681,7 +681,7 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_CookieDecodeBenchmark
@@ -697,7 +697,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCollectEval
@@ -713,7 +713,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCombineEval
@@ -729,7 +729,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpNestedFlatMapEval
@@ -745,7 +745,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpRouteTextPerf
@@ -761,7 +761,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_ProbeContentTypeBenchmark
@@ -777,7 +777,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_SchemeDecodeBenchmark
@@ -793,7 +793,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_SchemeDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark
@@ -809,7 +809,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCollectEval
@@ -825,7 +825,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCombineEval
@@ -841,7 +841,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpNestedFlatMapEval
@@ -857,7 +857,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpRouteTextPerf
@@ -873,7 +873,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_ProbeContentTypeBenchmark
@@ -889,7 +889,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_SchemeDecodeBenchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,7 +907,7 @@ jobs:
 
       - name: Format Output
         id: fomat_output
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh')  }}
         run: |
           cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
                     while IFS= read -r line; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,9 +670,65 @@ jobs:
           name: Jmh_Main_SchemeDecodeBenchmark
           path: Main_SchemeDecodeBenchmark.txt
 
+  Jmh_SchemeDecodeBenchmark 2:
+    name: Jmh SchemeDecodeBenchmark 2
+    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.8]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Benchmark_Current
+        id: Benchmark_Current
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Current_SchemeDecodeBenchmark 2.txt
+          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark 2" | grep "thrpt" >> ../Current_SchemeDecodeBenchmark 2.txt
+
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Current_SchemeDecodeBenchmark 2
+          path: Current_SchemeDecodeBenchmark 2.txt
+
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+          ref: main
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_SchemeDecodeBenchmark 2.txt
+          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark 2" | grep "thrpt" >> ../Main_SchemeDecodeBenchmark 2.txt
+
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark 2
+          path: Main_SchemeDecodeBenchmark 2.txt
+
   Jmh_publish:
     name: Jmh Publish
-    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark]
+    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_SchemeDecodeBenchmark 2]
     if: always()
     strategy:
       matrix:
@@ -681,7 +737,7 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_CookieDecodeBenchmark
@@ -697,7 +753,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCollectEval
@@ -713,7 +769,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCombineEval
@@ -729,7 +785,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpNestedFlatMapEval
@@ -745,7 +801,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpRouteTextPerf
@@ -761,7 +817,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_ProbeContentTypeBenchmark
@@ -777,7 +833,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_SchemeDecodeBenchmark
@@ -793,7 +849,23 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_SchemeDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Current_SchemeDecodeBenchmark 2
+
+      - name: Result Current SchemeDecodeBenchmark 2
+        id: Result_Current_SchemeDecodeBenchmark 2
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        run: |
+          while IFS= read -r line; do
+             IFS=' ' read -ra PARSED_RESULT <<< "$line"
+             echo ${PARSED_RESULT[1]} >> parsed_Current.txt
+             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
+             echo $B_VALUE >> Current.txt
+           done < Current_SchemeDecodeBenchmark 2.txt
+
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark
@@ -809,7 +881,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCollectEval
@@ -825,7 +897,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCombineEval
@@ -841,7 +913,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpNestedFlatMapEval
@@ -857,7 +929,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpRouteTextPerf
@@ -873,7 +945,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_ProbeContentTypeBenchmark
@@ -889,7 +961,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_SchemeDecodeBenchmark
@@ -904,6 +976,22 @@ jobs:
              B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
              echo $B_VALUE >> Main.txt
            done < Main_SchemeDecodeBenchmark.txt
+
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark 2
+
+      - name: Result Main SchemeDecodeBenchmark 2
+        id: Result_Main_SchemeDecodeBenchmark 2
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        run: |
+          while IFS= read -r line; do
+             IFS=' ' read -ra PARSED_RESULT <<< "$line"
+             echo ${PARSED_RESULT[1]} >> parsed_Main.txt
+             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
+             echo $B_VALUE >> Main.txt
+           done < Main_SchemeDecodeBenchmark 2.txt
 
       - name: Format Output
         id: fomat_output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,8 @@ jobs:
           cat > Current_CookieDecodeBenchmark.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 CookieDecodeBenchmark" | grep "thrpt" >> ../Current_CookieDecodeBenchmark.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_CookieDecodeBenchmark
           path: Current_CookieDecodeBenchmark.txt
@@ -327,7 +328,8 @@ jobs:
           cat > Main_CookieDecodeBenchmark.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 CookieDecodeBenchmark" | grep "thrpt" >> ../Main_CookieDecodeBenchmark.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark
           path: Main_CookieDecodeBenchmark.txt
@@ -361,7 +363,8 @@ jobs:
           cat > Current_HttpCollectEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCollectEval" | grep "thrpt" >> ../Current_HttpCollectEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_HttpCollectEval
           path: Current_HttpCollectEval.txt
@@ -381,7 +384,8 @@ jobs:
           cat > Main_HttpCollectEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCollectEval" | grep "thrpt" >> ../Main_HttpCollectEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_HttpCollectEval
           path: Main_HttpCollectEval.txt
@@ -415,7 +419,8 @@ jobs:
           cat > Current_HttpCombineEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCombineEval" | grep "thrpt" >> ../Current_HttpCombineEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_HttpCombineEval
           path: Current_HttpCombineEval.txt
@@ -435,7 +440,8 @@ jobs:
           cat > Main_HttpCombineEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCombineEval" | grep "thrpt" >> ../Main_HttpCombineEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_HttpCombineEval
           path: Main_HttpCombineEval.txt
@@ -469,7 +475,8 @@ jobs:
           cat > Current_HttpNestedFlatMapEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpNestedFlatMapEval" | grep "thrpt" >> ../Current_HttpNestedFlatMapEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_HttpNestedFlatMapEval
           path: Current_HttpNestedFlatMapEval.txt
@@ -489,7 +496,8 @@ jobs:
           cat > Main_HttpNestedFlatMapEval.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpNestedFlatMapEval" | grep "thrpt" >> ../Main_HttpNestedFlatMapEval.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_HttpNestedFlatMapEval
           path: Main_HttpNestedFlatMapEval.txt
@@ -523,7 +531,8 @@ jobs:
           cat > Current_HttpRouteTextPerf.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpRouteTextPerf" | grep "thrpt" >> ../Current_HttpRouteTextPerf.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_HttpRouteTextPerf
           path: Current_HttpRouteTextPerf.txt
@@ -543,7 +552,8 @@ jobs:
           cat > Main_HttpRouteTextPerf.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpRouteTextPerf" | grep "thrpt" >> ../Main_HttpRouteTextPerf.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_HttpRouteTextPerf
           path: Main_HttpRouteTextPerf.txt
@@ -577,7 +587,8 @@ jobs:
           cat > Current_ProbeContentTypeBenchmark.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 ProbeContentTypeBenchmark" | grep "thrpt" >> ../Current_ProbeContentTypeBenchmark.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Current_ProbeContentTypeBenchmark
           path: Current_ProbeContentTypeBenchmark.txt
@@ -597,14 +608,14 @@ jobs:
           cat > Main_ProbeContentTypeBenchmark.txt
           sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 ProbeContentTypeBenchmark" | grep "thrpt" >> ../Main_ProbeContentTypeBenchmark.txt
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: Jmh_Main_ProbeContentTypeBenchmark
           path: Main_ProbeContentTypeBenchmark.txt
 
-  Jmh_publish:
-    name: Jmh Publish
-    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark]
+  Jmh_SchemeDecodeBenchmark:
+    name: Jmh SchemeDecodeBenchmark
     if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
     strategy:
       matrix:
@@ -613,7 +624,65 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Benchmark_Current
+        id: Benchmark_Current
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Current_SchemeDecodeBenchmark.txt
+          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark" | grep "thrpt" >> ../Current_SchemeDecodeBenchmark.txt
+
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Current_SchemeDecodeBenchmark
+          path: Current_SchemeDecodeBenchmark.txt
+
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+          ref: main
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_SchemeDecodeBenchmark.txt
+          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark" | grep "thrpt" >> ../Main_SchemeDecodeBenchmark.txt
+
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark
+          path: Main_SchemeDecodeBenchmark.txt
+
+  Jmh_publish:
+    name: Jmh Publish
+    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark]
+    if: always()
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.8]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_CookieDecodeBenchmark
 
@@ -627,7 +696,8 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_CookieDecodeBenchmark.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCollectEval
 
@@ -641,7 +711,8 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCollectEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCombineEval
 
@@ -655,7 +726,8 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCombineEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpNestedFlatMapEval
 
@@ -669,7 +741,8 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpNestedFlatMapEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpRouteTextPerf
 
@@ -683,7 +756,8 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpRouteTextPerf.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_ProbeContentTypeBenchmark
 
@@ -697,7 +771,23 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_ProbeContentTypeBenchmark.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Current_SchemeDecodeBenchmark
+
+      - name: Result Current SchemeDecodeBenchmark
+        id: Result_Current_SchemeDecodeBenchmark
+        run: |
+          while IFS= read -r line; do
+             IFS=' ' read -ra PARSED_RESULT <<< "$line"
+             echo ${PARSED_RESULT[1]} >> parsed_Current.txt
+             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
+             echo $B_VALUE >> Current.txt
+           done < Current_SchemeDecodeBenchmark.txt
+
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark
 
@@ -711,7 +801,8 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_CookieDecodeBenchmark.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCollectEval
 
@@ -725,7 +816,8 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCollectEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCombineEval
 
@@ -739,7 +831,8 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCombineEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpNestedFlatMapEval
 
@@ -753,7 +846,8 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpNestedFlatMapEval.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpRouteTextPerf
 
@@ -767,7 +861,8 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpRouteTextPerf.txt
 
-      - uses: actions/download-artifact@v3
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_ProbeContentTypeBenchmark
 
@@ -781,8 +876,24 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_ProbeContentTypeBenchmark.txt
 
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark
+
+      - name: Result Main SchemeDecodeBenchmark
+        id: Result_Main_SchemeDecodeBenchmark
+        run: |
+          while IFS= read -r line; do
+             IFS=' ' read -ra PARSED_RESULT <<< "$line"
+             echo ${PARSED_RESULT[1]} >> parsed_Main.txt
+             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
+             echo $B_VALUE >> Main.txt
+           done < Main_SchemeDecodeBenchmark.txt
+
       - name: Format Output
         id: fomat_output
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
                     while IFS= read -r line; do
@@ -810,7 +921,8 @@ jobs:
            echo ::set-output name=body::$(echo $body)
 
       
-      - uses: peter-evans/commit-comment@v1
+      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        uses: peter-evans/commit-comment@v1
         with:
           sha: ${{github.sha}}
           body: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,7 +688,7 @@ jobs:
 
       - name: Result Current CookieDecodeBenchmark
         id: Result_Current_CookieDecodeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -704,7 +704,7 @@ jobs:
 
       - name: Result Current HttpCollectEval
         id: Result_Current_HttpCollectEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -720,7 +720,7 @@ jobs:
 
       - name: Result Current HttpCombineEval
         id: Result_Current_HttpCombineEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -736,7 +736,7 @@ jobs:
 
       - name: Result Current HttpNestedFlatMapEval
         id: Result_Current_HttpNestedFlatMapEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -752,7 +752,7 @@ jobs:
 
       - name: Result Current HttpRouteTextPerf
         id: Result_Current_HttpRouteTextPerf
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -768,7 +768,7 @@ jobs:
 
       - name: Result Current ProbeContentTypeBenchmark
         id: Result_Current_ProbeContentTypeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -784,7 +784,7 @@ jobs:
 
       - name: Result Current SchemeDecodeBenchmark
         id: Result_Current_SchemeDecodeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -800,7 +800,7 @@ jobs:
 
       - name: Result Main CookieDecodeBenchmark
         id: Result_Main_CookieDecodeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -816,7 +816,7 @@ jobs:
 
       - name: Result Main HttpCollectEval
         id: Result_Main_HttpCollectEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -832,7 +832,7 @@ jobs:
 
       - name: Result Main HttpCombineEval
         id: Result_Main_HttpCombineEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -848,7 +848,7 @@ jobs:
 
       - name: Result Main HttpNestedFlatMapEval
         id: Result_Main_HttpNestedFlatMapEval
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -864,7 +864,7 @@ jobs:
 
       - name: Result Main HttpRouteTextPerf
         id: Result_Main_HttpRouteTextPerf
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -880,7 +880,7 @@ jobs:
 
       - name: Result Main ProbeContentTypeBenchmark
         id: Result_Main_ProbeContentTypeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -896,7 +896,7 @@ jobs:
 
       - name: Result Main SchemeDecodeBenchmark
         id: Result_Main_SchemeDecodeBenchmark
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,65 +670,9 @@ jobs:
           name: Jmh_Main_SchemeDecodeBenchmark
           path: Main_SchemeDecodeBenchmark.txt
 
-  Jmh_SchemeDecodeBenchmark 2:
-    name: Jmh SchemeDecodeBenchmark 2
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        scala: [2.13.8]
-        java: [temurin@11]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: zio-http
-
-      - uses: actions/setup-java@v2
-        with:
-          distribution: temurin
-          java-version: 8
-
-      - name: Benchmark_Current
-        id: Benchmark_Current
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
-        run: |
-          cd zio-http
-          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
-          cat > Current_SchemeDecodeBenchmark 2.txt
-          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark 2" | grep "thrpt" >> ../Current_SchemeDecodeBenchmark 2.txt
-
-      - if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Jmh_Current_SchemeDecodeBenchmark 2
-          path: Current_SchemeDecodeBenchmark 2.txt
-
-      - uses: actions/checkout@v2
-        with:
-          path: zio-http
-          ref: main
-
-      - name: Benchmark_Main
-        id: Benchmark_Main
-        env:
-          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
-        run: |
-          cd zio-http
-          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
-          cat > Main_SchemeDecodeBenchmark 2.txt
-          sbt -no-colors -v "zhttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark 2" | grep "thrpt" >> ../Main_SchemeDecodeBenchmark 2.txt
-
-      - if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Jmh_Main_SchemeDecodeBenchmark 2
-          path: Main_SchemeDecodeBenchmark 2.txt
-
   Jmh_publish:
     name: Jmh Publish
-    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_SchemeDecodeBenchmark 2]
+    needs: [Jmh_CookieDecodeBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark]
     if: always()
     strategy:
       matrix:
@@ -852,22 +796,6 @@ jobs:
       - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
         uses: actions/download-artifact@v3
         with:
-          name: Jmh_Current_SchemeDecodeBenchmark 2
-
-      - name: Result Current SchemeDecodeBenchmark 2
-        id: Result_Current_SchemeDecodeBenchmark 2
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
-        run: |
-          while IFS= read -r line; do
-             IFS=' ' read -ra PARSED_RESULT <<< "$line"
-             echo ${PARSED_RESULT[1]} >> parsed_Current.txt
-             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
-             echo $B_VALUE >> Current.txt
-           done < Current_SchemeDecodeBenchmark 2.txt
-
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
-        uses: actions/download-artifact@v3
-        with:
           name: Jmh_Main_CookieDecodeBenchmark
 
       - name: Result Main CookieDecodeBenchmark
@@ -976,22 +904,6 @@ jobs:
              B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
              echo $B_VALUE >> Main.txt
            done < Main_SchemeDecodeBenchmark.txt
-
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
-        uses: actions/download-artifact@v3
-        with:
-          name: Jmh_Main_SchemeDecodeBenchmark 2
-
-      - name: Result Main SchemeDecodeBenchmark 2
-        id: Result_Main_SchemeDecodeBenchmark 2
-        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
-        run: |
-          while IFS= read -r line; do
-             IFS=' ' read -ra PARSED_RESULT <<< "$line"
-             echo ${PARSED_RESULT[1]} >> parsed_Main.txt
-             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
-             echo $B_VALUE >> Main.txt
-           done < Main_SchemeDecodeBenchmark 2.txt
 
       - name: Format Output
         id: fomat_output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
 
   Jmh_CookieDecodeBenchmark:
     name: Jmh CookieDecodeBenchmark
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -336,7 +336,7 @@ jobs:
 
   Jmh_HttpCollectEval:
     name: Jmh HttpCollectEval
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -392,7 +392,7 @@ jobs:
 
   Jmh_HttpCombineEval:
     name: Jmh HttpCombineEval
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -448,7 +448,7 @@ jobs:
 
   Jmh_HttpNestedFlatMapEval:
     name: Jmh HttpNestedFlatMapEval
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -504,7 +504,7 @@ jobs:
 
   Jmh_HttpRouteTextPerf:
     name: Jmh HttpRouteTextPerf
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -560,7 +560,7 @@ jobs:
 
   Jmh_ProbeContentTypeBenchmark:
     name: Jmh ProbeContentTypeBenchmark
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -616,7 +616,7 @@ jobs:
 
   Jmh_SchemeDecodeBenchmark:
     name: Jmh SchemeDecodeBenchmark
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -681,7 +681,7 @@ jobs:
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_CookieDecodeBenchmark
@@ -697,7 +697,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCollectEval
@@ -713,7 +713,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpCombineEval
@@ -729,7 +729,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpNestedFlatMapEval
@@ -745,7 +745,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_HttpRouteTextPerf
@@ -761,7 +761,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_ProbeContentTypeBenchmark
@@ -777,7 +777,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Current_SchemeDecodeBenchmark
@@ -793,7 +793,7 @@ jobs:
              echo $B_VALUE >> Current.txt
            done < Current_SchemeDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark
@@ -809,7 +809,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_CookieDecodeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCollectEval
@@ -825,7 +825,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCollectEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpCombineEval
@@ -841,7 +841,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpCombineEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpNestedFlatMapEval
@@ -857,7 +857,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpNestedFlatMapEval.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_HttpRouteTextPerf
@@ -873,7 +873,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_HttpRouteTextPerf.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_ProbeContentTypeBenchmark
@@ -889,7 +889,7 @@ jobs:
              echo $B_VALUE >> Main.txt
            done < Main_ProbeContentTypeBenchmark.txt
 
-      - if: ${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_SchemeDecodeBenchmark
@@ -935,7 +935,7 @@ jobs:
            echo ::set-output name=body::$(echo $body)
 
       
-      - if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+      - if: ${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}
         uses: peter-evans/commit-comment@v1
         with:
           sha: ${{github.sha}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,6 +688,7 @@ jobs:
 
       - name: Result Current CookieDecodeBenchmark
         id: Result_Current_CookieDecodeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -703,6 +704,7 @@ jobs:
 
       - name: Result Current HttpCollectEval
         id: Result_Current_HttpCollectEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -718,6 +720,7 @@ jobs:
 
       - name: Result Current HttpCombineEval
         id: Result_Current_HttpCombineEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -733,6 +736,7 @@ jobs:
 
       - name: Result Current HttpNestedFlatMapEval
         id: Result_Current_HttpNestedFlatMapEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -748,6 +752,7 @@ jobs:
 
       - name: Result Current HttpRouteTextPerf
         id: Result_Current_HttpRouteTextPerf
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -763,6 +768,7 @@ jobs:
 
       - name: Result Current ProbeContentTypeBenchmark
         id: Result_Current_ProbeContentTypeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -778,6 +784,7 @@ jobs:
 
       - name: Result Current SchemeDecodeBenchmark
         id: Result_Current_SchemeDecodeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -793,6 +800,7 @@ jobs:
 
       - name: Result Main CookieDecodeBenchmark
         id: Result_Main_CookieDecodeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -808,6 +816,7 @@ jobs:
 
       - name: Result Main HttpCollectEval
         id: Result_Main_HttpCollectEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -823,6 +832,7 @@ jobs:
 
       - name: Result Main HttpCombineEval
         id: Result_Main_HttpCombineEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -838,6 +848,7 @@ jobs:
 
       - name: Result Main HttpNestedFlatMapEval
         id: Result_Main_HttpNestedFlatMapEval
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -853,6 +864,7 @@ jobs:
 
       - name: Result Main HttpRouteTextPerf
         id: Result_Main_HttpRouteTextPerf
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -868,6 +880,7 @@ jobs:
 
       - name: Result Main ProbeContentTypeBenchmark
         id: Result_Main_ProbeContentTypeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"
@@ -883,6 +896,7 @@ jobs:
 
       - name: Result Main SchemeDecodeBenchmark
         id: Result_Main_SchemeDecodeBenchmark
+        if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
         run: |
           while IFS= read -r line; do
              IFS=' ' read -ra PARSED_RESULT <<< "$line"

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -117,7 +117,7 @@ object JmhBenchmarkWorkflow {
             ref = UseRef.Public("peter-evans", "commit-comment", "v1"),
             cond = Some ("${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}"),
             params = Map(
-              "sha"  -> "${{github.sha}}",
+              "sha"  -> "${{github.event.pull_request.head.sha}}",
               "body" ->
                 """
                   |**\uD83D\uDE80 Jmh Benchmark:**

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -49,6 +49,7 @@ object JmhBenchmarkWorkflow {
         ),
       ),
       WorkflowStep.Run(
+        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}"),
         commands = List(s"""while IFS= read -r line; do
                            |   IFS=' ' read -ra PARSED_RESULT <<< "$$line"
                            |   echo $${PARSED_RESULT[1]} >> parsed_$branch.txt

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -43,7 +43,7 @@ object JmhBenchmarkWorkflow {
     Seq(
       WorkflowStep.Use(
         ref = UseRef.Public("actions", "download-artifact", "v3"),
-        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}"),
+        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}"),
         params =Map(
           "name" -> s"Jmh_${branch}_${l.head}",
         ),

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -66,7 +66,7 @@ object JmhBenchmarkWorkflow {
    * Format result and set output
    */
   def formatOutput() = WorkflowStep.Run(
-    cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}"),
+    cond = Some ("${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh')  }}"),
     commands = List(
       s"""cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
          |          while IFS= read -r line; do

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -49,7 +49,7 @@ object JmhBenchmarkWorkflow {
         ),
       ),
       WorkflowStep.Run(
-        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}"),
+        cond = Some ("${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}"),
         commands = List(s"""while IFS= read -r line; do
                            |   IFS=' ' read -ra PARSED_RESULT <<< "$$line"
                            |   echo $${PARSED_RESULT[1]} >> parsed_$branch.txt

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -43,7 +43,7 @@ object JmhBenchmarkWorkflow {
     Seq(
       WorkflowStep.Use(
         ref = UseRef.Public("actions", "download-artifact", "v3"),
-        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}"),
+        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}"),
         params =Map(
           "name" -> s"Jmh_${branch}_${l.head}",
         ),

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -43,7 +43,7 @@ object JmhBenchmarkWorkflow {
     Seq(
       WorkflowStep.Use(
         ref = UseRef.Public("actions", "download-artifact", "v3"),
-        cond = Some ("${{ github.event.label.name == 'run jmh' && github.event.pull_request.head.repo.full_name == 'dream11/zio-http' }}"),
+        cond = Some ("${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}"),
         params =Map(
           "name" -> s"Jmh_${branch}_${l.head}",
         ),
@@ -115,7 +115,7 @@ object JmhBenchmarkWorkflow {
           formatOutput(),
           WorkflowStep.Use(
             ref = UseRef.Public("peter-evans", "commit-comment", "v1"),
-            cond = Some ("${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}"),
+            cond = Some ("${{ github.event.pull_request.head.repo.full_name == 'dream11/zio-http' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}"),
             params = Map(
               "sha"  -> "${{github.sha}}",
               "body" ->
@@ -141,7 +141,7 @@ object JmhBenchmarkWorkflow {
       name = s"Jmh ${l.head}",
       scalas = List(Scala213),
       cond = Some(
-        "${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}",
+        "${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run jmh') }}",
       ),
       steps = List(
         WorkflowStep.Use(

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/SchemeDecodeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/SchemeDecodeBenchmark.scala
@@ -1,0 +1,18 @@
+package zhttp.benchmarks
+import org.openjdk.jmh.annotations._
+import zhttp.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class SchemeDecodeBenchmark {
+  private val MAX = 1000000
+
+  @Benchmark
+  def benchmarkSchemeDecode(): Unit = {
+    (0 to MAX).foreach(_ => Scheme.decode("HTTP"))
+    ()
+  }
+}


### PR DESCRIPTION
Currently, after adding the label `run jmh`, if the main branch doesn't have a benchmark file and current branch has it then the ci step fails and doesn't proceed further. 