### PR TITLE
Don't depend on scala-collection-compat when using Scala >= 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,8 +106,13 @@ lazy val zhttp = (project in file("zio-http"))
       `zio-test`,
       `zio-test-sbt`,
       `netty-incubator`,
-      `scala-compact-collection`,
     ),
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n <= 12 => Seq(`scala-compact-collection`)
+        case _                       => Seq.empty
+      }
+    },
   )
   .dependsOn(zhttpLogging)
 


### PR DESCRIPTION
Counterpart of https://github.com/dream11/zio-http/pull/1275