### PR TITLE
Improve performance of ZIO HTTP by using ZIO.refailCause in more places

### DIFF
--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -132,7 +132,7 @@ object Body {
               len    <- ZIO.attemptBlocking(fs.read(buffer)).mapError(Some(_))
               bytes  <-
                 if (len > 0) ZIO.succeed(Chunk.fromArray(buffer.slice(0, len)))
-                else ZIO.fail(Option.empty[Throwable])
+                else failNoStacktrace
             } yield bytes
           }
           .ensuring(ZIO.succeed(fs.close()))

--- a/zio-http/src/main/scala/zio/http/HExit.scala
+++ b/zio-http/src/main/scala/zio/http/HExit.scala
@@ -72,7 +72,7 @@ sealed trait HExit[-R, +E, +A] { self =>
     case HExit.Success(a)  => ZIO.succeed(a)
     case HExit.Failure(e)  => ZIO.fail(Option(e))
     case HExit.Die(e)      => ZIO.die(e)
-    case HExit.Empty       => ZIO.fail(None)
+    case HExit.Empty       => failNoStacktrace
     case HExit.Effect(zio) => zio
   }
 }

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -5,7 +5,12 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{FullHttpResponse, HttpResponse}
 import zio.http.headers.HeaderExtension
 import zio.http.html._
-import zio.http.service.{CLIENT_INBOUND_HANDLER, CLIENT_STREAMING_BODY_HANDLER, ChannelFuture, ClientResponseStreamHandler}
+import zio.http.service.{
+  CLIENT_INBOUND_HANDLER,
+  CLIENT_STREAMING_BODY_HANDLER,
+  ChannelFuture,
+  ClientResponseStreamHandler,
+}
 import zio.http.socket.{SocketApp, WebSocketFrame}
 import zio.{Cause, Task, Unsafe, ZIO}
 

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -5,14 +5,9 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{FullHttpResponse, HttpResponse}
 import zio.http.headers.HeaderExtension
 import zio.http.html._
-import zio.http.service.{
-  CLIENT_INBOUND_HANDLER,
-  CLIENT_STREAMING_BODY_HANDLER,
-  ChannelFuture,
-  ClientResponseStreamHandler,
-}
+import zio.http.service.{CLIENT_INBOUND_HANDLER, CLIENT_STREAMING_BODY_HANDLER, ChannelFuture, ClientResponseStreamHandler}
 import zio.http.socket.{SocketApp, WebSocketFrame}
-import zio.{Task, Unsafe, ZIO}
+import zio.{Cause, Task, Unsafe, ZIO}
 
 import java.io.{IOException, PrintWriter, StringWriter}
 
@@ -76,7 +71,7 @@ final case class Response private (
 
   private[zio] def close: Task[Unit] = self.attribute.channel match {
     case Some(channel) => ChannelFuture.unit(channel.close())
-    case None          => ZIO.fail(new IOException("Channel context isn't available"))
+    case None          => ZIO.refailCause(Cause.fail(new IOException("Channel context isn't available")))
   }
 
   /**

--- a/zio-http/src/main/scala/zio/http/package.scala
+++ b/zio-http/src/main/scala/zio/http/package.scala
@@ -21,5 +21,5 @@ package object http extends PathSyntax with RequestSyntax with RouteDecoderModul
   object HeaderNames  extends headers.HeaderNames
   object HeaderValues extends headers.HeaderValues
 
-  val failNoStacktrace: ZIO[Any, None.type, Nothing] = ZIO.refailCause(Cause.fail(None))
+  private val failNoStacktrace: ZIO[Any, None.type, Nothing] = ZIO.refailCause(Cause.fail(None))
 }

--- a/zio-http/src/main/scala/zio/http/package.scala
+++ b/zio-http/src/main/scala/zio/http/package.scala
@@ -21,5 +21,5 @@ package object http extends PathSyntax with RequestSyntax with RouteDecoderModul
   object HeaderNames  extends headers.HeaderNames
   object HeaderValues extends headers.HeaderValues
 
-  private val failNoStacktrace: ZIO[Any, None.type, Nothing] = ZIO.refailCause(Cause.fail(None))
+  private[http] val failNoStacktrace: ZIO[Any, None.type, Nothing] = ZIO.refailCause(Cause.fail(None))
 }

--- a/zio-http/src/main/scala/zio/http/package.scala
+++ b/zio-http/src/main/scala/zio/http/package.scala
@@ -20,4 +20,6 @@ package object http extends PathSyntax with RequestSyntax with RouteDecoderModul
 
   object HeaderNames  extends headers.HeaderNames
   object HeaderValues extends headers.HeaderValues
+
+  val failNoStacktrace: ZIO[Any, None.type, Nothing] = ZIO.refailCause(Cause.fail(None))
 }

--- a/zio-http/src/main/scala/zio/http/service/ChannelFuture.scala
+++ b/zio-http/src/main/scala/zio/http/service/ChannelFuture.scala
@@ -21,7 +21,7 @@ final class ChannelFuture[A] private (jFuture: Future[A]) {
           jFuture.cause() match {
             case null                     => cb(ZIO.attempt(Option(jFuture.get)))
             case _: CancellationException => cb(ZIO.succeed(Option.empty))
-            case cause                    => cb(ZIO.fail(cause))
+            case cause                    => cb(ZIO.refailCause(Cause.fail(cause)))
           }
         }
         jFuture.addListener(handler)

--- a/zio-http/src/test/scala/zio/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpSpec.scala
@@ -209,7 +209,7 @@ object HttpSpec extends ZIOSpecDefault with HExitAssertion {
         assert(actual)(isSuccess(equalTo("C")))
       },
       test("should resolve second") {
-        val a      = Http.fromHExit(HExit.Effect(ZIO.fail(None)))
+        val a      = Http.fromHExit(HExit.Effect(failNoStacktrace))
         val b      = Http.succeed(2)
         val actual = (a ++ b).execute(()).toZIO.either
         assertZIO(actual)(isRight)

--- a/zio-http/src/test/scala/zio/http/internal/DynamicServer.scala
+++ b/zio-http/src/test/scala/zio/http/internal/DynamicServer.scala
@@ -29,12 +29,12 @@ object DynamicServer {
       for {
         id  <- req.headerValue(APP_ID) match {
           case Some(id) => ZIO.succeed(id)
-          case None     => ZIO.fail(None)
+          case None     => failNoStacktrace
         }
         app <- get(id)
         res <- app match {
           case Some(app) => app(req)
-          case None      => ZIO.fail(None)
+          case None      => failNoStacktrace
         }
       } yield res
     }


### PR DESCRIPTION
Replaced ZIO.fail(None) with ZIO.refailCause (stacktrace is not needed) and replaced in some places in order to improve performance 