### PR TITLE
Fix: Allow multiple `set-cookie` headers in response

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -1,6 +1,6 @@
 package zhttp.http
 
-import io.netty.handler.codec.http.{CombinedHttpHeaders, HttpHeaderNames, HttpHeaders}
+import io.netty.handler.codec.http.{CombinedHttpHeaders, HttpHeaders}
 import zhttp.http.headers.{HeaderConstructors, HeaderExtension}
 import zio.Chunk
 
@@ -40,10 +40,7 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
   private[zhttp] def encode: HttpHeaders =
     self.toList
       .foldLeft[HttpHeaders](new CombinedHttpHeaders(true)) { case (headers, entry) =>
-        if (entry._1.contentEquals(HttpHeaderNames.CONTENT_TYPE))
-          headers.set(entry._1, entry._2)
-        else
-          headers.add(entry._1, entry._2)
+        headers.add(entry._1, entry._2)
       }
 
 }

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -39,8 +39,14 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
    */
   private[zhttp] def encode: HttpHeaders =
     self.toList.foldLeft[HttpHeaders](new DefaultHttpHeaders()) { case (headers, entry) =>
-      headers.set(entry._1, entry._2)
+      if (entry._1.contentEquals(HeaderNames.setCookie)) {
+        headers.add(entry._1, entry._2)
+      } else if (headers.contains(entry._1) && !entry._1.contentEquals(HeaderNames.contentType)) {
+        headers.set(entry._1, s"${headers.get(entry._1)}, ${entry._2}")
+      } else
+        headers.set(entry._1, entry._2)
     }
+
 }
 
 object Headers extends HeaderConstructors {

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -1,6 +1,6 @@
 package zhttp.http
 
-import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders}
+import io.netty.handler.codec.http.{CombinedHttpHeaders, HttpHeaderNames, HttpHeaders}
 import zhttp.http.headers.{HeaderConstructors, HeaderExtension}
 import zio.Chunk
 
@@ -38,13 +38,13 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
    * Converts a Headers to [io.netty.handler.codec.http.HttpHeaders]
    */
   private[zhttp] def encode: HttpHeaders =
-    self.toList.foldLeft[HttpHeaders](new DefaultHttpHeaders()) { case (headers, entry) =>
-      if (entry._1.contentEquals(HeaderNames.setCookie))
-        headers.add(entry._1, entry._2)
-      else
-        headers.set(entry._1, entry._2)
-
-    }
+    self.toList
+      .foldLeft[HttpHeaders](new CombinedHttpHeaders(true)) { case (headers, entry) =>
+        if (entry._1.contentEquals(HttpHeaderNames.CONTENT_TYPE))
+          headers.set(entry._1, entry._2)
+        else
+          headers.add(entry._1, entry._2)
+      }
 
 }
 

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -39,12 +39,11 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
    */
   private[zhttp] def encode: HttpHeaders =
     self.toList.foldLeft[HttpHeaders](new DefaultHttpHeaders()) { case (headers, entry) =>
-      if (entry._1.contentEquals(HeaderNames.setCookie)) {
+      if (entry._1.contentEquals(HeaderNames.setCookie))
         headers.add(entry._1, entry._2)
-      } else if (headers.contains(entry._1) && !entry._1.contentEquals(HeaderNames.contentType)) {
-        headers.set(entry._1, s"${headers.get(entry._1)}, ${entry._2}")
-      } else
+      else
         headers.set(entry._1, entry._2)
+
     }
 
 }

--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderModifier.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderModifier.scala
@@ -127,7 +127,7 @@ trait HeaderModifier[+A] { self =>
     addHeaders(Headers.contentTransferEncoding(value))
 
   final def withContentType(value: CharSequence): A =
-    addHeaders(Headers.contentType(value))
+    setHeaders(Headers.contentType(value))
 
   final def withCookie(value: CharSequence): A =
     addHeaders(Headers.cookie(value))

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -228,8 +228,8 @@ object HeaderSpec extends ZIOSpecDefault {
           test("should encode multiple content-type headers with same name in a single header") {
             val headers =
               Headers(HeaderNames.contentType, "application/json") ++ Headers(HeaderNames.contentType, "text/plain")
-            val result  = headers.encode.contains(HeaderNames.contentType, "text/plain", true)
-            assertTrue(result)
+            val result  = headers.encode
+            assertTrue(result.contains(HeaderNames.contentType, "text/plain", true))
           }
       }
   }

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -224,13 +224,7 @@ object HeaderSpec extends ZIOSpecDefault {
           val cookieHeaders = Headers(HeaderNames.setCookie, "x1") ++ Headers(HeaderNames.setCookie, "x2")
           val result        = cookieHeaders.encode.entries().size()
           assertTrue(result == 2)
-        } +
-          test("should encode multiple content-type headers with same name in a single header") {
-            val headers =
-              Headers(HeaderNames.contentType, "application/json") ++ Headers(HeaderNames.contentType, "text/plain")
-            val result  = headers.encode
-            assertTrue(result.contains(HeaderNames.contentType, "text/plain", true))
-          }
+        }
       }
   }
 

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -225,11 +225,6 @@ object HeaderSpec extends ZIOSpecDefault {
           val result        = cookieHeaders.encode.entries().size()
           assertTrue(result == 2)
         } +
-          test("should encode multiple headers with same name in a single header") {
-            val headers = Headers(HeaderNames.pragma, "x1") ++ Headers(HeaderNames.pragma, "x2")
-            val result  = headers.encode.contains(HeaderNames.pragma, "x1, x2", true)
-            assertTrue(result)
-          } +
           test("should encode multiple content-type headers with same name in a single header") {
             val headers =
               Headers(HeaderNames.contentType, "application/json") ++ Headers(HeaderNames.contentType, "text/plain")

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -4,7 +4,7 @@ import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValues}
 import zhttp.http.Headers.BearerSchemeName
 import zhttp.http.middleware.Auth.Credentials
 import zio.test.Assertion._
-import zio.test.{Gen, ZIOSpecDefault, assert, check}
+import zio.test.{Gen, ZIOSpecDefault, assert, assertTrue, check}
 
 object HeaderSpec extends ZIOSpecDefault {
 
@@ -217,6 +217,24 @@ object HeaderSpec extends ZIOSpecDefault {
               val actual = Headers(HttpHeaderNames.CONTENT_LENGTH, c.toString).contentLength
               assert(actual)(isNone)
             }
+          }
+      } +
+      suite("encode") {
+        test("should encode multiple cookie headers as two separate headers") {
+          val cookieHeaders = Headers(HeaderNames.setCookie, "x1") ++ Headers(HeaderNames.setCookie, "x2")
+          val result        = cookieHeaders.encode.entries().size()
+          assertTrue(result == 2)
+        } +
+          test("should encode multiple headers with same name in a single header") {
+            val headers = Headers(HeaderNames.pragma, "x1") ++ Headers(HeaderNames.pragma, "x2")
+            val result  = headers.encode.contains(HeaderNames.pragma, "x1, x2", true)
+            assertTrue(result)
+          } +
+          test("should encode multiple content-type headers with same name in a single header") {
+            val headers =
+              Headers(HeaderNames.contentType, "application/json") ++ Headers(HeaderNames.contentType, "text/plain")
+            val result  = headers.encode.contains(HeaderNames.contentType, "text/plain", true)
+            assertTrue(result)
           }
       }
   }


### PR DESCRIPTION
Re-implemented `Header.encode`  function according to [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-field-lines-and-combined-fi).
fixes #1354