### PR TITLE
Benchmarking Fixes

### DIFF
--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,6 +1,11 @@
 // DO NOT EDIT! This file is auto-generated.
 
-// This file enables sbt-bloop to create bloop config files.
+// This plugin enables semantic information to be produced by sbt.
+// It also adds support for debugging using the Debug Adapter Protocol
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
+addSbtPlugin("org.scalameta" % "sbt-metals" % "0.11.8")
+
+// This plugin adds the BSP debug capability to sbt server.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "2.2.0")
 

--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -49,11 +49,11 @@ object Main extends ZIOAppDefault {
     .flowControl(false)
     .objectAggregator(-1)
 
-  private val configLayer  = ServerConfig.live(config)
-  
+  private val configLayer = ServerConfig.live(config)
+
   private val errorHandler = Some((_: Throwable) => ZIO.unit)
-  
-  val run: UIO[ExitCode]   =
+
+  val run: UIO[ExitCode] =
     app
       .flatMap(http => Server.serve(http, errorHandler).provide(configLayer, Server.live))
       .exitCode

--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -49,11 +49,12 @@ object Main extends ZIOAppDefault {
     .flowControl(false)
     .objectAggregator(-1)
 
-  private val configLayer = ServerConfig.live(config)
-
-  val run: UIO[ExitCode] =
+  private val configLayer  = ServerConfig.live(config)
+  
+  private val errorHandler = Some((_: Throwable) => ZIO.unit)
+  
+  val run: UIO[ExitCode]   =
     app
-      .flatMap(Server.serve(_).provide(configLayer, Server.live))
+      .flatMap(http => Server.serve(http, errorHandler).provide(configLayer, Server.live))
       .exitCode
-
 }


### PR DESCRIPTION
**Current Status**
- Tech Empower Benchmarks automatically run on Dream11 infrastructure.
- The result of the benchmarks are comments on the commit id every time (like [here])
- The comment doesn't happen on external PRs (this is to save infra cost).

**Proposed**
- Benchmarks should run on both - external and internal PRs.
- Infrastructure should be moved to ZIO #1531
- Benchmarks should fail, if it goes below a certain threshold.

[here]: https://github.com/zio/zio-http/commit/a26152cec38ac8332b847b2874b1ec6c397a5d68#comments