### PR TITLE
Fix: Request Streaming

### DIFF
--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -26,7 +26,7 @@ object ServerSpec extends HttpRunnableSpec {
 
   private val app                 =
     serve(DynamicServer.app, Some(Server.requestDecompression(true) ++ Server.enableObjectAggregator(4096)))
-  private val appWithReqStreaming = serve(DynamicServer.app, None)
+  private val appWithReqStreaming = serve(DynamicServer.app, Some(Server.requestDecompression(true)))
 
   def dynamicAppSpec = suite("DynamicAppSpec") {
     suite("success") {

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -164,7 +164,7 @@ object ServerSpec extends HttpRunnableSpec {
       }
   }
 
-  def responseSpec    = suite("ResponseSpec") {
+  def responseSpec = suite("ResponseSpec") {
     testM("data") {
       checkAllM(nonEmptyContent) { case (string, data) =>
         val res = Http.fromData(data).deploy.bodyAsString.run()
@@ -258,6 +258,7 @@ object ServerSpec extends HttpRunnableSpec {
           }
       }
   }
+
   def requestBodySpec = suite("RequestBodySpec") {
     testM("POST Request stream") {
       val app: Http[Any, Throwable, Request, Response] = Http.collect[Request] { case req =>
@@ -298,6 +299,6 @@ object ServerSpec extends HttpRunnableSpec {
       val spec = dynamicAppSpec + responseSpec + requestSpec + requestBodySpec + serverErrorSpec
       suiteM("app without request streaming") { app.as(List(spec)).useNow } +
         suiteM("app with request streaming") { appWithReqStreaming.as(List(spec)).useNow }
-    }.provideCustomLayerShared(env) @@ timeout(30 seconds) @@ sequential
+    }.provideCustomLayerShared(env) @@ timeout(20 seconds)
 
 }


### PR DESCRIPTION
fixes #1221

There were multiple problems in the implementation

1. The `canHaveBody` method was checking on the `HttpMethod` type to detect if the request will contain any body. This isn't correct because you can technically have a GET request with some body. The right way would be to check the headers viz. `ContentLength` and `TransferEncoding`. This is a bit slow but correct.
2. When the body isn't available, returning an `HttpData.UnsafeAsync` for `data` makes the user wait forever. Because the async never completes. So the change for returning `HttpData.Empty` is more appropriate.

---
Weird thing to observe is that no tests ever failed because of this. I had to remove `@@ sequential` aspect for the current tests to fail.