### PR TITLE
added implementation to prettify error message as middleware

### DIFF
--- a/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/middleware/WebSpec.scala
@@ -260,6 +260,21 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
         }
       },
     ),
+    suite("prettify error") {
+      test("should not add anything to the body  as request do not have an accept header") {
+        val app = (Http.error("Error !!!") @@ beautifyErrors) header "content-type"
+        assertZIO(app(Request()))(isNone)
+      } +
+        test("should return a html body as the request has accept header set to text/html.") {
+          val app = (Http
+            .error("Error !!!") @@ beautifyErrors) header "content-type"
+          assertZIO(
+            app(
+              Request(headers = Headers.accept(HeaderValues.textHtml)),
+            ),
+          )(isSome(equalTo("text/html")))
+        }
+    },
   )
 
   private def cond(flg: Boolean) = (_: Any) => flg

--- a/zio-http/src/test/scala/zio/http/service/ClientSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientSpec.scala
@@ -27,10 +27,10 @@ object ClientSpec extends HttpRunnableSpec {
       val res = app.deploy.body.mapZIO(_.asString).run(method = Method.POST, body = Body.fromString("ZIO user"))
       assertZIO(res)(equalTo("ZIO user"))
     },
-    test("non empty content") {
+    test("empty content") {
       val app             = Http.empty
       val responseContent = app.deploy.body.run().flatMap(_.asString.map(_.length))
-      assertZIO(responseContent)(isGreaterThan(0))
+      assertZIO(responseContent)(equalTo(0))
     },
     test("text content") {
       val app             = Http.text("zio user does not exist")

--- a/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
@@ -51,7 +51,7 @@ object ServerSpec extends HttpRunnableSpec {
       } +
         test("header is set") {
           val res = app.deploy.headerValue(HeaderNames.contentLength).run()
-          assertZIO(res)(isSome(equalTo("439")))
+          assertZIO(res)(isSome(equalTo("0")))
         }
     } +
       suite("error") {
@@ -60,9 +60,9 @@ object ServerSpec extends HttpRunnableSpec {
           val res = app.deploy.status.run()
           assertZIO(res)(equalTo(Status.InternalServerError))
         } +
-          test("content is set") {
+          test("content is empty") {
             val res = app.deploy.body.mapZIO(_.asString).run()
-            assertZIO(res)(containsString("SERVER_ERROR"))
+            assertZIO(res)(isEmptyString)
           } +
           test("header is set") {
             val res = app.deploy.headerValue(HeaderNames.contentLength).run()
@@ -75,9 +75,9 @@ object ServerSpec extends HttpRunnableSpec {
           val res = app.deploy.status.run()
           assertZIO(res)(equalTo(Status.InternalServerError))
         } +
-          test("content is set") {
+          test("content is empty") {
             val res = app.deploy.body.mapZIO(_.asString).run()
-            assertZIO(res)(containsString("SERVER_ERROR"))
+            assertZIO(res)(isEmptyString)
           } +
           test("header is set") {
             val res = app.deploy.headerValue(HeaderNames.contentLength).run()
@@ -334,9 +334,9 @@ object ServerSpec extends HttpRunnableSpec {
       val res = app.deploy.status.run()
       assertZIO(res)(equalTo(Status.InternalServerError))
     } +
-      test("content is set") {
+      test("content is empty") {
         val res = app.deploy.body.mapZIO(_.asString).run()
-        assertZIO(res)(containsString("SERVER_ERROR"))
+        assertZIO(res)(isEmptyString)
       } +
       test("header is set") {
         val res = app.deploy.headers.run().map(_.headerValue("Content-Length"))


### PR DESCRIPTION
- In case of an HTTP 500 error, the content of the Response will be empty.
- The stack trace of the error in html format will be part of the response only if the `beautifyErrors` middleware is added to the HttpApp.

Fixes #1282 