### PR TITLE
Rename root for better rendering in tooling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ ThisBuild / githubWorkflowBuildPostamble :=
   ).steps
 
 lazy val root = (project in file("."))
-  .settings(stdSettings("root"))
+  .settings(stdSettings("zio-http-root"))
   .settings(publishSetting(false))
   .aggregate(
     zioHttp,


### PR DESCRIPTION
IntelliJ for example renders the name of the main module on the top of the window. With this change, it is easy to see that the window belongs to zio-http.

I think this has no implications for the code.