### PR TITLE
Refactor: make `req.unsafeEncode` public

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Request.scala
+++ b/zio-http/src/main/scala/zhttp/http/Request.scala
@@ -16,7 +16,7 @@ trait Request extends HeaderExtension[Request] with HttpDataExtension[Request] {
   /**
    * Gets the HttpRequest
    */
-  private[zhttp] def unsafeEncode: HttpRequest
+  def unsafeEncode: HttpRequest
 
   def copy(
     version: Version = self.version,


### PR DESCRIPTION
This allows developers to create their own custom implementation of `Request` by extending `Request`. This is good for some advanced usecases.