### PR TITLE
chore: Remove unnecessary dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,8 +95,7 @@ lazy val zhttp = (project in file("zio-http"))
   .settings(meta)
   .settings(
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    libraryDependencies ++= Seq(
-      netty,
+    libraryDependencies ++= netty ++ Seq(
       `zio`,
       `zio-streams`,
       `zio-test`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,15 @@ object Dependencies {
   val `jwt-core`                 = "com.github.jwt-scala"   %% "jwt-core"                % JwtCoreVersion
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
-  val netty             = "io.netty" % "netty-all" % NettyVersion
+  val netty =
+    Seq(
+      "netty-codec-http",
+      "netty-transport-native-epoll",
+      "netty-transport-native-kqueue",
+    ).map { name =>
+      "io.netty" % name % NettyVersion
+    }
+
   val `netty-incubator` =
     "io.netty.incubator" % "netty-incubator-transport-native-io_uring" % NettyIncubatorVersion classifier "linux-x86_64"
 


### PR DESCRIPTION
fixes #1246 

**Before** `zhttp/dependencyStats`
```
sbt:root> zhttp/dependencyStats
[info]    TotSize    JarSize #TDe #Dep Module
[info]   8.856 MB ------- MB   38    5 io.d11:zhttp_2.13:1.0.0.0-RC27+32-3f1aee03+20220514-1419-SNAPSHOT
[info]   4.596 MB   0.004 MB   29   29 io.netty:netty-all:4.1.77.Final
[info]   4.118 MB   0.621 MB    4    1 dev.zio:zio-streams_2.13:1.0.14
[info]   3.497 MB   2.867 MB    3    2 dev.zio:zio_2.13:1.0.14
[info]   2.634 MB   0.019 MB   10    1 io.netty:netty-resolver-dns-native-macos:4.1.77.Final
[info]   2.615 MB   0.009 MB    9    3 io.netty:netty-resolver-dns-classes-macos:4.1.77.Final
[info]   2.563 MB   0.157 MB    7    7 io.netty:netty-resolver-dns:4.1.77.Final
[info]   2.341 MB   0.528 MB    5    5 io.netty:netty-handler:4.1.77.Final
[info]   1.878 MB   0.065 MB    5    4 io.netty:netty-codec-dns:4.1.77.Final
[info]   1.812 MB   0.337 MB    4    3 io.netty:netty-codec:4.1.77.Final
[info]   1.697 MB   0.039 MB    6    5 io.netty:netty-transport-native-epoll:4.1.77.Final
[info]   1.658 MB   0.140 MB    5    4 io.netty:netty-transport-classes-epoll:4.1.77.Final
[info]   1.654 MB   0.036 MB    6    1 io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.14.Final
[info]   1.651 MB   0.025 MB    6    5 io.netty:netty-transport-native-kqueue:4.1.77.Final
[info]   1.627 MB   0.108 MB    5    4 io.netty:netty-transport-classes-kqueue:4.1.77.Final
[info]   1.618 MB   0.099 MB    5    4 io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.14.Final
[info]   1.519 MB   0.043 MB    4    3 io.netty:netty-transport-native-unix-common:4.1.77.Final
[info]   1.475 MB   0.481 MB    3    3 io.netty:netty-transport:4.1.77.Final
[info]   0.957 MB   0.304 MB    1    1 io.netty:netty-buffer:4.1.77.Final
[info]   0.691 MB   0.038 MB    1    1 io.netty:netty-resolver:4.1.77.Final
[info]   0.653 MB   0.653 MB    0    0 io.netty:netty-common:4.1.77.Final
[info]   0.639 MB   0.639 MB    0    0 io.netty:netty-codec-http:4.1.77.Final
[info]   0.583 MB   0.488 MB    1    1 dev.zio:izumi-reflect_2.13:1.1.3
[info]   0.474 MB   0.474 MB    0    0 io.netty:netty-codec-http2:4.1.77.Final
[info]   0.119 MB   0.119 MB    0    0 io.netty:netty-codec-socks:4.1.77.Final
[info]   0.100 MB   0.100 MB    0    0 io.netty:netty-codec-mqtt:4.1.77.Final
[info]   0.095 MB   0.095 MB    0    0 dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.13:1.1.3
[info]   0.049 MB   0.049 MB    0    0 io.netty:netty-transport-sctp:4.1.77.Final
[info]   0.047 MB   0.047 MB    0    0 dev.zio:zio-stacktracer_2.13:1.0.14
[info]   0.045 MB   0.045 MB    0    0 io.netty:netty-codec-redis:4.1.77.Final
[info]   0.043 MB   0.043 MB    0    0 io.netty:netty-codec-memcache:4.1.77.Final
[info]   0.036 MB   0.036 MB    0    0 io.netty:netty-codec-haproxy:4.1.77.Final
[info]   0.032 MB   0.032 MB    0    0 io.netty:netty-transport-udt:4.1.77.Final
[info]   0.029 MB   0.029 MB    0    0 io.netty:netty-codec-stomp:4.1.77.Final
[info]   0.024 MB   0.024 MB    0    0 io.netty:netty-handler-proxy:4.1.77.Final
[info]   0.020 MB   0.020 MB    0    0 io.netty:netty-codec-smtp:4.1.77.Final
[info]   0.018 MB   0.018 MB    0    0 io.netty:netty-codec-xml:4.1.77.Final
[info]   0.018 MB   0.018 MB    0    0 io.netty:netty-transport-rxtx:4.1.77.Final
[info]   0.006 MB   0.006 MB    0    0 org.scala-lang.modules:scala-collection-compat_2.13:2.7.0
[info]
[info] Columns are
[info]  - Jar-Size including dependencies
[info]  - Jar-Size
[info]  - Number of transitive dependencies
[info]  - Number of direct dependencies
[info]  - ModuleID
```
**After** `zhttp/dependencyStats`
```
[info]    TotSize    JarSize #TDe #Dep Module
[info]   7.541 MB ------- MB   20    7 io.d11:zhttp_2.13:1.0.0.0-RC27+33-a1cd0f1a+20220514-1424-SNAPSHOT
[info]   4.118 MB   0.621 MB    4    1 dev.zio:zio-streams_2.13:1.0.14
[info]   3.497 MB   2.867 MB    3    2 dev.zio:zio_2.13:1.0.14
[info]   2.980 MB   0.639 MB    6    5 io.netty:netty-codec-http:4.1.77.Final
[info]   2.341 MB   0.528 MB    5    5 io.netty:netty-handler:4.1.77.Final
[info]   1.812 MB   0.337 MB    4    3 io.netty:netty-codec:4.1.77.Final
[info]   1.664 MB   0.006 MB    6    5 io.netty:netty-transport-native-epoll:4.1.77.Final
[info]   1.658 MB   0.140 MB    5    4 io.netty:netty-transport-classes-epoll:4.1.77.Final
[info]   1.654 MB   0.036 MB    6    1 io.netty.incubator:netty-incubator-transport-native-io_uring:0.0.14.Final
[info]   1.632 MB   0.006 MB    6    5 io.netty:netty-transport-native-kqueue:4.1.77.Final
[info]   1.627 MB   0.108 MB    5    4 io.netty:netty-transport-classes-kqueue:4.1.77.Final
[info]   1.618 MB   0.099 MB    5    4 io.netty.incubator:netty-incubator-transport-classes-io_uring:0.0.14.Final
[info]   1.519 MB   0.043 MB    4    3 io.netty:netty-transport-native-unix-common:4.1.77.Final
[info]   1.475 MB   0.481 MB    3    3 io.netty:netty-transport:4.1.77.Final
[info]   0.957 MB   0.304 MB    1    1 io.netty:netty-buffer:4.1.77.Final
[info]   0.691 MB   0.038 MB    1    1 io.netty:netty-resolver:4.1.77.Final
[info]   0.653 MB   0.653 MB    0    0 io.netty:netty-common:4.1.77.Final
[info]   0.583 MB   0.488 MB    1    1 dev.zio:izumi-reflect_2.13:1.1.3
[info]   0.095 MB   0.095 MB    0    0 dev.zio:izumi-reflect-thirdparty-boopickle-shaded_2.13:1.1.3
[info]   0.047 MB   0.047 MB    0    0 dev.zio:zio-stacktracer_2.13:1.0.14
[info]   0.006 MB   0.006 MB    0    0 org.scala-lang.modules:scala-collection-compat_2.13:2.7.0
[info]
[info] Columns are
[info]  - Jar-Size including dependencies
[info]  - Jar-Size
[info]  - Number of transitive dependencies
[info]  - Number of direct dependencies
[info]  - ModuleID
```