### PR TITLE
Convert headers from case class to sealed trait

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpHeadersBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpHeadersBenchmark.scala
@@ -1,0 +1,22 @@
+package zhttp.benchmarks
+
+import org.openjdk.jmh.annotations._
+import zhttp.http._
+
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class HttpHeadersBenchmark {
+  @Benchmark
+  def benchmarkApp(): Unit = {
+    val _ = Headers.empty
+      .addHeader("Content-Type", "application/json")
+      .addHeader("Content-Length", "0")
+      .addHeader("Accepts", "application/json")
+      .withContentEncoding("utf-8")
+      .removeHeader("Accepts")
+    ()
+  }
+}

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpHeadersBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/HttpHeadersBenchmark.scala
@@ -1,5 +1,6 @@
 package zhttp.benchmarks
 
+import io.netty.handler.codec.http.ReadOnlyHttpHeaders
 import org.openjdk.jmh.annotations._
 import zhttp.http._
 
@@ -10,7 +11,7 @@ import java.util.concurrent.TimeUnit
 @OutputTimeUnit(TimeUnit.SECONDS)
 class HttpHeadersBenchmark {
   @Benchmark
-  def benchmarkApp(): Unit = {
+  def benchmarkWriteApp(): Unit = {
     val _ = Headers.empty
       .addHeader("Content-Type", "application/json")
       .addHeader("Content-Length", "0")
@@ -18,5 +19,38 @@ class HttpHeadersBenchmark {
       .withContentEncoding("utf-8")
       .removeHeader("Accepts")
     ()
+  }
+
+  @Benchmark
+  def benchmarkReadHeaders(): Unit = {
+    val headers = Headers(
+      ("Content-Type", "application/json"),
+      ("Content-Length", "0"),
+      ("Accepts", "application/json"),
+      ("Content-Encoding", "utf-8"),
+    )
+
+    val _ = headers.header("Content-Encoding")
+    val _ = headers.header("Content-Type")
+  }
+
+  @Benchmark
+  def benchmarkHttpHeaders(): Unit = {
+    val headers = Headers.make(
+      new ReadOnlyHttpHeaders(
+        true,
+        "Content-Type",
+        "application/json",
+        "Content-Length",
+        "0",
+        "Accepts",
+        "application/json",
+        "Content-Encoding",
+        "utf-8",
+      ),
+    )
+
+    val _ = headers.header("Content-Encoding")
+    val _ = headers.header("Content-Type")
   }
 }

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -15,22 +15,48 @@ import scala.jdk.CollectionConverters._
  * defined here. A better place would be one of the traits extended by
  * `HeaderExtension`.
  */
-final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers] {
+
+/**
+ * Represents an immutable collection of headers i.e. essentially a
+ * Chunk[(String, String)]. It extends HeaderExtensions and has a ton of
+ * powerful operators that can be used to add, remove and modify headers.
+ *
+ * NOTE: Generic operators that are not specific to `Headers` should not be
+ * defined here. A better place would be one of the traits extended by
+ * `HeaderExtension`.
+ */
+sealed trait Headers extends HeaderExtension[Headers] {
   self =>
 
-  def ++(other: Headers): Headers = self.combine(other)
+  def ++(other: Headers): Headers = HeadersCons(self, other)
 
-  def combine(other: Headers): Headers = Headers(self.toChunk ++ other.toChunk)
+  def combine(other: Headers): Headers = HeadersCons(self, other)
 
-  def combineIf(cond: Boolean)(other: Headers): Headers = if (cond) Headers(self.toChunk ++ other.toChunk) else self
+  def combineIf(cond: Boolean)(other: Headers): Headers = if (cond)
+    HeadersCons(self, other)
+  else self
 
   override def headers: Headers = self
 
-  def modify(f: Header => Header): Headers = Headers(toChunk.map(f(_)))
+  def modify(f: Header => Header): Headers = ModifyHeaders(f, self)
 
-  def toList: List[(String, String)] = toChunk.map { case (name, value) => (name.toString, value.toString) }.toList
+  def toList: List[(String, String)] = self match {
+    case EmptyHeaders                    => List()
+    case HeadersCons(a, b)               => a.toList ++ b.toList
+    case HeadersFromChunk(chunk)         => chunk.map(h => (h._1.toString, h._2.toString)).toList
+    case HeadersFromHttp(headers)        =>
+      headers
+        .iteratorCharSequence()
+        .asScala
+        .map(h => (h.getKey.toString, h.getValue.toString))
+        .toList
+    case ModifyHeaders(modify, headers)  => headers.toList.map(modify).map(h => (h._1.toString, h._2.toString))
+    case UpdatedHeaders(update, headers) =>
+      update(headers).toList
+  }
 
-  override def updateHeaders(update: Headers => Headers): Headers = update(self)
+  override def updateHeaders(update: Headers => Headers): Headers =
+    UpdatedHeaders(update, this)
 
   def when(cond: Boolean): Headers = if (cond) self else Headers.empty
 
@@ -38,36 +64,35 @@ final case class Headers(toChunk: Chunk[Header]) extends HeaderExtension[Headers
    * Converts a Headers to [io.netty.handler.codec.http.HttpHeaders]
    */
   private[zhttp] def encode: HttpHeaders =
-    self.toList
-      .foldLeft[HttpHeaders](new CombinedHttpHeaders(true)) { case (headers, entry) =>
-        headers.add(entry._1, entry._2)
-      }
-
+    self.toList.foldLeft[HttpHeaders](new CombinedHttpHeaders(true)) { case (headers, entry) =>
+      headers.add(entry._1, entry._2)
+    }
 }
+
+case object EmptyHeaders                                              extends Headers
+case class HeadersFromChunk(value: Chunk[Header])                     extends Headers
+case class HeadersFromHttp(value: HttpHeaders)                        extends Headers
+case class UpdatedHeaders(update: Headers => Headers, value: Headers) extends Headers
+case class ModifyHeaders(modify: Header => Header, value: Headers)    extends Headers
+case class HeadersCons(a: Headers, b: Headers)                        extends Headers
 
 object Headers extends HeaderConstructors {
 
-  val empty: Headers   = Headers(Nil)
+  val empty: Headers   = EmptyHeaders
   val BasicSchemeName  = "Basic"
   val BearerSchemeName = "Bearer"
 
-  def apply(name: CharSequence, value: CharSequence): Headers = Headers(Chunk((name, value)))
+  def apply(name: CharSequence, value: CharSequence): Headers = HeadersFromChunk(Chunk((name, value)))
 
-  def apply(tuples: Header*): Headers = Headers(Chunk.fromIterable(tuples))
+  def apply(tuples: Header*): Headers = HeadersFromChunk(Chunk.fromIterable(tuples))
 
-  def apply(iter: Iterable[Header]): Headers = Headers(Chunk.fromIterable(iter))
+  def apply(iter: Iterable[Header]): Headers = HeadersFromChunk(Chunk.fromIterable(iter))
 
   def ifThenElse(cond: Boolean)(onTrue: => Headers, onFalse: => Headers): Headers = if (cond) onTrue else onFalse
 
-  def make(headers: HttpHeaders): Headers = Headers {
-    headers
-      .iteratorCharSequence()
-      .asScala
-      .map(h => (h.getKey, h.getValue))
-      .toList
-  }
+  def make(headers: HttpHeaders): Headers = HeadersFromHttp(headers)
 
-  def when(cond: Boolean)(headers: => Headers): Headers = if (cond) headers else Headers.empty
+  def when(cond: Boolean)(headers: => Headers): Headers = if (cond) headers else EmptyHeaders
 
   private[zhttp] def decode(headers: HttpHeaders): Headers =
     Headers(headers.entries().asScala.toList.map(entry => (entry.getKey, entry.getValue)))

--- a/zio-http/src/main/scala/zhttp/http/Headers.scala
+++ b/zio-http/src/main/scala/zhttp/http/Headers.scala
@@ -78,8 +78,11 @@ case class HeadersFromChunk(value: Chunk[Header])                     extends He
     value.find(h => contentEqualsIgnoreCase(h._1, headerName))
 }
 case class HeadersFromHttp(value: HttpHeaders)                        extends Headers {
-  override def header(headerName: CharSequence): Option[Header] =
-    Option(value.get(headerName)).map((headerName, _))
+  override def header(headerName: CharSequence): Option[Header] = {
+    val header = value.get(headerName)
+    if (header != null) Some((headerName, header))
+    else None
+  }
 }
 case class UpdatedHeaders(update: Headers => Headers, value: Headers) extends Headers
 case class ModifyHeaders(modify: Header => Header, value: Headers)    extends Headers

--- a/zio-http/src/main/scala/zhttp/http/headers/HeaderGetters.scala
+++ b/zio-http/src/main/scala/zhttp/http/headers/HeaderGetters.scala
@@ -184,7 +184,7 @@ trait HeaderGetters[+A] { self =>
   final def from: Option[CharSequence] =
     headerValue(HeaderNames.from)
 
-  final def header(headerName: CharSequence): Option[Header] =
+  def header(headerName: CharSequence): Option[Header] =
     headers.toList
       .find(h => contentEqualsIgnoreCase(h._1, headerName))
 

--- a/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/HeaderSpec.scala
@@ -226,6 +226,27 @@ object HeaderSpec extends ZIOSpecDefault {
         assertTrue(result == 2)
       },
     ),
+    suite("modifyHeaders")(
+      test("should remove header") {
+        val actual = Headers
+          .contentType("application/json")
+          .removeHeader(HeaderNames.contentType.toString)
+        assert(actual.hasHeader(HeaderNames.contentType.toString))(equalTo(false))
+        assert(actual.contentType)(isNone)
+        assert(actual.toList)(isEmpty)
+      },
+      test("should update a specific header") {
+        val actual = Headers
+          .contentType("application/json")
+          .withContentEncoding("utf-8")
+          .modify(header =>
+            if (HeaderNames.contentType.toString() == header._1) (header._1, "application/pdf") else header,
+          )
+
+        assert(actual.contentType)(isSome(equalTo("application/pdf")))
+        assert(actual.contentEncoding)(isSome(equalTo("utf-8")))
+      },
+    ),
   )
 
   private val contentTypeXhtmlXml       = Headers(HeaderNames.contentType, HeaderValues.applicationXhtml)


### PR DESCRIPTION
Attempt to implement #1007.

Headers ADT's are:
```scala
case object EmptyHeaders extends Headers
case class HeadersFromChunk(value: Chunk[Header]) extends Headers
case class HeadersFromHttp(value: HttpHeaders) extends Headers
case class UpdatedHeaders(update: Headers => Headers, value: Headers) extends Headers
case class ModifyHeaders(modify: Header => Header, value: Headers) extends Headers
case class HeadersCons(a: Headers, b: Headers) extends Headers
```

Added some naive/basic benchmark (HttpHeadersBenchmark), adding and removing some headers:
```scala
    val _ = Headers.empty
      .addHeader("Content-Type", "application/json")
      .addHeader("Content-Length", "0")
      .addHeader("Accepts", "application/json")
      .withContentEncoding("utf-8")
      .removeHeader("Accepts")
```
* Case class headers:   1597240,295 ops/sec
* Sealed trait headers:  8030336,433 ops/sec

full output goes below

Current case class headers:
```
[info] # JMH version: 1.32
[info] # VM version: JDK 17, OpenJDK 64-Bit Server VM, 17+35-2724
[info] # VM invoker: /Users/jgoday/Library/Caches/Coursier/jvm/openjdk@1.17.0/Contents/Home/bin/java
[info] # VM options: -Dio.netty.leakDetectionLevel=paranoid -DZHttpLogLevel=INFO
[info] # Blackhole mode: full + dont-inline hint
[info] # Warmup: 3 iterations, 10 s each
[info] # Measurement: 3 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: zhttp.benchmarks.HttpHeadersBenchmark.benchmarkApp
[info] # Run progress: 0,00% complete, ETA 00:01:00
[info] # Fork: 1 of 1
[info] # Warmup Iteration   1: 1486934,006 ops/s
[info] # Warmup Iteration   2: 1637439,246 ops/s
[info] # Warmup Iteration   3: 1636375,782 ops/s
[info] Iteration   1: 1640994,184 ops/s
[info] Iteration   2: 1537598,331 ops/s
[info] Iteration   3: 1613128,370 ops/s
[info] Result "zhttp.benchmarks.HttpHeadersBenchmark.benchmarkApp":
[info]   1597240,295 ±(99.9%) 975996,330 ops/s [Average]
[info]   (min, avg, max) = (1537598,331, 1597240,295, 1640994,184), stdev = 53497,652
[info]   CI (99.9%): [621243,965, 2573236,625] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:00
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                           Mode  Cnt        Score        Error  Units
[info] HttpHeadersBenchmark.benchmarkApp  thrpt    3  1597240,295 ± 975996,330  ops/s
[success] Total time: 89 s (01:29), completed 27 jul 2022 0:27:43
```

Sealed trait headers:
```
[info] # JMH version: 1.32
[info] # VM version: JDK 17, OpenJDK 64-Bit Server VM, 17+35-2724
[info] # VM invoker: /Users/jgoday/Library/Caches/Coursier/jvm/openjdk@1.17.0/Contents/Home/bin/java
[info] # VM options: -Dio.netty.leakDetectionLevel=paranoid -DZHttpLogLevel=INFO
[info] # Blackhole mode: full + dont-inline hint
[info] # Warmup: 3 iterations, 10 s each
[info] # Measurement: 3 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 1 thread, will synchronize iterations
[info] # Benchmark mode: Throughput, ops/time
[info] # Benchmark: zhttp.benchmarks.HttpHeadersBenchmark.benchmarkApp
[info] # Run progress: 0,00% complete, ETA 00:01:00
[info] # Fork: 1 of 1
[info] # Warmup Iteration   1: 7536276,582 ops/s
[info] # Warmup Iteration   2: 7992448,592 ops/s
[info] # Warmup Iteration   3: 8060069,362 ops/s
[info] Iteration   1: 8011678,794 ops/s
[info] Iteration   2: 8016804,008 ops/s
[info] Iteration   3: 8062526,497 ops/s
[info] Result "zhttp.benchmarks.HttpHeadersBenchmark.benchmarkApp":
[info]   8030336,433 ±(99.9%) 510732,071 ops/s [Average]
[info]   (min, avg, max) = (8011678,794, 8030336,433, 8062526,497), stdev = 27994,948
[info]   CI (99.9%): [7519604,362, 8541068,504] (assumes normal distribution)
[info] # Run complete. Total time: 00:01:00
[info] REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
[info] why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
[info] experiments, perform baseline and negative tests that provide experimental control, make sure
[info] the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
[info] Do not assume the numbers tell you what you want them to tell.
[info] Benchmark                           Mode  Cnt        Score        Error  Units
[info] HttpHeadersBenchmark.benchmarkApp  thrpt    3  8030336,433 ± 510732,071  ops/s
[success] Total time: 82 s (01:22), completed 27 jul 2022 0:22:10
```

