### PR TITLE
Refactor: drop `Http.route`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Http.scala
+++ b/zio-http/src/main/scala/zhttp/http/Http.scala
@@ -975,11 +975,6 @@ object Http {
   def responseZIO[R, E](res: ZIO[R, E, Response]): HttpApp[R, E] = Http.fromZIO(res)
 
   /**
-   * Creates an Http that delegates to other Https.
-   */
-  def route[A]: Http.PartialRoute[A] = Http.PartialRoute(())
-
-  /**
    * Creates an HTTP app which always responds with the same status code and
    * empty data.
    */
@@ -1048,11 +1043,6 @@ object Http {
   final case class PartialCollectHExit[A](unit: Unit) extends AnyVal {
     def apply[R, E, B](pf: PartialFunction[A, HExit[R, E, B]]): Http[R, E, A, B] =
       FromFunctionHExit(a => if (pf.isDefinedAt(a)) pf(a) else HExit.empty)
-  }
-
-  final case class PartialRoute[A](unit: Unit) extends AnyVal {
-    def apply[R, E, B](pf: PartialFunction[A, Http[R, E, A, B]]): Http[R, E, A, B] =
-      Http.collect[A] { case r if pf.isDefinedAt(r) => pf(r) }.flatten
   }
 
   final case class PartialContraFlatMap[-R, +E, -A, +B, X](self: Http[R, E, A, B]) extends AnyVal {

--- a/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpSpec.scala
@@ -251,9 +251,9 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
         assert(actual)(isSuccess(equalTo("B")))
       },
     ),
-    suite("route")(
+    suite("collectHttp")(
       test("should delegate to its HTTP apps") {
-        val app    = Http.route[Int] {
+        val app    = Http.collectHttp[Int] {
           case 1 => Http.succeed(1)
           case 2 => Http.succeed(2)
         }
@@ -261,7 +261,7 @@ object HttpSpec extends DefaultRunnableSpec with HExitAssertion {
         assert(actual)(isSuccess(equalTo(2)))
       },
       test("should be empty if no matches") {
-        val app    = Http.route[Int](Map.empty)
+        val app    = Http.collectHttp[Int](Map.empty)
         val actual = app.execute(1)
         assert(actual)(isEmpty)
       },


### PR DESCRIPTION
Dropping `route` as it's the same as `collectHttp`