### PR TITLE
 ZIO logger based logger transport and request logging middleware 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val zioHttpLogging = (project in file("zio-http-logging"))
   )
   .settings(
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    libraryDependencies ++= Seq(`zio-test`, `zio-test-sbt`),
+    libraryDependencies ++= Seq(`zio`, `zio-test`, `zio-test-sbt`),
   )
 
 lazy val zioHttpExample = (project in file("zio-http-example"))

--- a/zio-http-logging/src/main/scala/zio/logging/Logger.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/Logger.scala
@@ -9,7 +9,7 @@ import java.nio.file.Path
  * This is the base class for all logging operations. Logger is a collection of
  * LoggerTransports. Internally whenever a message needs to be logged, it is
  * broadcasted to all the available transports. The transports can internally
- * decide what to do with the mssage and discard it if the message or the level
+ * decide what to do with the message and discard it if the message or the level
  * is not relevant to the transport.
  */
 final case class Logger(transports: List[LoggerTransport]) extends LoggerMacroExtensions { self =>

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,6 +1,7 @@
 package zio.logging
 
 import zio._
+import zio.logging.LogLevel
 import zio.logging.Logger.SourcePos
 
 import java.io.{PrintWriter, StringWriter}

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,8 +1,7 @@
 package zio.logging
 
-import zio._
-import zio.logging.LogLevel
 import zio.logging.Logger.SourcePos
+import zio.{LogLevel => _, _}
 
 import java.io.{PrintWriter, StringWriter}
 import java.nio.file.{Files, Path, StandardOpenOption}

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,7 +1,6 @@
 package zio.logging
 
 import zio._
-import zio.logging.LogLevel
 import zio.logging.Logger.SourcePos
 
 import java.io.{PrintWriter, StringWriter}

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,6 +1,7 @@
 package zio.logging
 
-import zio.{Cause, FiberId, FiberRefs, Trace, ZIO}
+import zio._
+import zio.logging.LogLevel
 import zio.logging.Logger.SourcePos
 
 import java.io.{PrintWriter, StringWriter}
@@ -12,13 +13,32 @@ import java.util
  * Provides a way to build and configure transports for logging. Transports are
  * used to, format and serialize LogLines and them to a backend.
  */
-private[logging] trait LoggerTransport {
+private[logging] trait LoggerTransport { self =>
   def dispatch(
     msg: String,
     cause: Option[Throwable],
     level: LogLevel,
     sourceLocation: Option[SourcePos],
   ): Unit
+
+  /**
+   * Converts the current LoggerTransport to a Logger.
+   */
+  final def toLogger: Logger = Logger(List(self))
+
+  def addTags(tags: Iterable[String]): LoggerTransport
+  def withFilter(filter: String => Boolean): LoggerTransport
+  def withFormat(format: LogFormat): LoggerTransport
+  def withLevel(level: LogLevel): LoggerTransport
+  def withTags(tags: List[String]): LoggerTransport
+
+  val level: LogLevel
+
+  private[zio] val isDebugEnabled: Boolean
+  private[zio] val isErrorEnabled: Boolean
+  private[zio] val isInfoEnabled: Boolean
+  private[zio] val isTraceEnabled: Boolean
+  private[zio] val isWarnEnabled: Boolean
 }
 
 object LoggerTransport {
@@ -97,10 +117,72 @@ object LoggerTransport {
         }
       }
 
-    /**
-     * Converts the current LoggerTransport to a Logger.
-     */
-    final def toLogger: Logger = Logger(List(self))
+    final def withFilter(filter: String => Boolean): LoggerTransport = self.copy(filter = filter)
+
+    final def withFormat(format: LogFormat): LoggerTransport = self.copy(format = format)
+
+    final def withLevel(level: LogLevel): LoggerTransport = self.copy(level = level)
+
+    final def withTags(tags: List[String]): LoggerTransport = self.copy(tags = tags)
+  }
+
+  private[logging] class ZioLoggerTransport(
+    loggers: Set[ZLogger[String, Any]],
+    format: LogFormat = LogFormat.inlineMinimal,
+    val level: LogLevel = LogLevel.Error,
+    filter: String => Boolean = _ => true,
+    tags: List[String] = Nil,
+  ) extends LoggerTransport {
+    self =>
+
+    final private[zio] val isDebugEnabled: Boolean = self.level <= LogLevel.Debug
+    final private[zio] val isErrorEnabled: Boolean = self.level <= LogLevel.Error
+    final private[zio] val isInfoEnabled: Boolean  = self.level <= LogLevel.Info
+    final private[zio] val isTraceEnabled: Boolean = self.level <= LogLevel.Trace
+    final private[zio] val isWarnEnabled: Boolean  = self.level <= LogLevel.Warn
+
+    final def addTags(tags: Iterable[String]): LoggerTransport = self.copy(tags = self.tags ++ tags)
+
+    final def copy(
+      format: LogFormat = self.format,
+      level: LogLevel = self.level,
+      filter: String => Boolean = self.filter,
+      tags: List[String] = self.tags,
+    ): LoggerTransport = {
+      new ZioLoggerTransport(loggers, format, level, filter, tags) {
+        override def dispatch(
+          msg: String,
+          cause: Option[Throwable],
+          level: LogLevel,
+          sourceLocation: Option[SourcePos],
+        ): Unit =
+          self.dispatch(msg, cause, level, sourceLocation)
+      }
+    }
+
+    override def dispatch(
+      msg: String,
+      cause: Option[Throwable],
+      level: LogLevel,
+      sourceLocation: Option[SourcePos],
+    ): Unit = {
+      if (self.level <= level) {
+        if (filter(msg)) {
+          for (logger <- loggers) {
+            logger(
+              sourceLocation.map(pos => Trace.apply("zio-http", pos.file, pos.line)).getOrElse(Trace.empty),
+              FiberId.None,
+              toZioLogLevel(level),
+              () => msg,
+              cause.map(Cause.die(_)).getOrElse(Cause.empty),
+              FiberRefs.empty,
+              List(),
+              self.tags.map(_ -> "").toMap,
+            )
+          }
+        }
+      }
+    }
 
     final def withFilter(filter: String => Boolean): LoggerTransport = self.copy(filter = filter)
 
@@ -110,17 +192,25 @@ object LoggerTransport {
 
     final def withTags(tags: List[String]): LoggerTransport = self.copy(tags = tags)
 
+    private def toZioLogLevel(level: LogLevel): _root_.zio.LogLevel =
+      level match {
+        case LogLevel.Trace => _root_.zio.LogLevel.Trace
+        case LogLevel.Debug => _root_.zio.LogLevel.Debug
+        case LogLevel.Info  => _root_.zio.LogLevel.Info
+        case LogLevel.Warn  => _root_.zio.LogLevel.Warning
+        case LogLevel.Error => _root_.zio.LogLevel.Error
+      }
   }
 
-  def console: LoggerTransport = new DefaultLoggerTransport() {
+  def console: DefaultLoggerTransport = new DefaultLoggerTransport() {
     override def run(charSequence: CharSequence): Unit = println(charSequence)
   }
 
-  def empty: LoggerTransport = new DefaultLoggerTransport() {
+  def empty: DefaultLoggerTransport = new DefaultLoggerTransport() {
     override def run(charSequence: CharSequence): Unit = ()
   }
 
-  def file(path: Path): LoggerTransport = new DefaultLoggerTransport() { self =>
+  def file(path: Path): DefaultLoggerTransport = new DefaultLoggerTransport() { self =>
     override def run(charSequence: CharSequence): Unit = Files.write(
       path,
       util.Arrays.asList(charSequence),
@@ -131,35 +221,6 @@ object LoggerTransport {
 
   def zio: ZIO[Any, Nothing, LoggerTransport] =
     ZIO.loggers.map { loggers =>
-      new LoggerTransport {
-        override def dispatch(
-          msg: String,
-          cause: Option[Throwable],
-          level: LogLevel,
-          sourceLocation: Option[SourcePos],
-        ): Unit = {
-          for (logger <- loggers) {
-            logger(
-              sourceLocation.map(pos => Trace.apply("zio-http", pos.file, pos.line)).getOrElse(Trace.empty),
-              FiberId.None,
-              toZioLogLevel(level),
-              () => msg,
-              cause.map(Cause.die(_)).getOrElse(Cause.empty),
-              FiberRefs.empty,
-              List(),
-              Map.empty,
-            )
-          }
-        }
-
-        private def toZioLogLevel(level: LogLevel): _root_.zio.LogLevel =
-          level match {
-            case LogLevel.Trace => _root_.zio.LogLevel.Trace
-            case LogLevel.Debug => _root_.zio.LogLevel.Debug
-            case LogLevel.Info  => _root_.zio.LogLevel.Info
-            case LogLevel.Warn  => _root_.zio.LogLevel.Warning
-            case LogLevel.Error => _root_.zio.LogLevel.Error
-          }
-      }
+      new ZioLoggerTransport(loggers)
     }
 }

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,5 +1,6 @@
 package zio.logging
 
+import zio.{Cause, FiberId, FiberRefs, Trace, ZIO}
 import zio.logging.Logger.SourcePos
 
 import java.io.{PrintWriter, StringWriter}
@@ -11,105 +12,115 @@ import java.util
  * Provides a way to build and configure transports for logging. Transports are
  * used to, format and serialize LogLines and them to a backend.
  */
-private[logging] abstract class LoggerTransport(
-  format: LogFormat = LogFormat.inlineMinimal,
-  val level: LogLevel = LogLevel.Error,
-  filter: String => Boolean = _ => true,
-  tags: List[String] = Nil,
-) { self =>
-
-  final private[zio] val isDebugEnabled: Boolean = self.level <= LogLevel.Debug
-  final private[zio] val isErrorEnabled: Boolean = self.level <= LogLevel.Error
-  final private[zio] val isInfoEnabled: Boolean  = self.level <= LogLevel.Info
-  final private[zio] val isTraceEnabled: Boolean = self.level <= LogLevel.Trace
-  final private[zio] val isWarnEnabled: Boolean  = self.level <= LogLevel.Warn
-
-  final private def buildLines(
-    msg: String,
-    throwable: Option[Throwable],
-    logLevel: LogLevel,
-    tags: List[String],
-    sourceLocation: Option[SourcePos],
-  ): List[LogLine] = {
-    throwable.fold(
-      List(LogLine(LocalDateTime.now(), thread, logLevel, msg, tags, throwable, sourceLocation)),
-    ) { t =>
-      List(
-        LogLine(LocalDateTime.now(), thread, logLevel, msg, tags, throwable, sourceLocation),
-        LogLine(
-          LocalDateTime.now(),
-          thread,
-          logLevel,
-          stackTraceAsString(t),
-          tags,
-          throwable,
-          sourceLocation,
-        ),
-      )
-    }
-  }
-
-  final private def stackTraceAsString(throwable: Throwable): String = {
-    val sw = new StringWriter
-    throwable.printStackTrace(new PrintWriter(sw))
-    sw.toString
-  }
-
-  final private def thread = Thread.currentThread()
-
-  def run(charSequence: CharSequence): Unit
-
-  final def addTags(tags: Iterable[String]): LoggerTransport = self.copy(tags = self.tags ++ tags)
-
-  final def copy(
-    format: LogFormat = self.format,
-    level: LogLevel = self.level,
-    filter: String => Boolean = self.filter,
-    tags: List[String] = self.tags,
-  ): LoggerTransport = {
-    new LoggerTransport(format, level, filter, tags) {
-      override def run(charSequence: CharSequence): Unit = self.run(charSequence)
-    }
-  }
-
-  final def dispatch(
+private[logging] trait LoggerTransport {
+  def dispatch(
     msg: String,
     cause: Option[Throwable],
     level: LogLevel,
     sourceLocation: Option[SourcePos],
-  ): Unit =
-    if (self.level <= level) {
-      buildLines(msg, cause, level, self.tags, sourceLocation).foreach { line =>
-        val formatted = format(line)
-        if (filter(formatted)) run(formatted)
-      }
-    }
-
-  /**
-   * Converts the current LoggerTransport to a Logger.
-   */
-  final def toLogger: Logger = Logger(List(self))
-
-  final def withFilter(filter: String => Boolean): LoggerTransport = self.copy(filter = filter)
-
-  final def withFormat(format: LogFormat): LoggerTransport = self.copy(format = format)
-
-  final def withLevel(level: LogLevel): LoggerTransport = self.copy(level = level)
-
-  final def withTags(tags: List[String]): LoggerTransport = self.copy(tags = tags)
-
+  ): Unit
 }
 
 object LoggerTransport {
-  def console: LoggerTransport = new LoggerTransport() {
+  private[logging] abstract class DefaultLoggerTransport(
+    format: LogFormat = LogFormat.inlineMinimal,
+    val level: LogLevel = LogLevel.Error,
+    filter: String => Boolean = _ => true,
+    tags: List[String] = Nil,
+  ) extends LoggerTransport {
+    self =>
+
+    final private[zio] val isDebugEnabled: Boolean = self.level <= LogLevel.Debug
+    final private[zio] val isErrorEnabled: Boolean = self.level <= LogLevel.Error
+    final private[zio] val isInfoEnabled: Boolean  = self.level <= LogLevel.Info
+    final private[zio] val isTraceEnabled: Boolean = self.level <= LogLevel.Trace
+    final private[zio] val isWarnEnabled: Boolean  = self.level <= LogLevel.Warn
+
+    final private def buildLines(
+      msg: String,
+      throwable: Option[Throwable],
+      logLevel: LogLevel,
+      tags: List[String],
+      sourceLocation: Option[SourcePos],
+    ): List[LogLine] = {
+      throwable.fold(
+        List(LogLine(LocalDateTime.now(), thread, logLevel, msg, tags, throwable, sourceLocation)),
+      ) { t =>
+        List(
+          LogLine(LocalDateTime.now(), thread, logLevel, msg, tags, throwable, sourceLocation),
+          LogLine(
+            LocalDateTime.now(),
+            thread,
+            logLevel,
+            stackTraceAsString(t),
+            tags,
+            throwable,
+            sourceLocation,
+          ),
+        )
+      }
+    }
+
+    final private def stackTraceAsString(throwable: Throwable): String = {
+      val sw = new StringWriter
+      throwable.printStackTrace(new PrintWriter(sw))
+      sw.toString
+    }
+
+    final private def thread = Thread.currentThread()
+
+    protected def run(charSequence: CharSequence): Unit
+
+    final def addTags(tags: Iterable[String]): LoggerTransport = self.copy(tags = self.tags ++ tags)
+
+    final def copy(
+      format: LogFormat = self.format,
+      level: LogLevel = self.level,
+      filter: String => Boolean = self.filter,
+      tags: List[String] = self.tags,
+    ): LoggerTransport = {
+      new DefaultLoggerTransport(format, level, filter, tags) {
+        override def run(charSequence: CharSequence): Unit = self.run(charSequence)
+      }
+    }
+
+    final def dispatch(
+      msg: String,
+      cause: Option[Throwable],
+      level: LogLevel,
+      sourceLocation: Option[SourcePos],
+    ): Unit =
+      if (self.level <= level) {
+        buildLines(msg, cause, level, self.tags, sourceLocation).foreach { line =>
+          val formatted = format(line)
+          if (filter(formatted)) run(formatted)
+        }
+      }
+
+    /**
+     * Converts the current LoggerTransport to a Logger.
+     */
+    final def toLogger: Logger = Logger(List(self))
+
+    final def withFilter(filter: String => Boolean): LoggerTransport = self.copy(filter = filter)
+
+    final def withFormat(format: LogFormat): LoggerTransport = self.copy(format = format)
+
+    final def withLevel(level: LogLevel): LoggerTransport = self.copy(level = level)
+
+    final def withTags(tags: List[String]): LoggerTransport = self.copy(tags = tags)
+
+  }
+
+  def console: LoggerTransport = new DefaultLoggerTransport() {
     override def run(charSequence: CharSequence): Unit = println(charSequence)
   }
 
-  def empty: LoggerTransport = new LoggerTransport() {
+  def empty: LoggerTransport = new DefaultLoggerTransport() {
     override def run(charSequence: CharSequence): Unit = ()
   }
 
-  def file(path: Path): LoggerTransport = new LoggerTransport() { self =>
+  def file(path: Path): LoggerTransport = new DefaultLoggerTransport() { self =>
     override def run(charSequence: CharSequence): Unit = Files.write(
       path,
       util.Arrays.asList(charSequence),
@@ -117,4 +128,38 @@ object LoggerTransport {
       StandardOpenOption.CREATE,
     ): Unit
   }
+
+  def zio: ZIO[Any, Nothing, LoggerTransport] =
+    ZIO.loggers.map { loggers =>
+      new LoggerTransport {
+        override def dispatch(
+          msg: String,
+          cause: Option[Throwable],
+          level: LogLevel,
+          sourceLocation: Option[SourcePos],
+        ): Unit = {
+          for (logger <- loggers) {
+            logger(
+              sourceLocation.map(pos => Trace.apply("zio-http", pos.file, pos.line)).getOrElse(Trace.empty),
+              FiberId.None,
+              toZioLogLevel(level),
+              () => msg,
+              cause.map(Cause.die(_)).getOrElse(Cause.empty),
+              FiberRefs.empty,
+              List(),
+              Map.empty,
+            )
+          }
+        }
+
+        private def toZioLogLevel(level: LogLevel): _root_.zio.LogLevel =
+          level match {
+            case LogLevel.Trace => _root_.zio.LogLevel.Trace
+            case LogLevel.Debug => _root_.zio.LogLevel.Debug
+            case LogLevel.Info  => _root_.zio.LogLevel.Info
+            case LogLevel.Warn  => _root_.zio.LogLevel.Warning
+            case LogLevel.Error => _root_.zio.LogLevel.Error
+          }
+      }
+    }
 }

--- a/zio-http-logging/src/test/scala/zio/logging/LoggerSpec.scala
+++ b/zio-http-logging/src/test/scala/zio/logging/LoggerSpec.scala
@@ -1,4 +1,5 @@
 package zio.logging
+import zio.logging.LoggerTransport.DefaultLoggerTransport
 import zio.test._
 
 import scala.collection.mutable.ListBuffer
@@ -71,7 +72,7 @@ object LoggerSpec extends ZIOSpecDefault {
     ),
   )
 
-  final class MemoryTransport extends LoggerTransport() {
+  final class MemoryTransport extends DefaultLoggerTransport() {
     val buffer: ListBuffer[String] = ListBuffer.empty[String]
     def reset(): Unit              = buffer.clear()
     def stdout: String             = buffer.mkString("\n")

--- a/zio-http/src/main/scala/zio/http/middleware/RequestLogging.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/RequestLogging.scala
@@ -1,0 +1,20 @@
+package zio.http.middleware
+
+import zio.{Clock, ZIO}
+import zio.http.{Middleware, Patch}
+
+import java.io.IOException
+
+private[zio] trait RequestLogging {
+
+  final def requestLogging: HttpMiddleware[Any, IOException] =
+    Middleware.interceptZIOPatch(req => Clock.nanoTime.map(start => (req.method, req.url, start))) {
+      case (response, (method, url, start)) =>
+        for {
+          end <- Clock.nanoTime
+          _   <- ZIO
+            .logInfo(s"${response.status.asJava.code()} ${method} ${url.encode} ${(end - start) / 1000000}ms") // TODO
+        } yield Patch.empty
+    }
+
+}

--- a/zio-http/src/main/scala/zio/http/middleware/RequestLogging.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/RequestLogging.scala
@@ -1,20 +1,78 @@
 package zio.http.middleware
 
-import zio.{Clock, ZIO}
-import zio.http.{Middleware, Patch}
+import zio.http.{Middleware, Patch, Status}
+import zio.{Clock, LogAnnotation, LogLevel, ZIO}
 
-import java.io.IOException
+import java.nio.charset.{Charset, StandardCharsets}
 
 private[zio] trait RequestLogging {
 
-  final def requestLogging: HttpMiddleware[Any, IOException] =
-    Middleware.interceptZIOPatch(req => Clock.nanoTime.map(start => (req.method, req.url, start))) {
-      case (response, (method, url, start)) =>
-        for {
-          end <- Clock.nanoTime
-          _   <- ZIO
-            .logInfo(s"${response.status.asJava.code()} ${method} ${url.encode} ${(end - start) / 1000000}ms") // TODO
-        } yield Patch.empty
+  final def requestLogging(
+    level: Status => LogLevel = (_: Status) => LogLevel.Info,
+    loggedRequestHeaders: Set[String] = Set.empty,
+    loggedResponseHeader: Set[String] = Set.empty,
+    logRequestBody: Boolean = false,
+    logResponseBody: Boolean = false,
+    requestCharset: Charset = StandardCharsets.UTF_8,
+    responseCharset: Charset = StandardCharsets.UTF_8,
+  ): HttpMiddleware[Any, Throwable] =
+    Middleware.interceptZIOPatch { request =>
+      Clock.nanoTime.map(start => (request, start))
+    } { case (response, (request, start)) =>
+      for {
+        end <- Clock.nanoTime
+        durationMs = (end - start) / 1000000
+        patch <- ZIO
+          .logLevel(level(response.status)) {
+            val requestHeaders  =
+              request.headers.toList.collect {
+                case (name, value) if loggedRequestHeaders.contains(name) => LogAnnotation(name, value)
+              }.toSet
+            val responseHeaders =
+              response.headers.toList.collect {
+                case (name, value) if loggedResponseHeader.contains(name) => LogAnnotation(name, value)
+              }.toSet
+
+            val requestBody  = if (request.body.isComplete) request.body.asChunk.map(Some(_)) else ZIO.none
+            val responseBody = if (response.body.isComplete) response.body.asChunk.map(Some(_)) else ZIO.none
+
+            requestBody.flatMap { requestBodyChunk =>
+              responseBody.flatMap { responseBodyChunk =>
+                val bodyAnnotations = Set(
+                  requestBodyChunk.map(chunk => LogAnnotation("request_size", chunk.size.toString)),
+                  requestBodyChunk.flatMap(chunk =>
+                    if (logRequestBody)
+                      Some(LogAnnotation("request", new String(chunk.toArray, requestCharset)))
+                    else None,
+                  ),
+                  responseBodyChunk.map(chunk => LogAnnotation("response_size", chunk.size.toString)),
+                  responseBodyChunk.flatMap(chunk =>
+                    if (logResponseBody)
+                      Some(LogAnnotation("response", new String(chunk.toArray, responseCharset)))
+                    else None,
+                  ),
+                ).flatten
+
+                ZIO.logAnnotate(
+                  Set(
+                    LogAnnotation("status_code", response.status.asJava.code().toString),
+                    LogAnnotation("method", request.method.toString()),
+                    LogAnnotation("url", request.url.encode),
+                    LogAnnotation("duration_ms", durationMs.toString),
+                  ) union
+                    requestHeaders union
+                    responseHeaders union
+                    bodyAnnotations,
+                ) {
+                  ZIO
+                    .log("Http request served")
+                    .as(Patch.empty)
+                }
+              }
+            }
+          }
+          .mapError(Option(_))
+      } yield patch
     }
 
 }

--- a/zio-http/src/main/scala/zio/http/middleware/Web.scala
+++ b/zio-http/src/main/scala/zio/http/middleware/Web.scala
@@ -11,7 +11,12 @@ import java.io.IOException
 /**
  * Middlewares on an HttpApp
  */
-private[zio] trait Web extends Cors with Csrf with Auth with HeaderModifier[HttpMiddleware[Any, Nothing]] {
+private[zio] trait Web
+    extends Cors
+    with Csrf
+    with Auth
+    with RequestLogging
+    with HeaderModifier[HttpMiddleware[Any, Nothing]] {
   self =>
 
   /**


### PR DESCRIPTION
- Adds a `LoggerTransport` that forwards all zio-http logs to ZIO core loggers
- Defines a `Middleware` that logs request/response details directly to ZIO core, taking advantage of its annotation support.

Notes:
- Instead of directly logging through ZIO core we could extend the zio-http specfific logger interface to support annotations and then go through that
- One thing I wanted to add (and I did with akka-http multiple times in the past) but does not seem to be possible at the moment is to wrap streaming response bodies in a way to measure its completion (when the stream is fully consumed) and optionally capture and log the whole streamed response body (or optionally just its length)

Resolves #1451 and #1450 