### PR TITLE
feat: add support for server response compression

### DIFF
--- a/zio-http/src/main/scala/zio/http/ServerConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ServerConfig.scala
@@ -164,22 +164,22 @@ object ServerConfig {
   }
 
   object CompressionOptions {
-    val Level = 6
-    val Bits  = 15
-    val Mem   = 8
+    val DefaultLevel = 6
+    val DefaultBits  = 15
+    val DefaultMem   = 8
 
     /**
      * Creates GZip CompressionOptions. Defines defaults as per
      * io.netty.handler.codec.compression.GzipOptions#DEFAULT
      */
-    def gzip(level: Int = Level, bits: Int = Bits, mem: Int = Mem): CompressionOptions =
+    def gzip(level: Int = DefaultLevel, bits: Int = DefaultBits, mem: Int = DefaultMem): CompressionOptions =
       CompressionOptions(level, bits, mem, GZip)
 
     /**
      * Creates Deflate CompressionOptions. Defines defaults as per
      * io.netty.handler.codec.compression.DeflateOptions#DEFAULT
      */
-    def deflate(level: Int = Level, bits: Int = Bits, mem: Int = Mem): CompressionOptions =
+    def deflate(level: Int = DefaultLevel, bits: Int = DefaultBits, mem: Int = DefaultMem): CompressionOptions =
       CompressionOptions(level, bits, mem, Deflate)
 
     sealed trait CompressionType

--- a/zio-http/src/main/scala/zio/http/ServerConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ServerConfig.scala
@@ -1,6 +1,6 @@
 package zio.http
 
-import io.netty.handler.codec.compression.{StandardCompressionOptions, CompressionOptions => JCompressionOptions}
+import io.netty.handler.codec.compression.{CompressionOptions => JCompressionOptions, StandardCompressionOptions}
 import io.netty.util.ResourceLeakDetector
 import zio.ZLayer
 import zio.http.ServerConfig.{LeakDetectionLevel, ResponseCompressionConfig}

--- a/zio-http/src/main/scala/zio/http/ServerConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ServerConfig.scala
@@ -151,6 +151,21 @@ object ServerConfig {
     options: IndexedSeq[CompressionOptions] = IndexedSeq.empty,
   )
 
+  /**
+   * @param level
+   *   defines compression level, {@code 1} yields the fastest compression and
+   *   {@code 9} yields the best compression. {@code 0} means no compression.
+   * @param bits
+   *   defines windowBits, The base two logarithm of the size of the history
+   *   buffer. The value should be in the range {@code 9} to {@code 15}
+   *   inclusive. Larger values result in better compression at the expense of
+   *   memory usage
+   * @param mem
+   *   defines memlevel, How much memory should be allocated for the internal
+   *   compression state. {@code 1} uses minimum memory and {@code 9} uses
+   *   maximum memory. Larger values result in better and faster compression at
+   *   the expense of memory usage
+   */
   final case class CompressionOptions(
     level: Int,
     bits: Int,

--- a/zio-http/src/main/scala/zio/http/service/ServerChannelInitializer.scala
+++ b/zio-http/src/main/scala/zio/http/service/ServerChannelInitializer.scala
@@ -49,7 +49,12 @@ final case class ServerChannelInitializer[R](
     if (cfg.requestDecompression._1)
       pipeline.addLast(HTTP_REQUEST_DECOMPRESSION, new HttpContentDecompressor(cfg.requestDecompression._2))
 
-    // TODO: See if server codec is really required
+    cfg.responseCompression.foreach(ops => {
+      pipeline.addLast(
+        HTTP_RESPONSE_COMPRESSION,
+        new HttpContentCompressor(ops.contentThreshold, ops.options.map(_.toJava): _*),
+      )
+    })
 
     // ObjectAggregator
     // Always add ObjectAggregator

--- a/zio-http/src/main/scala/zio/http/service/package.scala
+++ b/zio-http/src/main/scala/zio/http/service/package.scala
@@ -31,6 +31,7 @@ package object service extends Logging {
   private[zio] val CLIENT_STREAMING_BODY_HANDLER      = "CLIENT_STREAMING_BODY_HANDLER"
   private[zio] val WEB_SOCKET_CLIENT_PROTOCOL_HANDLER = "WEB_SOCKET_CLIENT_PROTOCOL_HANDLER"
   private[zio] val HTTP_REQUEST_DECOMPRESSION         = "HTTP_REQUEST_DECOMPRESSION"
+  private[service] val HTTP_RESPONSE_COMPRESSION      = "HTTP_RESPONSE_COMPRESSION"
   private[zio] val LOW_LEVEL_LOGGING                  = "LOW_LEVEL_LOGGING"
   private[zio] val PROXY_HANDLER                      = "PROXY_HANDLER"
   private[zio] val HTTP_CONTENT_HANDLER               = "HTTP_CONTENT_HANDLER"

--- a/zio-http/src/main/scala/zio/http/service/package.scala
+++ b/zio-http/src/main/scala/zio/http/service/package.scala
@@ -31,7 +31,7 @@ package object service extends Logging {
   private[zio] val CLIENT_STREAMING_BODY_HANDLER      = "CLIENT_STREAMING_BODY_HANDLER"
   private[zio] val WEB_SOCKET_CLIENT_PROTOCOL_HANDLER = "WEB_SOCKET_CLIENT_PROTOCOL_HANDLER"
   private[zio] val HTTP_REQUEST_DECOMPRESSION         = "HTTP_REQUEST_DECOMPRESSION"
-  private[service] val HTTP_RESPONSE_COMPRESSION      = "HTTP_RESPONSE_COMPRESSION"
+  private[zio] val HTTP_RESPONSE_COMPRESSION          = "HTTP_RESPONSE_COMPRESSION"
   private[zio] val LOW_LEVEL_LOGGING                  = "LOW_LEVEL_LOGGING"
   private[zio] val PROXY_HANDLER                      = "PROXY_HANDLER"
   private[zio] val HTTP_CONTENT_HANDLER               = "HTTP_CONTENT_HANDLER"

--- a/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
@@ -9,6 +9,7 @@ import zio.test.TestAspect._
 import zio.test._
 import zio.{Chunk, Scope, ZIO, durationInt}
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 object ServerSpec extends HttpRunnableSpec {
@@ -20,7 +21,11 @@ object ServerSpec extends HttpRunnableSpec {
   } yield (data.mkString(""), content)
 
   private val MaxSize = 1024 * 10
-  val configApp       = ServerConfig.default.requestDecompression(true, true).objectAggregator(MaxSize)
+  val configApp       = ServerConfig
+    .default
+    .requestDecompression(true, true)
+    .objectAggregator(MaxSize)
+    .responseCompression()
 
   private val app = serve(DynamicServer.app)
 
@@ -121,30 +126,61 @@ object ServerSpec extends HttpRunnableSpec {
           assertZIO(res)(equalTo("abc"))
         }
       } +
-      suite("decompression") {
-        val app     = Http.collectZIO[Request] { case req => req.body.asString.map(body => Response.text(body)) }.deploy
-        val content = "some-text"
-        val stream  = ZStream.fromChunk(Chunk.fromArray(content.getBytes))
+      suite("compression") {
+        val body = "some-text"
+        val bodyAsStream = ZStream.fromChunk(Chunk.fromArray(body.getBytes))
 
-        test("gzip") {
-          val res = for {
-            body     <- stream.via(ZPipeline.gzip()).runCollect
-            response <- app.run(
-              body = Body.fromChunk(body),
-              headers = Headers.contentEncoding(HeaderValues.gzip),
+        val app = Http.collectZIO[Request] { case req => req.body.asString.map(body => Response.text(body)) }.deploy
+
+        def roundTrip[R, E <: Throwable](
+                                          app: HttpApp[R, Throwable],
+                                          headers: Headers,
+                                          contentStream: ZStream[R, E, Byte],
+                                          compressor: ZPipeline[R, E, Byte, Byte],
+                                          decompressor: ZPipeline[R, E, Byte, Byte],
+                                        ) = for {
+          compressed <- contentStream.via(compressor).runCollect
+          response <- app.run(body = Body.fromChunk(compressed), headers = headers)
+          body <- response.body.asChunk.flatMap(ch => ZStream.fromChunk(ch).via(decompressor).runCollect)
+        } yield new String(body.toArray, StandardCharsets.UTF_8)
+
+        test("should decompress request and compress response") {
+          checkAll(
+            Gen.fromIterable(
+              List(
+                // Content-Encoding,   Client Request Compressor, Accept-Encoding,      Client Response Decompressor
+                (HeaderValues.gzip, ZPipeline.gzip(), HeaderValues.gzip, ZPipeline.gunzip()),
+                (HeaderValues.deflate, ZPipeline.deflate(), HeaderValues.deflate, ZPipeline.inflate()),
+                (HeaderValues.gzip, ZPipeline.gzip(), HeaderValues.deflate, ZPipeline.inflate()),
+                (HeaderValues.deflate, ZPipeline.deflate(), HeaderValues.gzip, ZPipeline.gunzip()),
+              ),
+            ),
+          ) { case (contentEncoding, compressor, acceptEncoding, decompressor) =>
+            val result = roundTrip(
+              app,
+              Headers.acceptEncoding(acceptEncoding) ++ Headers.contentEncoding(contentEncoding),
+              bodyAsStream,
+              compressor,
+              decompressor,
             )
-          } yield response
-          assertZIO(res.flatMap(_.body.asString))(equalTo(content))
+            assertZIO(result)(equalTo(body))
+          }
         } +
-          test("deflate") {
-            val res = for {
-              body     <- stream.via(ZPipeline.deflate()).runCollect
-              response <- app.run(
-                body = Body.fromChunk(body),
-                headers = Headers.contentEncoding(HeaderValues.deflate),
+          test("pass through for unsupported accept encoding request") {
+            val result = app.run(
+              body = Body.fromString(body),
+              headers = Headers.acceptEncoding(HeaderValues.br),
+            )
+            assertZIO(result.flatMap(_.body.asString))(equalTo(body))
+          } +
+          test("fail on getting compressed response") {
+            checkAll(Gen.fromIterable(List(HeaderValues.gzip, HeaderValues.deflate, HeaderValues.gzipDeflate))) { ae =>
+              val result = app.run(
+                body = Body.fromString(body),
+                headers = Headers.acceptEncoding(ae),
               )
-            } yield response
-            assertZIO(res.flatMap(_.body.asString))(equalTo(content))
+              assertZIO(result.flatMap(_.body.asString))(not(equalTo(body)))
+            }
           }
       },
   )

--- a/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
@@ -9,9 +9,6 @@ import zio.test.TestAspect._
 import zio.test._
 import zio.{Chunk, Scope, ZIO, durationInt}
 
-import java.nio.charset.StandardCharsets
-import java.nio.file.Paths
-
 object ServerSpec extends HttpRunnableSpec {
   import html._
 

--- a/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
@@ -9,6 +9,9 @@ import zio.test.TestAspect._
 import zio.test._
 import zio.{Chunk, Scope, ZIO, durationInt}
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+
 object ServerSpec extends HttpRunnableSpec {
   import html._
 


### PR DESCRIPTION
# Description
This PR adds in support for Http Response Compression as a Server config. The server needs to be built with the appropriate config `Server.responseCompression` by setting `contentSizeThreshold` and an `IndexedSeq` of `CompressionOptions`, based on this config, the internal netty handler will be added to the pipeline with the set `CompressionOptions`.

## Changelog
* Server Config for HttpResponseCompression
* Add HttpContentCompressor in ServerChannelInitializer
* New Type for CompressionOptions
* Test Cases