### PR TITLE
Fix: Logging Checks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbt.librarymanagement.ScalaArtifacts.isScala3
 val releaseDrafterVersion = "5"
 
 // Setting default log level to INFO
-val _ = sys.props += ("ZHttpLogLevel" -> "INFO")
+val _ = sys.props += ("ZHttpLogLevel" -> ZHttpLogLevel)
 
 // CI Configuration
 ThisBuild / githubWorkflowJavaVersions   := Seq(JavaSpec.graalvm("21.1.0", "11"), JavaSpec.temurin("8"))

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -4,11 +4,14 @@ import scalafix.sbt.ScalafixPlugin.autoImport._
 import xerial.sbt.Sonatype.autoImport._
 
 object BuildHelper extends ScalaSettings {
-  val Scala212           = "2.12.15"
-  val Scala213           = "2.13.8"
-  val ScalaDotty         = "3.1.2"
-  val ScoverageVersion   = "1.9.3"
-  val JmhVersion         = "0.4.3"
+  val Scala212         = "2.12.15"
+  val Scala213         = "2.13.8"
+  val ScalaDotty       = "3.1.2"
+  val ScoverageVersion = "1.9.3"
+  val JmhVersion       = "0.4.3"
+
+  val ZHttpLogLevel = "DEBUG"
+
   private val stdOptions = Seq(
     "-deprecation",
     "-encoding",
@@ -63,8 +66,8 @@ object BuildHelper extends ScalaSettings {
     Test / parallelExecution               := true,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     autoAPIMappings                        := true,
-    ThisBuild / javaOptions                := Seq("-Dio.netty.leakDetectionLevel=paranoid", "-DZHttpLogLevel=INFO"),
-    ThisBuild / fork                       := true,
+    ThisBuild / javaOptions := Seq("-Dio.netty.leakDetectionLevel=paranoid", s"-DZHttpLogLevel=${ZHttpLogLevel}"),
+    ThisBuild / fork        := true,
   )
 
   def runSettings(className: String = "example.HelloWorld") = Seq(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -10,7 +10,7 @@ object BuildHelper extends ScalaSettings {
   val ScoverageVersion = "1.9.3"
   val JmhVersion       = "0.4.3"
 
-  val ZHttpLogLevel = "DEBUG"
+  val ZHttpLogLevel = "INFO"
 
   private val stdOptions = Seq(
     "-deprecation",

--- a/zio-http-logging/src/main/scala-2/zhttp/logging/macros/LoggerMacroImpl.scala
+++ b/zio-http-logging/src/main/scala-2/zhttp/logging/macros/LoggerMacroImpl.scala
@@ -32,6 +32,18 @@ private[zhttp] object LoggerMacroImpl {
     val level: Tree          = q"_root_.zhttp.logging.LogLevel.${TermName(logLevelName)}"
     val isEnabled: Tree      = q"""${c.prefix.tree}.${TermName(s"is${logLevelName}Enabled")}"""
 
+    /**
+     * LogLevel Hierarchy: Trace < Debug < Info < Warn < Error
+     *
+     * We add the log statement if and only if the level in the statement is
+     * greater than or equal to the detected level from the env/props.
+     *
+     * Eg: If the level is set to Info, then only info, warn and error
+     * statements will be allowed.
+     *
+     * If the level is set to `Debug` then only debug, info, warn and error will
+     * be allowed.
+     */
     if (logLevel >= Logger.detectedLevel)
       q"""
       if($isEnabled) {

--- a/zio-http-logging/src/main/scala-2/zhttp/logging/macros/LoggerMacroImpl.scala
+++ b/zio-http-logging/src/main/scala-2/zhttp/logging/macros/LoggerMacroImpl.scala
@@ -32,18 +32,16 @@ private[zhttp] object LoggerMacroImpl {
     val level: Tree          = q"_root_.zhttp.logging.LogLevel.${TermName(logLevelName)}"
     val isEnabled: Tree      = q"""${c.prefix.tree}.${TermName(s"is${logLevelName}Enabled")}"""
 
-    /**
-     * LogLevel Hierarchy: Trace < Debug < Info < Warn < Error
-     *
-     * We add the log statement if and only if the level in the statement is
-     * greater than or equal to the detected level from the env/props.
-     *
-     * Eg: If the level is set to Info, then only info, warn and error
-     * statements will be allowed.
-     *
-     * If the level is set to `Debug` then only debug, info, warn and error will
-     * be allowed.
-     */
+    // LogLevel Hierarchy: Trace < Debug < Info < Warn < Error
+    //
+    // We add the log statement if and only if the level in the statement is
+    // greater than or equal to the detected level from the env/props.
+    //
+    // Eg: If the level is set to Info, then only info, warn and error
+    // statements will be allowed.
+    //
+    // If the level is set to `Debug` then only debug, info, warn and error will
+    // be allowed.
     if (logLevel >= Logger.detectedLevel)
       q"""
       if($isEnabled) {

--- a/zio-http-logging/src/main/scala/zhttp/logging/Font.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/Font.scala
@@ -1,0 +1,55 @@
+package zhttp.logging
+
+import zhttp.logging.Font._
+
+private[logging] sealed trait Font { self =>
+  def toAnsiColor: String = self match {
+    case BLACK      => Console.BLACK
+    case BLACK_B    => Console.BLACK_B
+    case BLINK      => Console.BLINK
+    case BLUE       => Console.BLUE
+    case BLUE_B     => Console.BLUE_B
+    case BOLD       => Console.BOLD
+    case CYAN       => Console.CYAN
+    case CYAN_B     => Console.CYAN_B
+    case GREEN      => Console.GREEN
+    case GREEN_B    => Console.GREEN_B
+    case INVISIBLE  => Console.INVISIBLE
+    case MAGENTA    => Console.MAGENTA
+    case MAGENTA_B  => Console.MAGENTA_B
+    case RED        => Console.RED
+    case RED_B      => Console.RED_B
+    case RESET      => Console.RESET
+    case REVERSED   => Console.REVERSED
+    case UNDERLINED => Console.UNDERLINED
+    case WHITE      => Console.WHITE
+    case WHITE_B    => Console.WHITE_B
+    case YELLOW     => Console.YELLOW
+    case YELLOW_B   => Console.YELLOW_B
+  }
+}
+
+object Font {
+  case object BLACK      extends Font
+  case object RED        extends Font
+  case object GREEN      extends Font
+  case object YELLOW     extends Font
+  case object BLUE       extends Font
+  case object MAGENTA    extends Font
+  case object CYAN       extends Font
+  case object WHITE      extends Font
+  case object BLACK_B    extends Font
+  case object RED_B      extends Font
+  case object GREEN_B    extends Font
+  case object YELLOW_B   extends Font
+  case object BLUE_B     extends Font
+  case object MAGENTA_B  extends Font
+  case object CYAN_B     extends Font
+  case object WHITE_B    extends Font
+  case object RESET      extends Font
+  case object BOLD       extends Font
+  case object UNDERLINED extends Font
+  case object BLINK      extends Font
+  case object REVERSED   extends Font
+  case object INVISIBLE  extends Font
+}

--- a/zio-http-logging/src/main/scala/zhttp/logging/LogFormat.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LogFormat.scala
@@ -2,187 +2,184 @@ package zhttp.logging
 
 import zhttp.logging.LogFormat.DateFormat.ISODateTime
 
-import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 object Setup {
   final case class DefaultFormat(format: LogLine => String) {
     def apply(line: LogLine): String = format(line)
   }
-
 }
 
 sealed trait LogFormat { self =>
   import LogFormat._
 
-  def <+>(that: LogFormat): LogFormat = self combine that
+  final def |-|(other: LogFormat): LogFormat = Combine(self, " ", other)
 
-  def combine(that: LogFormat): LogFormat = LogFormat.Combine(self, that)
+  final def \\(other: LogFormat): LogFormat = Combine(self, "\n", other)
 
-  final def color(color: Color): LogFormat = ColorWrap(color, self)
+  final def <+>(that: LogFormat): LogFormat = Combine(self, "", that)
 
-  final def wrap(wrapper: TextWrapper): LogFormat = TextWrappers(wrapper, self)
+  final def -(other: LogFormat): LogFormat = Combine(self, "-", other)
 
-  final def fixed(size: Int): LogFormat = Fixed(size, self)
+  final def apply(line: LogLine): String = {
+    val colorStack = collection.mutable.Stack.empty[Font]
 
-  final def |-|(other: LogFormat): LogFormat = Spaced(self, other)
+    def loop(self: LogFormat, line: LogLine): String = {
+      self match {
+        case Location                      => line.sourceLocation.map(sp => s"${sp.file} ${sp.line}").getOrElse("")
+        case FormatDate(dateFormat)        =>
+          dateFormat match {
+            case DateFormat.ISODateTime => line.timestamp.format(DateTimeFormatter.ISO_TIME)
+          }
+        case ThreadName(includeThreadName) => if (includeThreadName) line.thread.getName else ""
+        case ThreadId(includeThreadId)     => if (includeThreadId) line.thread.getId.toString else ""
+        case Level                         => line.level.name
+        case Combine(left, sep, right)     => loop(left, line) + sep + loop(right, line)
+        case FontWrap(font, fmt)           =>
+          colorStack.push(font)
+          val msg   = loop(fmt, line)
+          val start = font.toAnsiColor
+          colorStack.pop()
+          val end   = colorStack.map(_.toAnsiColor).mkString("")
+          s"${start}${msg}${Console.RESET}$end"
+        case Msg                           => line.message
+        case Tags                          => line.tags.mkString(":")
+        case Literal(msg)                  => msg
+        case Format(fmt, f)                => loop(f(loop(fmt, line)), line)
+      }
+    }
 
-  final def -(other: LogFormat): LogFormat = Dash(self, other)
+    loop(self, line)
+  }
 
-  final def \\(other: LogFormat): LogFormat = NewLine(self, other)
+  final def autoColor: LogFormat =
+    self.format(str => self.font(AutoColorSeq(str.hashCode.abs % AutoColorSeq.length)))
 
-  final def trim: LogFormat = Trim(self)
+  final def black: LogFormat = font(Font.BLACK)
 
-  def apply(line: LogLine): String = LogFormat.run(self, line)
+  final def blackB: LogFormat = font(Font.BLACK_B)
 
+  final def blink: LogFormat = font(Font.BLINK)
+
+  final def blue: LogFormat = font(Font.BLUE)
+
+  final def blueB: LogFormat = font(Font.BLUE_B)
+
+  final def bold: LogFormat = font(Font.BOLD)
+
+  final def bracket: LogFormat = transform(msg => s"[${msg}]")
+
+  final def cyan: LogFormat = font(Font.CYAN)
+
+  final def cyanB: LogFormat = font(Font.CYAN_B)
+
+  final def fixed(n: Int): LogFormat = transform(_.padTo(n, ' '))
+
+  final def flipColor: LogFormat = self.font(Font.REVERSED)
+
+  final def font(font: Font): LogFormat = FontWrap(font, self)
+
+  final def format(f: String => LogFormat): LogFormat = LogFormat.Format(self, f)
+
+  final def green: LogFormat = font(Font.GREEN)
+
+  final def greenB: LogFormat = font(Font.GREEN_B)
+
+  final def invisible: LogFormat = font(Font.INVISIBLE)
+
+  final def lowercase: LogFormat = transform(_.toLowerCase)
+
+  final def magenta: LogFormat = font(Font.MAGENTA)
+
+  final def magentaB: LogFormat = font(Font.MAGENTA_B)
+
+  final def red: LogFormat = font(Font.RED)
+
+  final def redB: LogFormat = font(Font.RED_B)
+
+  final def reset: LogFormat = font(Font.RESET)
+
+  final def reversed: LogFormat = font(Font.REVERSED)
+
+  final def transform(f: String => String): LogFormat = format(s => LogFormat.Literal(f(s)))
+
+  final def trim: LogFormat = transform(_.trim)
+
+  final def underline: LogFormat = self.font(Font.UNDERLINED)
+
+  final def underlined: LogFormat = font(Font.UNDERLINED)
+
+  final def uppercase: LogFormat = transform(_.toUpperCase)
+
+  final def white: LogFormat = font(Font.WHITE)
+
+  final def whiteB: LogFormat = font(Font.WHITE_B)
+
+  final def yellow: LogFormat = font(Font.YELLOW)
+
+  final def yellowB: LogFormat = font(Font.YELLOW_B)
 }
 
 object LogFormat {
 
+  val AutoColorSeq: Array[Font] = Array(
+    Font.BLUE,
+    Font.CYAN,
+    Font.GREEN,
+    Font.MAGENTA,
+    Font.YELLOW,
+  )
+
+  def colored: LogFormat =
+    LogFormat.level.uppercase.bracket.fixed(7).white |-|
+      LogFormat.tags.autoColor.flipColor |-|
+      LogFormat.message
+
+  def date(dateFormat: DateFormat): LogFormat = FormatDate(dateFormat)
+
+  def level: LogFormat = Level
+
+  def literal(a: String): LogFormat = Literal(a)
+
+  def location: LogFormat = Location
+
+  def maximus: LogFormat =
+    LogFormat.tags.bracket |-|
+      LogFormat.date(ISODateTime) |-|
+      LogFormat.threadName.bracket |-|
+      LogFormat.location.bracket |-|
+      LogFormat.level - LogFormat.message
+
+  def message: LogFormat = Msg
+
+  def tags: LogFormat = Tags
+
+  def threadId: LogFormat = ThreadId(true)
+
+  def threadName: LogFormat = ThreadName(true)
+
   sealed trait DateFormat
+
+  final case class FormatDate(dateFormat: DateFormat) extends LogFormat
+
+  final case class ThreadName(includeThreadName: Boolean) extends LogFormat
+
+  final case class ThreadId(includeThreadId: Boolean) extends LogFormat
+
+  final case class Combine(left: LogFormat, sep: String, right: LogFormat) extends LogFormat
+
+  final case class FontWrap(font: Font, fmt: LogFormat) extends LogFormat
+
+  final case class Literal(lit: String) extends LogFormat
+
+  final case class Format(fmt: LogFormat, f: String => LogFormat) extends LogFormat
+
   object DateFormat {
     case object ISODateTime extends DateFormat
   }
 
-  sealed trait Color
-  object Color {
-    case object RED     extends Color
-    case object BLUE    extends Color
-    case object YELLOW  extends Color
-    case object CYAN    extends Color
-    case object GREEN   extends Color
-    case object MAGENTA extends Color
-    case object WHITE   extends Color
-    case object RESET   extends Color
-    case object DEFAULT extends Color
-
-    def asConsole(color: Color): String = color match {
-      case RED     => Console.RED
-      case BLUE    => Console.BLUE
-      case YELLOW  => Console.YELLOW
-      case CYAN    => Console.CYAN
-      case GREEN   => Console.GREEN
-      case MAGENTA => Console.MAGENTA
-      case WHITE   => Console.WHITE
-      case RESET   => Console.RESET
-      case DEFAULT => ""
-    }
-  }
-
-  sealed trait TextWrapper
-  object TextWrapper {
-    case object BRACKET extends TextWrapper
-    case object QUOTED  extends TextWrapper
-    case object EMPTY   extends TextWrapper
-  }
-
-  final case class FormatDate(dateFormat: DateFormat)                                            extends LogFormat
-  final case class ThreadName(includeThreadName: Boolean)                                        extends LogFormat
-  final case class ThreadId(includeThreadId: Boolean)                                            extends LogFormat
-  case object LoggerLevel                                                                        extends LogFormat
-  final case class Combine(left: LogFormat, right: LogFormat)                                    extends LogFormat
-  final case class ColorWrap(color: Color, configuration: LogFormat)                             extends LogFormat
-  final case class LineColor(info: Color, error: Color, debug: Color, trace: Color, warn: Color) extends LogFormat
-  final case class TextWrappers(wrapper: TextWrapper, configuration: LogFormat)                  extends LogFormat
-  final case class Fixed(size: Int, configuration: LogFormat)                                    extends LogFormat
-  final case class Spaced(left: LogFormat, right: LogFormat)                                     extends LogFormat
-  final case class Dash(left: LogFormat, right: LogFormat)                                       extends LogFormat
-  final case class NewLine(left: LogFormat, right: LogFormat)                                    extends LogFormat
-  final case class Trim(logFmt: LogFormat)                                                       extends LogFormat
-  case object SourceLocation                                                                     extends LogFormat
-  case object Msg                                                                                extends LogFormat
-  case object Tags                                                                               extends LogFormat
-
-  def logLevel: LogFormat                     = LoggerLevel
-  def date(dateFormat: DateFormat): LogFormat = FormatDate(dateFormat)
-  def threadName: LogFormat                   = ThreadName(true)
-  def threadId: LogFormat                     = ThreadId(true)
-  def msg: LogFormat                          = Msg
-  def sourceLocation: LogFormat               = SourceLocation
-  def tags: LogFormat                         = Tags
-
-  def color(info: Color, error: Color, debug: Color, trace: Color, warn: Color): LogFormat =
-    LineColor(info, error, debug, trace, warn)
-
-  private def run(logFormat: LogFormat, logLine: LogLine): String = {
-
-    logFormat match {
-      case SourceLocation                => logLine.sourceLocation.map(sp => s"${sp.file} ${sp.line}").getOrElse("")
-      case FormatDate(dateFormat)        => formatDate(dateFormat, logLine.timestamp)
-      case ThreadName(includeThreadName) => if (includeThreadName) logLine.thread.getName else ""
-      case ThreadId(includeThreadId)     => if (includeThreadId) logLine.thread.getId.toString else ""
-      case LoggerLevel                   => logLine.level.name
-      case Combine(left, right)          => left(logLine) ++ right(logLine)
-      case ColorWrap(color, conf)        =>
-        colorText(color, conf(logLine))
-      case TextWrappers(wrapper, conf)   => wrap(wrapper, conf(logLine))
-      case Fixed(_, conf)                => conf(logLine)
-      case Spaced(left, right)           => left(logLine) + " " + right(logLine)
-      case Dash(left, right)             => left(logLine) + " - " + right(logLine)
-      case NewLine(left, right)          => left(logLine) + "\n" + right(logLine)
-      case Msg                           => logLine.message
-      case Trim(conf)                    => conf(logLine).trim
-      case LineColor(info, error, debug, trace, warn) =>
-        logLine.level match {
-          case LogLevel.Trace => Color.asConsole(trace)
-          case LogLevel.Debug => Color.asConsole(debug)
-          case LogLevel.Info  => Color.asConsole(info)
-          case LogLevel.Warn  => Color.asConsole(warn)
-          case LogLevel.Error => Color.asConsole(error)
-        }
-      case Tags                                       => logLine.tags.mkString(",")
-    }
-  }
-
-  private def formatDate(format: LogFormat.DateFormat, time: LocalDateTime): String = format match {
-    case DateFormat.ISODateTime => time.format(DateTimeFormatter.ISO_TIME)
-  }
-
-  /**
-   * Wrap a text if the text is not empty.
-   */
-  private def wrap(wrapper: TextWrapper, value: String): String = {
-    if (value.isEmpty) ""
-    else
-      wrapper match {
-        case TextWrapper.BRACKET => s"[$value]"
-        case TextWrapper.QUOTED  => s"{$value}"
-        case TextWrapper.EMPTY   => value
-      }
-  }
-
-  private def colorText(color: Color, value: String): String = {
-    val consoleColor = Color.asConsole(color)
-    color match {
-      case Color.RED     => s"$consoleColor$value${Console.RESET}"
-      case Color.BLUE    => s"$consoleColor$value${Console.RESET}"
-      case Color.YELLOW  => s"$consoleColor$value${Console.RESET}"
-      case Color.CYAN    => s"$consoleColor$value${Console.RESET}"
-      case Color.GREEN   => s"$consoleColor$value${Console.RESET}"
-      case Color.MAGENTA => s"$consoleColor$value${Console.RESET}"
-      case Color.WHITE   => s"$consoleColor$value${Console.RESET}"
-      case Color.RESET   => Console.RESET
-      case Color.DEFAULT => value
-    }
-  }
-
-  val minimal: LogFormat =
-    LogFormat.Tags.wrap(TextWrapper.BRACKET) |-|
-      LogFormat.sourceLocation.wrap(TextWrapper.BRACKET) |-|
-      LogFormat.msg
-
-  val maximus: LogFormat =
-    LogFormat.Tags.wrap(TextWrapper.BRACKET) |-|
-      LogFormat.date(ISODateTime) |-|
-      LogFormat.threadName.wrap(TextWrapper.BRACKET) |-|
-      LogFormat.sourceLocation.wrap(TextWrapper.BRACKET) |-|
-      LogFormat.logLevel - LogFormat.msg
-
-  val colored: LogFormat = LogFormat.color(
-    info = Color.GREEN,
-    error = Color.RED,
-    debug = Color.CYAN,
-    warn = Color.YELLOW,
-    trace = Color.WHITE,
-  ) <+> minimal
+  case object Level    extends LogFormat
+  case object Location extends LogFormat
+  case object Msg      extends LogFormat
+  case object Tags     extends LogFormat
 }

--- a/zio-http-logging/src/main/scala/zhttp/logging/LogFormat.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LogFormat.scala
@@ -117,6 +117,11 @@ object LogFormat {
     Font.GREEN,
     Font.MAGENTA,
     Font.YELLOW,
+    Font.BLUE_B,
+    Font.CYAN_B,
+    Font.GREEN_B,
+    Font.MAGENTA_B,
+    Font.YELLOW_B,
   )
 
   def inlineColored: LogFormat =

--- a/zio-http-logging/src/main/scala/zhttp/logging/LogLevel.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LogLevel.scala
@@ -40,24 +40,24 @@ object LogLevel {
    * Automatically detects the level from the environment variable
    */
   def detectFromEnv(name: String): Option[LogLevel] =
-    sys.env.get(name).map(fromString)
+    sys.env.get(name).flatMap(fromString)
 
   /**
    * Automatically detects the level from the system properties
    */
   def detectFromProps(name: String): Option[LogLevel] =
-    sys.props.get(name).map(fromString)
+    sys.props.get(name).flatMap(fromString)
 
   /**
    * Detects the LogLevel given any random string
    */
-  def fromString(string: String): LogLevel = string.toUpperCase match {
-    case "TRACE" => Trace
-    case "DEBUG" => Debug
-    case "INFO"  => Info
-    case "WARN"  => Warn
-    case "ERROR" => Error
-    case _       => Error
+  def fromString(string: String): Option[LogLevel] = string.toUpperCase match {
+    case "TRACE" => Option(Trace)
+    case "DEBUG" => Option(Debug)
+    case "INFO"  => Option(Info)
+    case "WARN"  => Option(Warn)
+    case "ERROR" => Option(Error)
+    case _       => None
   }
 
   case object Trace extends LogLevel(1)

--- a/zio-http-logging/src/main/scala/zhttp/logging/LogLevel.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LogLevel.scala
@@ -18,6 +18,8 @@ sealed abstract class LogLevel(val id: Int) extends Product with Serializable { 
   }
 
   final override def toString: String = name
+
+  final def toTransport: LoggerTransport = LoggerTransport.empty.withLevel(self)
 }
 
 /**

--- a/zio-http-logging/src/main/scala/zhttp/logging/Logger.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/Logger.scala
@@ -106,7 +106,7 @@ final case class Logger(transports: List[LoggerTransport]) extends LoggerMacroEx
 object Logger {
   private[zhttp] val detectedLevel: LogLevel = LogLevel.detectFromProps("ZHttpLogLevel").getOrElse(LogLevel.Error)
 
-  def console: Logger = Logger(List(LoggerTransport.console))
+  def console: Logger = LoggerTransport.console.toLogger
 
   def file(path: Path): Logger = Logger(List(LoggerTransport.file(path)))
 

--- a/zio-http-logging/src/main/scala/zhttp/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LoggerTransport.scala
@@ -12,7 +12,7 @@ import java.util
  * used to, format and serialize LogLines and them to a backend.
  */
 private[logging] abstract class LoggerTransport(
-  format: LogFormat = LogFormat.minimal,
+  format: LogFormat = LogFormat.colored,
   val level: LogLevel = LogLevel.Error,
   filter: String => Boolean = _ => true,
   tags: List[String] = Nil,
@@ -78,7 +78,8 @@ private[logging] abstract class LoggerTransport(
   ): Unit =
     if (self.level <= level) {
       buildLines(msg, cause, level, self.tags, sourceLocation).foreach { line =>
-        if (filter(format(line))) run(format(line))
+        val formatted = format(line)
+        if (filter(formatted)) run(formatted)
       }
     }
 

--- a/zio-http-logging/src/main/scala/zhttp/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zhttp/logging/LoggerTransport.scala
@@ -20,11 +20,11 @@ private[logging] abstract class LoggerTransport(
 
   def run(charSequence: CharSequence): Unit
 
-  final private[zhttp] val isDebugEnabled: Boolean = self.level >= LogLevel.Debug
-  final private[zhttp] val isErrorEnabled: Boolean = self.level >= LogLevel.Error
-  final private[zhttp] val isInfoEnabled: Boolean  = self.level >= LogLevel.Info
-  final private[zhttp] val isTraceEnabled: Boolean = self.level >= LogLevel.Trace
-  final private[zhttp] val isWarnEnabled: Boolean  = self.level >= LogLevel.Warn
+  final private[zhttp] val isDebugEnabled: Boolean = self.level <= LogLevel.Debug
+  final private[zhttp] val isErrorEnabled: Boolean = self.level <= LogLevel.Error
+  final private[zhttp] val isInfoEnabled: Boolean  = self.level <= LogLevel.Info
+  final private[zhttp] val isTraceEnabled: Boolean = self.level <= LogLevel.Trace
+  final private[zhttp] val isWarnEnabled: Boolean  = self.level <= LogLevel.Warn
 
   final private def buildLines(
     msg: String,

--- a/zio-http-logging/src/test/scala/zhttp/logging/LogLevelSpec.scala
+++ b/zio-http-logging/src/test/scala/zhttp/logging/LogLevelSpec.scala
@@ -12,12 +12,12 @@ object LogLevelSpec extends DefaultRunnableSpec {
     },
     testM("encode decode") {
       checkAll(Gen.fromIterable(LogLevel.all)) { level =>
-        assertTrue(LogLevel.fromString(level.toString) == level)
+        assertTrue(LogLevel.fromString(level.toString) == Some(level))
       }
     },
     testM("any value with the exception of defined values for LogLevel should be set to Error log level.") {
       checkAll(Gen.fromIterable(List("not defined", "unknown", "disable"))) { level =>
-        assertTrue(LogLevel.fromString(level) == LogLevel.Error)
+        assertTrue(LogLevel.fromString(level) == Some(LogLevel.Error))
       }
     },
   )

--- a/zio-http-logging/src/test/scala/zhttp/logging/LogLevelSpec.scala
+++ b/zio-http-logging/src/test/scala/zhttp/logging/LogLevelSpec.scala
@@ -15,9 +15,9 @@ object LogLevelSpec extends DefaultRunnableSpec {
         assertTrue(LogLevel.fromString(level.toString) == Some(level))
       }
     },
-    testM("any value with the exception of defined values for LogLevel should be set to Error log level.") {
+    testM("any invalid value should not decode") {
       checkAll(Gen.fromIterable(List("not defined", "unknown", "disable"))) { level =>
-        assertTrue(LogLevel.fromString(level) == Some(LogLevel.Error))
+        assertTrue(LogLevel.fromString(level) == None)
       }
     },
   )

--- a/zio-http-logging/src/test/scala/zhttp/logging/LoggerSpec.scala
+++ b/zio-http-logging/src/test/scala/zhttp/logging/LoggerSpec.scala
@@ -25,6 +25,50 @@ object LoggerSpec extends DefaultRunnableSpec {
         assertTrue(transport.stdout == s"${level} ABC")
       }
     },
+    suite("LoggerTransport")(
+      suite("level checks")(
+        test("Error") {
+          val logger = LogLevel.Error.toTransport
+          assertTrue(logger.isErrorEnabled) &&
+          assertTrue(!logger.isWarnEnabled) &&
+          assertTrue(!logger.isInfoEnabled) &&
+          assertTrue(!logger.isDebugEnabled) &&
+          assertTrue(!logger.isTraceEnabled)
+        },
+        test("Warn") {
+          val logger = LogLevel.Warn.toTransport
+          assertTrue(logger.isErrorEnabled) &&
+          assertTrue(logger.isWarnEnabled) &&
+          assertTrue(!logger.isInfoEnabled) &&
+          assertTrue(!logger.isDebugEnabled) &&
+          assertTrue(!logger.isTraceEnabled)
+        },
+        test("Info") {
+          val logger = LogLevel.Info.toTransport
+          assertTrue(logger.isErrorEnabled) &&
+          assertTrue(logger.isWarnEnabled) &&
+          assertTrue(logger.isInfoEnabled) &&
+          assertTrue(!logger.isDebugEnabled) &&
+          assertTrue(!logger.isTraceEnabled)
+        },
+        test("Debug") {
+          val logger = LogLevel.Debug.toTransport
+          assertTrue(logger.isErrorEnabled) &&
+          assertTrue(logger.isWarnEnabled) &&
+          assertTrue(logger.isInfoEnabled) &&
+          assertTrue(logger.isDebugEnabled) &&
+          assertTrue(!logger.isTraceEnabled)
+        },
+        test("Trace") {
+          val logger = LogLevel.Trace.toTransport
+          assertTrue(logger.isErrorEnabled) &&
+          assertTrue(logger.isWarnEnabled) &&
+          assertTrue(logger.isInfoEnabled) &&
+          assertTrue(logger.isDebugEnabled) &&
+          assertTrue(logger.isTraceEnabled)
+        },
+      ),
+    ),
   )
 
   final class MemoryTransport extends LoggerTransport() {

--- a/zio-http-logging/src/test/scala/zhttp/logging/LoggerSpec.scala
+++ b/zio-http-logging/src/test/scala/zhttp/logging/LoggerSpec.scala
@@ -17,7 +17,7 @@ object LoggerSpec extends DefaultRunnableSpec {
       }
     },
     testM("logs message") {
-      val format  = LogFormat.logLevel |-| LogFormat.msg
+      val format  = LogFormat.level |-| LogFormat.message
       val message = "ABC"
       checkAll(Gen.fromIterable(LogLevel.all)) { level =>
         val transport = MemoryTransport.make

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -19,7 +19,7 @@ private[zhttp] final case class Handler[R](
     with WebSocketUpgrade[R] { self =>
 
   override def channelRead0(ctx: Ctx, msg: HttpObject): Unit = {
-    log.debug(s"Message: ${msg.getClass.getSimpleName}")
+    log.debug(s"Message: [${msg.getClass.getName}]")
     implicit val iCtx: ChannelHandlerContext = ctx
     msg match {
       case jReq: FullHttpRequest =>
@@ -50,7 +50,7 @@ private[zhttp] final case class Handler[R](
         }
       case jReq: HttpRequest     =>
         val hasBody = canHaveBody(jReq)
-        log.debug(s"HasBody: ${hasBody}")
+        log.debug(s"HasBody: [${hasBody}]")
         if (hasBody) ctx.channel().config().setAutoRead(false): Unit
         try
           unsafeRun(

--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -129,13 +129,9 @@ private[zhttp] final case class Handler[R](
                   }
               },
             res =>
-              if (self.isWebSocket(res)) UIO(self.upgradeToWebSocket(jReq, res))
-              else {
-                for {
-                  _ <- ZIO {
-                    resWriter.write(res, jReq)
-                  }
-                } yield ()
+              UIO {
+                if (self.isWebSocket(res)) self.upgradeToWebSocket(jReq, res)
+                else resWriter.write(res, jReq)
               },
           )
         }

--- a/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
+++ b/zio-http/src/main/scala/zhttp/service/HttpRuntime.scala
@@ -15,14 +15,18 @@ import scala.jdk.CollectionConverters._
  * channel closes.
  */
 final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
+  private val log = HttpRuntime.log
 
   private def closeListener(rtm: Runtime[Any], fiber: Fiber.Runtime[_, _]): GenericFutureListener[Future[_ >: Void]] =
-    (_: Future[_ >: Void]) => rtm.unsafeRunAsync_(fiber.interrupt): Unit
+    (_: Future[_ >: Void]) => {
+      log.debug(s"Connection Closed for Fiber: ${fiber.id}")
+      rtm.unsafeRunAsync_(fiber.interrupt): Unit
+    }
 
   private def onFailure(ctx: ChannelHandlerContext, cause: Cause[Throwable]) = {
     cause.failureOption.orElse(cause.dieOption) match {
       case None    => ()
-      case Some(_) => Log.error("HttpRuntimeException:" + cause.prettyPrint)
+      case Some(_) => log.error("HttpRuntimeException:" + cause.prettyPrint)
     }
     if (ctx.channel().isOpen) ctx.close()
   }
@@ -39,10 +43,15 @@ final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
         close <- UIO {
           val close = closeListener(rtm, fiber)
           ctx.channel().closeFuture.addListener(close)
+          log.debug(s"Added Close Listener for Fiber: ${fiber.id}")
           close
         }
         _     <- fiber.join
-        _     <- UIO(ctx.channel().closeFuture().removeListener(close))
+        _     <- UIO {
+          log.debug(s"Fiber Completed: ${fiber.id}")
+          ctx.channel().closeFuture().removeListener(close)
+          log.debug(s"Removed Close Listener for Fiber: ${fiber.id}")
+        }
       } yield ()) {
         case Exit.Success(_)     => ()
         case Exit.Failure(cause) => onFailure(ctx, cause)
@@ -62,6 +71,8 @@ final class HttpRuntime[+R](strategy: HttpRuntime.Strategy[R]) {
 }
 
 object HttpRuntime {
+  private[zhttp] val log = Log.withTags("HttpRuntime")
+
   def dedicated[R](group: JEventLoopGroup): URIO[R, HttpRuntime[R]] =
     Strategy.dedicated(group).map(runtime => new HttpRuntime[R](runtime))
 

--- a/zio-http/src/main/scala/zhttp/service/Logging.scala
+++ b/zio-http/src/main/scala/zhttp/service/Logging.scala
@@ -1,6 +1,6 @@
 package zhttp.service
 
-import zhttp.logging.Logger
+import zhttp.logging.{LogFormat, Logger}
 
 /**
  * Base trait to configure logging. Feel free to edit this file as per your
@@ -23,5 +23,6 @@ trait Logging {
    * Global Logging instance used to add log statements everywhere in the
    * application.
    */
-  private[zhttp] val Log: Logger = Logger.console.detectLevelFromProps(PropName)
+  private[zhttp] val Log: Logger = Logger.console.detectLevelFromProps(PropName).withFormat(LogFormat.inlineColored)
+
 }

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -3,7 +3,6 @@ package zhttp.service
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel.ChannelPipeline
 import io.netty.util.ResourceLeakDetector
-import zhttp.http.Http._
 import zhttp.http.{Http, HttpApp}
 import zhttp.service.server.ServerSSLHandler._
 import zhttp.service.server._
@@ -156,6 +155,7 @@ object Server {
   val paranoidLeakDetection: UServer = LeakDetection(LeakDetectionLevel.PARANOID)
   val disableKeepAlive: UServer      = Server.KeepAlive(false)
   val consolidateFlush: UServer      = ConsolidateFlush(true)
+  private[zhttp] val log             = Log.withTags("Server")
 
   def acceptContinue: UServer = Server.AcceptContinue(true)
 
@@ -215,7 +215,7 @@ object Server {
     Server(http)
       .withPort(port)
       .make
-      .flatMap(start => ZManaged.succeed(Log.info(s"Server started on port: ${start.port}")))
+      .flatMap(start => ZManaged.succeed(log.info(s"Started on port: ${start.port}")))
       .useForever
       .provideSomeLayer[R](EventLoopGroup.auto(0) ++ ServerChannelFactory.auto)
   }

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -195,6 +195,9 @@ object Server {
       port <- ZManaged.effect(chf.channel().localAddress().asInstanceOf[InetSocketAddress].getPort)
     } yield {
       ResourceLeakDetector.setLevel(settings.leakDetectionLevel.jResourceLeakDetectionLevel)
+      log.debug(s"Keep Alive: [${settings.keepAlive}]")
+      log.debug(s"Leak Detection: [${settings.leakDetectionLevel}]")
+      log.info(s"Started on port: [${port}]")
       Start(port)
     }
   }
@@ -215,7 +218,6 @@ object Server {
     Server(http)
       .withPort(port)
       .make
-      .flatMap(start => ZManaged.succeed(log.info(s"Started on port: ${start.port}")))
       .useForever
       .provideSomeLayer[R](EventLoopGroup.auto(0) ++ ServerChannelFactory.auto)
   }

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -148,6 +148,7 @@ sealed trait Server[-R, +E] { self =>
     Concat(self, UnsafeServerBootstrap(unsafeServerbootstrap))
 }
 object Server {
+  import Http.HttpAppSyntax
   val disableFlowControl: UServer    = Server.FlowControl(false)
   val disableLeakDetection: UServer  = LeakDetection(LeakDetectionLevel.DISABLED)
   val simpleLeakDetection: UServer   = LeakDetection(LeakDetectionLevel.SIMPLE)

--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -197,6 +197,7 @@ object Server {
       ResourceLeakDetector.setLevel(settings.leakDetectionLevel.jResourceLeakDetectionLevel)
       log.debug(s"Keep Alive: [${settings.keepAlive}]")
       log.debug(s"Leak Detection: [${settings.leakDetectionLevel}]")
+      log.debug(s"Transport: [${eventLoopGroup.getClass.getName}]")
       log.info(s"Started on port: [${port}]")
       Start(port)
     }


### PR DESCRIPTION
- doc: add ScalaDoc for macro generation.
- refactor: make `LogLevel.fromString` return an `Option` instead of `Error` when nothing is found
- feature: add `toTransport` to LogLevel
- fix: flags such as `isDebugEnabled`, `isErrorEnabled` etc.
- refactor: set global LogLevel in build
- debug: add log statements
