### PR TITLE
zio2-branch: upgrade netty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,8 +98,7 @@ lazy val zhttp = (project in file("zio-http"))
   .settings(meta)
   .settings(
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    libraryDependencies ++= Seq(
-      netty,
+    libraryDependencies ++= netty ++ Seq(
       `zio`,
       `zio-streams`,
       `zio-test`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,15 @@ object Dependencies {
   val `jwt-core`                 = "com.github.jwt-scala"   %% "jwt-core"                % JwtCoreVersion
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
-  val netty             = "io.netty" % "netty-all" % NettyVersion
+  val netty =
+    Seq(
+      "netty-codec-http",
+      "netty-transport-native-epoll",
+      "netty-transport-native-kqueue",
+    ).map { name =>
+      "io.netty" % name % NettyVersion
+    }
+
   val `netty-incubator` =
     "io.netty.incubator" % "netty-incubator-transport-native-io_uring" % NettyIncubatorVersion classifier "linux-x86_64"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   val JwtCoreVersion                = "9.0.5"
-  val NettyVersion                  = "4.1.75.Final"
-  val NettyIncubatorVersion         = "0.0.13.Final"
+  val NettyVersion                  = "4.1.77.Final"
+  val NettyIncubatorVersion         = "0.0.14.Final"
   val ScalaCompactCollectionVersion = "2.7.0"
   val ZioVersion                    = "2.0.0-RC6"
   val SttpVersion                   = "3.3.18"


### PR DESCRIPTION
Apply netty upgrades to zio2 branch (already applied to main branch - based on dependabot PRs)
* https://github.com/dream11/zio-http/pull/1249
* https://github.com/dream11/zio-http/pull/1241
* https://github.com/dream11/zio-http/pull/1255