### PR TITLE
Multipart #1559

### DIFF
--- a/zio-http-example/src/main/scala/example/MultipartServer.scala
+++ b/zio-http-example/src/main/scala/example/MultipartServer.scala
@@ -1,0 +1,30 @@
+package example
+
+import zio.http._
+import zio.http.model.Multipart.FileUpload
+import zio.stream.ZPipeline
+import zio.{ZIO, ZIOAppDefault, ZLayer}
+
+object MultipartServer extends ZIOAppDefault {
+
+  val app = Http.collectZIO[Request] { case req =>
+    ZIO.scoped {
+      req.body.multipart.flatMap(x =>
+        ZIO.foreachDiscard(x)(m =>
+          (ZIO.debug(s"${m.name} - ${m.getClass.getSimpleName} - ${m.length}")) *>
+            ZIO.whenCase(m) { case u: FileUpload =>
+              ZIO.debug(s"File name: ${u.filename}}") *>
+                u.content.via(ZPipeline.utf8Decode >>> ZPipeline.splitLines).foreach(ZIO.debug(_))
+            },
+        ),
+      )
+    } as Response.ok
+  }
+
+  val run =
+    ZIO.debug("To test upload big file:\ncurl -v -F key1=value1 -F upload=@bigfile.txt localhost:8080") *>
+      Server
+        .serve(app)
+        .provide(ZLayer.succeed(ServerConfig.default.objectAggregator(1024 * 3000)), Server.live)
+        .exitCode
+}

--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -3,7 +3,7 @@ package zio.http
 import io.netty.buffer.{ByteBuf, ByteBufUtil, Unpooled}
 import io.netty.channel.{DefaultFileRegion, Channel => JChannel}
 import io.netty.handler.codec.http.{FullHttpRequest, LastHttpContent}
-import io.netty.handler.codec.http.multipart.{HttpPostMultipartRequestDecoder, InterfaceHttpData}
+import io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder
 import io.netty.util.AsciiString
 import zio._
 import zio.http.model.{HTTP_CHARSET, Multipart}

--- a/zio-http/src/main/scala/zio/http/MultipartConverter.scala
+++ b/zio-http/src/main/scala/zio/http/MultipartConverter.scala
@@ -1,10 +1,10 @@
 package zio.http
 
 import io.netty.handler.codec.http.multipart._
-import zio.{RIO, Scope, ZIO}
 import zio.http.model.Multipart
 import zio.http.model.Multipart.{Attribute, FileUpload}
 import zio.stream.ZStream
+import zio.{RIO, Scope, ZIO}
 
 import java.nio.file.Paths
 

--- a/zio-http/src/main/scala/zio/http/MultipartConverter.scala
+++ b/zio-http/src/main/scala/zio/http/MultipartConverter.scala
@@ -1,0 +1,66 @@
+package zio.http
+
+import io.netty.handler.codec.http.multipart._
+import zio.{RIO, Scope, ZIO}
+import zio.http.model.Multipart
+import zio.http.model.Multipart.{Attribute, FileUpload}
+import zio.stream.ZStream
+
+import java.nio.file.Paths
+
+object MultipartConverter {
+
+  def convert(data: InterfaceHttpData): RIO[Scope, Multipart] = data match {
+
+    case attribute: io.netty.handler.codec.http.multipart.Attribute =>
+      val value: RIO[Scope, String] = attribute match {
+        case a: DiskAttribute   => ZIO.attempt(a.getValue)
+        case a: MemoryAttribute => ZIO.succeed(a.getValue)
+        case a: MixedAttribute  =>
+          // TODO should I just use this instead of pattern matching?
+          if (a.isInMemory)
+            ZIO.succeed(a.getValue)
+          else
+            ZIO.attempt(a.getValue)
+      }
+
+      value.map(v =>
+        Attribute(
+          attribute.getName,
+          attribute.length,
+          attribute.definedLength,
+          attribute.getCharset.name,
+          v,
+        ),
+      )
+
+    case fileUpload: io.netty.handler.codec.http.multipart.FileUpload =>
+      val value: ZStream[Any, Throwable, Byte] = fileUpload match {
+        case u: DiskFileUpload   =>
+          ZStream.fromPath(u.getFile.toPath)
+        case u: MemoryFileUpload =>
+          ZStream.fromIterable(u.get)
+        case u: MixedFileUpload  =>
+          // TODO should I just use this instead of pattern matching?
+          if (u.isInMemory)
+            ZStream.fromIterable(u.get)
+          else {
+            println(s"FFF ${u.getFile.toPath}")
+            ZStream.fromPath(u.getFile.toPath)
+          }
+      }
+      ZIO.succeed(
+        FileUpload(
+          fileUpload.getName,
+          fileUpload.length,
+          fileUpload.definedLength,
+          fileUpload.getCharset.name,
+          fileUpload.getFilename,
+          fileUpload.getContentType,
+          fileUpload.getContentTransferEncoding,
+          value,
+        ),
+      )
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/model/Multipart.scala
+++ b/zio-http/src/main/scala/zio/http/model/Multipart.scala
@@ -1,0 +1,51 @@
+package zio.http.model
+
+import zio.http.model.Multipart.{Attribute, FileUpload}
+import zio.stream.ZStream
+
+sealed trait Multipart {
+  def name: String
+  def length: Long
+
+  /**
+   * Returns the defined length of the HttpData.
+   *
+   * If no Content-Length is provided in the request, the defined length is
+   * always 0 (whatever during decoding or in final state).
+   *
+   * If Content-Length is provided in the request, this is this given defined
+   * length. This value does not change, whatever during decoding or in the
+   * final state.
+   *
+   * This method could be used for instance to know the amount of bytes
+   * transmitted for one particular HttpData, for example one {@link FileUpload}
+   * or any known big {@link Attribute}.
+   *
+   * @return
+   *   the defined length of the HttpData
+   */
+  def definedLength: Long
+  def charset: String
+}
+
+object Multipart {
+
+  case class Attribute(
+    name: String,
+    length: Long,
+    definedLength: Long,
+    charset: String,
+    value: String,
+  ) extends Multipart
+
+  case class FileUpload(
+    name: String,
+    length: Long,
+    definedLength: Long,
+    charset: String,
+    filename: String,
+    contentType: String,
+    contentTransferEncoding: String,
+    content: ZStream[Any, Throwable, Byte],
+  ) extends Multipart
+}

--- a/zio-http/src/main/scala/zio/http/model/Multipart.scala
+++ b/zio-http/src/main/scala/zio/http/model/Multipart.scala
@@ -8,7 +8,7 @@ sealed trait Multipart {
   def length: Long
 
   /**
-   * Returns the defined length of the HttpData.
+   * Returns the defined bytes length of the HttpData.
    *
    * If no Content-Length is provided in the request, the defined length is
    * always 0 (whatever during decoding or in final state).
@@ -17,12 +17,8 @@ sealed trait Multipart {
    * length. This value does not change, whatever during decoding or in the
    * final state.
    *
-   * This method could be used for instance to know the amount of bytes
-   * transmitted for one particular HttpData, for example one {@link FileUpload}
-   * or any known big {@link Attribute}.
-   *
    * @return
-   *   the defined length of the HttpData
+   *   the defined bytes length of the HttpData
    */
   def definedLength: Long
   def charset: String

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -113,7 +113,7 @@ private[zio] final case class ServerInboundHandler(
       nettyReq match {
         case nettyReq: FullHttpRequest =>
           Request(
-            Body.fromByteBuf(nettyReq.content()),
+            Body.fromFullHttpRequest(nettyReq),
             Headers.make(nettyReq.headers()),
             Method.fromHttpMethod(nettyReq.method()),
             URL.fromString(nettyReq.uri()).getOrElse(URL.empty),


### PR DESCRIPTION
I created this PR, just to have some input how to solve it. It is still WIP.

Is this a good approach to use netty's `HttpPostMultipartRequestDecoder`? If so I need to implement it also in for `addAsyncBodyHandler`. Should I rather use my own sealed trait instead of netty's `InterfaceHttpData` in the body? Thiss way when we change netty to something else the api will stay the same.

If this approach is not best I can do manual parsing on the stream as they did it in [http4s](https://github.com/http4s/http4s/tree/main/core/shared/src/main/scala/org/http4s/multipart) but it is much more work. Plugging this in will be easier though as I could use just `Body.asStream`.

What do you think?

And I will delete the bigfile.txt.