### PR TITLE
Feature: Add `request` method on `Client` as `public`

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -23,7 +23,7 @@ import java.net.{InetSocketAddress, URI}
 final case class Client[R](rtm: HttpRuntime[R], cf: JChannelFactory[Channel], el: JEventLoopGroup)
     extends HttpMessageCodec {
 
-  private[zhttp] def request(request: Request, clientConfig: Config): Task[Response] =
+  def request(request: Request, clientConfig: Config): Task[Response] =
     for {
       promise <- Promise.make[Throwable, Response]
       jReq    <- encode(request)


### PR DESCRIPTION
Remove private package visibility on Client request method. 

Fix https://github.com/dream11/zio-http/issues/1231