### PR TITLE
Add Accept-Ranges header codec

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
@@ -18,8 +18,9 @@ trait HeaderCodecs {
   final val acceptLanguage: HeaderCodec[AcceptLanguage]           =
     header(HeaderNames.acceptLanguage.toString(), TextCodec.string)
       .transform(AcceptLanguage.toAcceptLanguage, AcceptLanguage.fromAcceptLanguage)
-  final val acceptRanges: HeaderCodec[String]                     =
+  final val acceptRanges: HeaderCodec[AcceptRanges]               =
     header(HeaderNames.acceptRanges.toString(), TextCodec.string)
+      .transform(AcceptRanges.to, AcceptRanges.from)
   final val acceptPatch: HeaderCodec[AcceptPatch]                 =
     header(HeaderNames.acceptPatch.toString(), TextCodec.string)
       .transform(AcceptPatch.toAcceptPatch, AcceptPatch.fromAcceptPatch)

--- a/zio-http/src/main/scala/zio/http/model/headers/values/AcceptRanges.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/AcceptRanges.scala
@@ -1,11 +1,11 @@
 package zio.http.model.headers.values
 
 /**
- * The Accept-Ranges HTTP response header is a marker used by the server
- * to advertise its support for partial requests from the client for file
+ * The Accept-Ranges HTTP response header is a marker used by the server to
+ * advertise its support for partial requests from the client for file
  * downloads. The value of this field indicates the unit that can be used to
- * define a range. By default the RFC 7233 specification supports only 2 possible
- * values.
+ * define a range. By default the RFC 7233 specification supports only 2
+ * possible values.
  */
 sealed trait AcceptRanges {
   val name: String

--- a/zio-http/src/main/scala/zio/http/model/headers/values/AcceptRanges.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/AcceptRanges.scala
@@ -1,0 +1,34 @@
+package zio.http.model.headers.values
+
+/**
+ * The Accept-Ranges HTTP response header is a marker used by the server
+ * to advertise its support for partial requests from the client for file
+ * downloads. The value of this field indicates the unit that can be used to
+ * define a range. By default the RFC 7233 specification supports only 2 possible
+ * values.
+ */
+sealed trait AcceptRanges {
+  val name: String
+}
+
+object AcceptRanges {
+  case object Bytes               extends AcceptRanges {
+    override val name = "bytes"
+  }
+  case object None                extends AcceptRanges {
+    override val name = "none"
+  }
+  case object InvalidAcceptRanges extends AcceptRanges {
+    override val name = ""
+  }
+
+  def from(acceptRangers: AcceptRanges): String =
+    acceptRangers.name
+
+  def to(value: String): AcceptRanges =
+    value match {
+      case Bytes.name => Bytes
+      case None.name  => None
+      case _          => InvalidAcceptRanges
+    }
+}

--- a/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
@@ -304,4 +304,7 @@ object HttpGen {
       ContentEncoding.InvalidEncoding,
     ),
   )
+
+  def acceptRanges: Gen[Any, AcceptRanges] =
+    Gen.elements(AcceptRanges.Bytes, AcceptRanges.None, AcceptRanges.InvalidAcceptRanges)
 }

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptRangesSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptRangesSpec.scala
@@ -19,6 +19,6 @@ object AcceptRangesSpec extends ZIOSpecDefault {
         check(HttpGen.acceptRanges) { acceptRanges =>
           assertTrue(AcceptRanges.to(AcceptRanges.from(acceptRanges)) == acceptRanges)
         }
-      }
+      },
     )
 }

--- a/zio-http/src/test/scala/zio/http/model/headers/values/AcceptRangesSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/AcceptRangesSpec.scala
@@ -1,0 +1,24 @@
+package zio.http.model.headers.values
+
+import zio.Scope
+import zio.http.internal.HttpGen
+import zio.test._
+
+object AcceptRangesSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Nothing] =
+    suite("Accept ranges header suite")(
+      test("parsing valid values") {
+        assertTrue(AcceptRanges.to("bytes") == AcceptRanges.Bytes) &&
+        assertTrue(AcceptRanges.to("none") == AcceptRanges.None)
+      },
+      test("parsing invalid values") {
+        assertTrue(AcceptRanges.to("") == AcceptRanges.InvalidAcceptRanges) &&
+        assertTrue(AcceptRanges.to("strings") == AcceptRanges.InvalidAcceptRanges)
+      },
+      test("accept ranges header must be symmetrical") {
+        check(HttpGen.acceptRanges) { acceptRanges =>
+          assertTrue(AcceptRanges.to(AcceptRanges.from(acceptRanges)) == acceptRanges)
+        }
+      }
+    )
+}


### PR DESCRIPTION
Accept-Ranges header codec for #1524 

I noticed that other codecs use the following notation: `<HeaderName>.to<HeaderName>` and `<HeaderName>.from<HeaderName>`

Is there any reason in it? Why not just use `<HeaderName>.to` and `<HeaderName>.from`?