### PR TITLE
Restrict values for `OpenAPI.Link` parameters/body & add json rendering

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/openapi/JsonRenderer.scala
+++ b/zio-http/src/main/scala/zio/http/api/openapi/JsonRenderer.scala
@@ -2,6 +2,7 @@ package zio.http.api.openapi
 
 import zio.NonEmptyChunk
 import zio.http.api.Doc
+import zio.http.api.openapi.OpenAPI.LiteralOrExpression
 import zio.http.model.Status
 
 import java.net.URI
@@ -109,5 +110,16 @@ private[openapi] object JsonRenderer {
   implicit def tupleRenderable[A, B](implicit rA: Renderable[A], rB: Renderable[B]): Renderable[(A, B)] =
     new Renderable[(A, B)] {
       def render(a: (A, B)): String = s"{${renderKey(a._1)}:${rB.render(a._2)}}"
+    }
+
+  implicit def literalOrExpressionRenderable: Renderable[LiteralOrExpression] =
+    new Renderable[LiteralOrExpression] {
+      def render(a: LiteralOrExpression): String = a match {
+        case LiteralOrExpression.NumberLiteral(value)  => implicitly[Renderable[Long]].render(value)
+        case LiteralOrExpression.DecimalLiteral(value) => implicitly[Renderable[Double]].render(value)
+        case LiteralOrExpression.StringLiteral(value)  => implicitly[Renderable[String]].render(value)
+        case LiteralOrExpression.BooleanLiteral(value) => implicitly[Renderable[Boolean]].render(value)
+        case LiteralOrExpression.Expression(value)     => implicitly[Renderable[String]].render(value)
+      }
     }
 }

--- a/zio-http/src/test/scala/zio/http/api/openapi/JsonRendererSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/openapi/JsonRendererSpec.scala
@@ -1,7 +1,6 @@
 package zio.http.api.openapi
 
 import zio.http.api.Doc
-import zio.http.api.openapi.JsonRenderer._
 import zio.http.api.openapi.OpenAPI.Parameter.{Definition, QueryParameter}
 import zio.http.api.openapi.OpenAPI.Schema.ResponseSchema
 import zio.http.api.openapi.OpenAPI.SecurityScheme.ApiKey
@@ -61,6 +60,17 @@ object JsonRendererSpec extends ZIOSpecDefault {
       test("render doc") {
         val rendered = JsonRenderer.renderFields("doc" -> Doc.p(Doc.Span.uri(new URI("https://google.com"))))
         val expected = """{"doc":"<p><a href="https://google.com">https://google.com</a></p>"}"""
+        assertTrue(rendered == expected)
+      },
+      test("render LiteralOrExpression") {
+        val rendered = JsonRenderer.renderFields(
+          "string"     -> (OpenAPI.LiteralOrExpression.StringLiteral("string"): OpenAPI.LiteralOrExpression),
+          "number"     -> (OpenAPI.LiteralOrExpression.NumberLiteral(1): OpenAPI.LiteralOrExpression),
+          "decimal"    -> (OpenAPI.LiteralOrExpression.DecimalLiteral(1.0): OpenAPI.LiteralOrExpression),
+          "boolean"    -> (OpenAPI.LiteralOrExpression.BooleanLiteral(true): OpenAPI.LiteralOrExpression),
+          "expression" -> OpenAPI.LiteralOrExpression.expression("expression"),
+        )
+        val expected = """{"string":"string","number":1,"decimal":1.0,"boolean":true,"expression":"expression"}"""
         assertTrue(rendered == expected)
       },
       test("throw exception for duplicate keys") {


### PR DESCRIPTION
@jdegoes I checked on the specs again, and I think the right type is `Literal | Expression`.
Expressions have their own syntax that could be checked (maybe with a regex), but it seems quite complicated and I am not sure if checking it is necessary.