### PR TITLE
Accept-Patch header + MediaType optional parameters

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
@@ -19,8 +19,9 @@ trait HeaderCodecs {
       .transform(AcceptLanguage.toAcceptLanguage, AcceptLanguage.fromAcceptLanguage)
   final val acceptRanges: HeaderCodec[String]                     =
     header(HeaderNames.acceptRanges.toString(), TextCodec.string)
-  final val acceptPatch: HeaderCodec[String]                      =
+  final val acceptPatch: HeaderCodec[AcceptPatch]                 =
     header(HeaderNames.acceptPatch.toString(), TextCodec.string)
+      .transform(AcceptPatch.toAcceptPatch, AcceptPatch.fromAcceptPatch)
   final val accessControlAllowCredentials: HeaderCodec[String]    =
     header(HeaderNames.accessControlAllowCredentials.toString(), TextCodec.string)
   final val accessControlAllowHeaders: HeaderCodec[String]        =

--- a/zio-http/src/main/scala/zio/http/model/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/model/MediaType.scala
@@ -2,6 +2,8 @@ package zio.http.model
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
+import scala.annotation.tailrec
+
 final case class MediaType(
   mainType: String,
   subType: String,
@@ -9,6 +11,7 @@ final case class MediaType(
   binary: Boolean = false,
   fileExtensions: List[String] = Nil,
   extensions: Map[String, String] = Map.empty,
+  parameters: Map[String, String] = Map.empty,
 ) {
   def fullType: String = s"$mainType/$subType"
 }
@@ -17,7 +20,48 @@ object MediaType extends MimeDB {
   private val extensionMap: Map[String, MediaType]   = allMediaTypes.flatMap(m => m.fileExtensions.map(_ -> m)).toMap
   private val contentTypeMap: Map[String, MediaType] = allMediaTypes.map(m => m.fullType -> m).toMap
 
-  def forContentType(contentType: String): Option[MediaType] = contentTypeMap.get(contentType)
+  def forContentType(contentType: String): Option[MediaType] = {
+    val index = contentType.indexOf(";")
+    if (index == -1)
+      contentTypeMap.get(contentType)
+    else {
+      val (contentType1, parameter) = contentType.splitAt(index)
+      contentTypeMap
+        .get(contentType1)
+        .map(_.copy(parameters = parseOptionalParameters(parameter.tail.split(";"))))
+    }
+  }
 
   def forFileExtension(ext: String): Option[MediaType] = extensionMap.get(ext)
+
+  def parseCustomMediaType(customMediaType: String): Option[MediaType] = {
+    val contentTypeParts = customMediaType.split('/')
+    if (contentTypeParts.length == 2) {
+      val subtypeParts = contentTypeParts(1).split(';')
+      if (subtypeParts.length >= 1) {
+        Some(
+          MediaType(
+            mainType = contentTypeParts.head,
+            subType = subtypeParts.head,
+            parameters = if (subtypeParts.length >= 2) parseOptionalParameters(subtypeParts.tail) else Map.empty,
+          ),
+        )
+      } else None
+    } else None
+  }
+
+  private def parseOptionalParameters(parameters: Array[String]): Map[String, String] = {
+    @tailrec
+    def loop(parameters: Seq[String], parameterMap: Map[String, String]): Map[String, String] = parameters match {
+      case Seq(parameter, tail @ _*) =>
+        val parameterParts = parameter.split("=")
+        val newMap         =
+          if (parameterParts.length == 2) parameterMap + (parameterParts.head -> parameterParts(1))
+          else parameterMap
+        loop(tail, newMap)
+      case _                         => parameterMap
+    }
+
+    loop(parameters.toIndexedSeq, Map.empty)
+  }
 }

--- a/zio-http/src/main/scala/zio/http/model/headers/values/Accept.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/Accept.scala
@@ -1,5 +1,6 @@
 package zio.http.model.headers.values
 
+import zio.Chunk
 import zio.http.model.MediaType
 
 import scala.util.Try
@@ -13,7 +14,7 @@ object Accept {
    * The Accept header value one or more MIME types optionally weighed with
    * quality factor.
    */
-  final case class AcceptValue(mimeTypes: List[MediaTypeWithQFactor]) extends Accept
+  final case class AcceptValue(mimeTypes: Chunk[MediaTypeWithQFactor]) extends Accept
 
   final case class MediaTypeWithQFactor(mediaType: MediaType, qFactor: Option[Double])
 
@@ -32,30 +33,23 @@ object Accept {
     val acceptHeaderValues: Array[MediaTypeWithQFactor] = value
       .split(',')
       .map(_.trim)
-      .map { subvalue =>
-        val parts = subvalue.split(';')
-        if (parts.length >= 1) {
-          val qFactor = if (parts.length == 2) {
-            val qFactorParts = parts.tail.head.split('=')
-            if (qFactorParts.length == 2) {
-              Try(qFactorParts.tail.head.toDouble).toOption
-            } else None
-          } else None
-
-          MediaType
-            .forContentType(parts.head)
-            .map(MediaTypeWithQFactor(_, qFactor))
-            .getOrElse {
-              val mediaTypeParts = parts.head.split('/')
-              if (mediaTypeParts.length == 2) {
-                MediaTypeWithQFactor(MediaType(mediaTypeParts.head, mediaTypeParts.tail.head), qFactor)
-              } else null
-            }
-        } else null
+      .map { subValue =>
+        MediaType
+          .forContentType(subValue)
+          .map(mt => MediaTypeWithQFactor(mt, extractQFactor(mt)))
+          .getOrElse {
+            MediaType
+              .parseCustomMediaType(subValue)
+              .map(mt => MediaTypeWithQFactor(mt, extractQFactor(mt)))
+              .orNull
+          }
       }
 
     if (acceptHeaderValues.nonEmpty && acceptHeaderValues.length == acceptHeaderValues.count(_ != null))
-      AcceptValue(acceptHeaderValues.toList)
+      AcceptValue(Chunk.fromArray(acceptHeaderValues))
     else InvalidAcceptValue
   }
+
+  private def extractQFactor(mediaType: MediaType): Option[Double] =
+    mediaType.parameters.get("q").flatMap(qFactor => Try(qFactor.toDouble).toOption)
 }

--- a/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
@@ -3,6 +3,10 @@ package zio.http.model.headers.values
 import zio.Chunk
 import zio.http.model.MediaType
 
+/**
+ * The Accept-Patch response HTTP header advertises which media-type the server is able to understand
+ * in a PATCH request.
+ */
 sealed trait AcceptPatch
 
 object AcceptPatch {

--- a/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
@@ -1,0 +1,41 @@
+package zio.http.model.headers.values
+
+import zio.Chunk
+import zio.http.model.MediaType
+
+sealed trait AcceptPatch
+
+object AcceptPatch {
+
+  case class AcceptPatchValue(mediaTypes: Chunk[MediaType]) extends AcceptPatch
+
+  case object InvalidAcceptPatchValue extends AcceptPatch
+
+  def fromAcceptPatch(acceptPatch: AcceptPatch): String = acceptPatch match {
+    case AcceptPatchValue(mediaTypes) => mediaTypes.map(_.fullType).mkString(",")
+    case InvalidAcceptPatchValue      => ""
+  }
+
+  def toAcceptPatch(value: String): AcceptPatch = {
+    if (value.nonEmpty) {
+      val parsedMediaTypes = Chunk.fromArray(
+        value
+          .split(",")
+          .map(mediaTypeStr =>
+            MediaType
+              .forContentType(mediaTypeStr)
+              .getOrElse(
+                MediaType
+                  .parseCustomMediaType(mediaTypeStr)
+                  .orNull
+              )
+          )
+      )
+      if (parsedMediaTypes.length == parsedMediaTypes.count(_ != null))
+        AcceptPatchValue(parsedMediaTypes)
+      else
+        InvalidAcceptPatchValue
+    } else InvalidAcceptPatchValue
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/AcceptPatch.scala
@@ -4,8 +4,8 @@ import zio.Chunk
 import zio.http.model.MediaType
 
 /**
- * The Accept-Patch response HTTP header advertises which media-type the server is able to understand
- * in a PATCH request.
+ * The Accept-Patch response HTTP header advertises which media-type the server
+ * is able to understand in a PATCH request.
  */
 sealed trait AcceptPatch
 
@@ -31,9 +31,9 @@ object AcceptPatch {
               .getOrElse(
                 MediaType
                   .parseCustomMediaType(mediaTypeStr)
-                  .orNull
-              )
-          )
+                  .orNull,
+              ),
+          ),
       )
       if (parsedMediaTypes.length == parsedMediaTypes.count(_ != null))
         AcceptPatchValue(parsedMediaTypes)

--- a/zio-http/src/test/scala/zio/http/model/MediaTypeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/MediaTypeSpec.scala
@@ -11,11 +11,13 @@ object MediaTypeSpec extends ZIOSpecDefault with MimeDB {
       assertTrue(MediaType.parseCustomMediaType("custom/mime").contains(MediaType("custom", "mime")))
     },
     test("optional parameter parsing") {
-      assertTrue(MediaType.forContentType("application/json;p1=1;p2=2;p3=\"quoted\"")
-        .contains(
-          application.`json`.copy(parameters = Map("p1" -> "1", "p2" -> "2", "p3" -> "\"quoted\""))
-        )
+      assertTrue(
+        MediaType
+          .forContentType("application/json;p1=1;p2=2;p3=\"quoted\"")
+          .contains(
+            application.`json`.copy(parameters = Map("p1" -> "1", "p2" -> "2", "p3" -> "\"quoted\"")),
+          ),
       )
-    }
+    },
   )
 }

--- a/zio-http/src/test/scala/zio/http/model/MediaTypeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/MediaTypeSpec.scala
@@ -1,0 +1,21 @@
+package zio.http.model
+
+import zio.test._
+
+object MediaTypeSpec extends ZIOSpecDefault with MimeDB {
+  override def spec = suite("MediaTypeSpec")(
+    test("predefined mime type parsing") {
+      assertTrue(MediaType.forContentType("application/json").contains(application.`json`))
+    },
+    test("custom mime type parsing") {
+      assertTrue(MediaType.parseCustomMediaType("custom/mime").contains(MediaType("custom", "mime")))
+    },
+    test("optional parameter parsing") {
+      assertTrue(MediaType.forContentType("application/json;p1=1;p2=2;p3=\"quoted\"")
+        .contains(
+          application.`json`.copy(parameters = Map("p1" -> "1", "p2" -> "2", "p3" -> "\"quoted\""))
+        )
+      )
+    }
+  )
+}

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptPatchSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptPatchSpec.scala
@@ -10,12 +10,12 @@ object AcceptPatchSpec extends ZIOSpecDefault with MimeDB {
     test("AcceptPatch header transformation must be symmetrical") {
       assertTrue(
         AcceptPatch.toAcceptPatch(AcceptPatch.fromAcceptPatch(AcceptPatchValue(Chunk(text.`html`))))
-          == AcceptPatchValue(Chunk(text.`html`))
+          == AcceptPatchValue(Chunk(text.`html`)),
       )
     },
     test("invalid values parsing") {
       assertTrue(AcceptPatch.toAcceptPatch("invalidString") == InvalidAcceptPatchValue) &&
-        assertTrue(AcceptPatch.toAcceptPatch("") == InvalidAcceptPatchValue)
+      assertTrue(AcceptPatch.toAcceptPatch("") == InvalidAcceptPatchValue)
     },
   )
 }

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptPatchSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptPatchSpec.scala
@@ -1,0 +1,21 @@
+package zio.http.model.headers.values
+
+import zio.Chunk
+import zio.http.model.MimeDB
+import zio.http.model.headers.values.AcceptPatch._
+import zio.test._
+
+object AcceptPatchSpec extends ZIOSpecDefault with MimeDB {
+  override def spec = suite("AcceptPatch header suite")(
+    test("AcceptPatch header transformation must be symmetrical") {
+      assertTrue(
+        AcceptPatch.toAcceptPatch(AcceptPatch.fromAcceptPatch(AcceptPatchValue(Chunk(text.`html`))))
+          == AcceptPatchValue(Chunk(text.`html`))
+      )
+    },
+    test("invalid values parsing") {
+      assertTrue(AcceptPatch.toAcceptPatch("invalidString") == InvalidAcceptPatchValue) &&
+        assertTrue(AcceptPatch.toAcceptPatch("") == InvalidAcceptPatchValue)
+    },
+  )
+}

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptSpec.scala
@@ -1,5 +1,6 @@
 package zio.http.model.headers.values
 
+import zio.Chunk
 import zio.http.model.headers.values.Accept.{AcceptValue, InvalidAcceptValue, MediaTypeWithQFactor}
 import zio.http.model.{MediaType, MimeDB}
 import zio.test._
@@ -12,23 +13,31 @@ object AcceptSpec extends ZIOSpecDefault with MimeDB {
       assertTrue(Accept.toAccept("text/html;q=0.8, bla=q") == InvalidAcceptValue)
     },
     test("parsing of valid Accept values") {
-      assertTrue(Accept.toAccept("text/html") == AcceptValue(List(MediaTypeWithQFactor(text.`html`, None)))) &&
       assertTrue(
-        Accept.toAccept("text/html;q=0.8") == AcceptValue(List(MediaTypeWithQFactor(text.`html`, Some(0.8)))),
+        Accept.toAccept("text/html") == AcceptValue(Chunk(MediaTypeWithQFactor(text.`html`, None)))
       ) &&
-      assertTrue(Accept.toAccept("text/*") == AcceptValue(List(MediaTypeWithQFactor(MediaType("text", "*"), None)))) &&
-      assertTrue(Accept.toAccept("*/*") == AcceptValue(List(MediaTypeWithQFactor(MediaType("*", "*"), None)))) &&
       assertTrue(
-        Accept.toAccept("*/*;q=0.1") == AcceptValue(List(MediaTypeWithQFactor(MediaType("*", "*"), Some(0.1)))),
+        Accept.toAccept("text/html;q=0.8") ==
+          AcceptValue(Chunk(MediaTypeWithQFactor(text.`html`.withQFactor(0.8), Some(0.8)))),
+      ) &&
+      assertTrue(
+        Accept.toAccept("text/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("text", "*"), None)))
+      ) &&
+      assertTrue(
+        Accept.toAccept("*/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("*", "*"), None)))
+      ) &&
+      assertTrue(
+        Accept.toAccept("*/*;q=0.1") ==
+          AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("*", "*").withQFactor(0.1), Some(0.1)))),
       ) &&
       assertTrue(
         Accept.toAccept("text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8") ==
           AcceptValue(
-            List(
+            Chunk(
               MediaTypeWithQFactor(text.`html`, None),
               MediaTypeWithQFactor(application.`xhtml+xml`, None),
-              MediaTypeWithQFactor(application.`xml`, Some(0.9)),
-              MediaTypeWithQFactor(MediaType("*", "*"), Some(0.8)),
+              MediaTypeWithQFactor(application.`xml`.withQFactor(0.9), Some(0.9)),
+              MediaTypeWithQFactor(MediaType("*", "*").withQFactor(0.8), Some(0.8)),
             ),
           ),
       )
@@ -38,4 +47,11 @@ object AcceptSpec extends ZIOSpecDefault with MimeDB {
       assertTrue(allMediaTypes.map(_.fullType) == results)
     },
   )
+
+  implicit class MediaTypeTestOps(mediaType: MediaType) {
+    def withQFactor(double: Double): MediaType = {
+      mediaType
+        .copy(parameters = Map("q" -> double.toString))
+    }
+  }
 }

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptSpec.scala
@@ -14,17 +14,17 @@ object AcceptSpec extends ZIOSpecDefault with MimeDB {
     },
     test("parsing of valid Accept values") {
       assertTrue(
-        Accept.toAccept("text/html") == AcceptValue(Chunk(MediaTypeWithQFactor(text.`html`, None)))
+        Accept.toAccept("text/html") == AcceptValue(Chunk(MediaTypeWithQFactor(text.`html`, None))),
       ) &&
       assertTrue(
         Accept.toAccept("text/html;q=0.8") ==
           AcceptValue(Chunk(MediaTypeWithQFactor(text.`html`.withQFactor(0.8), Some(0.8)))),
       ) &&
       assertTrue(
-        Accept.toAccept("text/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("text", "*"), None)))
+        Accept.toAccept("text/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("text", "*"), None))),
       ) &&
       assertTrue(
-        Accept.toAccept("*/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("*", "*"), None)))
+        Accept.toAccept("*/*") == AcceptValue(Chunk(MediaTypeWithQFactor(MediaType("*", "*"), None))),
       ) &&
       assertTrue(
         Accept.toAccept("*/*;q=0.1") ==

--- a/zio-http/src/test/scala/zio/http/model/headers/values/DNTSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/DNTSpec.scala
@@ -1,7 +1,6 @@
 package zio.http.model.headers.values
 
 import zio.Scope
-import zio.http.model.headers.values.DNT
 import zio.http.model.headers.values.DNT.{
   InvalidDNTValue,
   NotSpecifiedDNTValue,

--- a/zio-http/src/test/scala/zio/http/model/headers/values/DNTSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/DNTSpec.scala
@@ -1,4 +1,4 @@
-package zio.http.model.headers
+package zio.http.model.headers.values
 
 import zio.Scope
 import zio.http.model.headers.values.DNT

--- a/zio-http/src/test/scala/zio/http/model/headers/values/ETagSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/ETagSpec.scala
@@ -1,7 +1,6 @@
 package zio.http.model.headers.values
 
 import zio.Scope
-import zio.http.model.headers.values.ETag
 import zio.http.model.headers.values.ETag.{InvalidETagValue, StrongETagValue, WeakETagValue}
 import zio.test._
 

--- a/zio-http/src/test/scala/zio/http/model/headers/values/ETagSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/ETagSpec.scala
@@ -1,4 +1,4 @@
-package zio.http.model.headers
+package zio.http.model.headers.values
 
 import zio.Scope
 import zio.http.model.headers.values.ETag

--- a/zio-http/src/test/scala/zio/http/model/headers/values/HostSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/HostSpec.scala
@@ -1,4 +1,4 @@
-package zio.http.model.headers
+package zio.http.model.headers.values
 
 import zio.http.internal.HttpGen
 import zio.http.model.headers.values.Host

--- a/zio-http/src/test/scala/zio/http/model/headers/values/HostSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/HostSpec.scala
@@ -1,7 +1,6 @@
 package zio.http.model.headers.values
 
 import zio.http.internal.HttpGen
-import zio.http.model.headers.values.Host
 import zio.http.model.headers.values.Host.{HostValue, InvalidHostValue}
 import zio.test._
 


### PR DESCRIPTION
- Added optional parameters to MediaType definition, according to [RFC 2616 Section 3.7](https://www.rfc-editor.org/rfc/rfc2616#section-3.7)
- Refactor Accept header to use optional parameter
- Added Accept-Patch header