### PR TITLE
fix: get started link

### DIFF
--- a/docs/website/src/pages/index.js
+++ b/docs/website/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/v1.x/index">
+            to="/docs/v1.x/">
             Get Started
           </Link>
         </div>


### PR DESCRIPTION
The link currently redirect to a "Page Not Found" error page