### PR TITLE
Fix: Host header must include port

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Client.scala
+++ b/zio-http/src/main/scala/zhttp/service/Client.scala
@@ -63,12 +63,8 @@ final case class Client[R](rtm: HttpRuntime[R], cf: JChannelFactory[JChannel], e
   ): JChannelFuture = {
 
     try {
-      val (host, port) = (req.url.host, req.url.port) match {
-        case (Some(host), Some(port)) => (host, port)
-        case (Some(host), None) => (host, 80)
-        case _ => assert(false, "Host name is required")
-          ("", -1)
-      }
+      val host = req.url.host.getOrElse { assert(false, "Host name is required"); "" }
+      val port = req.url.port.getOrElse(80)
 
       val isWebSocket = req.url.scheme.exists(_.isWebSocket)
       val isSSL       = req.url.scheme.exists(_.isSecure)

--- a/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
@@ -20,10 +20,9 @@ trait EncodeRequest {
 
       val encodedReqHeaders = req.headers.encode
 
-      val headers = (req.url.host, req.url.port) match {
-        case (Some(host), Some(port)) => encodedReqHeaders.set(HttpHeaderNames.HOST, s"$host:$port")
-        case (Some(host), None)       => encodedReqHeaders.set(HttpHeaderNames.HOST, host)
-        case _                        => encodedReqHeaders
+      val headers = req.url.host match {
+        case Some(host) => encodedReqHeaders.set(HttpHeaderNames.HOST, req.url.port.fold(host)(port => s"$host:$port"))
+        case _          => encodedReqHeaders
       }
 
       val writerIndex = content.writerIndex()

--- a/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
+++ b/zio-http/src/main/scala/zhttp/service/EncodeRequest.scala
@@ -20,9 +20,10 @@ trait EncodeRequest {
 
       val encodedReqHeaders = req.headers.encode
 
-      val headers = req.url.host match {
-        case Some(value) => encodedReqHeaders.set(HttpHeaderNames.HOST, value)
-        case None        => encodedReqHeaders
+      val headers = (req.url.host, req.url.port) match {
+        case (Some(host), Some(port)) => encodedReqHeaders.set(HttpHeaderNames.HOST, s"$host:$port")
+        case (Some(host), None)       => encodedReqHeaders.set(HttpHeaderNames.HOST, host)
+        case _                        => encodedReqHeaders
       }
 
       val writerIndex = content.writerIndex()

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -67,7 +67,7 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(anyClientParam) { params =>
         val req =
           encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
+        assertZIO(req)(equalTo((params.url.host.zip(params.url.port)).fold(params.url.host) { case (host, port) =>
           Some(s"$host:$port")
         }))
       }
@@ -76,7 +76,7 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(clientParamWithAbsoluteUrl) { params =>
         val req = encode(params)
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
+        assertZIO(req)(equalTo((params.url.host.zip(params.url.port)).fold(params.url.host) { case (host, port) =>
           Some(s"$host:$port")
         }))
       }

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -67,7 +67,7 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(anyClientParam) { params =>
         val req =
           encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo((params.url.host.zip(params.url.port)).fold(params.url.host) { case (host, port) =>
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
           Some(s"$host:$port")
         }))
       }
@@ -76,7 +76,7 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(clientParamWithAbsoluteUrl) { params =>
         val req = encode(params)
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo((params.url.host.zip(params.url.port)).fold(params.url.host) { case (host, port) =>
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
           Some(s"$host:$port")
         }))
       }

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -67,14 +67,14 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(anyClientParam) { params =>
         val req =
           encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host))
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host){case (host, port) => Some(s"$host:$port")}))
       }
     },
     test("host header when absolute url") {
       check(clientParamWithAbsoluteUrl) { params =>
         val req = encode(params)
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host))
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host){case (host, port) => Some(s"$host:$port")}))
       }
     },
     test("only one host header exists") {

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -67,14 +67,18 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(anyClientParam) { params =>
         val req =
           encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host){case (host, port) => Some(s"$host:$port")}))
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
+          Some(s"$host:$port")
+        }))
       }
     },
     test("host header when absolute url") {
       check(clientParamWithAbsoluteUrl) { params =>
         val req = encode(params)
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host){case (host, port) => Some(s"$host:$port")}))
+        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
+          Some(s"$host:$port")
+        }))
       }
     },
     test("only one host header exists") {

--- a/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
+++ b/zio-http/src/test/scala/zhttp/http/EncodeRequestSpec.scala
@@ -67,8 +67,9 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(anyClientParam) { params =>
         val req =
           encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
-          Some(s"$host:$port")
+        assertZIO(req)(equalTo((params.url.host, params.url.port) match {
+          case (Some(host), Some(port)) => Some(s"$host:$port")
+          case _                        => params.url.host
         }))
       }
     },
@@ -76,8 +77,9 @@ object EncodeRequestSpec extends ZIOSpecDefault with EncodeRequest {
       check(clientParamWithAbsoluteUrl) { params =>
         val req = encode(params)
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
-        assertZIO(req)(equalTo(params.url.host.zip(params.url.port).fold(params.url.host) { case (host, port) =>
-          Some(s"$host:$port")
+        assertZIO(req)(equalTo((params.url.host, params.url.port) match {
+          case (Some(host), Some(port)) => Some(s"$host:$port")
+          case _                        => params.url.host
         }))
       }
     },


### PR DESCRIPTION
Fixes #1372 - according to HTTP 1.1 spec (https://datatracker.ietf.org/doc/html/rfc2616#section-14.23) Host header must include port if the request is sent to the custom port