### PR TITLE
Feat: add support for server response compression

### DIFF
--- a/zio-http/src/main/scala/zhttp/service/Server.scala
+++ b/zio-http/src/main/scala/zhttp/service/Server.scala
@@ -5,7 +5,7 @@ import io.netty.channel.ChannelPipeline
 import io.netty.util.ResourceLeakDetector
 import zhttp.http.{Http, HttpApp}
 import zhttp.service.server.ServerSSLHandler._
-import zhttp.service.server.{CompressionOptions, _}
+import zhttp.service.server._
 import zio._
 
 import java.net.{InetAddress, InetSocketAddress}

--- a/zio-http/src/main/scala/zhttp/service/package.scala
+++ b/zio-http/src/main/scala/zhttp/service/package.scala
@@ -34,5 +34,6 @@ package object service extends Logging {
   private[service] val LOW_LEVEL_LOGGING                  = "LOW_LEVEL_LOGGING"
   private[service] val PROXY_HANDLER                      = "PROXY_HANDLER"
   private[service] val HTTP_CONTENT_HANDLER               = "HTTP_CONTENT_HANDLER"
+  private[service] val HTTP_RESPONSE_COMPRESSION          = "HTTP_RESPONSE_COMPRESSION"
 
 }

--- a/zio-http/src/main/scala/zhttp/service/server/CompressionOptions.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/CompressionOptions.scala
@@ -1,0 +1,34 @@
+package zhttp.service.server
+
+import io.netty.handler.codec.compression.{CompressionOptions => JCompressionOptions, StandardCompressionOptions}
+
+final case class CompressionOptions(level: Int, bits: Int, mem: Int, kind: CompressionOptions.CompressionType) { self =>
+  def toJava: JCompressionOptions = self.kind match {
+    case CompressionOptions.GZip    => StandardCompressionOptions.gzip(self.level, self.bits, self.mem)
+    case CompressionOptions.Deflate => StandardCompressionOptions.deflate(self.level, self.bits, self.mem)
+  }
+}
+
+object CompressionOptions {
+  val Level = 6
+  val Bits  = 15
+  val Mem   = 8
+
+  /**
+   * Creates GZip CompressionOptions. Defines defaults as per
+   * io.netty.handler.codec.compression.GzipOptions#DEFAULT
+   */
+  def gzip(level: Int = Level, bits: Int = Bits, mem: Int = Mem): CompressionOptions =
+    CompressionOptions(level, bits, mem, GZip)
+
+  /**
+   * Creates Deflate CompressionOptions. Defines defaults as per
+   * io.netty.handler.codec.compression.DeflateOptions#DEFAULT
+   */
+  def deflate(level: Int = Level, bits: Int = Bits, mem: Int = Mem): CompressionOptions =
+    CompressionOptions(level, bits, mem, Deflate)
+
+  sealed trait CompressionType
+  private case object GZip    extends CompressionType
+  private case object Deflate extends CompressionType
+}

--- a/zio-http/src/main/scala/zhttp/service/server/ServerChannelInitializer.scala
+++ b/zio-http/src/main/scala/zhttp/service/server/ServerChannelInitializer.scala
@@ -50,6 +50,15 @@ final case class ServerChannelInitializer[R](
     if (cfg.requestDecompression._1)
       pipeline.addLast(HTTP_REQUEST_DECOMPRESSION, new HttpContentDecompressor(cfg.requestDecompression._2))
 
+    if (cfg.responseCompression._2.nonEmpty)
+      pipeline.addLast(
+        HTTP_RESPONSE_COMPRESSION,
+        new HttpContentCompressor(
+          cfg.responseCompression._1,
+          cfg.responseCompression._2.map(_.toJava): _*,
+        ),
+      )
+
     // TODO: See if server codec is really required
 
     // ObjectAggregator

--- a/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zhttp/service/ServerSpec.scala
@@ -150,7 +150,7 @@ object ServerSpec extends HttpRunnableSpec {
           Http.collectZIO[Request] { case req => req.body.asString.map(body => Response.text(body)) }.deploy
 
         def roundTrip[R, E <: Throwable](
-          app: Http[R, Throwable, Request, Response],
+          app: HttpApp[R, Throwable],
           headers: Headers,
           contentStream: ZStream[R, E, Byte],
           compressor: ZPipeline[R, E, Byte, Byte],


### PR DESCRIPTION
# Description
This PR adds in support for Http Response Compression as a Server config. The server needs to be built with the appropriate config `Server.responseCompression` by setting `contentSizeThreshold` and an `IndexedSeq` of `CompressionOptions`, based on this config, the internal netty handler will be added to the pipeline with the set `CompressionOptions`.

## Changelog
* Server Config for HttpResponseCompression
* Add HttpContentCompressor in ServerChannelInitializer
* New Type for CompressionOptions
* Test Cases