### PR TITLE
Fix: Use `zExec.unsafeRunUninterruptible` where appropriate

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/WebSocketAppHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/WebSocketAppHandler.scala
@@ -38,7 +38,7 @@ final class WebSocketAppHandler[R](
 
   override def exceptionCaught(ctx: ChannelHandlerContext, x: Throwable): Unit = {
     app.error match {
-      case Some(v) => zExec.unsafeRun(ctx)(v(x).uninterruptible)
+      case Some(v) => zExec.unsafeRunUninterruptible(ctx)(v(x))
       case None    => ctx.fireExceptionCaught(x)
     }
     ()

--- a/zio-http/src/main/scala/zhttp/service/client/ClientInboundHandler.scala
+++ b/zio-http/src/main/scala/zhttp/service/client/ClientInboundHandler.scala
@@ -29,7 +29,7 @@ final class ClientInboundHandler[R](
     msg.touch("handlers.ClientInboundHandler-channelRead0")
     // NOTE: The promise is made uninterruptible to be able to complete the promise in a error situation.
     // It allows to avoid loosing the message from pipeline in case the channel pipeline is closed due to an error.
-    zExec.unsafeRun(ctx)(promise.succeed(Response.unsafeFromJResponse(msg)).uninterruptible)
+    zExec.unsafeRunUninterruptible(ctx)(promise.succeed(Response.unsafeFromJResponse(msg)))
 
     if (isWebSocket) {
       ctx.fireChannelRead(msg.retain())
@@ -38,7 +38,7 @@ final class ClientInboundHandler[R](
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, error: Throwable): Unit = {
-    zExec.unsafeRun(ctx)(promise.fail(error).uninterruptible)
+    zExec.unsafeRunUninterruptible(ctx)(promise.fail(error))
     releaseRequest()
   }
 


### PR DESCRIPTION
As a fix for #1147 the method `zExec.unsafeRunInterruptible` was created, because when using the pattern:
  `zExec.unsafeRun(<sometask>.uninterruptible)`
it was possible to be interrupted before `<sometask>` was started causing callbacks to be missed.

Replacing the above with `zExec.unsafeRunInterruptible(<sometask>)` fixed this.

This commit replaces the remaining instances of this pattern to also use `unsafeRunUninterruptible`, fixing a similar race condition in `Client` code observed in #1252.