### PR TITLE
Fix: Drop dependency on `scala-collection-compat` when using Scala >= 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,8 +105,13 @@ lazy val zhttp = (project in file("zio-http"))
       `zio-test`,
       `zio-test-sbt`,
       `netty-incubator`,
-      `scala-compact-collection`,
     ),
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n <= 12 => Seq(`scala-compact-collection`)
+        case _                       => Seq.empty
+      }
+    },
   )
 
 lazy val zhttpBenchmarks = (project in file("zio-http-benchmarks"))


### PR DESCRIPTION
This is only an issue for Scala 3 projects that depend on Scala 2 projects using `scala-collection-compat_2.13` (such as `scalameta`).

In such cases there's an sbt conflict:

```
[error] Modules were resolved with conflicting cross-version suffixes ...
[error]    org.scala-lang.modules:scala-collection-compat _3, _2.13
```

As `scalameta` is not available yet for Scala 3, there's no easy solution for now.
