### PR TITLE
Refactor: Drop test composition syntax

### DIFF
--- a/zio-http/src/test/scala/zhttp/html/DomSpec.scala
+++ b/zio-http/src/test/scala/zhttp/html/DomSpec.scala
@@ -1,89 +1,87 @@
 package zhttp.html
 
-import zio.test.{Gen, ZIOSpecDefault, assertTrue, check, checkAll}
+import zhttp.html.HtmlGen.{tagGen, voidTagGen}
+import zio.test.{ZIOSpecDefault, assertTrue, check, checkAll}
 
 object DomSpec extends ZIOSpecDefault {
-  def spec = suite("DomSpec") {
+  def spec = suite("DomSpec")(
     test("empty") {
       val dom = Dom.empty
       assertTrue(dom.encode == "")
-    } +
-      test("text") {
-        val dom = Dom.text("abc")
-        assertTrue(dom.encode == "abc")
-      } +
-      test("element") {
-        val dom = Dom.element("div")
-        assertTrue(dom.encode == "<div></div>")
-      } +
-      suite("element with children") {
-        test("element with children") {
-          val dom = Dom.element("div", Dom.element("div"))
-          assertTrue(dom.encode == "<div><div></div></div>")
-        } +
-          test("element with multiple children") {
-            val dom = Dom.element("div", Dom.element("div"), Dom.element("div"), Dom.element("div"))
-            assertTrue(dom.encode == "<div><div></div><div></div><div></div></div>")
-          } +
-          test("element with nested children") {
-            val dom = Dom.element("div", Dom.element("div", Dom.element("div", Dom.element("div"))))
-            assertTrue(dom.encode == "<div><div><div><div></div></div></div></div>")
-          } +
-          test("element with text") {
-            val dom = Dom.element("div", Dom.text("abc"))
-            assertTrue(dom.encode == "<div>abc</div>")
-          } +
-          test("void element with children") {
-            val dom = Dom.element("br", Dom.text("Hello"))
-            assertTrue(dom.encode == "<br>Hello</br>")
-          }
-      } +
-      suite("Attribute") {
-        test("constant") {
-          val dom = Dom.attr("href", "https://www.zio-http.com")
-          assertTrue(dom.encode == """href="https://www.zio-http.com"""")
-        }
-      } +
-      suite("element with attributes") {
-        test("constant") {
-          val dom = Dom.element("a", Dom.attr("href", "https://www.zio-http.com"))
-          assertTrue(dom.encode == """<a href="https://www.zio-http.com"></a>""")
-        } +
-          test("multiple constant") {
-            val dom = Dom.element(
-              "a",
-              Dom.attr("href", "https://www.zio-http.com"),
-              Dom.attr("title", "click me!"),
-            )
-            assertTrue(dom.encode == """<a href="https://www.zio-http.com" title="click me!"></a>""")
-          }
-      } +
-      test("element with attribute & children") {
+    },
+    test("text") {
+      val dom = Dom.text("abc")
+      assertTrue(dom.encode == "abc")
+    },
+    test("element") {
+      val dom = Dom.element("div")
+      assertTrue(dom.encode == "<div></div>")
+    },
+    suite("element with children")(
+      test("element with children") {
+        val dom = Dom.element("div", Dom.element("div"))
+        assertTrue(dom.encode == "<div><div></div></div>")
+      },
+      test("element with multiple children") {
+        val dom = Dom.element("div", Dom.element("div"), Dom.element("div"), Dom.element("div"))
+        assertTrue(dom.encode == "<div><div></div><div></div><div></div></div>")
+      },
+      test("element with nested children") {
+        val dom = Dom.element("div", Dom.element("div", Dom.element("div", Dom.element("div"))))
+        assertTrue(dom.encode == "<div><div><div><div></div></div></div></div>")
+      },
+      test("element with text") {
+        val dom = Dom.element("div", Dom.text("abc"))
+        assertTrue(dom.encode == "<div>abc</div>")
+      },
+      test("void element with children") {
+        val dom = Dom.element("br", Dom.text("Hello"))
+        assertTrue(dom.encode == "<br>Hello</br>")
+      },
+    ),
+    suite("Attribute") {
+      test("constant") {
+        val dom = Dom.attr("href", "https://www.zio-http.com")
+        assertTrue(dom.encode == """href="https://www.zio-http.com"""")
+      }
+    },
+    suite("element with attributes")(
+      test("constant") {
+        val dom = Dom.element("a", Dom.attr("href", "https://www.zio-http.com"))
+        assertTrue(dom.encode == """<a href="https://www.zio-http.com"></a>""")
+      },
+      test("multiple constant") {
         val dom = Dom.element(
           "a",
           Dom.attr("href", "https://www.zio-http.com"),
-          Dom.text("zio-http"),
+          Dom.attr("title", "click me!"),
         )
+        assertTrue(dom.encode == """<a href="https://www.zio-http.com" title="click me!"></a>""")
+      },
+    ),
+    test("element with attribute & children") {
+      val dom = Dom.element(
+        "a",
+        Dom.attr("href", "https://www.zio-http.com"),
+        Dom.text("zio-http"),
+      )
 
-        assertTrue(dom.encode == """<a href="https://www.zio-http.com">zio-http</a>""")
-      } +
-      suite("Self Closing") {
-        val voidTagGen: Gen[Any, CharSequence] = Gen.fromIterable(Element.voidElementNames)
-        val tagGen: Gen[Any, String]           =
-          Gen.stringBounded(1, 5)(Gen.alphaChar).filterNot(Element.voidElementNames.contains)
+      assertTrue(dom.encode == """<a href="https://www.zio-http.com">zio-http</a>""")
+    },
+    suite("Self Closing")(
+      test("void") {
+        checkAll(voidTagGen) { name =>
+          val dom = Dom.element(name)
+          assertTrue(dom.encode == s"<${name}/>")
+        }
+      },
+      test("not void") {
+        check(tagGen) { name =>
+          val dom = Dom.element(name)
+          assertTrue(dom.encode == s"<${name}></${name}>")
+        }
+      },
+    ),
+  )
 
-        test("void") {
-          checkAll(voidTagGen) { name =>
-            val dom = Dom.element(name)
-            assertTrue(dom.encode == s"<${name}/>")
-          }
-        } +
-          test("not void") {
-            check(tagGen) { name =>
-              val dom = Dom.element(name)
-              assertTrue(dom.encode == s"<${name}></${name}>")
-            }
-          }
-      }
-  }
 }

--- a/zio-http/src/test/scala/zhttp/html/HtmlGen.scala
+++ b/zio-http/src/test/scala/zhttp/html/HtmlGen.scala
@@ -1,0 +1,9 @@
+package zhttp.html
+
+import zio.test.Gen
+
+object HtmlGen {
+  val voidTagGen: Gen[Any, CharSequence] = Gen.fromIterable(Element.voidElementNames)
+  val tagGen: Gen[Any, String]           =
+    Gen.stringBounded(1, 5)(Gen.alphaChar).filterNot(Element.voidElementNames.contains)
+}

--- a/zio-http/src/test/scala/zhttp/html/HtmlSpec.scala
+++ b/zio-http/src/test/scala/zhttp/html/HtmlSpec.scala
@@ -10,47 +10,47 @@ case object HtmlSpec extends ZIOSpecDefault {
         val view     = html(head(), body(div()))
         val expected = """<html><head></head><body><div></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
-      } +
-        test("tags with attributes") {
-          val view     = html(body(div(css := "container" :: Nil, "Hello!")))
-          val expected = """<html><body><div class="container">Hello!</div></body></html>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        test("tags with children") {
-          val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
-          val expected =
-            """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        test("tags with attributes and children") {
-          val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
-          val expected =
-            """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        test("tags with attributes and children") {
-          val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
-          val expected =
-            """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        test("tags with attributes and children") {
-          val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
-          val expected =
-            """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        test("tags with attributes and children") {
-          val view     = div("Hello!", css := "container" :: Nil)
-          val expected = """<div class="container">Hello!</div>"""
-          assert(view.encode)(equalTo(expected.stripMargin))
-        } +
-        suite("implicit conversions")(
-          test("from unit") {
-            val view: Html = {}
-            assert(view.encode)(equalTo(""))
-          },
-        ),
+      },
+      test("tags with attributes") {
+        val view     = html(body(div(css := "container" :: Nil, "Hello!")))
+        val expected = """<html><body><div class="container">Hello!</div></body></html>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with children") {
+        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val expected =
+          """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with attributes and children") {
+        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val expected =
+          """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with attributes and children") {
+        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val expected =
+          """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with attributes and children") {
+        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val expected =
+          """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with attributes and children") {
+        val view     = div("Hello!", css := "container" :: Nil)
+        val expected = """<div class="container">Hello!</div>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      suite("implicit conversions")(
+        test("from unit") {
+          val view: Html = {}
+          assert(view.encode)(equalTo(""))
+        },
+      ),
     )
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/ContentTypeSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/ContentTypeSpec.scala
@@ -10,37 +10,37 @@ import zio.test._
 
 object ContentTypeSpec extends HttpRunnableSpec {
 
-  val contentSpec = suite("Content type header on file response") {
+  val contentSpec = suite("Content type header on file response")(
     test("mp4") {
       val res = Http.fromResource("TestFile2.mp4").deploy.contentType.run()
       assertZIO(res)(isSome(equalTo("video/mp4")))
-    } +
-      test("js") {
-        val res = Http.fromResource("TestFile3.js").deploy.contentType.run()
-        assertZIO(res)(isSome(equalTo("application/javascript")))
-      } +
-      test("no extension") {
-        val res = Http.fromResource("TestFile4").deploy.contentType.run()
-        assertZIO(res)(isNone)
-      } +
-      test("css") {
-        val res = Http.fromResource("TestFile5.css").deploy.contentType.run()
-        assertZIO(res)(isSome(equalTo("text/css")))
-      } +
-      test("mp3") {
-        val res = Http.fromResource("TestFile6.mp3").deploy.contentType.run()
-        assertZIO(res)(isSome(equalTo("audio/mpeg")))
-      } +
-      test("unidentified extension") {
-        val res = Http.fromResource("truststore.jks").deploy.contentType.run()
-        assertZIO(res)(isNone)
-      } +
-      test("already set content-type") {
-        val expected = MediaType.application.`json`
-        val res      = Http.fromResource("TestFile6.mp3").map(_.withMediaType(expected)).deploy.contentType.run()
-        assertZIO(res)(isSome(equalTo(expected.fullType)))
-      }
-  }
+    },
+    test("js") {
+      val res = Http.fromResource("TestFile3.js").deploy.contentType.run()
+      assertZIO(res)(isSome(equalTo("application/javascript")))
+    },
+    test("no extension") {
+      val res = Http.fromResource("TestFile4").deploy.contentType.run()
+      assertZIO(res)(isNone)
+    },
+    test("css") {
+      val res = Http.fromResource("TestFile5.css").deploy.contentType.run()
+      assertZIO(res)(isSome(equalTo("text/css")))
+    },
+    test("mp3") {
+      val res = Http.fromResource("TestFile6.mp3").deploy.contentType.run()
+      assertZIO(res)(isSome(equalTo("audio/mpeg")))
+    },
+    test("unidentified extension") {
+      val res = Http.fromResource("truststore.jks").deploy.contentType.run()
+      assertZIO(res)(isNone)
+    },
+    test("already set content-type") {
+      val expected = MediaType.application.`json`
+      val res      = Http.fromResource("TestFile6.mp3").map(_.withMediaType(expected)).deploy.contentType.run()
+      assertZIO(res)(isSome(equalTo(expected.fullType)))
+    },
+  )
 
   private val env =
     EventLoopGroup.nio() ++ ChannelFactory.nio ++ ServerChannelFactory.nio ++ DynamicServer.live ++ Scope.default

--- a/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/CookieSpec.scala
@@ -5,27 +5,27 @@ import zio.test.Assertion.{equalTo, isSome}
 import zio.test._
 
 object CookieSpec extends ZIOSpecDefault {
-  def spec = suite("Cookies") {
-    suite("response cookies") {
+  def spec = suite("Cookies")(
+    suite("response cookies")(
       test("encode/decode signed/unsigned cookies with secret") {
         check(HttpGen.cookies) { cookie =>
           val expected = cookie.encode
           val actual   = Cookie.decodeResponseCookie(expected, cookie.secret).map(_.encode)
           assert(actual)(isSome(equalTo(expected)))
         }
-      }
-    } +
-      suite("request cookies") {
-        test("encode/decode multiple cookies") {
-          check(for {
-            name         <- Gen.string
-            content      <- Gen.string
-            cookieList   <- Gen.listOf(Gen.const(Cookie(name, content)))
-            cookieString <- Gen.const(cookieList.map(x => s"${x.name}=${x.content}").mkString(";"))
-          } yield (cookieList, cookieString)) { case (cookies, message) =>
-            assert(Cookie.decodeRequestCookie(message))(equalTo(cookies))
-          }
+      },
+    ),
+    suite("request cookies")(
+      test("encode/decode multiple cookies") {
+        check(for {
+          name         <- Gen.string
+          content      <- Gen.string
+          cookieList   <- Gen.listOf(Gen.const(Cookie(name, content)))
+          cookieString <- Gen.const(cookieList.map(x => s"${x.name}=${x.content}").mkString(";"))
+        } yield (cookieList, cookieString)) { case (cookies, message) =>
+          assert(Cookie.decodeRequestCookie(message))(equalTo(cookies))
         }
-      }
-  }
+      },
+    ),
+  )
 }

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -28,67 +28,67 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
     } yield data,
   )
 
-  def spec = suite("EncodeClientParams") {
+  def spec = suite("EncodeClientParams")(
     test("method") {
       check(anyClientParam) { params =>
         val req = encode(params).map(_.method())
         assertZIO(req)(equalTo(params.method.toJava))
       }
-    } +
-      test("method on HttpData.RandomAccessFile") {
-        check(HttpGen.clientParamsForFileHttpData()) { params =>
-          val req = encode(params).map(_.method())
-          assertZIO(req)(equalTo(params.method.toJava))
-        }
-      } +
-      suite("uri") {
-        test("uri") {
-          check(anyClientParam) { params =>
-            val req = encode(params).map(_.uri())
-            assertZIO(req)(equalTo(params.url.relative.encode))
-          }
-        } +
-          test("uri on HttpData.RandomAccessFile") {
-            check(HttpGen.clientParamsForFileHttpData()) { params =>
-              val req = encode(params).map(_.uri())
-              assertZIO(req)(equalTo(params.url.relative.encode))
-            }
-          }
-      } +
-      test("content-length") {
-        check(clientParamWithFiniteData(5)) { params =>
-          val req = encode(params).map(
-            _.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).toLong,
-          )
-          assertZIO(req)(equalTo(5L))
-        }
-      } +
-      test("host header") {
-        check(anyClientParam) { params =>
-          val req =
-            encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-          assertZIO(req)(equalTo(params.url.host))
-        }
-      } +
-      test("host header when absolute url") {
-        check(clientParamWithAbsoluteUrl) { params =>
-          val req = encode(params)
-            .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-          assertZIO(req)(equalTo(params.url.host))
-        }
-      } +
-      test("only one host header exists") {
-        check(clientParamWithAbsoluteUrl) { params =>
-          val req = encode(params)
-            .map(_.headers().getAll(HttpHeaderNames.HOST).size)
-          assertZIO(req)(equalTo(1))
-        }
-      } +
-      test("http version") {
-        check(anyClientParam) { params =>
-          val req = encode(params).map(i => i.protocolVersion())
-          assertZIO(req)(equalTo(params.version.toJava))
-        }
+    },
+    test("method on HttpData.RandomAccessFile") {
+      check(HttpGen.clientParamsForFileHttpData()) { params =>
+        val req = encode(params).map(_.method())
+        assertZIO(req)(equalTo(params.method.toJava))
       }
-  }
+    },
+    suite("uri")(
+      test("uri") {
+        check(anyClientParam) { params =>
+          val req = encode(params).map(_.uri())
+          assertZIO(req)(equalTo(params.url.relative.encode))
+        }
+      },
+      test("uri on HttpData.RandomAccessFile") {
+        check(HttpGen.clientParamsForFileHttpData()) { params =>
+          val req = encode(params).map(_.uri())
+          assertZIO(req)(equalTo(params.url.relative.encode))
+        }
+      },
+    ),
+    test("content-length") {
+      check(clientParamWithFiniteData(5)) { params =>
+        val req = encode(params).map(
+          _.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).toLong,
+        )
+        assertZIO(req)(equalTo(5L))
+      }
+    },
+    test("host header") {
+      check(anyClientParam) { params =>
+        val req =
+          encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
+        assertZIO(req)(equalTo(params.url.host))
+      }
+    },
+    test("host header when absolute url") {
+      check(clientParamWithAbsoluteUrl) { params =>
+        val req = encode(params)
+          .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
+        assertZIO(req)(equalTo(params.url.host))
+      }
+    },
+    test("only one host header exists") {
+      check(clientParamWithAbsoluteUrl) { params =>
+        val req = encode(params)
+          .map(_.headers().getAll(HttpHeaderNames.HOST).size)
+        assertZIO(req)(equalTo(1))
+      }
+    },
+    test("http version") {
+      check(anyClientParam) { params =>
+        val req = encode(params).map(i => i.protocolVersion())
+        assertZIO(req)(equalTo(params.version.toJava))
+      }
+    },
+  )
 }

--- a/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/GetBodyAsStringSpec.scala
@@ -13,7 +13,7 @@ object GetBodyAsStringSpec extends ZIOSpecDefault {
     val charsetGen: Gen[Any, Charset] =
       Gen.fromIterable(List(UTF_8, UTF_16, UTF_16BE, UTF_16LE, US_ASCII, ISO_8859_1))
 
-    suite("binary chunk") {
+    suite("binary chunk")(
       test("should map bytes according to charset given") {
 
         check(charsetGen) { charset =>
@@ -27,13 +27,13 @@ object GetBodyAsStringSpec extends ZIOSpecDefault {
           val expected = new String(Chunk.fromArray("abc".getBytes(charset)).toArray, charset)
           assertZIO(encoded)(equalTo(expected))
         }
-      } +
-        test("should map bytes to default utf-8 if no charset given") {
-          val request  = Request(url = URL(!!), data = HttpData.BinaryChunk(Chunk.fromArray("abc".getBytes())))
-          val encoded  = request.bodyAsString
-          val expected = new String(Chunk.fromArray("abc".getBytes()).toArray, HTTP_CHARSET)
-          assertZIO(encoded)(equalTo(expected))
-        }
-    }
+      },
+      test("should map bytes to default utf-8 if no charset given") {
+        val request  = Request(url = URL(!!), data = HttpData.BinaryChunk(Chunk.fromArray("abc".getBytes())))
+        val encoded  = request.bodyAsString
+        val expected = new String(Chunk.fromArray("abc".getBytes()).toArray, HTTP_CHARSET)
+        assertZIO(encoded)(equalTo(expected))
+      },
+    )
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/HExitSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HExitSpec.scala
@@ -14,55 +14,55 @@ object HExitSpec extends ZIOSpecDefault with HExitAssertion {
         succeed(1) === isSuccess(equalTo(1)) &&
         fail(1) === isFailure(equalTo(1)) &&
         fromZIO(ZIO.succeed(1)) === isEffect
-      } +
-        test("flatMapError") {
-          succeed(0) *> fail(1) <> fail(2) === isFailure(equalTo(2)) &&
-          succeed(0) *> fail(1) *> fail(2) === isFailure(equalTo(1))
-        } +
-        suite("defaultWith")(
-          test("succeed") {
-            empty <+> succeed(1) === isSuccess(equalTo(1)) &&
-            succeed(1) <+> empty === isSuccess(equalTo(1)) &&
-            succeed(1) <+> succeed(2) === isSuccess(equalTo(1)) &&
-            succeed(1) <+> empty === isSuccess(equalTo(1)) &&
-            empty <+> empty === isEmpty
-          } +
-            test("fail") {
-              empty <+> fail(1) === isFailure(equalTo(1)) &&
-              fail(1) <+> empty === isFailure(equalTo(1)) &&
-              fail(1) <+> fail(2) === isFailure(equalTo(1)) &&
-              fail(1) <+> empty === isFailure(equalTo(1))
-            } +
-            test("die") {
-              val t  = new Throwable("boom")
-              val t1 = new Throwable("blah")
-              empty <+> die(t) === isDie(equalTo(t)) &&
-              fail(1) <+> die(t) === isFailure(equalTo(1)) &&
-              die(t) <+> fail(1) === isDie(equalTo(t)) &&
-              die(t) <+> die(t1) === isDie(equalTo(t))
-            } +
-            test("empty") {
-              empty <+> empty === isEmpty
-            } +
-            test("effect") {
-              fromZIO(ZIO.succeed(1)) <+> empty === isEffect &&
-              empty <+> fromZIO(ZIO.succeed(1)) === isEffect &&
-              empty *> fromZIO(ZIO.succeed(1)) *> fromZIO(ZIO.succeed(1)) === isEmpty
-            } +
-            test("nested succeed") {
-              empty <+> succeed(1) <+> succeed(2) === isSuccess(equalTo(1)) &&
-              succeed(1) <+> empty <+> succeed(2) === isSuccess(equalTo(1)) &&
-              empty <+> empty <+> succeed(1) === isSuccess(equalTo(1))
-            } +
-            test("flatMap") {
-              succeed(0) *> empty <+> succeed(1) === isSuccess(equalTo(1)) &&
-              empty *> empty <+> succeed(1) === isSuccess(equalTo(1)) &&
-              empty *> empty *> empty <+> succeed(1) === isSuccess(equalTo(1))
-            } +
-            test("reversed") {
-              empty <+> (empty <+> (empty <+> succeed(1))) === isSuccess(equalTo(1))
-            },
-        ),
+      },
+      test("flatMapError") {
+        succeed(0) *> fail(1) <> fail(2) === isFailure(equalTo(2)) &&
+        succeed(0) *> fail(1) *> fail(2) === isFailure(equalTo(1))
+      },
+      suite("defaultWith")(
+        test("succeed") {
+          empty <+> succeed(1) === isSuccess(equalTo(1)) &&
+          succeed(1) <+> empty === isSuccess(equalTo(1)) &&
+          succeed(1) <+> succeed(2) === isSuccess(equalTo(1)) &&
+          succeed(1) <+> empty === isSuccess(equalTo(1)) &&
+          empty <+> empty === isEmpty
+        },
+        test("fail") {
+          empty <+> fail(1) === isFailure(equalTo(1)) &&
+          fail(1) <+> empty === isFailure(equalTo(1)) &&
+          fail(1) <+> fail(2) === isFailure(equalTo(1)) &&
+          fail(1) <+> empty === isFailure(equalTo(1))
+        },
+        test("die") {
+          val t  = new Throwable("boom")
+          val t1 = new Throwable("blah")
+          empty <+> die(t) === isDie(equalTo(t)) &&
+          fail(1) <+> die(t) === isFailure(equalTo(1)) &&
+          die(t) <+> fail(1) === isDie(equalTo(t)) &&
+          die(t) <+> die(t1) === isDie(equalTo(t))
+        },
+        test("empty") {
+          empty <+> empty === isEmpty
+        },
+        test("effect") {
+          fromZIO(ZIO.succeed(1)) <+> empty === isEffect &&
+          empty <+> fromZIO(ZIO.succeed(1)) === isEffect &&
+          empty *> fromZIO(ZIO.succeed(1)) *> fromZIO(ZIO.succeed(1)) === isEmpty
+        },
+        test("nested succeed") {
+          empty <+> succeed(1) <+> succeed(2) === isSuccess(equalTo(1)) &&
+          succeed(1) <+> empty <+> succeed(2) === isSuccess(equalTo(1)) &&
+          empty <+> empty <+> succeed(1) === isSuccess(equalTo(1))
+        },
+        test("flatMap") {
+          succeed(0) *> empty <+> succeed(1) === isSuccess(equalTo(1)) &&
+          empty *> empty <+> succeed(1) === isSuccess(equalTo(1)) &&
+          empty *> empty *> empty <+> succeed(1) === isSuccess(equalTo(1))
+        },
+        test("reversed") {
+          empty <+> (empty <+> (empty <+> succeed(1))) === isSuccess(equalTo(1))
+        },
+      ),
     ) @@ timeout(5 second)
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -8,225 +8,225 @@ import zio.test.{Gen, ZIOSpecDefault, assert, assertTrue, check}
 
 object HeaderSpec extends ZIOSpecDefault {
 
-  def spec = suite("Header") {
+  def spec = suite("Header")(
     suite("getHeader")(
       test("should not return header that doesn't exist in list") {
         val actual = predefinedHeaders.header("dummyHeaderName")
         assert(actual)(isNone)
-      } +
-        test("should return header from predefined headers list by String") {
-          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
-          assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
-        } +
-        test("should return header from predefined headers list by String of another case") {
-          val actual = predefinedHeaders.headerValue("Content-Type")
-          assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
-        } +
-        test("should return header from predefined headers list by AsciiString") {
-          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
-          assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
-        } +
-        test("should return header from custom headers list by String") {
-          val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
-          assert(actual)(isSome(equalTo(customContentJsonHeader)))
-        } +
-        test("should return header from custom headers list by AsciiString") {
-          val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
-          assert(actual)(isSome(equalTo(customContentJsonHeader)))
-        },
-    ) +
-      suite("getHeaderValue") {
-        test("should return header value") {
-          val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
-          assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
-        }
-      } +
-      suite("contentType")(
-        test("should return content-type value") {
-          val actual = predefinedHeaders.contentType
-          assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
-        } +
-          test("should not return content-type value if it doesn't exist") {
-            val actual = acceptJson.contentType
-            assert(actual)(isNone)
-          },
-      ) +
-      suite("getAuthorizationHeader")(
-        test("should return authorization value") {
-          val authorizationValue = "dummyValue"
-          val actual             = Headers.authorization(authorizationValue).authorization
-          assert(actual)(isSome(equalTo(authorizationValue)))
-        } +
-          test("should not return authorization value if it doesn't exist") {
-            val actual = acceptJson.contentType
-            assert(actual)(isNone)
-          },
-      ) +
-      suite("hasHeader")(
-        test("should return true if content-type is application/json") {
-          val actual = contentTypeJson.hasHeader(HeaderNames.contentType, HeaderValues.applicationJson)
-          assert(actual)(isTrue)
-        },
-      ) +
-      suite("hasJsonContentType")(
-        test("should return true if content-type is application/json") {
-          val actual = contentTypeJson.hasJsonContentType
-          assert(actual)(isTrue)
-        } +
-          test("should return false if content-type is not application/json") {
-            val actual = contentTypeXml.hasJsonContentType
-            assert(actual)(isFalse)
-          } +
-          test("should return false if content-type doesn't exist") {
-            val headers = acceptJson
-            val actual  = headers.hasJsonContentType
-            assert(actual)(isFalse)
-          },
-      ) +
-      suite("isPlainTextContentType")(
-        test("should return true if content-type is text/plain") {
-          val actual = contentTypeTextPlain.hasTextPlainContentType
-          assert(actual)(isTrue)
-        } +
-          test("should return false if content-type is not text/plain") {
-            val actual = contentTypeXml.hasTextPlainContentType
-            assert(actual)(isFalse)
-          } +
-          test("should return false if content-type doesn't exist") {
-            val actual = acceptJson.hasTextPlainContentType
-            assert(actual)(isFalse)
-          },
-      ) +
-      suite("isXmlContentType")(
-        test("should return true if content-type is application/xml") {
-          val actual = contentTypeXml.hasXmlContentType
-          assert(actual)(isTrue)
-        } +
-          test("should return false if content-type is not application/xml") {
-            val actual = contentTypeTextPlain.hasXmlContentType
-            assert(actual)(isFalse)
-          } +
-          test("should return false if content-type doesn't exist") {
-            val headers = acceptJson
-            val actual  = headers.hasXmlContentType
-            assert(actual)(isFalse)
-          },
-      ) +
-      suite("isXhtmlXmlContentType")(
-        test("should return true if content-type is application/xhtml+xml") {
+      },
+      test("should return header from predefined headers list by String") {
+        val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
+        assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
+      },
+      test("should return header from predefined headers list by String of another case") {
+        val actual = predefinedHeaders.headerValue("Content-Type")
+        assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
+      },
+      test("should return header from predefined headers list by AsciiString") {
+        val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
+        assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
+      },
+      test("should return header from custom headers list by String") {
+        val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
+        assert(actual)(isSome(equalTo(customContentJsonHeader)))
+      },
+      test("should return header from custom headers list by AsciiString") {
+        val actual = customHeaders.header(HttpHeaderNames.CONTENT_TYPE)
+        assert(actual)(isSome(equalTo(customContentJsonHeader)))
+      },
+    ),
+    suite("getHeaderValue")(
+      test("should return header value") {
+        val actual = predefinedHeaders.headerValue(HttpHeaderNames.CONTENT_TYPE)
+        assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
+      },
+    ),
+    suite("contentType")(
+      test("should return content-type value") {
+        val actual = predefinedHeaders.contentType
+        assert(actual)(isSome(equalTo(HttpHeaderValues.APPLICATION_JSON.toString)))
+      },
+      test("should not return content-type value if it doesn't exist") {
+        val actual = acceptJson.contentType
+        assert(actual)(isNone)
+      },
+    ),
+    suite("getAuthorizationHeader")(
+      test("should return authorization value") {
+        val authorizationValue = "dummyValue"
+        val actual             = Headers.authorization(authorizationValue).authorization
+        assert(actual)(isSome(equalTo(authorizationValue)))
+      },
+      test("should not return authorization value if it doesn't exist") {
+        val actual = acceptJson.contentType
+        assert(actual)(isNone)
+      },
+    ),
+    suite("hasHeader")(
+      test("should return true if content-type is application/json") {
+        val actual = contentTypeJson.hasHeader(HeaderNames.contentType, HeaderValues.applicationJson)
+        assert(actual)(isTrue)
+      },
+    ),
+    suite("hasJsonContentType")(
+      test("should return true if content-type is application/json") {
+        val actual = contentTypeJson.hasJsonContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not application/json") {
+        val actual = contentTypeXml.hasJsonContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val headers = acceptJson
+        val actual  = headers.hasJsonContentType
+        assert(actual)(isFalse)
+      },
+    ),
+    suite("isPlainTextContentType")(
+      test("should return true if content-type is text/plain") {
+        val actual = contentTypeTextPlain.hasTextPlainContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not text/plain") {
+        val actual = contentTypeXml.hasTextPlainContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val actual = acceptJson.hasTextPlainContentType
+        assert(actual)(isFalse)
+      },
+    ),
+    suite("isXmlContentType")(
+      test("should return true if content-type is application/xml") {
+        val actual = contentTypeXml.hasXmlContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not application/xml") {
+        val actual = contentTypeTextPlain.hasXmlContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val headers = acceptJson
+        val actual  = headers.hasXmlContentType
+        assert(actual)(isFalse)
+      },
+    ),
+    suite("isXhtmlXmlContentType")(
+      test("should return true if content-type is application/xhtml+xml") {
 
-          val actual = contentTypeXhtmlXml.hasXhtmlXmlContentType
-          assert(actual)(isTrue)
-        } +
-          test("should return false if content-type is not application/xhtml+xml") {
-            val actual = contentTypeTextPlain.hasXhtmlXmlContentType
-            assert(actual)(isFalse)
-          } +
-          test("should return false if content-type doesn't exist") {
-            val actual = acceptJson.hasXhtmlXmlContentType
-            assert(actual)(isFalse)
-          },
-      ) +
-      suite("isFormUrlencodedContentType")(
-        test("should return true if content-type is application/x-www-form-urlencoded") {
-          val actual = contentTypeFormUrlEncoded.hasFormUrlencodedContentType
-          assert(actual)(isTrue)
-        } +
-          test("should return false if content-type is not application/x-www-form-urlencoded") {
-            val actual = contentTypeTextPlain.hasFormUrlencodedContentType
-            assert(actual)(isFalse)
-          } +
-          test("should return false if content-type doesn't exist") {
-            val actual = acceptJson.hasFormUrlencodedContentType
-            assert(actual)(isFalse)
-          },
-      ) +
-      suite("getBasicAuthorizationCredentials")(
-        test("should decode proper basic http authorization header") {
-          val actual = Headers.authorization("Basic dXNlcjpwYXNzd29yZCAxMQ==").basicAuthorizationCredentials
-          assert(actual)(isSome(equalTo(Credentials("user", "password 11"))))
-        } +
-          test("should decode basic http authorization header with empty name and password") {
-            val actual = Headers.authorization("Basic Og==").basicAuthorizationCredentials
-            assert(actual)(isSome(equalTo(Credentials("", ""))))
-          } +
-          test("should not decode improper base64") {
-            val actual = Headers.authorization("Basic Og=").basicAuthorizationCredentials
-            assert(actual)(isNone)
-          } +
-          test("should not decode only basic") {
-            val actual = Headers.authorization("Basic").basicAuthorizationCredentials
-            assert(actual)(isNone)
-          } +
-          test("should not decode basic contained header value") {
-            val actual = Headers.authorization("wrongBasic Og==").basicAuthorizationCredentials
-            assert(actual)(isNone)
-          } +
-          test("should get credentials for nonbasic schema") {
-            val actual = Headers.authorization("DummySchema Og==").basicAuthorizationCredentials
-            assert(actual)(isNone)
-          } +
-          test("should decode header from Header.basicHttpAuthorization") {
-            val username = "username"
-            val password = "password"
-            val actual   = Headers.basicAuthorizationHeader(username, password).basicAuthorizationCredentials
-            assert(actual)(isSome(equalTo(Credentials(username, password))))
-          } +
-          test("should decode value from Header.basicHttpAuthorization") {
-            val username = "username"
-            val password = "password"
-            val actual   = Headers
-              .basicAuthorizationHeader(username, password)
-              .headerValue(HeaderNames.authorization)
-            val expected = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
-            assert(actual)(isSome(equalTo(expected)))
-          },
-      ) +
-      suite("getBearerToken")(
-        test("should get bearer token") {
-          val token  = "token"
-          val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, token)).bearerToken
-          assert(actual)(isSome(equalTo(token)))
-        } +
-          test("should get empty bearer token") {
-            val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, "")).bearerToken
-            assert(actual)(isSome(equalTo("")))
-          } +
-          test("should not get bearer token for nonbearer schema") {
-            val actual = Headers.authorization("DummySchema token").bearerToken
-            assert(actual)(isNone)
-          } +
-          test("should not get bearer token for bearer contained header") {
-            val actual = Headers.authorization("wrongBearer token").bearerToken
-            assert(actual)(isNone)
-          },
-      ) +
-      suite("getContentLength") {
-        test("should get content-length") {
-          check(Gen.long) { c =>
-            val actual = Headers.contentLength(c).contentLength
-            assert(actual)(isSome(equalTo(c)))
-          }
-        } +
-          test("should not return content-length value if it doesn't exist") {
-            val actual = Headers.empty.contentType
-            assert(actual)(isNone)
-          } +
-          test("should get content-length") {
-            check(Gen.char) { c =>
-              val actual = Headers(HttpHeaderNames.CONTENT_LENGTH, c.toString).contentLength
-              assert(actual)(isNone)
-            }
-          }
-      } +
-      suite("encode") {
-        test("should encode multiple cookie headers as two separate headers") {
-          val cookieHeaders = Headers(HeaderNames.setCookie, "x1") ++ Headers(HeaderNames.setCookie, "x2")
-          val result        = cookieHeaders.encode.entries().size()
-          assertTrue(result == 2)
+        val actual = contentTypeXhtmlXml.hasXhtmlXmlContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not application/xhtml+xml") {
+        val actual = contentTypeTextPlain.hasXhtmlXmlContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val actual = acceptJson.hasXhtmlXmlContentType
+        assert(actual)(isFalse)
+      },
+    ),
+    suite("isFormUrlencodedContentType")(
+      test("should return true if content-type is application/x-www-form-urlencoded") {
+        val actual = contentTypeFormUrlEncoded.hasFormUrlencodedContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not application/x-www-form-urlencoded") {
+        val actual = contentTypeTextPlain.hasFormUrlencodedContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val actual = acceptJson.hasFormUrlencodedContentType
+        assert(actual)(isFalse)
+      },
+    ),
+    suite("getBasicAuthorizationCredentials")(
+      test("should decode proper basic http authorization header") {
+        val actual = Headers.authorization("Basic dXNlcjpwYXNzd29yZCAxMQ==").basicAuthorizationCredentials
+        assert(actual)(isSome(equalTo(Credentials("user", "password 11"))))
+      },
+      test("should decode basic http authorization header with empty name and password") {
+        val actual = Headers.authorization("Basic Og==").basicAuthorizationCredentials
+        assert(actual)(isSome(equalTo(Credentials("", ""))))
+      },
+      test("should not decode improper base64") {
+        val actual = Headers.authorization("Basic Og=").basicAuthorizationCredentials
+        assert(actual)(isNone)
+      },
+      test("should not decode only basic") {
+        val actual = Headers.authorization("Basic").basicAuthorizationCredentials
+        assert(actual)(isNone)
+      },
+      test("should not decode basic contained header value") {
+        val actual = Headers.authorization("wrongBasic Og==").basicAuthorizationCredentials
+        assert(actual)(isNone)
+      },
+      test("should get credentials for nonbasic schema") {
+        val actual = Headers.authorization("DummySchema Og==").basicAuthorizationCredentials
+        assert(actual)(isNone)
+      },
+      test("should decode header from Header.basicHttpAuthorization") {
+        val username = "username"
+        val password = "password"
+        val actual   = Headers.basicAuthorizationHeader(username, password).basicAuthorizationCredentials
+        assert(actual)(isSome(equalTo(Credentials(username, password))))
+      },
+      test("should decode value from Header.basicHttpAuthorization") {
+        val username = "username"
+        val password = "password"
+        val actual   = Headers
+          .basicAuthorizationHeader(username, password)
+          .headerValue(HeaderNames.authorization)
+        val expected = "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+        assert(actual)(isSome(equalTo(expected)))
+      },
+    ),
+    suite("getBearerToken")(
+      test("should get bearer token") {
+        val token  = "token"
+        val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, token)).bearerToken
+        assert(actual)(isSome(equalTo(token)))
+      },
+      test("should get empty bearer token") {
+        val actual = Headers.authorization(String.format("%s %s", BearerSchemeName, "")).bearerToken
+        assert(actual)(isSome(equalTo("")))
+      },
+      test("should not get bearer token for nonbearer schema") {
+        val actual = Headers.authorization("DummySchema token").bearerToken
+        assert(actual)(isNone)
+      },
+      test("should not get bearer token for bearer contained header") {
+        val actual = Headers.authorization("wrongBearer token").bearerToken
+        assert(actual)(isNone)
+      },
+    ),
+    suite("getContentLength")(
+      test("should get content-length") {
+        check(Gen.long) { c =>
+          val actual = Headers.contentLength(c).contentLength
+          assert(actual)(isSome(equalTo(c)))
         }
-      }
-  }
+      },
+      test("should not return content-length value if it doesn't exist") {
+        val actual = Headers.empty.contentType
+        assert(actual)(isNone)
+      },
+      test("should get content-length") {
+        check(Gen.char) { c =>
+          val actual = Headers(HttpHeaderNames.CONTENT_LENGTH, c.toString).contentLength
+          assert(actual)(isNone)
+        }
+      },
+    ),
+    suite("encode")(
+      test("should encode multiple cookie headers as two separate headers") {
+        val cookieHeaders = Headers(HeaderNames.setCookie, "x1") ++ Headers(HeaderNames.setCookie, "x2")
+        val result        = cookieHeaders.encode.entries().size()
+        assertTrue(result == 2)
+      },
+    ),
+  )
 
   private val contentTypeXhtmlXml       = Headers(HeaderNames.contentType, HeaderValues.applicationXhtml)
   private val contentTypeTextPlain      = Headers(HeaderNames.contentType, HeaderValues.textPlain)

--- a/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpDataSpec.scala
@@ -10,14 +10,13 @@ import zio.test._
 import java.io.File
 
 object HttpDataSpec extends ZIOSpecDefault {
+  private val testFile = new File(getClass.getResource("/TestFile.txt").getPath)
 
   override def spec =
-    suite("HttpDataSpec") {
-
-      val testFile = new File(getClass.getResource("/TestFile.txt").getPath)
-      suite("outgoing") {
+    suite("HttpDataSpec")(
+      suite("outgoing")(
         suite("encode")(
-          suite("fromStream") {
+          suite("fromStream")(
             test("success") {
               check(Gen.string) { payload =>
                 val stringBuffer    = payload.getBytes(HTTP_CHARSET)
@@ -25,8 +24,8 @@ object HttpDataSpec extends ZIOSpecDefault {
                 val res             = HttpData.fromStream(responseContent).toByteBuf.map(_.toString(HTTP_CHARSET))
                 assertZIO(res)(equalTo(payload))
               }
-            }
-          },
+            },
+          ),
           suite("fromFile")(
             test("failure") {
               val res = HttpData.fromFile(throw new Error("Failure")).toByteBuf.either
@@ -43,7 +42,7 @@ object HttpDataSpec extends ZIOSpecDefault {
               assertZIO(res)(equalTo("abc\nfoo"))
             },
           ),
-        )
-      }
-    } @@ timeout(10 seconds)
+        ),
+      ),
+    ) @@ timeout(10 seconds)
 }

--- a/zio-http/src/test/scala/zhttp/http/HttpErrorSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HttpErrorSpec.scala
@@ -4,22 +4,22 @@ import zio.test.Assertion.equalTo
 import zio.test.{ZIOSpecDefault, assert}
 
 object HttpErrorSpec extends ZIOSpecDefault {
-  def spec = suite("HttpError") {
-    suite("foldCause") {
+  def spec = suite("HttpError")(
+    suite("foldCause")(
       test("should fold the cause") {
         val error  = HttpError.InternalServerError(cause = Option(new Error("Internal server error")))
         val result = error.foldCause("")(cause => cause.getMessage)
         assert(result)(equalTo("Internal server error"))
-      } +
-        test("should fold with no cause") {
-          val error  = HttpError.NotFound(!!)
-          val result = error.foldCause("Page not found")(cause => cause.getMessage)
-          assert(result)(equalTo("Page not found"))
-        } +
-        test("should create custom error") {
-          val error = HttpError.Custom(451, "Unavailable for legal reasons.")
-          assert(error.status)(equalTo(Status.Custom(451)))
-        }
-    }
-  }
+      },
+      test("should fold with no cause") {
+        val error  = HttpError.NotFound(!!)
+        val result = error.foldCause("Page not found")(cause => cause.getMessage)
+        assert(result)(equalTo("Page not found"))
+      },
+      test("should create custom error") {
+        val error = HttpError.Custom(451, "Unavailable for legal reasons.")
+        assert(error.status)(equalTo(Status.Custom(451)))
+      },
+    ),
+  )
 }

--- a/zio-http/src/test/scala/zhttp/http/MiddlewareSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/MiddlewareSpec.scala
@@ -183,24 +183,24 @@ object MiddlewareSpec extends ZIOSpecDefault with HExitAssertion {
           test2 <- assertZIO(app(6))(equalTo(1))
         } yield test1 && test2
       } +
-      suite("codecHttp") {
+      suite("codecHttp")(
         test("codec success") {
           val a   = Http.collect[Int] { case v => v.toString }
           val b   = Http.collect[String] { case v => v.toInt }
           val mid = Middleware.codecHttp[String, Int](b, a)
           val app = Http.identity[Int] @@ mid
           assertZIO(app("2"))(equalTo("2"))
-        } +
-          test("encoder failure") {
-            val mid = Middleware.codecHttp[String, Int](Http.succeed(1), Http.fail("fail"))
-            val app = Http.identity[Int] @@ mid
-            assertZIO(app("2").exit)(fails(anything))
-          } +
-          test("decoder failure") {
-            val mid = Middleware.codecHttp[String, Int](Http.fail("fail"), Http.succeed(2))
-            val app = Http.identity[Int] @@ mid
-            assertZIO(app("2").exit)(fails(anything))
-          }
-      }
+        },
+        test("encoder failure") {
+          val mid = Middleware.codecHttp[String, Int](Http.succeed(1), Http.fail("fail"))
+          val app = Http.identity[Int] @@ mid
+          assertZIO(app("2").exit)(fails(anything))
+        },
+        test("decoder failure") {
+          val mid = Middleware.codecHttp[String, Int](Http.fail("fail"), Http.succeed(2))
+          val app = Http.identity[Int] @@ mid
+          assertZIO(app("2").exit)(fails(anything))
+        },
+      )
   }
 }

--- a/zio-http/src/test/scala/zhttp/http/ProxySpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/ProxySpec.scala
@@ -8,7 +8,7 @@ object ProxySpec extends ZIOSpecDefault {
   private val validUrl = URL.fromString("http://localhost:8123").toOption.getOrElse(URL.empty)
 
   override def spec = suite("Proxy")(
-    suite("Authenticated Proxy") {
+    suite("Authenticated Proxy")(
       test("successfully encode valid proxy") {
         val username = "unameTest"
         val password = "upassTest"
@@ -18,14 +18,15 @@ object ProxySpec extends ZIOSpecDefault {
         assert(encoded.map(_.username()))(isSome(equalTo(username))) &&
         assert(encoded.map(_.password()))(isSome(equalTo(password))) &&
         assert(encoded.map(_.authScheme()))(isSome(equalTo("basic")))
-      } +
-        test("fail to encode invalid proxy") {
-          val proxy   = Proxy(URL.empty)
-          val encoded = proxy.encode
+      },
+      test("fail to encode invalid proxy") {
+        val proxy   = Proxy(URL.empty)
+        val encoded = proxy.encode
 
-          assert(encoded.map(_.username()))(isNone)
-        }
-    } + suite("Unauthenticated proxy") {
+        assert(encoded.map(_.username()))(isNone)
+      },
+    ),
+    suite("Unauthenticated proxy")(
       test("successfully encode valid proxy") {
         val proxy   = Proxy(validUrl)
         val encoded = proxy.encode
@@ -34,7 +35,7 @@ object ProxySpec extends ZIOSpecDefault {
         assert(encoded.map(_.username()))(isSome(isNull)) &&
         assert(encoded.map(_.password()))(isSome(isNull)) &&
         assert(encoded.map(_.authScheme()))(isSome(equalTo("none")))
-      }
-    },
+      },
+    ),
   )
 }

--- a/zio-http/src/test/scala/zhttp/http/ResponseSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/ResponseSpec.scala
@@ -4,38 +4,38 @@ import zio.test.Assertion._
 import zio.test._
 
 object ResponseSpec extends ZIOSpecDefault {
-  def spec = suite("Response")(
-    suite("redirect") {
-      val location = "www.google.com"
+  private val location = "www.google.com"
+  def spec             = suite("Response")(
+    suite("redirect")(
       test("Temporary redirect should produce a response with a TEMPORARY_REDIRECT") {
         val x = Response.redirect(location)
         assertTrue(x.status == Status.TemporaryRedirect) &&
         assertTrue(x.headerValue(HeaderNames.location).contains(location))
-      } +
-        test("Temporary redirect should produce a response with a location") {
-          val x = Response.redirect(location)
-          assertTrue(x.headerValue(HeaderNames.location).contains(location))
-        } +
-        test("Permanent redirect should produce a response with a PERMANENT_REDIRECT") {
-          val x = Response.redirect(location, true)
-          assertTrue(x.status == Status.PermanentRedirect)
-        } +
-        test("Permanent redirect should produce a response with a location") {
-          val x = Response.redirect(location, true)
-          assertTrue(x.headerValue(HeaderNames.location).contains(location))
-        }
-    } +
-      suite("json")(
-        test("Json should set content type to ApplicationJson") {
-          val x = Response.json("""{"message": "Hello"}""")
-          assertTrue(x.headerValue(HeaderNames.contentType).contains(HeaderValues.applicationJson.toString))
-        },
-      ) +
-      suite("toHttp")(
-        test("should convert response to Http") {
-          val http = Http(Response.ok)
-          assertZIO(http(()))(equalTo(Response.ok))
-        },
-      ),
+      },
+      test("Temporary redirect should produce a response with a location") {
+        val x = Response.redirect(location)
+        assertTrue(x.headerValue(HeaderNames.location).contains(location))
+      },
+      test("Permanent redirect should produce a response with a PERMANENT_REDIRECT") {
+        val x = Response.redirect(location, true)
+        assertTrue(x.status == Status.PermanentRedirect)
+      },
+      test("Permanent redirect should produce a response with a location") {
+        val x = Response.redirect(location, true)
+        assertTrue(x.headerValue(HeaderNames.location).contains(location))
+      },
+    ),
+    suite("json")(
+      test("Json should set content type to ApplicationJson") {
+        val x = Response.json("""{"message": "Hello"}""")
+        assertTrue(x.headerValue(HeaderNames.contentType).contains(HeaderValues.applicationJson.toString))
+      },
+    ),
+    suite("toHttp")(
+      test("should convert response to Http") {
+        val http = Http(Response.ok)
+        assertZIO(http(()))(equalTo(Response.ok))
+      },
+    ),
   )
 }

--- a/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/SchemeSpec.scala
@@ -7,28 +7,28 @@ import zio.test.Assertion.isNone
 import zio.test._
 
 object SchemeSpec extends ZIOSpecDefault {
-  override def spec = suite("SchemeSpec") {
+  override def spec = suite("SchemeSpec")(
     test("string decode") {
       checkAll(HttpGen.scheme) { scheme =>
         assertTrue(Scheme.decode(scheme.encode).get == scheme)
       }
-    } +
-      test("null string decode") {
-        assert(Scheme.decode(null))(isNone)
-      } +
-      test("java http scheme") {
-        checkAll(jHttpScheme) { jHttpScheme =>
-          assertTrue(Scheme.fromJScheme(jHttpScheme).flatMap(_.toJHttpScheme).get == jHttpScheme)
-        }
-      } +
-      test("java websocket scheme") {
-        checkAll(jWebSocketScheme) { jWebSocketScheme =>
-          assertTrue(
-            Scheme.fromJScheme(jWebSocketScheme).flatMap(_.toJWebSocketScheme).get == jWebSocketScheme,
-          )
-        }
+    },
+    test("null string decode") {
+      assert(Scheme.decode(null))(isNone)
+    },
+    test("java http scheme") {
+      checkAll(jHttpScheme) { jHttpScheme =>
+        assertTrue(Scheme.fromJScheme(jHttpScheme).flatMap(_.toJHttpScheme).get == jHttpScheme)
       }
-  }
+    },
+    test("java websocket scheme") {
+      checkAll(jWebSocketScheme) { jWebSocketScheme =>
+        assertTrue(
+          Scheme.fromJScheme(jWebSocketScheme).flatMap(_.toJWebSocketScheme).get == jWebSocketScheme,
+        )
+      }
+    },
+  )
 
   private def jHttpScheme: Gen[Any, HttpScheme] = Gen.fromIterable(List(HttpScheme.HTTP, HttpScheme.HTTPS))
 

--- a/zio-http/src/test/scala/zhttp/http/middleware/AuthSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/AuthSpec.scala
@@ -26,62 +26,62 @@ object AuthSpec extends ZIOSpecDefault with HttpAppTestExtensions {
     ZIO.succeed(c == bearerToken)
   }
 
-  def spec = suite("AuthSpec") {
-    suite("basicAuth") {
+  def spec = suite("AuthSpec")(
+    suite("basicAuth")(
       test("HttpApp is accepted if the basic authentication succeeds") {
         val app = (Http.ok @@ basicAuthM).status
         assertZIO(app(Request().addHeaders(successBasicHeader)))(equalTo(Status.Ok))
-      } +
-        test("Uses forbidden app if the basic authentication fails") {
-          val app = (Http.ok @@ basicAuthM).status
-          assertZIO(app(Request().addHeaders(failureBasicHeader)))(equalTo(Status.Unauthorized))
-        } +
-        test("Responses should have WWW-Authentication header if Basic Auth failed") {
-          val app = Http.ok @@ basicAuthM header "WWW-AUTHENTICATE"
-          assertZIO(app(Request().addHeaders(failureBasicHeader)))(isSome)
-        }
-    } +
-      suite("basicAuthZIO") {
-        test("HttpApp is accepted if the basic authentication succeeds") {
-          val app = (Http.ok @@ basicAuthZIOM).status
-          assertZIO(app(Request().addHeaders(successBasicHeader)))(equalTo(Status.Ok))
-        } +
-          test("Uses forbidden app if the basic authentication fails") {
-            val app = (Http.ok @@ basicAuthZIOM).status
-            assertZIO(app(Request().addHeaders(failureBasicHeader)))(equalTo(Status.Unauthorized))
-          } +
-          test("Responses should have WWW-Authentication header if Basic Auth failed") {
-            val app = Http.ok @@ basicAuthZIOM header "WWW-AUTHENTICATE"
-            assertZIO(app(Request().addHeaders(failureBasicHeader)))(isSome)
-          }
-      } +
-      suite("bearerAuth") {
-        test("HttpApp is accepted if the bearer authentication succeeds") {
-          val app = (Http.ok @@ bearerAuthM).status
-          assertZIO(app(Request().addHeaders(successBearerHeader)))(equalTo(Status.Ok))
-        } +
-          test("Uses forbidden app if the bearer authentication fails") {
-            val app = (Http.ok @@ bearerAuthM).status
-            assertZIO(app(Request().addHeaders(failureBearerHeader)))(equalTo(Status.Unauthorized))
-          } +
-          test("Responses should have WWW-Authentication header if bearer Auth failed") {
-            val app = Http.ok @@ bearerAuthM header "WWW-AUTHENTICATE"
-            assertZIO(app(Request().addHeaders(failureBearerHeader)))(isSome)
-          }
-      } +
-      suite("bearerAuthZIO") {
-        test("HttpApp is accepted if the bearer authentication succeeds") {
-          val app = (Http.ok @@ bearerAuthZIOM).status
-          assertZIO(app(Request().addHeaders(successBearerHeader)))(equalTo(Status.Ok))
-        } +
-          test("Uses forbidden app if the bearer authentication fails") {
-            val app = (Http.ok @@ bearerAuthZIOM).status
-            assertZIO(app(Request().addHeaders(failureBearerHeader)))(equalTo(Status.Unauthorized))
-          } +
-          test("Responses should have WWW-Authentication header if bearer Auth failed") {
-            val app = Http.ok @@ bearerAuthZIOM header "WWW-AUTHENTICATE"
-            assertZIO(app(Request().addHeaders(failureBearerHeader)))(isSome)
-          }
-      }
-  }
+      },
+      test("Uses forbidden app if the basic authentication fails") {
+        val app = (Http.ok @@ basicAuthM).status
+        assertZIO(app(Request().addHeaders(failureBasicHeader)))(equalTo(Status.Unauthorized))
+      },
+      test("Responses should have WWW-Authentication header if Basic Auth failed") {
+        val app = Http.ok @@ basicAuthM header "WWW-AUTHENTICATE"
+        assertZIO(app(Request().addHeaders(failureBasicHeader)))(isSome)
+      },
+    ),
+    suite("basicAuthZIO")(
+      test("HttpApp is accepted if the basic authentication succeeds") {
+        val app = (Http.ok @@ basicAuthZIOM).status
+        assertZIO(app(Request().addHeaders(successBasicHeader)))(equalTo(Status.Ok))
+      },
+      test("Uses forbidden app if the basic authentication fails") {
+        val app = (Http.ok @@ basicAuthZIOM).status
+        assertZIO(app(Request().addHeaders(failureBasicHeader)))(equalTo(Status.Unauthorized))
+      },
+      test("Responses should have WWW-Authentication header if Basic Auth failed") {
+        val app = Http.ok @@ basicAuthZIOM header "WWW-AUTHENTICATE"
+        assertZIO(app(Request().addHeaders(failureBasicHeader)))(isSome)
+      },
+    ),
+    suite("bearerAuth")(
+      test("HttpApp is accepted if the bearer authentication succeeds") {
+        val app = (Http.ok @@ bearerAuthM).status
+        assertZIO(app(Request().addHeaders(successBearerHeader)))(equalTo(Status.Ok))
+      },
+      test("Uses forbidden app if the bearer authentication fails") {
+        val app = (Http.ok @@ bearerAuthM).status
+        assertZIO(app(Request().addHeaders(failureBearerHeader)))(equalTo(Status.Unauthorized))
+      },
+      test("Responses should have WWW-Authentication header if bearer Auth failed") {
+        val app = Http.ok @@ bearerAuthM header "WWW-AUTHENTICATE"
+        assertZIO(app(Request().addHeaders(failureBearerHeader)))(isSome)
+      },
+    ),
+    suite("bearerAuthZIO")(
+      test("HttpApp is accepted if the bearer authentication succeeds") {
+        val app = (Http.ok @@ bearerAuthZIOM).status
+        assertZIO(app(Request().addHeaders(successBearerHeader)))(equalTo(Status.Ok))
+      },
+      test("Uses forbidden app if the bearer authentication fails") {
+        val app = (Http.ok @@ bearerAuthZIOM).status
+        assertZIO(app(Request().addHeaders(failureBearerHeader)))(equalTo(Status.Unauthorized))
+      },
+      test("Responses should have WWW-Authentication header if bearer Auth failed") {
+        val app = Http.ok @@ bearerAuthZIOM header "WWW-AUTHENTICATE"
+        assertZIO(app(Request().addHeaders(failureBearerHeader)))(isSome)
+      },
+    ),
+  )
 }

--- a/zio-http/src/test/scala/zhttp/http/middleware/CorsSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/CorsSpec.scala
@@ -8,8 +8,8 @@ import zio.test.Assertion.hasSubset
 import zio.test._
 
 object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
-  override def spec = suite("CorsMiddlewares") {
-    val app = Http.ok @@ cors()
+  val app           = Http.ok @@ cors()
+  override def spec = suite("CorsMiddlewares")(
     test("OPTIONS request") {
       val request = Request(
         method = Method.OPTIONS,
@@ -30,25 +30,25 @@ object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         res <- app(request)
       } yield assert(res.headersAsList)(hasSubset(expected)) &&
         assertTrue(res.status == Status.NoContent)
-    } +
-      test("GET request") {
-        val request =
-          Request(
-            method = Method.GET,
-            url = URL(!! / "success"),
-            headers = Headers.accessControlRequestMethod(Method.GET) ++ Headers.origin("test-env"),
-          )
+    },
+    test("GET request") {
+      val request =
+        Request(
+          method = Method.GET,
+          url = URL(!! / "success"),
+          headers = Headers.accessControlRequestMethod(Method.GET) ++ Headers.origin("test-env"),
+        )
 
-        val expected = Headers
-          .accessControlExposeHeaders("*")
-          .withAccessControlAllowOrigin("test-env")
-          .withAccessControlAllowMethods(Method.GET)
-          .withAccessControlAllowCredentials(true)
-          .toList
+      val expected = Headers
+        .accessControlExposeHeaders("*")
+        .withAccessControlAllowOrigin("test-env")
+        .withAccessControlAllowMethods(Method.GET)
+        .withAccessControlAllowCredentials(true)
+        .toList
 
-        for {
-          res <- app(request)
-        } yield assert(res.headersAsList)(hasSubset(expected))
-      }
-  }
+      for {
+        res <- app(request)
+      } yield assert(res.headersAsList)(hasSubset(expected))
+    },
+  )
 }

--- a/zio-http/src/test/scala/zhttp/http/middleware/CsrfSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/CsrfSpec.scala
@@ -8,32 +8,32 @@ import zio.test.Assertion.equalTo
 import zio.test._
 
 object CsrfSpec extends ZIOSpecDefault with HttpAppTestExtensions {
-  override def spec = suite("CSRF Middlewares") {
-    val app           = (Http.ok @@ csrfValidate("x-token")).status
-    val setCookie     = Headers.cookie(Cookie("x-token", "secret"))
-    val invalidXToken = Headers("x-token", "secret1")
-    val validXToken   = Headers("x-token", "secret")
+  private val app           = (Http.ok @@ csrfValidate("x-token")).status
+  private val setCookie     = Headers.cookie(Cookie("x-token", "secret"))
+  private val invalidXToken = Headers("x-token", "secret1")
+  private val validXToken   = Headers("x-token", "secret")
+  override def spec         = suite("CSRF Middlewares")(
     test("x-token not present") {
       assertZIO(app(Request(headers = setCookie)))(equalTo(Status.Forbidden))
-    } +
-      test("x-token mismatch") {
-        assertZIO(app(Request(headers = setCookie ++ invalidXToken)))(
-          equalTo(Status.Forbidden),
-        )
-      } +
-      test("x-token match") {
-        assertZIO(app(Request(headers = setCookie ++ validXToken)))(
-          equalTo(Status.Ok),
-        )
-      } +
-      test("app execution skipped") {
-        for {
-          r <- Ref.make(false)
-          app = Http.ok.tapZIO(_ => r.set(true)) @@ csrfValidate("x-token")
-          _   <- app(Request(headers = setCookie ++ invalidXToken))
-          res <- r.get
-        } yield assert(res)(equalTo(false))
-      }
-  }
+    },
+    test("x-token mismatch") {
+      assertZIO(app(Request(headers = setCookie ++ invalidXToken)))(
+        equalTo(Status.Forbidden),
+      )
+    },
+    test("x-token match") {
+      assertZIO(app(Request(headers = setCookie ++ validXToken)))(
+        equalTo(Status.Ok),
+      )
+    },
+    test("app execution skipped") {
+      for {
+        r <- Ref.make(false)
+        app = Http.ok.tapZIO(_ => r.set(true)) @@ csrfValidate("x-token")
+        _   <- app(Request(headers = setCookie ++ invalidXToken))
+        res <- r.get
+      } yield assert(res)(equalTo(false))
+    },
+  )
 
 }

--- a/zio-http/src/test/scala/zhttp/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/middleware/WebSpec.scala
@@ -14,223 +14,223 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
   private val midA = Middleware.addHeader("X-Custom", "A")
   private val midB = Middleware.addHeader("X-Custom", "B")
 
-  def spec = suite("HttpMiddleware") {
-    suite("headers suite") {
+  def spec = suite("HttpMiddleware")(
+    suite("headers suite")(
       test("addHeaders") {
         val middleware = addHeaders(Headers("KeyA", "ValueA") ++ Headers("KeyB", "ValueB"))
         val headers    = (Http.ok @@ middleware).headerValues
         assertZIO(headers(Request()))(contains("ValueA") && contains("ValueB"))
+      },
+      test("addHeader") {
+        val middleware = addHeader("KeyA", "ValueA")
+        val headers    = (Http.ok @@ middleware).headerValues
+        assertZIO(headers(Request()))(contains("ValueA"))
+      },
+      test("updateHeaders") {
+        val middleware = updateHeaders(_ => Headers("KeyA", "ValueA"))
+        val headers    = (Http.ok @@ middleware).headerValues
+        assertZIO(headers(Request()))(contains("ValueA"))
+      },
+      test("removeHeader") {
+        val middleware = removeHeader("KeyA")
+        val headers    = (Http.succeed(Response.ok.setHeaders(Headers("KeyA", "ValueA"))) @@ middleware) header "KeyA"
+        assertZIO(headers(Request()))(isNone)
+      },
+    ),
+    suite("debug")(
+      test("log status method url and time") {
+        val program = runApp(app @@ debug) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
+      },
+      test("log 404 status method url and time") {
+        val program = runApp(Http.empty ++ Http.notFound @@ debug) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("404 GET /health 0ms\n")))
+      },
+    ),
+    suite("when")(
+      test("condition is true") {
+        val program = runApp(self.app @@ debug.when(_ => true)) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
       } +
-        test("addHeader") {
-          val middleware = addHeader("KeyA", "ValueA")
-          val headers    = (Http.ok @@ middleware).headerValues
-          assertZIO(headers(Request()))(contains("ValueA"))
-        } +
-        test("updateHeaders") {
-          val middleware = updateHeaders(_ => Headers("KeyA", "ValueA"))
-          val headers    = (Http.ok @@ middleware).headerValues
-          assertZIO(headers(Request()))(contains("ValueA"))
-        } +
-        test("removeHeader") {
-          val middleware = removeHeader("KeyA")
-          val headers    = (Http.succeed(Response.ok.setHeaders(Headers("KeyA", "ValueA"))) @@ middleware) header "KeyA"
-          assertZIO(headers(Request()))(isNone)
-        }
-    } +
-      suite("debug") {
-        test("log status method url and time") {
-          val program = runApp(app @@ debug) *> TestConsole.output
-          assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
-        } +
-          test("log 404 status method url and time") {
-            val program = runApp(Http.empty ++ Http.notFound @@ debug) *> TestConsole.output
-            assertZIO(program)(equalTo(Vector("404 GET /health 0ms\n")))
-          }
-      } +
-      suite("when") {
-        test("condition is true") {
-          val program = runApp(self.app @@ debug.when(_ => true)) *> TestConsole.output
-          assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
-        } +
-          test("condition is false") {
-            val log = runApp(self.app @@ debug.when(_ => false)) *> TestConsole.output
-            assertZIO(log)(equalTo(Vector()))
-          }
-      } +
-      suite("whenZIO") {
-        test("condition is true") {
-          val program = runApp(self.app @@ debug.whenZIO(_ => ZIO.succeed(true))) *> TestConsole.output
-          assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
-        } +
-          test("condition is false") {
-            val log = runApp(self.app @@ debug.whenZIO(_ => ZIO.succeed(false))) *> TestConsole.output
-            assertZIO(log)(equalTo(Vector()))
-          }
-      } +
-      suite("race") {
-        test("achieved") {
-          val program = runApp(self.app @@ timeout(5 seconds)).map(_.status)
-          assertZIO(program)(equalTo(Status.Ok))
-        } +
-          test("un-achieved") {
-            val program = runApp(self.app @@ timeout(500 millis)).map(_.status)
-            assertZIO(program)(equalTo(Status.RequestTimeout))
-          }
-      } +
-      suite("combine") {
-        test("before and after") {
-          val middleware = runBefore(Console.printLine("A"))
-          val program    = runApp(self.app @@ middleware) *> TestConsole.output
-          assertZIO(program)(equalTo(Vector("A\n")))
-        } +
-          test("add headers twice") {
-            val middleware = addHeader("KeyA", "ValueA") ++ addHeader("KeyB", "ValueB")
-            val headers    = (Http.ok @@ middleware).headerValues
-            assertZIO(headers(Request()))(contains("ValueA") && contains("ValueB"))
-          } +
-          test("add and remove header") {
-            val middleware = addHeader("KeyA", "ValueA") ++ removeHeader("KeyA")
-            val program    = (Http.ok @@ middleware) header "KeyA"
-            assertZIO(program(Request()))(isNone)
-          }
-      } +
-      suite("ifRequestThenElseZIO") {
-        test("if the condition is true take first") {
-          val app = (Http.ok @@ ifRequestThenElseZIO(condZIO(true))(midA, midB)) header "X-Custom"
-          assertZIO(app(Request()))(isSome(equalTo("A")))
-        } +
-          test("if the condition is false take 2nd") {
-            val app =
-              (Http.ok @@ ifRequestThenElseZIO(condZIO(false))(midA, midB)) header "X-Custom"
-            assertZIO(app(Request()))(isSome(equalTo("B")))
-          }
-      } +
-      suite("ifRequestThenElse") {
-        test("if the condition is true take first") {
-          val app = Http.ok @@ ifRequestThenElse(cond(true))(midA, midB) header "X-Custom"
-          assertZIO(app(Request()))(isSome(equalTo("A")))
-        } +
-          test("if the condition is false take 2nd") {
-            val app = Http.ok @@ ifRequestThenElse(cond(false))(midA, midB) header "X-Custom"
-            assertZIO(app(Request()))(isSome(equalTo("B")))
-          }
-      } +
-      suite("whenRequestZIO") {
-        test("if the condition is true apply middleware") {
-          val app = (Http.ok @@ whenRequestZIO(condZIO(true))(midA)) header "X-Custom"
-          assertZIO(app(Request()))(isSome(equalTo("A")))
-        } +
-          test("if the condition is false don't apply any middleware") {
-            val app = (Http.ok @@ whenRequestZIO(condZIO(false))(midA)) header "X-Custom"
-            assertZIO(app(Request()))(isNone)
-          }
-      } +
-      suite("whenRequest") {
-        test("if the condition is true apple middleware") {
-          val app = Http.ok @@ Middleware.whenRequest(cond(true))(midA) header "X-Custom"
-          assertZIO(app(Request()))(isSome(equalTo("A")))
-        } +
-          test("if the condition is false don't apply the middleware") {
-            val app = Http.ok @@ Middleware.whenRequest(cond(false))(midA) header "X-Custom"
-            assertZIO(app(Request()))(isNone)
-          }
-      } +
-      suite("cookie") {
-        test("addCookie") {
-          val cookie = Cookie("test", "testValue")
-          val app    = (Http.ok @@ addCookie(cookie)).header("set-cookie")
-          assertZIO(app(Request()))(
-            equalTo(Some(cookie.encode)),
-          )
-        } +
-          test("addCookieM") {
-            val cookie = Cookie("test", "testValue")
-            val app    =
-              (Http.ok @@ addCookieZIO(ZIO.succeed(cookie))).header("set-cookie")
-            assertZIO(app(Request()))(
-              equalTo(Some(cookie.encode)),
-            )
-          }
-      } +
-      suite("signCookies") {
-        test("should sign cookies") {
-          val cookie = Cookie("key", "value").withHttpOnly
-          val app    = Http.ok.withSetCookie(cookie) @@ signCookies("secret") header "set-cookie"
-          assertZIO(app(Request()))(isSome(equalTo(cookie.sign("secret").encode)))
-        } +
-          test("sign cookies no cookie header") {
-            val app = (Http.ok.addHeader("keyA", "ValueA") @@ signCookies("secret")).headerValues
-            assertZIO(app(Request()))(contains("ValueA"))
-          }
-      } +
-      suite("trailingSlashDrop")(
-        test("should drop trailing slash") {
-          val urls = Gen.fromIterable(
-            Seq(
-              ""        -> "",
-              "/"       -> "",
-              "/a"      -> "/a",
-              "/a/b"    -> "/a/b",
-              "/a/b/"   -> "/a/b",
-              "/a/"     -> "/a",
-              "/a/?a=1" -> "/a/?a=1",
-              "/a?a=1"  -> "/a?a=1",
-            ),
-          )
-          checkAll(urls) { case (url, expected) =>
-            val app = Http.collect[Request] { case req => Response.text(req.url.encode) } @@ dropTrailingSlash
-            for {
-              url      <- ZIO.fromEither(URL.fromString(url))
-              response <- app(Request(url = url))
-              text     <- response.bodyAsString
-            } yield assertTrue(text == expected)
-          }
+        test("condition is false") {
+          val log = runApp(self.app @@ debug.when(_ => false)) *> TestConsole.output
+          assertZIO(log)(equalTo(Vector()))
         },
-      ) +
-      suite("trailingSlashRedirect") {
-        test("should send a redirect response") {
-          val urls = Gen.fromIterable(
-            Seq(
-              "/"     -> "",
-              "/a/"   -> "/a",
-              "/a/b/" -> "/a/b",
-            ),
+    ),
+    suite("whenZIO")(
+      test("condition is true") {
+        val program = runApp(self.app @@ debug.whenZIO(_ => ZIO.succeed(true))) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("200 GET /health 1000ms\n")))
+      },
+      test("condition is false") {
+        val log = runApp(self.app @@ debug.whenZIO(_ => ZIO.succeed(false))) *> TestConsole.output
+        assertZIO(log)(equalTo(Vector()))
+      },
+    ),
+    suite("race")(
+      test("achieved") {
+        val program = runApp(self.app @@ timeout(5 seconds)).map(_.status)
+        assertZIO(program)(equalTo(Status.Ok))
+      },
+      test("un-achieved") {
+        val program = runApp(self.app @@ timeout(500 millis)).map(_.status)
+        assertZIO(program)(equalTo(Status.RequestTimeout))
+      },
+    ),
+    suite("combine")(
+      test("before and after") {
+        val middleware = runBefore(Console.printLine("A"))
+        val program    = runApp(self.app @@ middleware) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("A\n")))
+      },
+      test("add headers twice") {
+        val middleware = addHeader("KeyA", "ValueA") ++ addHeader("KeyB", "ValueB")
+        val headers    = (Http.ok @@ middleware).headerValues
+        assertZIO(headers(Request()))(contains("ValueA") && contains("ValueB"))
+      },
+      test("add and remove header") {
+        val middleware = addHeader("KeyA", "ValueA") ++ removeHeader("KeyA")
+        val program    = (Http.ok @@ middleware) header "KeyA"
+        assertZIO(program(Request()))(isNone)
+      },
+    ),
+    suite("ifRequestThenElseZIO")(
+      test("if the condition is true take first") {
+        val app = (Http.ok @@ ifRequestThenElseZIO(condZIO(true))(midA, midB)) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("A")))
+      },
+      test("if the condition is false take 2nd") {
+        val app =
+          (Http.ok @@ ifRequestThenElseZIO(condZIO(false))(midA, midB)) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("B")))
+      },
+    ),
+    suite("ifRequestThenElse")(
+      test("if the condition is true take first") {
+        val app = Http.ok @@ ifRequestThenElse(cond(true))(midA, midB) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("A")))
+      },
+      test("if the condition is false take 2nd") {
+        val app = Http.ok @@ ifRequestThenElse(cond(false))(midA, midB) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("B")))
+      },
+    ),
+    suite("whenRequestZIO")(
+      test("if the condition is true apply middleware") {
+        val app = (Http.ok @@ whenRequestZIO(condZIO(true))(midA)) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("A")))
+      },
+      test("if the condition is false don't apply any middleware") {
+        val app = (Http.ok @@ whenRequestZIO(condZIO(false))(midA)) header "X-Custom"
+        assertZIO(app(Request()))(isNone)
+      },
+    ),
+    suite("whenRequest")(
+      test("if the condition is true apple middleware") {
+        val app = Http.ok @@ Middleware.whenRequest(cond(true))(midA) header "X-Custom"
+        assertZIO(app(Request()))(isSome(equalTo("A")))
+      },
+      test("if the condition is false don't apply the middleware") {
+        val app = Http.ok @@ Middleware.whenRequest(cond(false))(midA) header "X-Custom"
+        assertZIO(app(Request()))(isNone)
+      },
+    ),
+    suite("cookie")(
+      test("addCookie") {
+        val cookie = Cookie("test", "testValue")
+        val app    = (Http.ok @@ addCookie(cookie)).header("set-cookie")
+        assertZIO(app(Request()))(
+          equalTo(Some(cookie.encode)),
+        )
+      },
+      test("addCookieM") {
+        val cookie = Cookie("test", "testValue")
+        val app    =
+          (Http.ok @@ addCookieZIO(ZIO.succeed(cookie))).header("set-cookie")
+        assertZIO(app(Request()))(
+          equalTo(Some(cookie.encode)),
+        )
+      },
+    ),
+    suite("signCookies")(
+      test("should sign cookies") {
+        val cookie = Cookie("key", "value").withHttpOnly
+        val app    = Http.ok.withSetCookie(cookie) @@ signCookies("secret") header "set-cookie"
+        assertZIO(app(Request()))(isSome(equalTo(cookie.sign("secret").encode)))
+      } +
+        test("sign cookies no cookie header") {
+          val app = (Http.ok.addHeader("keyA", "ValueA") @@ signCookies("secret")).headerValues
+          assertZIO(app(Request()))(contains("ValueA"))
+        },
+    ),
+    suite("trailingSlashDrop")(
+      test("should drop trailing slash") {
+        val urls = Gen.fromIterable(
+          Seq(
+            ""        -> "",
+            "/"       -> "",
+            "/a"      -> "/a",
+            "/a/b"    -> "/a/b",
+            "/a/b/"   -> "/a/b",
+            "/a/"     -> "/a",
+            "/a/?a=1" -> "/a/?a=1",
+            "/a?a=1"  -> "/a?a=1",
+          ),
+        )
+        checkAll(urls) { case (url, expected) =>
+          val app = Http.collect[Request] { case req => Response.text(req.url.encode) } @@ dropTrailingSlash
+          for {
+            url      <- ZIO.fromEither(URL.fromString(url))
+            response <- app(Request(url = url))
+            text     <- response.bodyAsString
+          } yield assertTrue(text == expected)
+        }
+      },
+    ),
+    suite("trailingSlashRedirect")(
+      test("should send a redirect response") {
+        val urls = Gen.fromIterable(
+          Seq(
+            "/"     -> "",
+            "/a/"   -> "/a",
+            "/a/b/" -> "/a/b",
+          ),
+        )
+
+        checkAll(urls zip Gen.fromIterable(Seq(true, false))) { case (url, expected, perm) =>
+          val app      = Http.ok @@ redirectTrailingSlash(perm)
+          val location = Some(expected)
+          val status   = if (perm) Status.PermanentRedirect else Status.TemporaryRedirect
+
+          for {
+            url      <- ZIO.fromEither(URL.fromString(url))
+            response <- app(Request(url = url))
+          } yield assertTrue(
+            response.status == status,
+            response.headers.location == location,
           )
+        }
+      },
+      test("should not send a redirect response") {
+        val urls = Gen.fromIterable(
+          Seq(
+            "",
+            "/a",
+            "/a/b",
+            "/a/b/?a=1",
+          ),
+        )
 
-          checkAll(urls zip Gen.fromIterable(Seq(true, false))) { case (url, expected, perm) =>
-            val app      = Http.ok @@ redirectTrailingSlash(perm)
-            val location = Some(expected)
-            val status   = if (perm) Status.PermanentRedirect else Status.TemporaryRedirect
-
-            for {
-              url      <- ZIO.fromEither(URL.fromString(url))
-              response <- app(Request(url = url))
-            } yield assertTrue(
-              response.status == status,
-              response.headers.location == location,
-            )
-          }
-        } +
-          test("should not send a redirect response") {
-            val urls = Gen.fromIterable(
-              Seq(
-                "",
-                "/a",
-                "/a/b",
-                "/a/b/?a=1",
-              ),
-            )
-
-            checkAll(urls) { url =>
-              val app = Http.ok @@ redirectTrailingSlash(true)
-              for {
-                url      <- ZIO.fromEither(URL.fromString(url))
-                response <- app(Request(url = url))
-              } yield assertTrue(response.status == Status.Ok)
-            }
-          }
-      }
-  }
+        checkAll(urls) { url =>
+          val app = Http.ok @@ redirectTrailingSlash(true)
+          for {
+            url      <- ZIO.fromEither(URL.fromString(url))
+            response <- app(Request(url = url))
+          } yield assertTrue(response.status == Status.Ok)
+        }
+      },
+    ),
+  )
 
   private def cond(flg: Boolean) = (_: Any) => flg
 

--- a/zio-http/src/test/scala/zhttp/service/ClientHttpsSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientHttpsSpec.scala
@@ -28,32 +28,32 @@ object ClientHttpsSpec extends ZIOSpecDefault {
 
   val sslOption: ClientSSLOptions =
     ClientSSLOptions.CustomSSL(SslContextBuilder.forClient().trustManager(trustManagerFactory).build())
-  override def spec               = suite("Https Client request") {
+  override def spec               = suite("Https Client request")(
     test("respond Ok") {
       val actual = Client.request("https://sports.api.decathlon.com/groups/water-aerobics")
       assertZIO(actual)(anything)
-    } +
-      test("respond Ok with sslOption") {
-        val actual = Client.request("https://sports.api.decathlon.com/groups/water-aerobics", ssl = sslOption)
-        assertZIO(actual)(anything)
-      } +
-      test("should respond as Bad Request") {
-        val actual = Client
-          .request(
-            "https://www.whatissslcertificate.com/google-has-made-the-list-of-untrusted-providers-of-digital-certificates/",
-            ssl = sslOption,
-          )
-          .map(_.status)
-        assertZIO(actual)(equalTo(Status.BadRequest))
-      } +
-      test("should throw DecoderException for handshake failure") {
-        val actual = Client
-          .request(
-            "https://untrusted-root.badssl.com/",
-            ssl = sslOption,
-          )
-          .exit
-        assertZIO(actual)(fails(isSubtype[DecoderException](anything)))
-      }
-  }.provideLayer(env) @@ timeout(30 seconds) @@ ignore
+    },
+    test("respond Ok with sslOption") {
+      val actual = Client.request("https://sports.api.decathlon.com/groups/water-aerobics", ssl = sslOption)
+      assertZIO(actual)(anything)
+    },
+    test("should respond as Bad Request") {
+      val actual = Client
+        .request(
+          "https://www.whatissslcertificate.com/google-has-made-the-list-of-untrusted-providers-of-digital-certificates/",
+          ssl = sslOption,
+        )
+        .map(_.status)
+      assertZIO(actual)(equalTo(Status.BadRequest))
+    },
+    test("should throw DecoderException for handshake failure") {
+      val actual = Client
+        .request(
+          "https://untrusted-root.badssl.com/",
+          ssl = sslOption,
+        )
+        .exit
+      assertZIO(actual)(fails(isSubtype[DecoderException](anything)))
+    },
+  ).provideLayer(env) @@ timeout(30 seconds) @@ ignore
 }

--- a/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ClientSpec.scala
@@ -16,87 +16,87 @@ object ClientSpec extends HttpRunnableSpec {
   private val env =
     EventLoopGroup.nio() ++ ChannelFactory.nio ++ ServerChannelFactory.nio ++ DynamicServer.live ++ Scope.default
 
-  def clientSpec = suite("ClientSpec") {
+  def clientSpec = suite("ClientSpec")(
     test("respond Ok") {
       val app = Http.ok.deploy.status.run()
       assertZIO(app)(equalTo(Status.Ok))
-    } +
-      test("non empty content") {
-        val app             = Http.text("abc")
-        val responseContent = app.deploy.body.run()
-        assertZIO(responseContent)(isNonEmpty)
-      } +
-      test("echo POST request content") {
-        val app = Http.collectZIO[Request] { case req => req.bodyAsString.map(Response.text(_)) }
-        val res = app.deploy.bodyAsString.run(method = Method.POST, content = HttpData.fromString("ZIO user"))
-        assertZIO(res)(equalTo("ZIO user"))
-      } +
-      test("non empty content") {
-        val app             = Http.empty
-        val responseContent = app.deploy.body.run().map(_.length)
-        assertZIO(responseContent)(isGreaterThan(0))
-      } +
-      test("text content") {
-        val app             = Http.text("zio user does not exist")
-        val responseContent = app.deploy.bodyAsString.run()
-        assertZIO(responseContent)(containsString("user"))
-      } +
-      test("handle connection failure") {
-        val res = Client.request("http://localhost:1").either
-        assertZIO(res)(isLeft(isSubtype[ConnectException](anything)))
-      } +
-      test("handle proxy connection failure") {
-        val res =
-          for {
-            validServerPort <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
-            serverUrl       <- ZIO.fromEither(URL.fromString(s"http://localhost:$validServerPort"))
-            proxyUrl        <- ZIO.fromEither(URL.fromString("http://localhost:0001"))
-            out             <- Client.request(
-              Request(url = serverUrl),
-              Config().withProxy(Proxy(proxyUrl)),
-            )
-          } yield out
-        assertZIO(res.either)(isLeft(isSubtype[ConnectException](anything)))
-      } +
-      test("proxy respond Ok") {
-        val res =
-          for {
-            port <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
-            url  <- ZIO.fromEither(URL.fromString(s"http://localhost:$port"))
-            id   <- DynamicServer.deploy(Http.ok)
-            proxy = Proxy.empty.withUrl(url).withHeaders(Headers(DynamicServer.APP_ID, id))
-            out <- Client.request(
-              Request(url = url),
-              Config().withProxy(proxy),
-            )
-          } yield out
-        assertZIO(res.either)(isRight)
-      } +
-      test("proxy respond Ok for auth server") {
-        val proxyAuthApp = Http.collect[Request] { case req =>
-          val proxyAuthHeaderName = HeaderNames.proxyAuthorization.toString
-          req.headers.toList.collectFirst { case (`proxyAuthHeaderName`, _) =>
-            Response.ok
-          }.getOrElse(Response.status(Status.Forbidden))
-        }
-
-        val res =
-          for {
-            port <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
-            url  <- ZIO.fromEither(URL.fromString(s"http://localhost:$port"))
-            id   <- DynamicServer.deploy(proxyAuthApp)
-            proxy = Proxy.empty
-              .withUrl(url)
-              .withHeaders(Headers(DynamicServer.APP_ID, id))
-              .withCredentials(Credentials("test", "test"))
-            out <- Client.request(
-              Request(url = url),
-              Config().withProxy(proxy),
-            )
-          } yield out
-        assertZIO(res.either)(isRight)
+    },
+    test("non empty content") {
+      val app             = Http.text("abc")
+      val responseContent = app.deploy.body.run()
+      assertZIO(responseContent)(isNonEmpty)
+    },
+    test("echo POST request content") {
+      val app = Http.collectZIO[Request] { case req => req.bodyAsString.map(Response.text(_)) }
+      val res = app.deploy.bodyAsString.run(method = Method.POST, content = HttpData.fromString("ZIO user"))
+      assertZIO(res)(equalTo("ZIO user"))
+    },
+    test("non empty content") {
+      val app             = Http.empty
+      val responseContent = app.deploy.body.run().map(_.length)
+      assertZIO(responseContent)(isGreaterThan(0))
+    },
+    test("text content") {
+      val app             = Http.text("zio user does not exist")
+      val responseContent = app.deploy.bodyAsString.run()
+      assertZIO(responseContent)(containsString("user"))
+    },
+    test("handle connection failure") {
+      val res = Client.request("http://localhost:1").either
+      assertZIO(res)(isLeft(isSubtype[ConnectException](anything)))
+    },
+    test("handle proxy connection failure") {
+      val res =
+        for {
+          validServerPort <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
+          serverUrl       <- ZIO.fromEither(URL.fromString(s"http://localhost:$validServerPort"))
+          proxyUrl        <- ZIO.fromEither(URL.fromString("http://localhost:0001"))
+          out             <- Client.request(
+            Request(url = serverUrl),
+            Config().withProxy(Proxy(proxyUrl)),
+          )
+        } yield out
+      assertZIO(res.either)(isLeft(isSubtype[ConnectException](anything)))
+    },
+    test("proxy respond Ok") {
+      val res =
+        for {
+          port <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
+          url  <- ZIO.fromEither(URL.fromString(s"http://localhost:$port"))
+          id   <- DynamicServer.deploy(Http.ok)
+          proxy = Proxy.empty.withUrl(url).withHeaders(Headers(DynamicServer.APP_ID, id))
+          out <- Client.request(
+            Request(url = url),
+            Config().withProxy(proxy),
+          )
+        } yield out
+      assertZIO(res.either)(isRight)
+    },
+    test("proxy respond Ok for auth server") {
+      val proxyAuthApp = Http.collect[Request] { case req =>
+        val proxyAuthHeaderName = HeaderNames.proxyAuthorization.toString
+        req.headers.toList.collectFirst { case (`proxyAuthHeaderName`, _) =>
+          Response.ok
+        }.getOrElse(Response.status(Status.Forbidden))
       }
-  }
+
+      val res =
+        for {
+          port <- ZIO.environmentWithZIO[DynamicServer](_.get.port)
+          url  <- ZIO.fromEither(URL.fromString(s"http://localhost:$port"))
+          id   <- DynamicServer.deploy(proxyAuthApp)
+          proxy = Proxy.empty
+            .withUrl(url)
+            .withHeaders(Headers(DynamicServer.APP_ID, id))
+            .withCredentials(Credentials("test", "test"))
+          out <- Client.request(
+            Request(url = url),
+            Config().withProxy(proxy),
+          )
+        } yield out
+      assertZIO(res.either)(isRight)
+    },
+  )
 
   override def spec = {
     suite("Client") {

--- a/zio-http/src/test/scala/zhttp/service/KeepAliveSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/KeepAliveSpec.scala
@@ -18,30 +18,30 @@ object KeepAliveSpec extends HttpRunnableSpec {
     EventLoopGroup.nio() ++ ChannelFactory.nio ++ ServerChannelFactory.nio ++ DynamicServer.live ++ Scope.default
   private val appKeepAliveEnabled = serve(DynamicServer.app)
 
-  def keepAliveSpec = suite("KeepAlive") {
-    suite("Http 1.1") {
+  def keepAliveSpec = suite("KeepAlive")(
+    suite("Http 1.1")(
       test("without connection close") {
         val res = app.deploy.headerValue(HeaderNames.connection).run()
         assertZIO(res)(isNone)
-      } +
-        test("with connection close") {
-          val res = app.deploy.headerValue(HeaderNames.connection).run(headers = connectionCloseHeader)
-          assertZIO(res)(isSome(equalTo("close")))
-        }
-    } +
-      suite("Http 1.0") {
-        test("without keep-alive") {
-          val res = app.deploy.headerValue(HeaderNames.connection).run(version = Version.Http_1_0)
-          assertZIO(res)(isSome(equalTo("close")))
-        } +
-          test("with keep-alive") {
-            val res = app.deploy
-              .headerValue(HeaderNames.connection)
-              .run(version = Version.Http_1_0, headers = keepAliveHeader)
-            assertZIO(res)(isNone)
-          }
-      }
-  }
+      },
+      test("with connection close") {
+        val res = app.deploy.headerValue(HeaderNames.connection).run(headers = connectionCloseHeader)
+        assertZIO(res)(isSome(equalTo("close")))
+      },
+    ),
+    suite("Http 1.0")(
+      test("without keep-alive") {
+        val res = app.deploy.headerValue(HeaderNames.connection).run(version = Version.Http_1_0)
+        assertZIO(res)(isSome(equalTo("close")))
+      },
+      test("with keep-alive") {
+        val res = app.deploy
+          .headerValue(HeaderNames.connection)
+          .run(version = Version.Http_1_0, headers = keepAliveHeader)
+        assertZIO(res)(isNone)
+      },
+    ),
+  )
 
   override def spec = {
     suite("ServerConfigSpec") {

--- a/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/SSLSpec.scala
@@ -45,40 +45,40 @@ object SSLSpec extends ZIOSpecDefault {
               .request("https://localhost:8073/success", ssl = ClientSSLOptions.CustomSSL(clientSSL1))
               .map(_.status)
             assertZIO(actual)(equalTo(Status.Ok))
-          } +
-            test("fail with DecoderException when client doesn't have the server certificate") {
-              val actual = Client
-                .request("https://localhost:8073/success", ssl = ClientSSLOptions.CustomSSL(clientSSL2))
-                .catchSome { case _: DecoderException =>
-                  ZIO.succeed("DecoderException")
-                }
-              assertZIO(actual)(equalTo("DecoderException"))
-            } +
-            test("succeed when client has default SSL") {
-              val actual = Client
-                .request("https://localhost:8073/success", ssl = ClientSSLOptions.DefaultSSL)
-                .map(_.status)
-              assertZIO(actual)(equalTo(Status.Ok))
-            } +
-            test("Https Redirect when client makes http request") {
-              val actual = Client
-                .request("http://localhost:8073/success", ssl = ClientSSLOptions.CustomSSL(clientSSL1))
-                .map(_.status)
-              assertZIO(actual)(equalTo(Status.PermanentRedirect))
-            } +
-            test("Https request with a large payload should respond with 413") {
-              check(payload) { payload =>
-                val actual = Client
-                  .request(
-                    "https://localhost:8073/text",
-                    Method.POST,
-                    ssl = ClientSSLOptions.CustomSSL(clientSSL1),
-                    content = HttpData.fromString(payload),
-                  )
-                  .map(_.status)
-                assertZIO(actual)(equalTo(Status.RequestEntityTooLarge))
+          },
+          test("fail with DecoderException when client doesn't have the server certificate") {
+            val actual = Client
+              .request("https://localhost:8073/success", ssl = ClientSSLOptions.CustomSSL(clientSSL2))
+              .catchSome { case _: DecoderException =>
+                ZIO.succeed("DecoderException")
               }
-            },
+            assertZIO(actual)(equalTo("DecoderException"))
+          },
+          test("succeed when client has default SSL") {
+            val actual = Client
+              .request("https://localhost:8073/success", ssl = ClientSSLOptions.DefaultSSL)
+              .map(_.status)
+            assertZIO(actual)(equalTo(Status.Ok))
+          },
+          test("Https Redirect when client makes http request") {
+            val actual = Client
+              .request("http://localhost:8073/success", ssl = ClientSSLOptions.CustomSSL(clientSSL1))
+              .map(_.status)
+            assertZIO(actual)(equalTo(Status.PermanentRedirect))
+          },
+          test("Https request with a large payload should respond with 413") {
+            check(payload) { payload =>
+              val actual = Client
+                .request(
+                  "https://localhost:8073/text",
+                  Method.POST,
+                  ssl = ClientSSLOptions.CustomSSL(clientSSL1),
+                  content = HttpData.fromString(payload),
+                )
+                .map(_.status)
+              assertZIO(actual)(equalTo(Status.RequestEntityTooLarge))
+            }
+          },
         ),
       ),
   ).provideSomeLayer[TestEnvironment](env) @@ timeout(5 second) @@ ignore

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -28,32 +28,32 @@ object ServerSpec extends HttpRunnableSpec {
     serve(DynamicServer.app, Some(Server.requestDecompression(true) ++ Server.enableObjectAggregator(MaxSize)))
   private val appWithReqStreaming = serve(DynamicServer.app, Some(Server.requestDecompression(true)))
 
-  def dynamicAppSpec = suite("DynamicAppSpec") {
-    suite("success") {
+  def dynamicAppSpec = suite("DynamicAppSpec")(
+    suite("success")(
       test("status is 200") {
         val status = Http.ok.deploy.status.run()
         assertZIO(status)(equalTo(Status.Ok))
+      },
+      test("status is 200") {
+        val res = Http.text("ABC").deploy.status.run()
+        assertZIO(res)(equalTo(Status.Ok))
+      },
+      test("content is set") {
+        val res = Http.text("ABC").deploy.bodyAsString.run()
+        assertZIO(res)(containsString("ABC"))
+      },
+    ),
+    suite("not found") {
+      val app = Http.empty
+      test("status is 404") {
+        val res = app.deploy.status.run()
+        assertZIO(res)(equalTo(Status.NotFound))
       } +
-        test("status is 200") {
-          val res = Http.text("ABC").deploy.status.run()
-          assertZIO(res)(equalTo(Status.Ok))
-        } +
-        test("content is set") {
-          val res = Http.text("ABC").deploy.bodyAsString.run()
-          assertZIO(res)(containsString("ABC"))
+        test("header is set") {
+          val res = app.deploy.headerValue(HeaderNames.contentLength).run()
+          assertZIO(res)(isSome(equalTo("439")))
         }
     } +
-      suite("not found") {
-        val app = Http.empty
-        test("status is 404") {
-          val res = app.deploy.status.run()
-          assertZIO(res)(equalTo(Status.NotFound))
-        } +
-          test("header is set") {
-            val res = app.deploy.headerValue(HeaderNames.contentLength).run()
-            assertZIO(res)(isSome(equalTo("439")))
-          }
-      } +
       suite("error") {
         val app = Http.fail(new Error("SERVER_ERROR"))
         test("status is 500") {
@@ -150,8 +150,8 @@ object ServerSpec extends HttpRunnableSpec {
             } yield response
             assertZIO(res.flatMap(_.bodyAsString))(equalTo(content))
           }
-      }
-  }
+      },
+  )
 
   def requestSpec = suite("RequestSpec") {
     val app: HttpApp[Any, Nothing] = Http.collect[Request] { case req =>
@@ -170,102 +170,102 @@ object ServerSpec extends HttpRunnableSpec {
       }
   }
 
-  def responseSpec = suite("ResponseSpec") {
+  def responseSpec = suite("ResponseSpec")(
     test("data") {
       check(nonEmptyContent) { case (string, data) =>
         val res = Http.fromData(data).deploy.bodyAsString.run()
         assertZIO(res)(equalTo(string))
       }
-    } +
-      test("data from file") {
-        val res = Http.fromResource("TestFile.txt").deploy.bodyAsString.run()
-        assertZIO(res)(equalTo("abc\nfoo"))
-      } +
-      test("content-type header on file response") {
-        val res =
-          Http
-            .fromResource("TestFile2.mp4")
-            .deploy
-            .headerValue(HeaderNames.contentType)
-            .run()
-            .map(_.getOrElse("Content type header not found."))
-        assertZIO(res)(equalTo("video/mp4"))
-      } +
-      test("status") {
-        checkAll(HttpGen.status) { case status =>
-          val res = Http.status(status).deploy.status.run()
-          assertZIO(res)(equalTo(status))
-        }
-
-      } +
-      test("header") {
-        check(HttpGen.header) { case header @ (name, value) =>
-          val res = Http.ok.addHeader(header).deploy.headerValue(name).run()
-          assertZIO(res)(isSome(equalTo(value)))
-        }
-      } +
-      test("text streaming") {
-        val res = Http.fromStream(ZStream("a", "b", "c")).deploy.bodyAsString.run()
-        assertZIO(res)(equalTo("abc"))
-      } +
-      test("echo streaming") {
-        val res = Http
-          .collectHttp[Request] { case req =>
-            Http.fromStream(ZStream.fromZIO(req.body).flattenChunks)
-          }
+    },
+    test("data from file") {
+      val res = Http.fromResource("TestFile.txt").deploy.bodyAsString.run()
+      assertZIO(res)(equalTo("abc\nfoo"))
+    },
+    test("content-type header on file response") {
+      val res =
+        Http
+          .fromResource("TestFile2.mp4")
           .deploy
-          .bodyAsString
-          .run(content = HttpData.fromString("abc"))
-        assertZIO(res)(equalTo("abc"))
-      } +
-      test("file-streaming") {
-        val path = getClass.getResource("/TestFile.txt").getPath
-        val res  = Http.fromStream(ZStream.fromPath(Paths.get(path))).deploy.bodyAsString.run()
-        assertZIO(res)(equalTo("abc\nfoo"))
-      } +
-      suite("html") {
-        test("body") {
-          val res = Http.html(html(body(div(id := "foo", "bar")))).deploy.bodyAsString.run()
-          assertZIO(res)(equalTo("""<!DOCTYPE html><html><body><div id="foo">bar</div></body></html>"""))
-        } +
-          test("content-type") {
-            val app = Http.html(html(body(div(id := "foo", "bar"))))
-            val res = app.deploy.headerValue(HeaderNames.contentType).run()
-            assertZIO(res)(isSome(equalTo(HeaderValues.textHtml.toString)))
-          }
-      } +
-      suite("content-length") {
-        suite("string") {
-          test("unicode text") {
-            val res = Http.text("äöü").deploy.contentLength.run()
-            assertZIO(res)(isSome(equalTo(6L)))
-          } +
-            test("already set") {
-              val res = Http.text("1234567890").withContentLength(4L).deploy.contentLength.run()
-              assertZIO(res)(isSome(equalTo(4L)))
-            }
-        }
-      } +
-      suite("memoize") {
-        test("concurrent") {
-          val size     = 100
-          val expected = (0 to size) map (_ => Status.Ok)
-          for {
-            response <- Response.text("abc").freeze
-            actual   <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
-          } yield assert(actual)(equalTo(expected))
-        } +
-          test("update after cache") {
-            val server = "ZIO-Http"
-            for {
-              res    <- Response.text("abc").freeze
-              actual <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
-            } yield assert(actual)(isSome(equalTo(server)))
-          }
+          .headerValue(HeaderNames.contentType)
+          .run()
+          .map(_.getOrElse("Content type header not found."))
+      assertZIO(res)(equalTo("video/mp4"))
+    },
+    test("status") {
+      checkAll(HttpGen.status) { case status =>
+        val res = Http.status(status).deploy.status.run()
+        assertZIO(res)(equalTo(status))
       }
-  }
 
-  def requestBodySpec = suite("RequestBodySpec") {
+    },
+    test("header") {
+      check(HttpGen.header) { case header @ (name, value) =>
+        val res = Http.ok.addHeader(header).deploy.headerValue(name).run()
+        assertZIO(res)(isSome(equalTo(value)))
+      }
+    },
+    test("text streaming") {
+      val res = Http.fromStream(ZStream("a", "b", "c")).deploy.bodyAsString.run()
+      assertZIO(res)(equalTo("abc"))
+    },
+    test("echo streaming") {
+      val res = Http
+        .collectHttp[Request] { case req =>
+          Http.fromStream(ZStream.fromZIO(req.body).flattenChunks)
+        }
+        .deploy
+        .bodyAsString
+        .run(content = HttpData.fromString("abc"))
+      assertZIO(res)(equalTo("abc"))
+    },
+    test("file-streaming") {
+      val path = getClass.getResource("/TestFile.txt").getPath
+      val res  = Http.fromStream(ZStream.fromPath(Paths.get(path))).deploy.bodyAsString.run()
+      assertZIO(res)(equalTo("abc\nfoo"))
+    },
+    suite("html")(
+      test("body") {
+        val res = Http.html(html(body(div(id := "foo", "bar")))).deploy.bodyAsString.run()
+        assertZIO(res)(equalTo("""<!DOCTYPE html><html><body><div id="foo">bar</div></body></html>"""))
+      },
+      test("content-type") {
+        val app = Http.html(html(body(div(id := "foo", "bar"))))
+        val res = app.deploy.headerValue(HeaderNames.contentType).run()
+        assertZIO(res)(isSome(equalTo(HeaderValues.textHtml.toString)))
+      },
+    ),
+    suite("content-length")(
+      suite("string") {
+        test("unicode text") {
+          val res = Http.text("äöü").deploy.contentLength.run()
+          assertZIO(res)(isSome(equalTo(6L)))
+        } +
+          test("already set") {
+            val res = Http.text("1234567890").withContentLength(4L).deploy.contentLength.run()
+            assertZIO(res)(isSome(equalTo(4L)))
+          }
+      },
+    ),
+    suite("memoize")(
+      test("concurrent") {
+        val size     = 100
+        val expected = (0 to size) map (_ => Status.Ok)
+        for {
+          response <- Response.text("abc").freeze
+          actual   <- ZIO.foreachPar(0 to size)(_ => Http.response(response).deploy.status.run())
+        } yield assert(actual)(equalTo(expected))
+      },
+      test("update after cache") {
+        val server = "ZIO-Http"
+        for {
+          res    <- Response.text("abc").freeze
+          actual <- Http.response(res).withServer(server).deploy.headerValue(HeaderNames.server).run()
+        } yield assert(actual)(isSome(equalTo(server)))
+      },
+    ),
+  )
+
+  def requestBodySpec = suite("RequestBodySpec")(
     test("POST Request stream") {
       val app: Http[Any, Throwable, Request, Response] = Http.collect[Request] { case req =>
         Response(data = HttpData.fromStream(req.bodyAsStream))
@@ -275,14 +275,14 @@ object ServerSpec extends HttpRunnableSpec {
           equalTo(c),
         )
       }
-    } +
-      test("FromASCIIString: toHttp") {
-        check(Gen.asciiString) { payload =>
-          val res = HttpData.fromAsciiString(AsciiString.cached(payload)).toHttp.map(_.toString(HTTP_CHARSET))
-          assertZIO(res.run())(equalTo(payload))
-        }
+    },
+    test("FromASCIIString: toHttp") {
+      check(Gen.asciiString) { payload =>
+        val res = HttpData.fromAsciiString(AsciiString.cached(payload)).toHttp.map(_.toString(HTTP_CHARSET))
+        assertZIO(res.run())(equalTo(payload))
       }
-  }
+    },
+  )
 
   def serverErrorSpec = suite("ServerErrorSpec") {
     val app = Http.fail(new Error("SERVER_ERROR"))

--- a/zio-http/src/test/scala/zhttp/service/StaticServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/StaticServerSpec.scala
@@ -29,41 +29,41 @@ object StaticServerSpec extends HttpRunnableSpec {
 
   private val app = serve { nonZIO ++ staticApp }
 
-  def nonZIOSpec = suite("NonZIOSpec") {
-    val methodGenWithoutHEAD: Gen[Any, Method] = Gen.fromIterable(
-      List(
-        Method.OPTIONS,
-        Method.GET,
-        Method.POST,
-        Method.PUT,
-        Method.PATCH,
-        Method.DELETE,
-        Method.TRACE,
-        Method.CONNECT,
-      ),
-    )
+  private val methodGenWithoutHEAD: Gen[Any, Method] = Gen.fromIterable(
+    List(
+      Method.OPTIONS,
+      Method.GET,
+      Method.POST,
+      Method.PUT,
+      Method.PATCH,
+      Method.DELETE,
+      Method.TRACE,
+      Method.CONNECT,
+    ),
+  )
+
+  def nonZIOSpec = suite("NonZIOSpec")(
     test("200 response") {
       checkAll(HttpGen.method) { method =>
         val actual = status(method, !! / "HExitSuccess")
         assertZIO(actual)(equalTo(Status.Ok))
       }
-    } +
-      test("500 response") {
-        checkAll(methodGenWithoutHEAD) { method =>
-          val actual = status(method, !! / "HExitFailure")
-          assertZIO(actual)(equalTo(Status.InternalServerError))
-        }
-      } +
-      test("404 response ") {
-        checkAll(methodGenWithoutHEAD) { method =>
-          val actual = status(method, !! / "A")
-          assertZIO(actual)(equalTo(Status.NotFound))
-        }
+    },
+    test("500 response") {
+      checkAll(methodGenWithoutHEAD) { method =>
+        val actual = status(method, !! / "HExitFailure")
+        assertZIO(actual)(equalTo(Status.InternalServerError))
       }
+    },
+    test("404 response ") {
+      checkAll(methodGenWithoutHEAD) { method =>
+        val actual = status(method, !! / "A")
+        assertZIO(actual)(equalTo(Status.NotFound))
+      }
+    },
+  )
 
-  }
-
-  def serverStartSpec = suite("ServerStartSpec") {
+  def serverStartSpec = suite("ServerStartSpec")(
     test("desired port") {
       val port = 8088
       ZIO.scoped {
@@ -71,15 +71,15 @@ object StaticServerSpec extends HttpRunnableSpec {
           assertZIO(ZIO.attempt(start.port))(equalTo(port))
         }
       }
-    } +
-      test("available port") {
-        ZIO.scoped {
-          (Server.port(0) ++ Server.app(Http.empty)).make.flatMap { start =>
-            assertZIO(ZIO.attempt(start.port))(not(equalTo(0)))
-          }
+    },
+    test("available port") {
+      ZIO.scoped {
+        (Server.port(0) ++ Server.app(Http.empty)).make.flatMap { start =>
+          assertZIO(ZIO.attempt(start.port))(not(equalTo(0)))
         }
       }
-  }
+    },
+  )
 
   override def spec =
     suite("Server") {
@@ -89,33 +89,33 @@ object StaticServerSpec extends HttpRunnableSpec {
         )
     }.provideSomeLayerShared[TestEnvironment](env) @@ timeout(30 seconds)
 
-  def staticAppSpec    = suite("StaticAppSpec") {
+  def staticAppSpec    = suite("StaticAppSpec")(
     test("200 response") {
       val actual = status(path = !! / "success")
       assertZIO(actual)(equalTo(Status.Ok))
-    } +
-      test("500 response on failure") {
-        val actual = status(path = !! / "failure")
-        assertZIO(actual)(equalTo(Status.InternalServerError))
-      } +
-      test("500 response on die") {
-        val actual = status(path = !! / "die")
-        assertZIO(actual)(equalTo(Status.InternalServerError))
-      } +
-      test("404 response") {
-        val actual = status(path = !! / "random")
-        assertZIO(actual)(equalTo(Status.NotFound))
-      } +
-      test("200 response with encoded path") {
-        val actual = status(path = !! / "get%2Fsuccess")
-        assertZIO(actual)(equalTo(Status.Ok))
-      } +
-      test("Multiple 200 response") {
-        for {
-          data <- status(path = !! / "success").repeatN(1024)
-        } yield assertTrue(data == Status.Ok)
-      }
-  }
+    },
+    test("500 response on failure") {
+      val actual = status(path = !! / "failure")
+      assertZIO(actual)(equalTo(Status.InternalServerError))
+    },
+    test("500 response on die") {
+      val actual = status(path = !! / "die")
+      assertZIO(actual)(equalTo(Status.InternalServerError))
+    },
+    test("404 response") {
+      val actual = status(path = !! / "random")
+      assertZIO(actual)(equalTo(Status.NotFound))
+    },
+    test("200 response with encoded path") {
+      val actual = status(path = !! / "get%2Fsuccess")
+      assertZIO(actual)(equalTo(Status.Ok))
+    },
+    test("Multiple 200 response") {
+      for {
+        data <- status(path = !! / "success").repeatN(1024)
+      } yield assertTrue(data == Status.Ok)
+    },
+  )
   def throwableAppSpec = suite("ThrowableAppSpec") {
     test("Throw inside Handler") {
       for {


### PR DESCRIPTION
Updated test suite to proper combine tests and suites, using `,` instead of `+` in the suites where there are no local variable shared between tests.

Fixes #1131 