### PR TITLE
fix(hexit): add lazy evaluation on defaultwith and orelse

### DIFF
--- a/benchmark-zio-http.sh
+++ b/benchmark-zio-http.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+set -e
 
 COMMIT_SHA=$(git rev-parse --short HEAD)
 ZIO_HTTP="zio/zio-http.git#$COMMIT_SHA"
@@ -9,15 +11,19 @@ fi
 
 if [ ! -d "../FrameworkBenchMarks" ]; then
     git clone https://github.com/zio/FrameworkBenchmarks.git ../FrameworkBenchMarks
-    git checkout master
 fi
 
-rm ../FrameworkBenchMarks/frameworks/Scala/zio-http/build.sbt
 rm ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
-cp ../FrameworkBenchMarks/frameworks/Scala/zio-http/base.build.sbt ../FrameworkBenchMarks/frameworks/Scala/zio-http/build.sbt
 cp ./zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
 cd ../FrameworkBenchMarks
-sed -i '' "s|---COMMIT_SHA---|${ZIO_HTTP}|g" frameworks/Scala/zio-http/build.sbt
+
+if [ -f "frameworks/Scala/zio-http/build.sbt.bak" ]; then
+    # if a backup (ie an original version exists), restore it, it's useful if you want to benchmark multiple commits in a row
+    mv frameworks/Scala/zio-http/build.sbt.bak frameworks/Scala/zio-http/build.sbt
+fi
+
+# this is compatible with both GNU and BSD sed
+sed -i.bak "s|---COMMIT_SHA---|${ZIO_HTTP}|g" frameworks/Scala/zio-http/build.sbt
 ./tfb --test zio-http | tee result
 RESULT_REQUEST=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "requests/sec: [0-9]+.[0-9]+")
 RESULT_CONCURRENCY=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "concurrency: [0-9]+")

--- a/zio-http/src/main/scala/zio/http/HExit.scala
+++ b/zio-http/src/main/scala/zio/http/HExit.scala
@@ -15,10 +15,10 @@ sealed trait HExit[-R, +E, +A] { self =>
   def >>=[R1 <: R, E1 >: E, B](ab: A => HExit[R1, E1, B])(implicit trace: Trace): HExit[R1, E1, B] =
     self.flatMap(ab)
 
-  def <>[R1 <: R, E1, A1 >: A](other: HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
+  def <>[R1 <: R, E1, A1 >: A](other: => HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
     self orElse other
 
-  def <+>[R1 <: R, E1 >: E, A1 >: A](other: HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
+  def <+>[R1 <: R, E1 >: E, A1 >: A](other: => HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
     this defaultWith other
 
   def *>[R1 <: R, E1 >: E, B](other: HExit[R1, E1, B])(implicit trace: Trace): HExit[R1, E1, B] =
@@ -26,7 +26,7 @@ sealed trait HExit[-R, +E, +A] { self =>
 
   def as[B](b: B)(implicit trace: Trace): HExit[R, E, B] = self.map(_ => b)
 
-  def defaultWith[R1 <: R, E1 >: E, A1 >: A](other: HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
+  def defaultWith[R1 <: R, E1 >: E, A1 >: A](other: => HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
     self.foldExit(HExit.failCause, HExit.succeed, other)
 
   def flatMap[R1 <: R, E1 >: E, B](ab: A => HExit[R1, E1, B])(implicit trace: Trace): HExit[R1, E1, B] =
@@ -38,7 +38,7 @@ sealed trait HExit[-R, +E, +A] { self =>
   def foldExit[R1 <: R, E1, B1](
     failure: Cause[E] => HExit[R1, E1, B1],
     success: A => HExit[R1, E1, B1],
-    empty: HExit[R1, E1, B1],
+    empty: => HExit[R1, E1, B1],
   )(implicit trace: Trace): HExit[R1, E1, B1] =
     self match {
       case HExit.Success(a)     => success(a)
@@ -64,7 +64,7 @@ sealed trait HExit[-R, +E, +A] { self =>
 
   def map[B](ab: A => B)(implicit trace: Trace): HExit[R, E, B] = self.flatMap(a => HExit.succeed(ab(a)))
 
-  def orElse[R1 <: R, E1, A1 >: A](other: HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
+  def orElse[R1 <: R, E1, A1 >: A](other: => HExit[R1, E1, A1])(implicit trace: Trace): HExit[R1, E1, A1] =
     self.foldExit(_ => other, HExit.succeed, HExit.empty)
 
   def toZIO(implicit trace: Trace): ZIO[R, Option[E], A] = self match {

--- a/zio-http/src/test/scala/zio/http/HExitSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HExitSpec.scala
@@ -3,7 +3,7 @@ package zio.http
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
-import zio.{Ref, ZIO, durationInt}
+import zio.{ZIO, durationInt}
 
 object HExitSpec extends ZIOSpecDefault with HExitAssertion {
   def spec: Spec[Environment, Any] = {

--- a/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ServerSpec.scala
@@ -55,6 +55,20 @@ object ServerSpec extends HttpRunnableSpec {
           assertZIO(res)(isSome(equalTo("0")))
         }
     } +
+      suite("side effect/lazyness") {
+        test("Should not execute side effect if the first app matches") {
+          var counter = 0
+          val app     = Http.collectZIO[Request] { case _ =>
+            counter += 1
+            ZIO.unit
+          } ++ Http.collectZIO[Request] { case _ =>
+            counter += 2
+            ZIO.unit
+          }
+          val effect  = app(Request.default(method = Method.GET, url = URL.empty))
+          assertZIO(effect.as(counter))(equalTo(1))
+        }
+      } +
       suite("error") {
         val app = Http.fail(new Error("SERVER_ERROR"))
         test("status is 500") {


### PR DESCRIPTION
Following a discussion on Discord, the original case was a bit more convoluted:

```scala
val app1 =
    Http.collectZIO[Request] {
      case Method.GET -> !! / "hello" / name  => 
        ZIO.succeed(Response.text(s"Hi ${name}!"))
    }

class ThisCase:
  def unapply(req:Request): Option[Int] =
    println("unapply!")
    Some(2)
 
val thisCase1 = ThisCase()
val app2 =  Http.collect[Request] { case thisCase1(n) => Response.ok }
val app = app1 ++ app2
```

This was in fact caused by the `execute` method of the `Http` class and more precisely the `combine` between one effectful app (`collectZIO` and any other app).
