### PR TITLE
Fix: Return empty URL in case of a parse failure

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Handler.scala
+++ b/zio-http/src/main/scala/zhttp/service/Handler.scala
@@ -31,7 +31,7 @@ private[zhttp] final case class Handler[R](
             new Request {
               override def method: Method = Method.fromHttpMethod(jReq.method())
 
-              override def url: URL = URL.fromString(jReq.uri()).getOrElse(null)
+              override def url: URL = URL.fromString(jReq.uri()).getOrElse(URL.empty)
 
               override def headers: Headers = Headers.make(jReq.headers())
 
@@ -73,7 +73,7 @@ private[zhttp] final case class Handler[R](
 
               override def method: Method = Method.fromHttpMethod(jReq.method())
 
-              override def url: URL = URL.fromString(jReq.uri()).getOrElse(null)
+              override def url: URL = URL.fromString(jReq.uri()).getOrElse(URL.empty)
 
               override def version: Version = Version.unsafeFromJava(jReq.protocolVersion())
 


### PR DESCRIPTION
fixes #1303 