### PR TITLE
Remove space after Expires in cookie

### DIFF
--- a/zio-http/src/main/scala/zhttp/http/Cookie.scala
+++ b/zio-http/src/main/scala/zhttp/http/Cookie.scala
@@ -179,7 +179,7 @@ object Cookie {
   private val sameSiteNone   = "none"
 
   val dateTimeFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss O ", Locale.ENGLISH).withZone(ZoneOffset.UTC)
+    DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss O", Locale.ENGLISH).withZone(ZoneOffset.UTC)
 
   sealed trait SameSite {
     def asString: String


### PR DESCRIPTION
Parsing cookies with and expires fails because the parser expects a space at the end. Also encoding cookie will have an extra space after the expires date.
Expected:
```Expires=Tue, 23 Aug 2022 21:07:21 GMT;```
actual:
```Expires=Tue, 23 Aug 2022 21:07:21 GMT ;```