### PR TITLE
Feature: Add `toJavaURI` and `toJavaURL` to `URL`

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/URL.scala
+++ b/zio-http/src/main/scala/zhttp/http/URL.scala
@@ -94,12 +94,10 @@ final case class URL(
   def toJavaURI: java.net.URI = new URI(encode)
 
   /**
-   * Returns a new java.net.URL representing this URL.
+   * Returns a new java.net.URL only if this URL represents an absolute
+   * location.
    */
-  def toJavaURL: Option[java.net.URL] = self.kind match {
-    case URL.Location.Relative => None
-    case _                     => Some(toJavaURI.toURL)
-  }
+  def toJavaURL: Option[java.net.URL] = if (self.kind == URL.Location.Relative) None else Some(toJavaURI.toURL)
 }
 object URL {
   private def fromAbsoluteURI(uri: URI): Option[URL] = {

--- a/zio-http/src/main/scala/zhttp/http/URL.scala
+++ b/zio-http/src/main/scala/zhttp/http/URL.scala
@@ -91,31 +91,15 @@ final case class URL(
   /**
    * Returns a new java.net.URI representing this URL.
    */
-  def toJavaURI: Option[java.net.URI] = self.kind match {
-    case URL.Location.Relative                     => None
-    case URL.Location.Absolute(scheme, host, port) =>
-      val queryStr    = queryParams.filter { case (k, _) => k.nonEmpty }.map { case (k, v) =>
-        v.map(v => s"$k=$v").mkString("&")
-      }.filter(_.nonEmpty).mkString("&")
-      val fragmentStr = fragment.map(_.raw).getOrElse(null)
-
-      Some(
-        new java.net.URI(
-          scheme.encode,
-          null,
-          host,
-          port,
-          if (path.leadingSlash || path.isEmpty) path.encode else (Path.root ++ path).encode,
-          if (queryStr.isEmpty) null else queryStr,
-          fragmentStr,
-        ),
-      )
-  }
+  def toJavaURI: java.net.URI = new URI(encode)
 
   /**
    * Returns a new java.net.URL representing this URL.
    */
-  def toJavaURL: Option[java.net.URL] = toJavaURI.map(_.toURL)
+  def toJavaURL: Option[java.net.URL] = self.kind match {
+    case URL.Location.Relative => None
+    case _                     => Some(toJavaURI.toURL)
+  }
 }
 object URL {
   private def fromAbsoluteURI(uri: URI): Option[URL] = {

--- a/zio-http/src/test/scala/zhttp/http/URLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/URLSpec.scala
@@ -83,27 +83,16 @@ object URLSpec extends ZIOSpecDefault {
         },
       ),
       suite("java interop")(
-        test("can not create a java.net.URI from a relative URL") {
+        test("can not create a java.net.URL from a relative URL") {
           check(HttpGen.genRelativeURL) { url =>
-            assert(url.toJavaURI)(isNone)
+            assert(url.toJavaURL)(isNone)
           }
         },
         test("converts a zhttp.http.URL to java.net.URI") {
-          check(HttpGen.genAbsoluteURL) { autoUrl =>
-            // converts an absolute URL with a relative path (non leading slash) to an absolute path
-            // to avoid encoding problems
-            val absoluteUrl =
-              if (autoUrl.path.nonEmpty && !autoUrl.path.leadingSlash)
-                autoUrl.setPath(Path.root ++ autoUrl.path)
-              else
-                autoUrl
-            val url         = URL.fromString(absoluteUrl.encode).getOrElse(absoluteUrl)
-            val uri         = url.toJavaURI
-            val reversedUrl = uri.flatMap(u => URL.fromString(u.toString).toOption)
-
-            assert(reversedUrl)(
-              equalTo(Some(url)),
-            )
+          check(HttpGen.genAbsoluteURL) { url =>
+            val httpURLString = url.encode
+            val javaURLString = url.toJavaURI.toString
+            assertTrue(httpURLString == javaURLString)
           }
         },
       ),

--- a/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zhttp/internal/HttpGen.scala
@@ -53,6 +53,12 @@ object HttpGen {
     port   <- Gen.int(0, 65536)
   } yield URL.Location.Absolute(scheme, host, port)
 
+  def genRelativeURL = for {
+    path        <- HttpGen.anyPath
+    kind        <- HttpGen.genRelativeLocation
+    queryParams <- Gen.mapOf(Gen.alphaNumericString, Gen.listOf(Gen.alphaNumericString))
+  } yield URL(path, kind, queryParams)
+
   def genAbsoluteURL = for {
     path        <- HttpGen.nonEmptyPath
     kind        <- HttpGen.genAbsoluteLocation


### PR DESCRIPTION
fixes #1337

It adds a conversion method to create a java.net.URI/URL from a zhttp.http.URL.

Uses HttpGen.genAbsoluteURL to test it against random urls. To avoid an encode exception, any relative path within an absolute location must be converted to an absolute one.

```
java.net.URISyntaxException: Relative path in absolute URI: https://S:321971123a/b
  at java.base/java.net.URI.checkPath(URI.java:1965)
```