### PR TITLE
feat: add metrics middleware

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val root = (project in file("."))
     zioHttpBenchmarks,
     zioHttpLogging,
     zioHttpExample,
-    zioHttpTestkit
+    zioHttpTestkit,
   )
 
 lazy val zioHttp = (project in file("zio-http"))

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -1,7 +1,7 @@
 package zio.http.middleware
 
-import zio.http.{Http, Middleware, Request, Response}
 import zio._
+import zio.http.{Http, Middleware, Request, Response}
 import zio.metrics.{Metric, MetricKeyType, MetricLabel}
 
 private[zio] trait Metrics {

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -11,6 +11,7 @@ private[zio] trait Metrics {
     totalRequestsName: String = "http_requests_total",
     requestDurationName: String = "http_request_duration_seconds",
     requestDurationBoundaries: MetricKeyType.Histogram.Boundaries = Metrics.defaultBoundaries,
+    extraLabels: Set[MetricLabel] = Set.empty,
   ): HttpMiddleware[Any, Nothing] = {
     new Middleware[Any, Nothing, Request, Response, Request, Response] {
       val requestsTotal      = Metric.counterInt(totalRequestsName)
@@ -24,7 +25,7 @@ private[zio] trait Metrics {
         Set(
           MetricLabel("method", req.method.toString),
           MetricLabel("path", pathLabelMapper.lift(req).getOrElse(req.path.toString())),
-        )
+        ) ++ extraLabels
 
       def labelsForResponse(res: Response): Set[MetricLabel] =
         Set(

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -54,7 +54,7 @@ private[zio] trait Metrics {
 
       def apply[R1 <: Any, E1 >: Nothing](
         http: Http[R1, E1, Request, Response],
-      ): Http[R1, E1, Request, Response] =
+      )(implicit trace: Trace): Http[R1, E1, Request, Response] =
         Http.fromOptionFunction[Request] { req =>
           val requestLabels = labelsForRequest(req)
 

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -5,98 +5,72 @@ import zio._
 import zio.metrics.{Metric, MetricKeyType, MetricLabel}
 
 private[zio] trait Metrics {
-  def metrics[R, E](
-    mapper: Metrics.Mapper = Map.empty,
-    boundaries: MetricKeyType.Histogram.Boundaries = Metrics.defaultBoundaries,
-  ): HttpMiddleware[R with Metrics.InFlightRequests, E] =
-    new Middleware[R with Metrics.InFlightRequests, E, Request, Response, Request, Response] {
-      private def metricLabelsForRequest(req: Request): Set[MetricLabel] =
+  def metrics(
+    pathLabelMapper: PartialFunction[Request, String] = Map.empty,
+    concurrentRequestsName: String = "http_concurrent_requests_total",
+    totalRequestsName: String = "http_requests_total",
+    requestDurationName: String = "http_request_duration_seconds",
+    requestDurationBoundaries: MetricKeyType.Histogram.Boundaries = Metrics.defaultBoundaries,
+  ): HttpMiddleware[Any, Nothing] = {
+    new Middleware[Any, Nothing, Request, Response, Request, Response] {
+      val requestsTotal      = Metric.counterInt(totalRequestsName)
+      val concurrentRequests = Metric.gauge(concurrentRequestsName)
+      val requestDuration    = Metric.histogram(requestDurationName, requestDurationBoundaries)
+      val status404          = Set(MetricLabel("status", "404"))
+      val status500          = Set(MetricLabel("status", "500"))
+      val nanosToSeconds     = 1e9d
+
+      def labelsForRequest(req: Request): Set[MetricLabel] =
         Set(
           MetricLabel("method", req.method.toString),
-          MetricLabel("path", mapper.lift(req).getOrElse(req.path.toString())),
+          MetricLabel("path", pathLabelMapper.lift(req).getOrElse(req.path.toString())),
         )
 
-      private def withRequestMeta[Type, In, Out](metric: Metric[Type, In, Out])(req: Request) =
-        metric.tagged(metricLabelsForRequest(req))
+      def labelsForResponse(res: Response): Set[MetricLabel] =
+        Set(
+          MetricLabel("status", res.status.code.toString),
+        )
 
-      private def requestsTotal(req: Request) =
-        withRequestMeta(Metric.counterInt("http_requests_total"))(req)
+      def observeRequest(start: Long, labels: Set[MetricLabel]) =
+        for {
+          _   <- requestsTotal.tagged(labels).increment
+          end <- Clock.nanoTime
+          took = end - start
+          _ <- requestDuration.tagged(labels).update(took / nanosToSeconds)
+        } yield ()
 
-      private val errorCount = Metric.counterInt("http_errors_total")
-
-      private def errorCountWithRequest(req: Request) =
-        withRequestMeta(errorCount)(req)
-
-      private def errorCountWithResponse(req: Request, res: Response) =
-        errorCountWithStatus(req, res.status.code.toString)
-
-      private def errorCountWithStatus(req: Request, status: String) =
-        errorCountWithRequest(req).tagged("status_code", status)
-
-      private def requestDuration(req: Request) =
-        withRequestMeta(
-          Metric.histogram(
-            "http_request_duration_seconds",
-            boundaries,
-          ),
-        )(req).trackDurationWith(toSeconds)
-
-      private val NANOS                  = 1e9d
-      private def toSeconds(d: Duration) =
-        (d.getSeconds() * NANOS + d.getNano()) / NANOS
-
-      def apply[R1 <: R with Metrics.InFlightRequests, E1 >: E](
+      def apply[R1 <: Any, E1 >: Nothing](
         http: Http[R1, E1, Request, Response],
       ): Http[R1, E1, Request, Response] =
         Http.fromOptionFunction[Request] { req =>
-          val labels = metricLabelsForRequest(req)
-          Metrics.InFlightRequests.increment(labels) *>
-            (http(req)
-              .ensuring(requestsTotal(req).increment *> Metrics.InFlightRequests.decrement(labels))
+          val requestLabels = labelsForRequest(req)
+
+          (for {
+            start <- Clock.nanoTime
+            _     <- concurrentRequests.tagged(requestLabels).increment
+            res   <- http(req)
               .tapBoth(
-                err =>
-                  err.fold(errorCountWithStatus(req, "404").increment)(_ => errorCountWithStatus(req, "500").increment),
-                res => ZIO.when(res.status.code > 399)(errorCountWithResponse(req, res).increment),
+                err => {
+                  observeRequest(start, requestLabels ++ err.fold(status404)(_ => status500))
+                },
+                response => {
+                  observeRequest(start, requestLabels ++ labelsForResponse(response))
+                },
               )
-              .tapDefect(_ => errorCountWithStatus(req, "500").increment)) @@ requestDuration(req)
+              .tapDefect(_ => {
+                observeRequest(start, requestLabels ++ status500)
+              })
+          } yield res).ensuring(concurrentRequests.tagged(requestLabels).decrement)
         }
     }
+  }
 }
 
 object Metrics {
-  type Mapper = PartialFunction[Request, String]
-
   // Prometheus defaults
   private[zio] val defaultBoundaries = MetricKeyType.Histogram.Boundaries.fromChunk(
     Chunk(
       .005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10,
     ),
   )
-
-  trait InFlightRequests {
-    def increment(labels: Set[MetricLabel]): UIO[Int]
-    def decrement(labels: Set[MetricLabel]): UIO[Int]
-    def get: UIO[Int]
-  }
-
-  object InFlightRequests {
-    def increment(labels: Set[MetricLabel]): URIO[InFlightRequests, Any] = ZIO.serviceWithZIO(_.increment(labels))
-    def decrement(labels: Set[MetricLabel]): URIO[InFlightRequests, Any] = ZIO.serviceWithZIO(_.decrement(labels))
-    val get: URIO[InFlightRequests, Int]                                 = ZIO.serviceWithZIO(_.get)
-
-    val live = ZLayer.fromZIO {
-      for {
-        ref <- Ref.make(0)
-        gauge = Metric.gauge("http_inflight_requests_total").contramap[Int](_.toDouble)
-      } yield new InFlightRequests {
-        def increment(labels: Set[MetricLabel]): UIO[Int] = ref.updateAndGet(_ + 1) @@ gauge.tagged(labels.toSet)
-
-        def decrement(labels: Set[MetricLabel]): UIO[Int] = ref.updateAndGet(_ - 1) @@ gauge.tagged(labels.toSet)
-
-        def get: UIO[Int] = ref.get
-      }
-    }
-  }
-
-  val live = Metrics.InFlightRequests.live
 }

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -5,6 +5,26 @@ import zio._
 import zio.metrics.{Metric, MetricKeyType, MetricLabel}
 
 private[zio] trait Metrics {
+
+  /**
+   * Adds metrics to a zio-http server.
+   *
+   * @param pathLabelMapper
+   *   A mapping function to map incoming paths to patterns, such as /users/1 to
+   *   /users/:id.
+   * @param totalRequestsName
+   *   Total HTTP requests metric name.
+   * @param requestDurationName
+   *   HTTP request duration metric name.
+   * @param requestDurationBoundaries
+   *   Boundaries for the HTTP request duration metric.
+   * @param extraLabels
+   *   A set of extra labels all metrics will be tagged with.
+   * @note
+   *   When using Prometheus as your metrics backend, make sure to provide a
+   *   `pathLabelMapper` in order to avoid
+   *   [[https://prometheus.io/docs/practices/naming/#labels high cardinality labels]].
+   */
   def metrics(
     pathLabelMapper: PartialFunction[Request, String] = Map.empty,
     concurrentRequestsName: String = "http_concurrent_requests_total",

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -41,7 +41,7 @@ private[zio] trait Metrics {
           ),
         )(req).trackDurationWith(toSeconds)
 
-      private val NANOS                  = 1_000_000_000.0d
+      private val NANOS                  = 1e9d
       private def toSeconds(d: Duration) =
         (d.getSeconds() * NANOS + d.getNano()) / NANOS
 

--- a/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Metrics.scala
@@ -1,0 +1,102 @@
+package zio.http.middleware
+
+import zio.http.{Http, Middleware, Request, Response}
+import zio._
+import zio.metrics.{Metric, MetricKeyType, MetricLabel}
+
+private[zio] trait Metrics {
+  def metrics[R, E](
+    mapper: Metrics.Mapper = Map.empty,
+    boundaries: MetricKeyType.Histogram.Boundaries = Metrics.defaultBoundaries,
+  ): HttpMiddleware[R with Metrics.InFlightRequests, E] =
+    new Middleware[R with Metrics.InFlightRequests, E, Request, Response, Request, Response] {
+      private def metricLabelsForRequest(req: Request): Set[MetricLabel] =
+        Set(
+          MetricLabel("method", req.method.toString),
+          MetricLabel("path", mapper.lift(req).getOrElse(req.path.toString())),
+        )
+
+      private def withRequestMeta[Type, In, Out](metric: Metric[Type, In, Out])(req: Request) =
+        metric.tagged(metricLabelsForRequest(req))
+
+      private def requestsTotal(req: Request) =
+        withRequestMeta(Metric.counterInt("http_requests_total"))(req)
+
+      private val errorCount = Metric.counterInt("http_errors_total")
+
+      private def errorCountWithRequest(req: Request) =
+        withRequestMeta(errorCount)(req)
+
+      private def errorCountWithResponse(req: Request, res: Response) =
+        errorCountWithStatus(req, res.status.code.toString)
+
+      private def errorCountWithStatus(req: Request, status: String) =
+        errorCountWithRequest(req).tagged("status_code", status)
+
+      private def requestDuration(req: Request) =
+        withRequestMeta(
+          Metric.histogram(
+            "http_request_duration_seconds",
+            boundaries,
+          ),
+        )(req).trackDurationWith(toSeconds)
+
+      private val NANOS                  = 1_000_000_000.0d
+      private def toSeconds(d: Duration) =
+        (d.getSeconds() * NANOS + d.getNano()) / NANOS
+
+      def apply[R1 <: R with Metrics.InFlightRequests, E1 >: E](
+        http: Http[R1, E1, Request, Response],
+      ): Http[R1, E1, Request, Response] =
+        Http.fromOptionFunction[Request] { req =>
+          val labels = metricLabelsForRequest(req)
+          Metrics.InFlightRequests.increment(labels) *>
+            (http(req)
+              .ensuring(requestsTotal(req).increment *> Metrics.InFlightRequests.decrement(labels))
+              .tapBoth(
+                err =>
+                  err.fold(errorCountWithStatus(req, "404").increment)(_ => errorCountWithStatus(req, "500").increment),
+                res => ZIO.when(res.status.code > 399)(errorCountWithResponse(req, res).increment),
+              )
+              .tapDefect(_ => errorCountWithStatus(req, "500").increment)) @@ requestDuration(req)
+        }
+    }
+}
+
+object Metrics {
+  type Mapper = PartialFunction[Request, String]
+
+  // Prometheus defaults
+  private[zio] val defaultBoundaries = MetricKeyType.Histogram.Boundaries.fromChunk(
+    Chunk(
+      .005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10,
+    ),
+  )
+
+  trait InFlightRequests {
+    def increment(labels: Set[MetricLabel]): UIO[Int]
+    def decrement(labels: Set[MetricLabel]): UIO[Int]
+    def get: UIO[Int]
+  }
+
+  object InFlightRequests {
+    def increment(labels: Set[MetricLabel]): URIO[InFlightRequests, Any] = ZIO.serviceWithZIO(_.increment(labels))
+    def decrement(labels: Set[MetricLabel]): URIO[InFlightRequests, Any] = ZIO.serviceWithZIO(_.decrement(labels))
+    val get: URIO[InFlightRequests, Int]                                 = ZIO.serviceWithZIO(_.get)
+
+    val live = ZLayer.fromZIO {
+      for {
+        ref <- Ref.make(0)
+        gauge = Metric.gauge("http_inflight_requests_total").contramap[Int](_.toDouble)
+      } yield new InFlightRequests {
+        def increment(labels: Set[MetricLabel]): UIO[Int] = ref.updateAndGet(_ + 1) @@ gauge.tagged(labels.toSet)
+
+        def decrement(labels: Set[MetricLabel]): UIO[Int] = ref.updateAndGet(_ - 1) @@ gauge.tagged(labels.toSet)
+
+        def get: UIO[Int] = ref.get
+      }
+    }
+  }
+
+  val live = Metrics.InFlightRequests.live
+}

--- a/zio-http/src/main/scala/zio/http/middleware/Web.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Web.scala
@@ -20,6 +20,7 @@ private[zio] trait Web
     with Csrf
     with Auth
     with RequestLogging
+    with Metrics
     with HeaderModifier[HttpMiddleware[Any, Nothing]] {
   self =>
 

--- a/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
@@ -50,9 +50,8 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         .tagged("method", "GET")
         .tagged("status", "200")
 
-      val app = Http
-        .collect[Request] { case Method.GET -> !! / "ok" => Http.ok }
-        .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_request_duration_seconds")))
+      val app: Http[Any, Nothing, Request, Response] = Http
+        .ok @@ metrics(extraLabels = Set(MetricLabel("test", "http_request_duration_seconds")))
 
       for {
         _        <- app(Request(method = Method.GET, url = URL(!! / "ok")))
@@ -69,7 +68,7 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
       for {
         promise <- Promise.make[Nothing, Unit]
         app = Http
-          .collect[Request] { case Method.GET -> !! / "slow" =>
+          .collect[Request] { case _ =>
             Http.fromZIO(promise.succeed(())) *> Http.ok.delay(10.seconds)
           }
           .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_concurrent_requests_total")))

--- a/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
@@ -1,0 +1,83 @@
+package zhttp.http.middleware
+
+import zhttp.http.Middleware.metrics
+import zhttp.http._
+import zhttp.internal.HttpAppTestExtensions
+import zio._
+import zio.metrics.{Metric, MetricState}
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.test._
+
+object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+  override def spec = suite("MetricsSpec")(
+    test("http_requests_total & http_errors_total") {
+      val app = Http
+        .collect[Request] {
+          case Method.GET -> !! / "ok"     => Http.ok
+          case Method.GET -> !! / "error"  => Http.error(HttpError.InternalServerError())
+          case Method.GET -> !! / "defect" => Http.die(new Throwable("boom"))
+        }
+        .flatten @@ metrics()
+
+      val total        = Metric.counterInt("http_requests_total")
+      val totalOk      = total.tagged("path", "/ok").tagged("method", "GET")
+      val totalErrors  = total.tagged("path", "/error").tagged("method", "GET")
+      val totalDefects = total.tagged("path", "/defect").tagged("method", "GET")
+
+      val errors         = Metric.counterInt("http_errors_total")
+      val errorsErrors   = errors.tagged("path", "/error").tagged("method", "GET").tagged("status_code", "500")
+      val errorsDefects  = errors.tagged("path", "/defect").tagged("method", "GET").tagged("status_code", "500")
+      val errorsNotFound = errors.tagged("path", "/not-found").tagged("method", "GET").tagged("status_code", "404")
+
+      for {
+        _ <- app(Request(method = Method.GET, url = URL(!! / "ok")))
+        _ <- app(Request(method = Method.GET, url = URL(!! / "error")))
+        _ <- app(Request(method = Method.GET, url = URL(!! / "defect"))).catchAllDefect(_ => ZIO.unit)
+        _ <- app(Request(method = Method.GET, url = URL(!! / "not-found"))).ignore.catchAllDefect(_ => ZIO.unit)
+        totalOkCount        <- totalOk.value
+        totalErrorsCount    <- totalErrors.value
+        totalDefectsCount   <- totalDefects.value
+        errorsErrorsCount   <- errorsErrors.value
+        errorsDefectsCount  <- errorsDefects.value
+        errorsNotFoundCount <- errorsNotFound.value
+      } yield assertTrue(totalOkCount == MetricState.Counter(1)) &&
+        assertTrue(totalErrorsCount == MetricState.Counter(1)) &&
+        assertTrue(totalDefectsCount == MetricState.Counter(1)) &&
+        assertTrue(errorsErrorsCount == MetricState.Counter(1)) &&
+        assertTrue(errorsDefectsCount == MetricState.Counter(1)) &&
+        assertTrue(errorsNotFoundCount == MetricState.Counter(1))
+    },
+    test("http_request_duration_seconds") {
+      val histogram = Metric
+        .histogram(
+          "http_request_duration_seconds",
+          Metrics.defaultBoundaries,
+        )
+        .tagged("path", "/ok")
+        .tagged("method", "GET")
+
+      for {
+        observed <- histogram.value.map(_.buckets.exists { case (_, count) => count > 0 })
+      } yield assertTrue(observed)
+    },
+    test("http_inflight_requests_total") {
+      val gauge = Metric.gauge("http_inflight_requests_total").tagged("path", "/slow").tagged("method", "GET")
+
+      for {
+        promise <- Promise.make[Nothing, Unit]
+        app = Http
+          .collect[Request] { case Method.GET -> !! / "slow" =>
+            Http.fromZIO(promise.succeed(())) *> Http.ok.delay(10.seconds)
+          }
+          .flatten @@ metrics()
+        before <- gauge.value
+        fiber  <- app(Request(method = Method.GET, url = URL(!! / "slow"))).fork
+        _      <- promise.await
+        during <- gauge.value
+        _      <- fiber.interrupt
+        after  <- gauge.value
+      } yield assertTrue(before == MetricState.Gauge(0)) &&
+        assertTrue(before == after) && assertTrue(during == MetricState.Gauge(1))
+    } @@ withLiveClock,
+  ).provideSomeLayerShared[TestEnvironment](Metrics.live) @@ sequential
+}

--- a/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
@@ -1,11 +1,11 @@
-package zhttp.http.middleware
+package zio.http.middleware
 
-import zhttp.http.Middleware.metrics
-import zhttp.http._
-import zhttp.internal.HttpAppTestExtensions
+import zio.http.Middleware.metrics
+import zio.http._
+import zio.http.internal.HttpAppTestExtensions
 import zio._
 import zio.metrics.{Metric, MetricState}
-import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.test.TestAspect.{sequential}
 import zio.test._
 
 object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
@@ -19,33 +19,25 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         }
         .flatten @@ metrics()
 
-      val total        = Metric.counterInt("http_requests_total")
-      val totalOk      = total.tagged("path", "/ok").tagged("method", "GET")
-      val totalErrors  = total.tagged("path", "/error").tagged("method", "GET")
-      val totalDefects = total.tagged("path", "/defect").tagged("method", "GET")
-
-      val errors         = Metric.counterInt("http_errors_total")
-      val errorsErrors   = errors.tagged("path", "/error").tagged("method", "GET").tagged("status_code", "500")
-      val errorsDefects  = errors.tagged("path", "/defect").tagged("method", "GET").tagged("status_code", "500")
-      val errorsNotFound = errors.tagged("path", "/not-found").tagged("method", "GET").tagged("status_code", "404")
+      val total         = Metric.counterInt("http_requests_total")
+      val totalOk       = total.tagged("path", "/ok").tagged("method", "GET").tagged("status", "200")
+      val totalErrors   = total.tagged("path", "/error").tagged("method", "GET").tagged("status", "500")
+      val totalDefects  = total.tagged("path", "/defect").tagged("method", "GET").tagged("status", "500")
+      val totalNotFound = total.tagged("path", "/not-found").tagged("method", "GET").tagged("status", "404")
 
       for {
         _ <- app(Request(method = Method.GET, url = URL(!! / "ok")))
         _ <- app(Request(method = Method.GET, url = URL(!! / "error")))
         _ <- app(Request(method = Method.GET, url = URL(!! / "defect"))).catchAllDefect(_ => ZIO.unit)
         _ <- app(Request(method = Method.GET, url = URL(!! / "not-found"))).ignore.catchAllDefect(_ => ZIO.unit)
-        totalOkCount        <- totalOk.value
-        totalErrorsCount    <- totalErrors.value
-        totalDefectsCount   <- totalDefects.value
-        errorsErrorsCount   <- errorsErrors.value
-        errorsDefectsCount  <- errorsDefects.value
-        errorsNotFoundCount <- errorsNotFound.value
+        totalOkCount       <- totalOk.value
+        totalErrorsCount   <- totalErrors.value
+        totalDefectsCount  <- totalDefects.value
+        totalNotFoundCount <- totalNotFound.value
       } yield assertTrue(totalOkCount == MetricState.Counter(1)) &&
         assertTrue(totalErrorsCount == MetricState.Counter(1)) &&
         assertTrue(totalDefectsCount == MetricState.Counter(1)) &&
-        assertTrue(errorsErrorsCount == MetricState.Counter(1)) &&
-        assertTrue(errorsDefectsCount == MetricState.Counter(1)) &&
-        assertTrue(errorsNotFoundCount == MetricState.Counter(1))
+        assertTrue(totalNotFoundCount == MetricState.Counter(1))
     },
     test("http_request_duration_seconds") {
       val histogram = Metric
@@ -55,13 +47,14 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         )
         .tagged("path", "/ok")
         .tagged("method", "GET")
+        .tagged("status", "200")
 
       for {
         observed <- histogram.value.map(_.buckets.exists { case (_, count) => count > 0 })
       } yield assertTrue(observed)
     },
-    test("http_inflight_requests_total") {
-      val gauge = Metric.gauge("http_inflight_requests_total").tagged("path", "/slow").tagged("method", "GET")
+    test("http_concurrent_requests_total") {
+      val gauge = Metric.gauge("http_concurrent_requests_total").tagged("path", "/slow").tagged("method", "GET")
 
       for {
         promise <- Promise.make[Nothing, Unit]
@@ -74,10 +67,10 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         fiber  <- app(Request(method = Method.GET, url = URL(!! / "slow"))).fork
         _      <- promise.await
         during <- gauge.value
-        _      <- fiber.interrupt
+        _      <- TestClock.adjust(11.seconds)
         after  <- gauge.value
       } yield assertTrue(before == MetricState.Gauge(0)) &&
         assertTrue(before == after) && assertTrue(during == MetricState.Gauge(1))
-    } @@ withLiveClock,
-  ).provideSomeLayerShared[TestEnvironment](Metrics.live) @@ sequential
+    },
+  ) @@ sequential
 }

--- a/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
@@ -26,10 +26,10 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
       val totalNotFound = total.tagged("path", "/not-found").tagged("method", "GET").tagged("status", "404")
 
       for {
-        _ <- app(Request(method = Method.GET, url = URL(!! / "ok")))
-        _ <- app(Request(method = Method.GET, url = URL(!! / "error")))
-        _ <- app(Request(method = Method.GET, url = URL(!! / "defect"))).catchAllDefect(_ => ZIO.unit)
-        _ <- app(Request(method = Method.GET, url = URL(!! / "not-found"))).ignore.catchAllDefect(_ => ZIO.unit)
+        _                  <- app(Request.get(url = URL(!! / "ok")))
+        _                  <- app(Request.get(url = URL(!! / "error")))
+        _                  <- app(Request.get(url = URL(!! / "defect"))).catchAllDefect(_ => ZIO.unit)
+        _                  <- app(Request.get(url = URL(!! / "not-found"))).ignore.catchAllDefect(_ => ZIO.unit)
         totalOkCount       <- totalOk.value
         totalErrorsCount   <- totalErrors.value
         totalDefectsCount  <- totalDefects.value
@@ -51,8 +51,8 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
       val totalOk = total.tagged("path", "/user/:id").tagged("method", "GET").tagged("status", "200")
 
       for {
-        _            <- app(Request(method = Method.GET, url = URL(!! / "user" / "1")))
-        _            <- app(Request(method = Method.GET, url = URL(!! / "user" / "2")))
+        _            <- app(Request.get(url = URL(!! / "user" / "1")))
+        _            <- app(Request.get(url = URL(!! / "user" / "2")))
         totalOkCount <- totalOk.value
       } yield assertTrue(totalOkCount == MetricState.Counter(2))
     },
@@ -71,7 +71,7 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
         Http.ok @@ metrics(extraLabels = Set(MetricLabel("test", "http_request_duration_seconds")))
 
       for {
-        _        <- app(Request(method = Method.GET, url = URL(!! / "ok")))
+        _        <- app(Request.get(url = URL(!! / "ok")))
         observed <- histogram.value.map(_.buckets.exists { case (_, count) => count > 0 })
       } yield assertTrue(observed)
     },
@@ -90,7 +90,7 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
           }
           .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_concurrent_requests_total")))
         before <- gauge.value
-        fiber  <- app(Request(method = Method.GET, url = URL(!! / "slow"))).fork
+        fiber  <- app(Request.get(url = URL(!! / "slow"))).fork
         _      <- promise.await
         during <- gauge.value
         _      <- TestClock.adjust(11.seconds)

--- a/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/MetricsSpec.scala
@@ -5,8 +5,8 @@ import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 import zio._
 import zio.metrics.{Metric, MetricState}
-import zio.test.TestAspect.{sequential}
 import zio.test._
+import zio.metrics.MetricLabel
 
 object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
   override def spec = suite("MetricsSpec")(
@@ -17,10 +17,10 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
           case Method.GET -> !! / "error"  => Http.error(HttpError.InternalServerError())
           case Method.GET -> !! / "defect" => Http.die(new Throwable("boom"))
         }
-        .flatten @@ metrics()
+        .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_requests_total & http_errors_total")))
 
-      val total         = Metric.counterInt("http_requests_total")
-      val totalOk       = total.tagged("path", "/ok").tagged("method", "GET").tagged("status", "200")
+      val total   = Metric.counterInt("http_requests_total").tagged("test", "http_requests_total & http_errors_total")
+      val totalOk = total.tagged("path", "/ok").tagged("method", "GET").tagged("status", "200")
       val totalErrors   = total.tagged("path", "/error").tagged("method", "GET").tagged("status", "500")
       val totalDefects  = total.tagged("path", "/defect").tagged("method", "GET").tagged("status", "500")
       val totalNotFound = total.tagged("path", "/not-found").tagged("method", "GET").tagged("status", "404")
@@ -45,16 +45,26 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
           "http_request_duration_seconds",
           Metrics.defaultBoundaries,
         )
+        .tagged("test", "http_request_duration_seconds")
         .tagged("path", "/ok")
         .tagged("method", "GET")
         .tagged("status", "200")
 
+      val app = Http
+        .collect[Request] { case Method.GET -> !! / "ok" => Http.ok }
+        .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_request_duration_seconds")))
+
       for {
+        _        <- app(Request(method = Method.GET, url = URL(!! / "ok")))
         observed <- histogram.value.map(_.buckets.exists { case (_, count) => count > 0 })
       } yield assertTrue(observed)
     },
     test("http_concurrent_requests_total") {
-      val gauge = Metric.gauge("http_concurrent_requests_total").tagged("path", "/slow").tagged("method", "GET")
+      val gauge = Metric
+        .gauge("http_concurrent_requests_total")
+        .tagged("test", "http_concurrent_requests_total")
+        .tagged("path", "/slow")
+        .tagged("method", "GET")
 
       for {
         promise <- Promise.make[Nothing, Unit]
@@ -62,7 +72,7 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
           .collect[Request] { case Method.GET -> !! / "slow" =>
             Http.fromZIO(promise.succeed(())) *> Http.ok.delay(10.seconds)
           }
-          .flatten @@ metrics()
+          .flatten @@ metrics(extraLabels = Set(MetricLabel("test", "http_concurrent_requests_total")))
         before <- gauge.value
         fiber  <- app(Request(method = Method.GET, url = URL(!! / "slow"))).fork
         _      <- promise.await
@@ -72,5 +82,5 @@ object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
       } yield assertTrue(before == MetricState.Gauge(0)) &&
         assertTrue(before == after) && assertTrue(during == MetricState.Gauge(1))
     },
-  ) @@ sequential
+  )
 }


### PR DESCRIPTION
Since ZIO 2.0 ships with integrated metrics support, I think it makes sense to include middleware for some standard metrics into zio-http.