### PR TITLE
Introduce fromJarResource

### DIFF
--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -182,10 +182,24 @@ object ServerSpec extends HttpRunnableSpec {
         val res = Http.fromResource("TestFile.txt").deploy.bodyAsString.run()
         assertM(res)(equalTo("abc\nfoo"))
       } +
+      testM("data from resource in jar") {
+        val res = Http.fromJarResource("TestFile.txt").deploy.bodyAsString.run()
+        assertM(res)(equalTo("abc\nfoo"))
+      } +
       testM("content-type header on file response") {
         val res =
           Http
             .fromResource("TestFile2.mp4")
+            .deploy
+            .headerValue(HeaderNames.contentType)
+            .run()
+            .map(_.getOrElse("Content type header not found."))
+        assertM(res)(equalTo("video/mp4"))
+      } +
+      testM("content-type header on jar resource response") {
+        val res =
+          Http
+            .fromJarResource("TestFile2.mp4")
             .deploy
             .headerValue(HeaderNames.contentType)
             .run()


### PR DESCRIPTION
This is a more complete version of https://github.com/dream11/zio-http/pull/1267 as it handles content type detection from resource extension and provides some tests.

So as already said by @guizmaii, the way `Http.fromResource` is coded does not work once the resource is inside a Jar because in this case `getResource(..).getUrl` does not return a file path.
The solution is to open the resource as a stream. The problem, in this case, is that:
- we need to iterate over the fulls stream size to provide a header about `Content-Length` or we should not provide it
- I have for the moment no idea how to handle directories (see unit test) properly: in fact when opening a stream on a directory, the stream contains a line for each subfolder/file of this directory!

So I got some questions if you are interesting in a final contribution from us:
- should we keep both fromResource/fromJarResource?
- should we look for a solution regarding `Content-Length`
- should we care about the issue with directory? I think I have a solution in mind but it's quite hacky...