### PR TITLE
Fix resource leak in `Http.fromResource`

### DIFF
--- a/zio-http/src/main/scala/zio/http/Http.scala
+++ b/zio-http/src/main/scala/zio/http/Http.scala
@@ -9,11 +9,12 @@ import zio.http.html._
 import zio.http.socket.{SocketApp, WebSocketChannelEvent}
 import zio.stream.ZStream
 
-import java.io.{File, IOException}
+import java.io.{File, FileNotFoundException, IOException}
 import java.net
 import java.net.{InetAddress, InetSocketAddress}
 import java.nio.charset.Charset
 import java.nio.file.Paths
+import java.util.zip.ZipFile
 import scala.annotation.unused
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
@@ -874,33 +875,31 @@ object Http {
         val bangIndex    = path.indexOf('!')
         val filePath     = path.substring(0, bangIndex)
         val resourcePath = path.substring(bangIndex + 2)
-        val appZIO       =
-          ZIO
-            .attemptBlockingIO(new java.util.zip.ZipFile(filePath))
-            .asSomeError
-            .flatMap { jar =>
-              val closeJar = ZIO.attemptBlocking(jar.close()).ignoreLogged
-              (for {
-                entry <- ZIO.attemptBlocking(Option(jar.getEntry(resourcePath))).some
-                _     <- ZIO.when(entry.isDirectory)(ZIO.fail(None))
-                contentLength = entry.getSize
-                inStream <- ZIO.attemptBlockingIO(jar.getInputStream(entry)).asSomeError
-                mediaType = determineMediaType(resourcePath)
-                app       =
-                  Http
-                    .fromStream(
-                      ZStream
-                        .fromInputStream(inStream)
-                        .ensuring(closeJar),
-                    )
-                    .withContentLength(contentLength)
-              } yield mediaType.fold(app)(t => app.withMediaType(t))).onError(_ => closeJar)
-            }
+        val mediaType    = determineMediaType(resourcePath)
+        val openZip      = ZIO.attemptBlockingIO(new ZipFile(filePath))
+        val closeZip     = (jar: ZipFile) => ZIO.attemptBlocking(jar.close()).ignoreLogged
+        def fileNotFound = new FileNotFoundException(s"Resource $resourcePath not found")
+        def isDirectory  = new IllegalArgumentException(s"Resource $resourcePath is a directory")
 
-        Http.fromZIO(appZIO).flatten.catchAll {
-          case Some(e) => Http.fail(e)
-          case None    => Http.empty
-        }
+        val appZIO =
+          ZIO.acquireReleaseWith(openZip)(closeZip) { jar =>
+            for {
+              entry <- ZIO
+                .attemptBlocking(Option(jar.getEntry(resourcePath)))
+                .collect(fileNotFound) { case Some(e) => e }
+              _     <- ZIO.when(entry.isDirectory)(ZIO.fail(isDirectory))
+              contentLength = entry.getSize
+              inZStream     = ZStream
+                .acquireReleaseWith(openZip)(closeZip)
+                .mapZIO(jar => ZIO.attemptBlocking(jar.getEntry(resourcePath) -> jar))
+                .flatMap { case (entry, jar) => ZStream.fromInputStream(jar.getInputStream(entry)) }
+              response      = Response(body = Body.fromStream(inZStream))
+            } yield mediaType.fold(response) { t =>
+              response.withMediaType(t).withContentLength(contentLength)
+            }
+          }
+
+        Http.fromZIO(appZIO).catchSome { case _: FileNotFoundException => Http.empty }
       case proto  =>
         Http.fail(new IllegalArgumentException(s"Unsupported protocol: $proto"))
     }


### PR DESCRIPTION
Hey, I am pretty sure, the current impl. is leaking resources.
`attemptBlockingIO(new java.util.zip.ZipFile(filePath))` is open the resource, but it is only **ensured** that is is closed once the stream is created. Wich for example does not happen, if the requested path leads to a directory `ZIO.when(entry.isDirectory)(ZIO.fail(None))`. There is this `onError(_ => closeJar)`, but this will not ensure that the resource is closed in case of an defect/interrupt.

I ended up with opening the resource twice. I tried it first with an `aquireReleaseWith` and creating the stream inside based on the jar, but this closes the resource before the stream finishes.

@adamgfraser am I right that this is leaking? Maybe you have an idea how to open it only once?