### PR TITLE
feature: Provide access to `ChannelHandlerContext` using `Http`.

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -1,16 +1,22 @@
 package zhttp.http
 
+import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{DefaultFullHttpRequest, HttpRequest}
 import zhttp.http.headers.HeaderExtension
 
-import java.net.InetAddress
+import java.io.IOException
 
 trait Request extends HeaderExtension[Request] with HttpDataExtension[Request] { self =>
 
   /**
-   * Updates the headers using the provided function
+   * Accesses the channel's context for more low level control
    */
-  final override def updateHeaders(update: Headers => Headers): Request = self.copy(headers = update(self.headers))
+  private[zhttp] def unsafeContext: ChannelHandlerContext
+
+  /**
+   * Gets the HttpRequest
+   */
+  private[zhttp] def unsafeEncode: HttpRequest
 
   def copy(
     version: Version = self.version,
@@ -23,13 +29,13 @@ trait Request extends HeaderExtension[Request] with HttpDataExtension[Request] {
     val h = headers
     val v = version
     new Request {
-      override def method: Method                     = m
-      override def url: URL                           = u
-      override def headers: Headers                   = h
-      override def version: Version                   = v
-      override def unsafeEncode: HttpRequest          = self.unsafeEncode
-      override def remoteAddress: Option[InetAddress] = self.remoteAddress
-      override def data: HttpData                     = self.data
+      override def method: Method                       = m
+      override def url: URL                             = u
+      override def headers: Headers                     = h
+      override def version: Version                     = v
+      override def unsafeEncode: HttpRequest            = self.unsafeEncode
+      override def data: HttpData                       = self.data
+      override def unsafeContext: ChannelHandlerContext = self.unsafeContext
     }
   }
 
@@ -59,39 +65,6 @@ trait Request extends HeaderExtension[Request] with HttpDataExtension[Request] {
   def path: Path = url.path
 
   /**
-   * Gets the remote address if available
-   */
-  def remoteAddress: Option[InetAddress]
-
-  /**
-   * Overwrites the method in the request
-   */
-  def setMethod(method: Method): Request = self.copy(method = method)
-
-  /**
-   * Overwrites the path in the request
-   */
-  def setPath(path: Path): Request = self.copy(url = self.url.copy(path = path))
-
-  /**
-   * Overwrites the url in the request
-   */
-  def setUrl(url: URL): Request = self.copy(url = url)
-
-  /**
-   * Returns a string representation of the request, useful for debugging,
-   * logging or other purposes. It contains the essential properties of HTTP
-   * request: protocol version, method, URL, headers and remote address.
-   */
-  override def toString =
-    s"Request($version, $method, $url, $headers, $remoteAddress)"
-
-  /**
-   * Gets the HttpRequest
-   */
-  private[zhttp] def unsafeEncode: HttpRequest
-
-  /**
    * Gets the complete url
    */
   def url: URL
@@ -100,6 +73,33 @@ trait Request extends HeaderExtension[Request] with HttpDataExtension[Request] {
    * Gets the request's http protocol version
    */
   def version: Version
+
+  /**
+   * Overwrites the method in the request
+   */
+  final def setMethod(method: Method): Request = self.copy(method = method)
+
+  /**
+   * Overwrites the path in the request
+   */
+  final def setPath(path: Path): Request = self.copy(url = self.url.copy(path = path))
+
+  /**
+   * Overwrites the url in the request
+   */
+  final def setUrl(url: URL): Request = self.copy(url = url)
+
+  /**
+   * Returns a string representation of the request, useful for debugging,
+   * logging or other purposes. It contains the essential properties of HTTP
+   * request: protocol version, method, URL, headers and remote address.
+   */
+  final override def toString = s"Request($version, $method, $url, $headers)"
+
+  /**
+   * Updates the headers using the provided function
+   */
+  final override def updateHeaders(update: Headers => Headers): Request = self.copy(headers = update(self.headers))
 
 }
 
@@ -113,28 +113,26 @@ object Request {
     method: Method = Method.GET,
     url: URL = URL.root,
     headers: Headers = Headers.empty,
-    remoteAddress: Option[InetAddress] = None,
     data: HttpData = HttpData.Empty,
   ): Request = {
-    val m  = method
-    val u  = url
-    val h  = headers
-    val ra = remoteAddress
-    val d  = data
-    val v  = version
+    val m = method
+    val u = url
+    val h = headers
+    val d = data
+    val v = version
 
     new Request {
-      override def method: Method                     = m
-      override def url: URL                           = u
-      override def headers: Headers                   = h
-      override def version: Version                   = v
-      override def unsafeEncode: HttpRequest          = {
+      override def method: Method                       = m
+      override def url: URL                             = u
+      override def headers: Headers                     = h
+      override def version: Version                     = v
+      override def unsafeEncode: HttpRequest            = {
         val jVersion = v.toJava
         val path     = url.relative.encode
         new DefaultFullHttpRequest(jVersion, method.toJava, path)
       }
-      override def remoteAddress: Option[InetAddress] = ra
-      override def data: HttpData                     = d
+      override def data: HttpData                       = d
+      override def unsafeContext: ChannelHandlerContext = throw new IOException("Request does not have a context")
 
     }
   }
@@ -143,15 +141,23 @@ object Request {
    * Lift request to TypedRequest with option to extract params
    */
   final class ParameterizedRequest[A](req: Request, val params: A) extends Request {
-    override def headers: Headers                   = req.headers
-    override def method: Method                     = req.method
-    override def remoteAddress: Option[InetAddress] = req.remoteAddress
-    override def url: URL                           = req.url
-    override def version: Version                   = req.version
-    override def unsafeEncode: HttpRequest          = req.unsafeEncode
-    override def data: HttpData                     = req.data
-    override def toString: String                   =
-      s"ParameterizedRequest($req, $params)"
+
+    /**
+     * Accesses the channel's context for more low level control
+     */
+    override private[zhttp] def unsafeContext = req.unsafeContext
+
+    override def data: HttpData = req.data
+
+    override def headers: Headers = req.headers
+
+    override def method: Method = req.method
+
+    override def unsafeEncode: HttpRequest = req.unsafeEncode
+
+    override def url: URL = req.url
+
+    override def version: Version = req.version
   }
 
   object ParameterizedRequest {

--- a/zio-http/src/test/scala/zhttp/http/RequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/RequestSpec.scala
@@ -10,7 +10,7 @@ object RequestSpec extends DefaultRunnableSpec {
       testM("should produce string representation of a request") {
         check(HttpGen.request) { req =>
           assert(req.toString)(
-            equalTo(s"Request(${req.version}, ${req.method}, ${req.url}, ${req.headers}, ${req.remoteAddress})"),
+            equalTo(s"Request(${req.version}, ${req.method}, ${req.url}, ${req.headers})"),
           )
         }
       } +
@@ -18,7 +18,7 @@ object RequestSpec extends DefaultRunnableSpec {
           check(HttpGen.parameterizedRequest(Gen.alphaNumericString)) { req =>
             assert(req.toString)(
               equalTo(
-                s"ParameterizedRequest(Request(${req.version}, ${req.method}, ${req.url}, ${req.headers}, ${req.remoteAddress}), ${req.params})",
+                s"Request(${req.version}, ${req.method}, ${req.url}, ${req.headers})",
               ),
             )
           }

--- a/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
@@ -139,7 +139,7 @@ object HttpGen {
     url     <- HttpGen.url
     headers <- Gen.listOf(HttpGen.header).map(Headers(_))
     data    <- HttpGen.httpData(Gen.listOf(Gen.alphaNumericString))
-  } yield Request(version, method, url, headers, None, data)
+  } yield Request(version, method, url, headers, data)
 
   def response[R](gContent: Gen[R, List[String]]): Gen[Random with Sized with R, Response] = {
     for {


### PR DESCRIPTION
Summary of changes produced in this PR


1. Adding support to access `ChannelHandlerContext` via `Http.context`

  ```scala
  val context: Http[Any, Nothing, Request, ChannelHandlerContext] = Http.context 
  ```

2. Adding to wrap an `HttpApp` using the `Http.usingContext` api

  ```scala
  val app = Http.usingContext { 
    ctx => Http.collect[Request] {
      case GET -> !! / "address" => Response.text(s"You connected via ${ctx.channel.remoteAddress}")
    }
  }
  ```
3. Deprecation of `request.remoteAddress`. This was an awkward API and made sense only in server context. Hence the public API is now moved into `Http.context`.