### PR TITLE
Add toHttpTransformer in Middleware

### DIFF
--- a/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
+++ b/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
@@ -20,8 +20,8 @@ object BasicAuthAPIExample extends ZIOAppDefault {
   val authMiddleware = MiddlewareSpec.auth
   val correlationId  = MiddlewareSpec.addCorrelationId
 
-  val middleware: MiddlewareSpec[Auth.Credentials, Int] =
-    MiddlewareSpec.auth ++ MiddlewareSpec.addCorrelationId.mapOut(out => out.transform[Int](_.toInt, _.toString))
+  val middleware: MiddlewareSpec[Auth.Credentials, String] =
+    MiddlewareSpec.auth ++ MiddlewareSpec.addCorrelationId
 
   val authMiddlewareHandler: api.Middleware[Any, Nothing, Auth.Credentials, Unit] =
     authMiddleware.implement(_ => ZIO.unit)

--- a/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
+++ b/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
@@ -20,8 +20,8 @@ object BasicAuthAPIExample extends ZIOAppDefault {
   val authMiddleware = MiddlewareSpec.auth
   val correlationId  = MiddlewareSpec.addCorrelationId
 
-  val middleware: MiddlewareSpec[Auth.Credentials, String] =
-    MiddlewareSpec.auth ++ MiddlewareSpec.addCorrelationId
+  val middleware: MiddlewareSpec[Auth.Credentials, Int] =
+    MiddlewareSpec.auth ++ MiddlewareSpec.addCorrelationId.mapOut(out => out.transform[Int](_.toInt, _.toString))
 
   val authMiddlewareHandler: api.Middleware[Any, Nothing, Auth.Credentials, Unit] =
     authMiddleware.implement(_ => ZIO.unit)

--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -72,6 +72,19 @@ sealed trait HttpCodec[-AtomTypes, Input] {
   ): HttpCodec[AtomTypes, Input2] =
     HttpCodec.TransformOrFail[AtomTypes, Input, Input2](self, in => Right(f(in)), g)
 
+  private[api] def isEmpty: Boolean =
+    self match {
+      case atom: HttpCodec.Atom[_, _]                                         =>
+        atom match {
+          case HttpCodec.Empty => true
+          case _               => false
+        }
+      case HttpCodec.WithDoc(in, _)                                           => in.isEmpty
+      case HttpCodec.TransformOrFail(api, _, _)                               => api.isEmpty
+      case HttpCodec.Combine(left, right, _) if left.isEmpty && right.isEmpty => true
+      case HttpCodec.Combine(_, _, _)                                         => false
+    }
+
 }
 
 object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {

--- a/zio-http/src/main/scala/zio/http/api/Middleware.scala
+++ b/zio-http/src/main/scala/zio/http/api/Middleware.scala
@@ -43,12 +43,6 @@ object Middleware {
   ): Middleware[R, E, A, B] =
     HandlerZIO(middlewareSpec, f)
 
-  def fromFunctionZIOWithRequest[R, E, A, B](
-    middlewareSpec: MiddlewareSpec[A, B],
-    f: A => ZIO[R, E, B],
-  ): Middleware[R, E, A, B] =
-    HandlerZIO(middlewareSpec, f)
-
   val none: Middleware[Any, Nothing, Unit, Unit] =
     fromFunction(MiddlewareSpec.none, _ => ())
 

--- a/zio-http/src/main/scala/zio/http/api/Middleware.scala
+++ b/zio-http/src/main/scala/zio/http/api/Middleware.scala
@@ -3,6 +3,9 @@ package zio.http.api
 import zio.ZIO
 import zio.http._
 import zio.http.model.Cookie
+import zio.schema.codec.JsonCodec
+
+import zio.http.api.internal.BodyCodec
 
 /**
  * A `Middleware` represents the implementation of a `MiddlewareSpec`,
@@ -14,6 +17,9 @@ sealed trait Middleware[-R, +E, I, O] { self =>
     outCombiner: Combiner[O, O2],
   ): Middleware[R1, E1, inCombiner.Out, outCombiner.Out] =
     Middleware.Concat[R1, E1, I, O, I2, O2, inCombiner.Out, outCombiner.Out](self, that, inCombiner, outCombiner)
+
+  def toHttpTransformer[R1 <: R, E1 >: E]: HttpApp[R1, E1] => HttpApp[R1, E1] =
+    Middleware.toHttpMiddleware(self)
 
 }
 
@@ -32,6 +38,12 @@ object Middleware {
     Handler(middlewareSpec, f)
 
   def fromFunctionZIO[R, E, A, B](
+    middlewareSpec: MiddlewareSpec[A, B],
+    f: A => ZIO[R, E, B],
+  ): Middleware[R, E, A, B] =
+    HandlerZIO(middlewareSpec, f)
+
+  def fromFunctionZIOWithRequest[R, E, A, B](
     middlewareSpec: MiddlewareSpec[A, B],
     f: A => ZIO[R, E, B],
   ): Middleware[R, E, A, B] =
@@ -58,4 +70,160 @@ object Middleware {
 
   private[api] final case class Handler[I, O](middlewareSpec: MiddlewareSpec[I, O], handler: I => O)
       extends Middleware[Any, Nothing, I, O]
+
+  private[api] def toHttpMiddleware[R, E, I, O](
+    middleware: Middleware[R, E, I, O],
+  ): HttpApp[R, E] => HttpApp[R, E] = {
+    var optionalState: Option[I] = None
+
+    middleware match {
+      case Middleware.HandlerZIO(middlewareSpec, handler) =>
+        applyHandler(middlewareSpec)(
+          handler,
+          input => { optionalState = Some(input) },
+          optionalState.getOrElse(().asInstanceOf[I]),
+        )
+
+      case concat: Middleware.Concat[R, E, _, _, _, _, _, _] =>
+        http => toHttpMiddleware(concat.right)(toHttpMiddleware(concat.left)(http))
+      case Middleware.Handler(spec, handler)                 =>
+        applyHandler(spec)(
+          i => ZIO.succeed(handler(i)),
+          input => { optionalState = Some(input) },
+          optionalState.getOrElse(().asInstanceOf[I]),
+        ) // FIXME: Reuse what's implemented for HandlerZIO
+      case peek: Middleware.PeekRequest[_, _, _, _]          => toHttpMiddleware(peek.middleware)
+    }
+  }
+
+  private[api] def applyHandler[R, E, I, O](middlewareSpec: MiddlewareSpec[I, O])(
+    handler: I => ZIO[R, E, O],
+    updateState: I => Unit,
+    state: I,
+  ): HttpApp[R, E] => HttpApp[R, E] = {
+    if (middlewareSpec.middlewareOut.isEmpty)
+      http => {
+        val incomingFunction =
+          loopMiddlewareIn(middlewareSpec.middlewareIn)
+        Http.fromOptionFunction[Request] { request =>
+          for {
+            input <- incomingFunction(request)
+            _     <- input match {
+              case Some(input) =>
+                updateState(input)
+                handler(input).mapError(Some(_))
+              case None        =>
+                ZIO.unit
+            }
+            b     <- http(request)
+          } yield b
+        }
+      }
+    else { http =>
+      {
+        val outgoingFn =
+          loopMiddlewareOut(middlewareSpec.middlewareOut, handler)
+
+        Http.fromOptionFunction[Request] { request =>
+          for {
+            response <- http(request)
+            response <- outgoingFn(response, state).mapError(Some(_))
+          } yield response
+        }
+      }
+    }
+  }
+
+  private[api] def loopMiddlewareIn[R, E, I1](
+    in: HttpCodec[CodecType.Header with CodecType.Query, I1],
+  ): Request => ZIO[R, Option[E], Option[I1]] = {
+    in match {
+      case atom: HttpCodec.Atom[CodecType.Header with CodecType.Query, _] =>
+        atom match {
+          case HttpCodec.Header(name, codec) =>
+            (request: Request) => ZIO.fromOption(request.headers.get(name).flatMap(codec.decode)).map(Some(_))
+
+          case HttpCodec.Query(key, codec) =>
+            (request: Request) =>
+              ZIO
+                .fromOption(
+                  request.url.queryParams.get(key).flatMap(_.headOption).flatMap(codec.decode),
+                )
+                .map(Some(_))
+
+          case HttpCodec.Empty =>
+            _ => ZIO.succeed(None)
+
+          case _ =>
+            _ => ZIO.fail(None)
+        }
+
+      case HttpCodec.WithDoc(in, _) =>
+        loopMiddlewareIn(in)
+
+      case HttpCodec.TransformOrFail(api, f, _) =>
+        request =>
+          loopMiddlewareIn(api)(request).map(
+            _.map(value =>
+              f(value).getOrElse(throw new Exception("Failed to transform the input retrieved in middleware")),
+            ),
+          )
+
+      case HttpCodec.Combine(left, right, inputCombiner) =>
+        request =>
+          loopMiddlewareIn(left)(request).zip(loopMiddlewareIn(right)(request)).map { a =>
+            for {
+              a1 <- a._1
+              a2 <- a._2
+            } yield inputCombiner.combine(a1, a2)
+          }
+    }
+  }
+
+  private[api] def loopMiddlewareOut[R, E, I, O](
+    out: HttpCodec[CodecType.ResponseType, O],
+    handler: I => ZIO[R, E, O],
+  ): (Response, I) => ZIO[R, E, Response] =
+    out match {
+      case atom: HttpCodec.Atom[CodecType.ResponseType, O] =>
+        atom match {
+          case HttpCodec.Header(name, codec) =>
+            (response, state) => handler(state).map(out => response.addHeader(name, codec.encode(out)))
+
+          case HttpCodec.Body(schema) =>
+            (response, state) =>
+              handler(state).map(o => response.copy(body = BodyCodec.Single(schema).encodeToBody(o, JsonCodec)))
+
+          case _ =>
+            (response, _) => ZIO.succeed(response)
+        }
+
+      case HttpCodec.WithDoc(in, _) =>
+        loopMiddlewareOut(in, handler)
+
+      case HttpCodec.TransformOrFail(api, f, _) =>
+        (response, state) =>
+          loopMiddlewareOut(
+            api,
+            (i: I) =>
+              handler(i).map(o =>
+                f(o) match {
+                  case Left(value)  =>
+                    throw new Exception(
+                      s"Failed to convert. ${value}",
+                    ) // Good to transformOrFail have polymorphic error type and use ZIO.fromEither
+                  case Right(value) => value
+                },
+              ),
+          )(
+            response,
+            state,
+          )
+
+      case HttpCodec.Combine(left, right, _) =>
+        (response, status) =>
+          loopMiddlewareOut(left, handler)(response, status).flatMap(response =>
+            loopMiddlewareOut(right, handler)(response, status),
+          )
+    }
 }

--- a/zio-http/src/main/scala/zio/http/api/ServiceSpec.scala
+++ b/zio-http/src/main/scala/zio/http/api/ServiceSpec.scala
@@ -1,7 +1,12 @@
 package zio.http.api
 
+import zio.http.api.internal.BodyCodec
+import zio.http.model.Status
 import zio.http.{Http, HttpApp, Request, Response}
+import zio.schema.codec.JsonCodec
 import zio.{Chunk, ZIO, http}
+
+import scala.collection.mutable.ListBuffer
 
 sealed trait ServiceSpec[MI, MO, -AllIds] { self =>
   final def ++[AllIds2](that: ServiceSpec[MI, MO, AllIds2]): ServiceSpec[MI, MO, AllIds with AllIds2] =
@@ -26,7 +31,7 @@ sealed trait ServiceSpec[MI, MO, -AllIds] { self =>
     service: Endpoints[R, E, AllIds1],
     midddleware: Middleware[R, E, MI, MO],
   ): HttpApp[R, E] =
-    ServiceSpec.toHttpMiddleware(midddleware)(service.toHttpApp)
+    midddleware.toHttpTransformer(service.toHttpApp)
 
   final def withMI[MI2](implicit ev: MI =:= MI2): ServiceSpec[MI2, MO, AllIds] =
     self.asInstanceOf[ServiceSpec[MI2, MO, AllIds]]
@@ -34,7 +39,8 @@ sealed trait ServiceSpec[MI, MO, -AllIds] { self =>
   final def withMO[MO2](implicit ev: MO =:= MO2): ServiceSpec[MI, MO2, AllIds] =
     self.asInstanceOf[ServiceSpec[MI, MO2, AllIds]]
 }
-object ServiceSpec                        {
+
+object ServiceSpec {
   private case object Empty                                    extends ServiceSpec[Unit, Unit, Any]
   private final case class Single[Id](api: EndpointSpec[_, _]) extends ServiceSpec[Unit, Unit, Id]
   private final case class Concat[MI, MO, AllIds1, AllIds2](
@@ -70,86 +76,4 @@ object ServiceSpec                        {
       case AddMiddleware(_, middlewareSpec0, _, _) => middlewareSpec0
     }
   }
-
-  def toHttpMiddleware[R, E, I, O](
-    middleware: Middleware[R, E, I, O],
-  ): HttpApp[R, E] => HttpApp[R, E] = {
-    middleware match {
-      // Type safety issues
-      // If both in and out exists, handler should only be applied to `in`
-      // If only either of them exist, handler shouldn't be applied to the one that is none
-      case Middleware.HandlerZIO(middlewareSpec, handler) =>
-        def loop[I1](
-          in: HttpCodec[CodecType.Header with CodecType.Query, I1],
-        ): Request => ZIO[R, Option[E], Option[I1]] = {
-
-          in match {
-            case atom: HttpCodec.Atom[CodecType.Header with CodecType.Query, _] =>
-              atom match {
-                case HttpCodec.Header(name, codec) =>
-                  (request: Request) => ZIO.fromOption(request.headers.get(name).flatMap(codec.decode)).map(Some(_))
-
-                case HttpCodec.Query(key, codec) =>
-                  (request: Request) =>
-                    ZIO
-                      .fromOption(
-                        request.url.queryParams.get(key).flatMap(_.headOption).flatMap(codec.decode),
-                      )
-                      .map(Some(_))
-
-                case HttpCodec.Empty =>
-                  _ => ZIO.succeed(None)
-
-                case _ =>
-                  _ => ZIO.fail(None)
-              }
-
-            case HttpCodec.WithDoc(in, _) =>
-              loop(in)
-
-            case HttpCodec.TransformOrFail(api, f, _) =>
-              request =>
-                loop(api)(request).map(
-                  _.map(value =>
-                    f(value).getOrElse(throw new Exception("Failed to transform the input retrieved in middleware")),
-                  ),
-                )
-
-            case HttpCodec.Combine(left, right, inputCombiner) =>
-              request =>
-                loop(left)(request).zip(loop(right)(request)).map { a =>
-                  for {
-                    a1 <- a._1
-                    a2 <- a._2
-                  } yield inputCombiner.combine(a1, a2)
-                }
-          }
-        }
-
-        val interceptFn =
-          loop(middlewareSpec.middlewareIn) // FIXME Also handle middlewareOut
-
-        http =>
-          Http.fromOptionFunction[Request] { a =>
-            for {
-              input <- interceptFn(a)
-
-              _ <- input match {
-                case Some(value) =>
-                  handler(value).mapError(Some(_))
-                case None        =>
-                  ZIO.unit // Handle HttpCodec.Empty properly in loop
-              } // FIXME:  MiddlewareOut to be implemented (only proof)  output will have to be used to form the final out
-
-              b <- http(a)
-            } yield b
-          }
-
-      case concat: Middleware.Concat[R, E, _, _, _, _, _, _] =>
-        http => toHttpMiddleware(concat.right)(toHttpMiddleware(concat.left)(http))
-      case Middleware.Handler(_, _)                 => identity // FIXME: Reuse what's implemented for HandlerZIO
-      case peek: Middleware.PeekRequest[_, _, _, _] => toHttpMiddleware(peek.middleware)
-    }
-  }
-
 }


### PR DESCRIPTION
The PR is not mean't to be merged, and mainly raised to have a discussion with @jdegoes.

PR is completing the existing functionality of converting a declarative `api.Middleware` to `HttpApp[R, E] => HttpApp[R, E]` handling both `MiddlewareSpec.In` and `MiddlewareSpec.out`.