### PR TITLE
Refactor SSLConfig data type for server

### DIFF
--- a/zio-http-example/src/main/scala/example/HttpsHelloWorld.scala
+++ b/zio-http-example/src/main/scala/example/HttpsHelloWorld.scala
@@ -1,9 +1,8 @@
 package example
 
 import zio._
-import zio.http._
 import zio.http.model.Method
-import zio.http.netty.server.ServerSSLHandler._
+import zio.http.{SSLConfig, _}
 
 object HttpsHelloWorld extends ZIOAppDefault {
   // Create HTTP route
@@ -13,21 +12,23 @@ object HttpsHelloWorld extends ZIOAppDefault {
   }
 
   /**
-   * sslcontext can be created using SslContexBuilder. In this example an
-   * inbuilt API using keystore is used. For testing this example using curl,
-   * setup the certificate named "server.crt" from resources for the OS.
-   * Alternatively you can create the keystore and certificate using the
-   * following link
+   * In this example an inbuilt API using keystore is used. For testing this
+   * example using curl, setup the certificate named "server.crt" from resources
+   * for the OS. Alternatively you can create the keystore and certificate using
+   * the following link
    * https://medium.com/@maanadev/netty-with-https-tls-9bf699e07f01
    */
-  val sslctx = ctxFromCert(
-    getClass().getClassLoader().getResourceAsStream("server.crt"),
-    getClass().getClassLoader().getResourceAsStream("server.key"),
+
+  val sslConfig = SSLConfig.fromResource(
+    behaviour = SSLConfig.HttpBehaviour.Accept,
+    certPath = "server.crt",
+    keyPath = "server.key",
   )
 
-  private val config      = ServerConfig.default
+  private val config = ServerConfig.default
     .port(8090)
-    .ssl(ServerSSLOptions(sslctx, SSLHttpBehaviour.Accept))
+    .ssl(sslConfig)
+
   private val configLayer = ServerConfig.live(config)
 
   override val run =

--- a/zio-http/src/main/scala/zio/http/SSLConfig.scala
+++ b/zio-http/src/main/scala/zio/http/SSLConfig.scala
@@ -1,0 +1,56 @@
+package zio.http
+
+import zio.http.SSLConfig._
+
+final case class SSLConfig(behaviour: HttpBehaviour, data: Data, provider: Provider)
+
+object SSLConfig {
+
+  def apply(data: Data): SSLConfig =
+    new SSLConfig(HttpBehaviour.Redirect, data, Provider.JDK)
+
+  def fromFile(certPath: String, keyPath: String): SSLConfig =
+    new SSLConfig(HttpBehaviour.Redirect, Data.FromFile(certPath, keyPath), Provider.JDK)
+
+  def fromFile(behaviour: HttpBehaviour, certPath: String, keyPath: String): SSLConfig =
+    new SSLConfig(behaviour, Data.FromFile(certPath, keyPath), Provider.JDK)
+
+  def fromResource(certPath: String, keyPath: String): SSLConfig =
+    new SSLConfig(HttpBehaviour.Redirect, Data.FromResource(certPath, keyPath), Provider.JDK)
+
+  def fromResource(behaviour: HttpBehaviour, certPath: String, keyPath: String): SSLConfig =
+    new SSLConfig(behaviour, Data.FromResource(certPath, keyPath), Provider.JDK)
+
+  def generate: SSLConfig =
+    new SSLConfig(HttpBehaviour.Redirect, Data.Generate, Provider.JDK)
+
+  def generate(behaviour: HttpBehaviour): SSLConfig =
+    new SSLConfig(behaviour, Data.Generate, Provider.JDK)
+
+  sealed trait HttpBehaviour
+  object HttpBehaviour {
+    case object Accept   extends HttpBehaviour
+    case object Fail     extends HttpBehaviour
+    case object Redirect extends HttpBehaviour
+  }
+
+  sealed trait Data
+  object Data {
+
+    /**
+     * A new public/private key pair will be generated and self-signed. Useful
+     * for testing/developer mode.
+     */
+    case object Generate extends Data
+
+    final case class FromFile(certPath: String, keyPath: String) extends Data
+
+    final case class FromResource(certPath: String, keyPath: String) extends Data
+  }
+
+  sealed trait Provider
+  object Provider {
+    case object JDK     extends Provider
+    case object OpenSSL extends Provider
+  }
+}

--- a/zio-http/src/main/scala/zio/http/ServerConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ServerConfig.scala
@@ -4,7 +4,6 @@ import io.netty.handler.codec.compression.{CompressionOptions => JCompressionOpt
 import io.netty.util.ResourceLeakDetector
 import zio.ZLayer
 import zio.http.ServerConfig.{LeakDetectionLevel, ResponseCompressionConfig}
-import zio.http.netty.server.ServerSSLHandler.ServerSSLOptions
 import zio.http.netty.{ChannelType, EventLoopGroups}
 
 import java.net.{InetAddress, InetSocketAddress}
@@ -12,7 +11,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 final case class ServerConfig(
   leakDetectionLevel: LeakDetectionLevel = LeakDetectionLevel.SIMPLE,
-  sslOption: Option[ServerSSLOptions] = None,
+  sslOption: Option[SSLConfig] = None,
   address: InetSocketAddress = new InetSocketAddress(8080),
   acceptContinue: Boolean = false,
   keepAlive: Boolean = true,
@@ -107,7 +106,7 @@ final case class ServerConfig(
   /**
    * Configure the server with the following ssl options.
    */
-  def ssl(sslOptions: ServerSSLOptions): ServerConfig = self.copy(sslOption = Some(sslOptions))
+  def ssl(sslOptions: SSLConfig): ServerConfig = self.copy(sslOption = Some(sslOptions))
 
   /**
    * Configure the server to use a maximum of nThreads to process requests.

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerChannelInitializer.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerChannelInitializer.scala
@@ -37,9 +37,8 @@ private[zio] final case class ServerChannelInitializer(
     log.debug(s"Connection initialized: ${channel.remoteAddress()}")
     // SSL
     // Add SSL Handler if CTX is available
-    cfg.sslOption.map(_.sslContext).foreach { ctx =>
-      pipeline
-        .addFirst(Names.SSLHandler, new ServerSSLDecoder(ctx, cfg.sslOption.map(_.httpBehaviour).orNull, cfg))
+    cfg.sslOption.foreach { sslCfg =>
+      pipeline.addFirst(Names.SSLHandler, new ServerSSLDecoder(sslCfg, cfg))
     }
 
     // ServerCodec

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerHttpsHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerHttpsHandler.scala
@@ -2,16 +2,17 @@ package zio.http.netty.server
 
 import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext, SimpleChannelInboundHandler}
 import io.netty.handler.codec.http.{DefaultHttpResponse, HttpMessage, HttpResponseStatus, HttpVersion}
-import zio.http.netty.server.ServerSSLHandler.SSLHttpBehaviour
+
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
-private[zio] class ServerHttpsHandler(httpBehaviour: SSLHttpBehaviour)
-    extends SimpleChannelInboundHandler[HttpMessage] {
+import zio.http.SSLConfig.HttpBehaviour
+
+private[zio] class ServerHttpsHandler(httpBehaviour: HttpBehaviour) extends SimpleChannelInboundHandler[HttpMessage] {
   override def channelRead0(ctx: ChannelHandlerContext, msg: HttpMessage): Unit = {
 
     // TODO: PatMat maybe???
     if (msg.isInstanceOf[HttpMessage]) {
-      if (httpBehaviour == SSLHttpBehaviour.Redirect) {
+      if (httpBehaviour == HttpBehaviour.Redirect) {
         val message  = msg.asInstanceOf[HttpMessage]
         val address  = message.headers.get("Host")
         val response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.PERMANENT_REDIRECT)

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerSSLDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerSSLDecoder.scala
@@ -3,18 +3,72 @@ package zio.http.netty.server
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.ByteToMessageDecoder
-import io.netty.handler.ssl.{SslContext, SslHandler}
-import zio.http.ServerConfig
+import io.netty.handler.ssl.ApplicationProtocolConfig.{
+  Protocol,
+  SelectedListenerFailureBehavior,
+  SelectorFailureBehavior,
+}
+import io.netty.handler.ssl.util.SelfSignedCertificate
+import io.netty.handler.ssl.{SslContext, SslHandler, _}
+import zio.http.SSLConfig.{HttpBehaviour, Provider}
 import zio.http.netty.Names
-import zio.http.netty.server.ServerSSLHandler.SSLHttpBehaviour
+import zio.http.{SSLConfig, ServerConfig}
 
+import java.io.FileInputStream
 import java.util
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
-private[zio] class ServerSSLDecoder(sslContext: SslContext, httpBehaviour: SSLHttpBehaviour, cfg: ServerConfig)
-    extends ByteToMessageDecoder {
+object SSLUtil {
+
+  implicit class SslContextBuilderOps(self: SslContextBuilder) {
+    def toNettyProvider(sslProvider: Provider): SslProvider = sslProvider match {
+      case Provider.OpenSSL => SslProvider.OPENSSL
+      case Provider.JDK     => SslProvider.JDK
+    }
+
+    def buildWithDefaultOptions(sslConfig: SSLConfig): SslContext = self
+      .sslProvider(toNettyProvider(sslConfig.provider))
+      .applicationProtocolConfig(
+        new ApplicationProtocolConfig(
+          Protocol.ALPN,
+          SelectorFailureBehavior.NO_ADVERTISE,
+          SelectedListenerFailureBehavior.ACCEPT,
+          ApplicationProtocolNames.HTTP_1_1,
+        ),
+      )
+      .build()
+  }
+
+  def sslConfigToSslContext(sslConfig: SSLConfig): SslContext = sslConfig.data match {
+    case SSLConfig.Data.Generate =>
+      val selfSigned = new SelfSignedCertificate()
+      SslContextBuilder
+        .forServer(selfSigned.key, selfSigned.cert)
+        .buildWithDefaultOptions(sslConfig)
+
+    case SSLConfig.Data.FromFile(certPath, keyPath) =>
+      val certInputStream = new FileInputStream(certPath)
+      val keyInputStream  = new FileInputStream(keyPath)
+      SslContextBuilder
+        .forServer(certInputStream, keyInputStream)
+        .buildWithDefaultOptions(sslConfig)
+
+    case SSLConfig.Data.FromResource(certPath, keyPath) =>
+      val certInputStream = getClass().getClassLoader().getResourceAsStream(certPath)
+      val keyInputStream  = getClass().getClassLoader().getResourceAsStream(keyPath)
+      SslContextBuilder
+        .forServer(certInputStream, keyInputStream)
+        .buildWithDefaultOptions(sslConfig)
+  }
+
+}
+
+private[zio] class ServerSSLDecoder(sslConfig: SSLConfig, cfg: ServerConfig) extends ByteToMessageDecoder {
+
   override def decode(context: ChannelHandlerContext, in: ByteBuf, out: util.List[AnyRef]): Unit = {
-    val pipeline = context.channel().pipeline()
+    val pipeline      = context.channel().pipeline()
+    val sslContext    = SSLUtil.sslConfigToSslContext(sslConfig)
+    val httpBehaviour = sslConfig.behaviour
     if (in.readableBytes < 5)
       ()
     else if (SslHandler.isEncrypted(in)) {
@@ -22,10 +76,10 @@ private[zio] class ServerSSLDecoder(sslContext: SslContext, httpBehaviour: SSLHt
       ()
     } else {
       httpBehaviour match {
-        case SSLHttpBehaviour.Accept =>
+        case HttpBehaviour.Accept =>
           pipeline.remove(this)
           ()
-        case _                       =>
+        case _                    =>
           pipeline.remove(Names.HttpRequestHandler)
           if (cfg.keepAlive) pipeline.remove(Names.HttpKeepAliveHandler)
           pipeline.remove(this)

--- a/zio-http/src/test/scala/zio/http/service/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/SSLSpec.scala
@@ -5,7 +5,6 @@ import io.netty.handler.ssl.SslContextBuilder
 import zio.http._
 import zio.http.model._
 import zio.http.netty.client.ClientSSLHandler._
-import zio.http.netty.server.ServerSSLHandler.{ServerSSLOptions, ctxFromCert}
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{ignore, timeout}
 import zio.test.{Gen, ZIOSpecDefault, assertZIO, check}
@@ -13,11 +12,8 @@ import zio.{Scope, ZIO, durationInt}
 
 object SSLSpec extends ZIOSpecDefault {
 
-  val serverSSL = ctxFromCert(
-    getClass().getClassLoader().getResourceAsStream("server.crt"),
-    getClass().getClassLoader().getResourceAsStream("server.key"),
-  )
-  val config    = ServerConfig.default.port(8073).ssl(ServerSSLOptions(serverSSL))
+  val sslConfig = SSLConfig.fromResource("server.crt", "server.key")
+  val config    = ServerConfig.default.port(8073).ssl(sslConfig)
 
   val clientSSL1 =
     SslContextBuilder.forClient().trustManager(getClass().getClassLoader().getResourceAsStream("server.crt")).build()


### PR DESCRIPTION
Decided to create this PR now since a lot changes and renaming are happening in the project.

This refactors the SSL config data type.

Follow ups:

- Refactor the SSL config data type for the client. It currently leaks Netty data types.
- Rewrite/fix the flaky tests in SSLSpec that are currently ignored. 


