### PR TITLE
Refactor: Rename `Server.error` to `Server.onError`

### DIFF
--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -50,7 +50,7 @@ object Main extends ZIOAppDefault {
     Server
       .app(app)
       .withPort(8080)
-      .withError(_ => ZIO.unit)
+      .onError(_ => ZIO.unit)
       .withLeakDetection(LeakDetectionLevel.DISABLED)
       .withConsolidateFlush(true)
       .withFlowControl(false)

--- a/zio-http/src/main/scala/zio/http/Server.scala
+++ b/zio-http/src/main/scala/zio/http/Server.scala
@@ -81,7 +81,7 @@ sealed trait Server[-R, +E] { self =>
   /**
    * Creates a new server with the errorHandler provided.
    */
-  def withError[R1](errorHandler: Throwable => ZIO[R1, Nothing, Unit]): Server[R with R1, E] =
+  def onError[R1](errorHandler: Throwable => ZIO[R1, Nothing, Unit]): Server[R with R1, E] =
     Concat(self, Server.OnError(errorHandler))
 
   /**

--- a/zio-http/src/main/scala/zio/http/Server.scala
+++ b/zio-http/src/main/scala/zio/http/Server.scala
@@ -175,7 +175,7 @@ object Server {
 
   def enableObjectAggregator(maxRequestSize: Int = Int.MaxValue): UServer = ObjectAggregator(maxRequestSize)
 
-  def error[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]): Server[R, Nothing] = Server.Error(errorHandler)
+  def onError[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]): Server[R, Nothing] = Server.Error(errorHandler)
 
   def make[R](
     server: Server[R, Throwable],

--- a/zio-http/src/main/scala/zio/http/Server.scala
+++ b/zio-http/src/main/scala/zio/http/Server.scala
@@ -16,7 +16,7 @@ sealed trait Server[-R, +E] { self =>
   private def settings[R1 <: R, E1 >: E](s: Config[R1, E1] = Config()): Config[R1, E1] = self match {
     case Concat(self, other)                   => other.settings(self.settings(s))
     case LeakDetection(level)                  => s.copy(leakDetectionLevel = level)
-    case Error(errorHandler)                   => s.copy(error = Some(errorHandler))
+    case OnError(errorHandler)                 => s.copy(error = Some(errorHandler))
     case Ssl(sslOption)                        => s.copy(sslOption = sslOption)
     case App(app)                              => s.copy(app = app)
     case Address(address)                      => s.copy(address = address)
@@ -82,7 +82,7 @@ sealed trait Server[-R, +E] { self =>
    * Creates a new server with the errorHandler provided.
    */
   def withError[R1](errorHandler: Throwable => ZIO[R1, Nothing, Unit]): Server[R with R1, E] =
-    Concat(self, Server.Error(errorHandler))
+    Concat(self, Server.OnError(errorHandler))
 
   /**
    * Creates a new server using netty FlowControlHandler if enable (@see <a
@@ -175,7 +175,7 @@ object Server {
 
   def enableObjectAggregator(maxRequestSize: Int = Int.MaxValue): UServer = ObjectAggregator(maxRequestSize)
 
-  def onError[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]): Server[R, Nothing] = Server.Error(errorHandler)
+  def onError[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]): Server[R, Nothing] = Server.OnError(errorHandler)
 
   def make[R](
     server: Server[R, Throwable],
@@ -274,7 +274,7 @@ object Server {
 
   private final case class LeakDetection(level: LeakDetectionLevel) extends UServer
 
-  private final case class Error[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]) extends Server[R, Nothing]
+  private final case class OnError[R](errorHandler: Throwable => ZIO[R, Nothing, Unit]) extends Server[R, Nothing]
 
   private final case class Ssl(sslOptions: ServerSSLOptions) extends UServer
 


### PR DESCRIPTION
fixes #1032 