### PR TITLE
Create default Response logging middleware

### DIFF
--- a/zio-http/src/main/scala/zio/http/middleware/Web.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Web.scala
@@ -37,17 +37,13 @@ private[zio] trait Web extends Cors with Csrf with Auth with HeaderModifier[Http
         } yield Patch.empty
     }
 
-  /*
-   * Questions:
-   *   What log level? Info?
-   */
-  final def logDefault: HttpMiddleware[Any, Nothing] = // TODO Confirm Nothing error.
+  final def logResponseDefault: HttpMiddleware[Any, Nothing] =
     interceptZIOPatch(req => Clock.nanoTime.map(start => (req.method, req.url, start))) {
       case (response, (method, url, start)) =>
         for {
           end <- Clock.nanoTime
           duration = (end - start) / 1000000
-          _   <- ZIO.log(s"${response.status.asJava.code()} ${method} ${url.encode} ${duration}ms")
+          _ <- ZIO.log(s"${response.status.asJava.code()} ${method} ${url.encode} ${duration}ms")
         } yield Patch.empty
     }
 
@@ -101,8 +97,6 @@ private[zio] trait Web extends Cors with Csrf with Auth with HeaderModifier[Http
    */
   final def interceptZIOPatch[R, E, S](req: Request => ZIO[R, Option[E], S]): PartialInterceptZIOPatch[R, E, S] =
     PartialInterceptZIOPatch(req)
-
-  // TODO Use above for request logging
 
   /**
    * Creates a middleware that produces a Patch for the Response

--- a/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
@@ -47,6 +47,22 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
         assertZIO(program)(equalTo(Vector("404 GET /health 0ms\n")))
       },
     ),
+    suite("logging")(
+      test("ZIO.log status method url and time") {
+        val program = runApp(app @@ log) *> TestConsole.output
+        for {
+          res <- program
+          fullLogs <- ZTestLogger.logOutput
+          logMessages = fullLogs.map(_.message())
+          _ <- ZIO.debug(logMessages)
+        } yield assert(res)(equalTo(Vector("200 GET /health 1000ms\n")))
+
+      },
+      test("ZIO.log 404 status method url and time") {
+        val program = runApp(Http.empty ++ Http.notFound @@ log) *> TestConsole.output
+        assertZIO(program)(equalTo(Vector("404 GET /health 0ms\n")))
+      },
+    ),
     suite("when")(
       test("condition is true") {
         val program = runApp(self.app @@ debug.when(_ => true)) *> TestConsole.output

--- a/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
@@ -49,18 +49,23 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
     ),
     suite("logging")(
       test("ZIO.log status method url and time") {
-        val program = runApp(app @@ log) *> TestConsole.output
+        val program = runApp(app @@ logDefault) *> ZTestLogger.logOutput
         for {
           res <- program
-          fullLogs <- ZTestLogger.logOutput
-          logMessages = fullLogs.map(_.message())
+          logMessages = res.map(_.message())
           _ <- ZIO.debug(logMessages)
-        } yield assert(res)(equalTo(Vector("200 GET /health 1000ms\n")))
-
+        } yield assert(logMessages.toVector)(equalTo(Vector("200 GET /health 1000ms")))
       },
       test("ZIO.log 404 status method url and time") {
-        val program = runApp(Http.empty ++ Http.notFound @@ log) *> TestConsole.output
-        assertZIO(program)(equalTo(Vector("404 GET /health 0ms\n")))
+//        val program = runApp(Http.empty ++ Http.notFound @@ logDefault) *> TestConsole.output
+
+
+        val program = runApp(Http.empty ++ Http.notFound @@ logDefault) *> ZTestLogger.logOutput
+        for {
+          res <- program
+          logMessages = res.map(_.message())
+          _ <- ZIO.debug(logMessages)
+        } yield assert(logMessages.toVector)(equalTo(Vector("404 GET /health 0ms")))
       },
     ),
     suite("when")(

--- a/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
@@ -48,24 +48,19 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
       },
     ),
     suite("logging")(
-      test("ZIO.log status method url and time") {
-        val program = runApp(app @@ logDefault) *> ZTestLogger.logOutput
+      test("log status method url and time") {
+        val program = runApp(app @@ logResponseDefault) *> ZTestLogger.logOutput
         for {
           res <- program
           logMessages = res.map(_.message())
-          _ <- ZIO.debug(logMessages)
-        } yield assert(logMessages.toVector)(equalTo(Vector("200 GET /health 1000ms")))
+        } yield assertTrue(logMessages == Chunk("200 GET /health 1000ms"))
       },
-      test("ZIO.log 404 status method url and time") {
-//        val program = runApp(Http.empty ++ Http.notFound @@ logDefault) *> TestConsole.output
-
-
-        val program = runApp(Http.empty ++ Http.notFound @@ logDefault) *> ZTestLogger.logOutput
+      test("log 404 status method url and time") {
+        val program = runApp(Http.empty ++ Http.notFound @@ logResponseDefault) *> ZTestLogger.logOutput
         for {
           res <- program
           logMessages = res.map(_.message())
-          _ <- ZIO.debug(logMessages)
-        } yield assert(logMessages.toVector)(equalTo(Vector("404 GET /health 0ms")))
+        } yield assertTrue(logMessages == Chunk("404 GET /health 0ms"))
       },
     ),
     suite("when")(


### PR DESCRIPTION
I'm sure we'll want to modify this, but it's just a starting point for discussion around #1451

Sample logs:
```
timestamp=2022-09-12T20:28:38.340849Z level=INFO thread=#zio-fiber-102 message="404 GET /health 0ms" location=zio.http.middleware.Web.logResponseDefault file=Web.scala line=46
timestamp=2022-09-12T20:28:38.340685Z level=INFO thread=#zio-fiber-103 message="200 GET /health 1000ms" location=zio.http.middleware.Web.logResponseDefault file=Web.scala line=46
```