### PR TITLE
Fix: Middleware type issues

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/IsMono.scala
+++ b/zio-http/src/main/scala/zhttp/http/IsMono.scala
@@ -1,0 +1,37 @@
+package zhttp.http
+
+import scala.annotation.implicitNotFound
+
+/**
+ * IsMono is a type-constraint that is used by the middleware api for allowing
+ * some operators only when the following condition is met.
+ *
+ * Condition: Since a middleware takes in an Http and returns a new Http,
+ * IsMono, makes sure that the type parameters of the incoming Http and the ones
+ * for the outgoing Http is the same.
+ *
+ * For Eg: IsMono will be defined for a middleware that looks as follows
+ * ```
+ * val mid: Middleware[Any, Nothing, Request, Response, Request, Response]
+ * ```
+ *
+ * This is because both the middleware is defined from (Request, Response) =>
+ * (Request, Response). Consider another example:
+ *
+ * ```
+ * val mid: Middleware[Any, Nothing, Request, Response, UserRequest, UserResponse]
+ * ```
+ *
+ * In this case, the incoming and outgoing types are different viz. (Request,
+ * Response) => (UserRequest, UserResponse), hence there is no IsMono defined
+ * for such middlewares.
+ */
+@implicitNotFound(
+  "This operation is only valid if the incoming and outgoing type of Http are same.",
+)
+sealed trait IsMono[-AIn, +BIn, +AOut, -BOut] {}
+
+object IsMono extends IsMono[Any, Nothing, Nothing, Any] {
+  implicit def mono[AIn, BIn, AOut, BOut](implicit a: AIn =:= AOut, b: BIn =:= BOut): IsMono[AIn, BIn, AOut, BOut] =
+    IsMono
+}

--- a/zio-http/src/main/scala/zhttp/http/Middleware.scala
+++ b/zio-http/src/main/scala/zhttp/http/Middleware.scala
@@ -1,6 +1,6 @@
 package zhttp.http
 
-import zhttp.http.middleware.Web
+import zhttp.http.middleware.{MonoMiddleware, Web}
 import zio.clock.Clock
 import zio.duration.Duration
 import zio.{UIO, ZIO}
@@ -159,8 +159,9 @@ trait Middleware[-R, +E, +AIn, -BIn, -AOut, +BOut] { self =>
   /**
    * Applies Middleware based only if the condition function evaluates to true
    */
-  final def when[AOut0 <: AOut](cond: AOut0 => Boolean): Middleware[R, E, AIn, BIn, AOut0, BOut] =
-    whenZIO(a => UIO(cond(a)))
+  final def when[AOut0 <: AOut](cond: AOut0 => Boolean)(implicit
+    ev: IsMono[AIn, BIn, AOut0, BOut],
+  ): Middleware[R, E, AIn, BIn, AOut0, BOut] = self.whenZIO(a => UIO(cond(a)))
 
   /**
    * Applies Middleware based only if the condition effectful function evaluates
@@ -168,14 +169,28 @@ trait Middleware[-R, +E, +AIn, -BIn, -AOut, +BOut] { self =>
    */
   final def whenZIO[R1 <: R, E1 >: E, AOut0 <: AOut](
     cond: AOut0 => ZIO[R1, E1, Boolean],
-  ): Middleware[R1, E1, AIn, BIn, AOut0, BOut] =
+  )(implicit ev: IsMono[AIn, BIn, AOut0, BOut]): Middleware[R1, E1, AIn, BIn, AOut0, BOut] = {
     Middleware.ifThenElseZIO[AOut0](cond(_))(
       isTrue = _ => self,
-      isFalse = _ => Middleware.identity,
+      isFalse = _ => Middleware.identity[AIn, BIn, AOut, BOut],
     )
+  }
 }
 
 object Middleware extends Web {
+
+  /**
+   * Creates a middleware which can allow or disallow access to an http based on
+   * the predicate
+   */
+  def allow[A, B](cond: A => Boolean): Middleware[Any, Nothing, A, B, A, B] =
+    allowZIO(a => UIO(cond(a)))
+
+  /**
+   * Creates a middleware which can allow or disallow access to an http based on
+   * the predicate effect
+   */
+  def allowZIO[A, B]: PartialAllowZIO[A, B] = new PartialAllowZIO[A, B](())
 
   /**
    * Creates a middleware using the specified encoder and decoder functions
@@ -203,6 +218,11 @@ object Middleware extends Web {
   def collectZIO[A]: PartialCollectZIO[A] = new PartialCollectZIO[A](())
 
   /**
+   * Creates a middleware which returns an empty http value
+   */
+  def empty: Middleware[Any, Nothing, Nothing, Any, Any, Nothing] = fromHttp(Http.empty)
+
+  /**
    * Creates a middleware which always fail with specified error
    */
   def fail[E](e: E): Middleware[Any, E, Nothing, Any, Any, Nothing] =
@@ -220,13 +240,19 @@ object Middleware extends Web {
     }
 
   /**
-   * An empty middleware that doesn't do anything
+   * An empty middleware that doesn't do perform any operations on the provided
+   * Http and returns it as it is.
    */
-  def identity: Middleware[Any, Nothing, Nothing, Any, Any, Nothing] =
-    new Middleware[Any, Nothing, Nothing, Any, Any, Nothing] {
-      override def apply[R1 <: Any, E1 >: Nothing](http: Http[R1, E1, Nothing, Any]): Http[R1, E1, Any, Nothing] =
-        http.asInstanceOf[Http[R1, E1, Any, Nothing]]
-    }
+  def identity[A, B]: MonoMiddleware[Any, Nothing, A, B] = Identity
+
+  /**
+   * An empty middleware that doesn't do perform any operations on the provided
+   * Http and returns it as it is.
+   */
+  def identity[AIn, BIn, AOut, BOut](implicit
+    ev: IsMono[AIn, BIn, AOut, BOut],
+  ): Middleware[Any, Nothing, AIn, BIn, AOut, BOut] =
+    Identity
 
   /**
    * Logical operator to decide which middleware to select based on the
@@ -256,46 +282,58 @@ object Middleware extends Web {
   def succeed[B](b: B): Middleware[Any, Nothing, Nothing, Any, Any, B] = fromHttp(Http.succeed(b))
 
   /**
-   * Creates a middleware which returns an empty http value
+   * Creates a new middleware using two transformation functions, one that's
+   * applied to the incoming type of the Http and one that applied to the
+   * outgoing type of the Http.
    */
-  def empty: Middleware[Any, Nothing, Nothing, Any, Any, Nothing] = fromHttp(Http.empty)
+  def transform[AOut, BIn]: PartialMono[AOut, BIn] = new PartialMono[AOut, BIn]({})
 
   /**
-   * Creates a middleware which can allow or disallow access to an http based on
-   * the predicate
+   * Creates a new middleware using two transformation functions, one that's
+   * applied to the incoming type of the Http and one that applied to the
+   * outgoing type of the Http.
    */
-  def allow[R, E, AIn, BIn, AOut, BOut](
-    cond: AOut => Boolean,
-  ): Middleware[R, E, AIn, BIn, AOut, BOut] =
-    Middleware.ifThenElse[AOut](cond(_))(
-      isTrue = _ => Middleware.identity,
-      isFalse = _ => Middleware.empty,
-    )
+  def transformZIO[AOut, BIn]: PartialMonoZIO[AOut, BIn] = new PartialMonoZIO[AOut, BIn]({})
 
-  /**
-   * Creates a middleware which can allow or disallow access to an http based on
-   * the predicate effect
-   */
-  def allowZIO[R, E, AIn, BIn, AOut, BOut](
-    cond: AOut => ZIO[R, E, Boolean],
-  ): Middleware[R, E, AIn, BIn, AOut, BOut] =
-    Middleware.ifThenElseZIO[AOut](cond(_))(
-      isTrue = _ => Middleware.identity,
-      isFalse = _ => Middleware.empty,
-    )
+  final class PartialAllowZIO[A, B](val unit: Unit) extends AnyVal {
+    def apply[R, E](cond: A => ZIO[R, E, Boolean]): MonoMiddleware[R, E, A, B] =
+      Middleware.ifThenElseZIO[A](cond(_))(
+        isTrue = _ => Middleware.identity[A, B],
+        isFalse = _ => Middleware.empty,
+      )
+  }
+
+  final class PartialMono[AOut, BIn](val unit: Unit) extends AnyVal {
+    def apply[AIn, BOut](
+      in: AOut => AIn,
+      out: BIn => BOut,
+    ): Middleware[Any, Nothing, AIn, BIn, AOut, BOut] =
+      Middleware.transformZIO[AOut, BIn](a => UIO(in(a)), b => UIO(out(b)))
+  }
+
+  final class PartialMonoZIO[AOut, BIn](val unit: Unit) extends AnyVal {
+    def apply[R, E, AIn, BOut](
+      in: AOut => ZIO[R, E, AIn],
+      out: BIn => ZIO[R, E, BOut],
+    ): Middleware[R, E, AIn, BIn, AOut, BOut] =
+      new Middleware[R, E, AIn, BIn, AOut, BOut] {
+        override def apply[R1 <: R, E1 >: E](http: Http[R1, E1, AIn, BIn]): Http[R1, E1, AOut, BOut] =
+          http.contramapZIO(in).mapZIO(out)
+      }
+  }
 
   final class PartialCollect[AOut](val unit: Unit) extends AnyVal {
     def apply[R, E, AIn, BIn, BOut](
       f: PartialFunction[AOut, Middleware[R, E, AIn, BIn, AOut, BOut]],
     ): Middleware[R, E, AIn, BIn, AOut, BOut] =
-      Middleware.fromHttp(Http.collect[AOut] { case aout if f.isDefinedAt(aout) => f(aout) }).flatten
+      Middleware.fromHttp(Http.collect[AOut] { case a if f.isDefinedAt(a) => f(a) }).flatten
   }
 
   final class PartialCollectZIO[AOut](val unit: Unit) extends AnyVal {
     def apply[R, E, AIn, BIn, BOut](
       f: PartialFunction[AOut, ZIO[R, E, Middleware[R, E, AIn, BIn, AOut, BOut]]],
     ): Middleware[R, E, AIn, BIn, AOut, BOut] =
-      Middleware.fromHttp(Http.collectZIO[AOut] { case aout if f.isDefinedAt(aout) => f(aout) }).flatten
+      Middleware.fromHttp(Http.collectZIO[AOut] { case a if f.isDefinedAt(a) => f(a) }).flatten
   }
 
   final class PartialIntercept[A, B](val unit: Unit) extends AnyVal {
@@ -381,5 +419,10 @@ object Middleware extends Web {
         override def apply[R2 <: R1, E2 >: E1](http: Http[R2, E2, AIn, BIn]): Http[R2, E2, AOut0, BOut] =
           self(http).contramapZIO(a => f(a))
       }
+  }
+
+  private object Identity extends Middleware[Any, Nothing, Nothing, Any, Any, Nothing] {
+    override def apply[R1 <: Any, E1 >: Nothing](http: Http[R1, E1, Nothing, Any]): Http[R1, E1, Any, Nothing] =
+      http.asInstanceOf[Http[R1, E1, Any, Nothing]]
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/middleware/Web.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/Web.scala
@@ -138,7 +138,9 @@ private[zhttp] trait Web extends Cors with Csrf with Auth with HeaderModifier[Ht
    * Times out the application with a 408 status code.
    */
   final def timeout(duration: Duration): HttpMiddleware[Clock, Nothing] =
-    Middleware.identity.race(Middleware.fromHttp(Http.status(Status.RequestTimeout).delayAfter(duration)))
+    Middleware
+      .identity[Request, Response]
+      .race(Middleware.fromHttp(Http.status(Status.RequestTimeout).delayAfter(duration)))
 
   /**
    * Creates a middleware that updates the response produced
@@ -150,15 +152,13 @@ private[zhttp] trait Web extends Cors with Csrf with Auth with HeaderModifier[Ht
    * Applies the middleware only when the condition for the headers are true
    */
   final def whenHeader[R, E](cond: Headers => Boolean, middleware: HttpMiddleware[R, E]): HttpMiddleware[R, E] =
-    middleware.when[Request](req => cond(req.headers))
+    middleware.when(req => cond(req.headers))
 
   /**
    * Applies the middleware only if the condition function evaluates to true
    */
-  final def whenRequest[R, E](cond: Request => Boolean)(
-    middleware: HttpMiddleware[R, E],
-  ): HttpMiddleware[R, E] =
-    middleware.when[Request](cond)
+  final def whenRequest[R, E](cond: Request => Boolean)(middleware: HttpMiddleware[R, E]): HttpMiddleware[R, E] =
+    middleware.when(cond)
 
   /**
    * Applies the middleware only if the condition function effectfully evaluates

--- a/zio-http/src/main/scala/zhttp/http/middleware/package.scala
+++ b/zio-http/src/main/scala/zhttp/http/middleware/package.scala
@@ -1,5 +1,6 @@
 package zhttp.http
 
 package object middleware {
-  type HttpMiddleware[-R, +E] = Middleware[R, E, Request, Response, Request, Response]
+  type HttpMiddleware[-R, +E]       = MonoMiddleware[R, E, Request, Response]
+  type MonoMiddleware[-R, +E, A, B] = Middleware[R, E, A, B, A, B]
 }


### PR DESCRIPTION
**Changes**

1. `Middleware.identity` changed: 
    ```scala
    // BEFORE
    Middleware[Any, Nothing, Nothing, Any, Any, Nothing]

    // AFTER
    Middleware[Any, Nothing, A, B, A, B]
    ```
2. `.when` and `whenZIO` operator is only applicable on `MonoMiddleware` now.
3. `Middleware.allow` and `Middleware.allowZIO` now produce `MonoMiddleware`.

**Feature**
1. Added `Middleware.transform` and `Middleware.transformZIO`
2. Added `Middleware.identity` overload that accepts 4 type params.