### PR TITLE
Added header codec for Transfer-Encoding

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
@@ -140,25 +140,27 @@ trait HeaderCodecs {
   final val setCookie: HeaderCodec[String]               = header(HeaderNames.setCookie.toString(), TextCodec.string)
   final val te: HeaderCodec[String]                      = header(HeaderNames.te.toString(), TextCodec.string)
   final val trailer: HeaderCodec[String]                 = header(HeaderNames.trailer.toString(), TextCodec.string)
-  final val transferEncoding: HeaderCodec[String]        =
-    header(HeaderNames.transferEncoding.toString(), TextCodec.string)
-  final val upgrade: HeaderCodec[String]                 = header(HeaderNames.upgrade.toString(), TextCodec.string)
-  final val upgradeInsecureRequests: HeaderCodec[String] =
+  final val transferEncoding: HeaderCodec[TransferEncoding] = header(
+    HeaderNames.transferEncoding.toString(),
+    TextCodec.string,
+  ).transform(TransferEncoding.toTransferEncoding, TransferEncoding.fromTransferEncoding)
+  final val upgrade: HeaderCodec[String]                    = header(HeaderNames.upgrade.toString(), TextCodec.string)
+  final val upgradeInsecureRequests: HeaderCodec[String]    =
     header(HeaderNames.upgradeInsecureRequests.toString(), TextCodec.string)
-  final val userAgent: HeaderCodec[String]               = header(HeaderNames.userAgent.toString(), TextCodec.string)
-  final val vary: HeaderCodec[String]                    = header(HeaderNames.vary.toString(), TextCodec.string)
-  final val via: HeaderCodec[String]                     = header(HeaderNames.via.toString(), TextCodec.string)
-  final val warning: HeaderCodec[String]                 = header(HeaderNames.warning.toString(), TextCodec.string)
-  final val webSocketLocation: HeaderCodec[String]       =
+  final val userAgent: HeaderCodec[String]                  = header(HeaderNames.userAgent.toString(), TextCodec.string)
+  final val vary: HeaderCodec[String]                       = header(HeaderNames.vary.toString(), TextCodec.string)
+  final val via: HeaderCodec[String]                        = header(HeaderNames.via.toString(), TextCodec.string)
+  final val warning: HeaderCodec[String]                    = header(HeaderNames.warning.toString(), TextCodec.string)
+  final val webSocketLocation: HeaderCodec[String]          =
     header(HeaderNames.webSocketLocation.toString(), TextCodec.string)
-  final val webSocketOrigin: HeaderCodec[String]         =
+  final val webSocketOrigin: HeaderCodec[String]            =
     header(HeaderNames.webSocketOrigin.toString(), TextCodec.string)
-  final val webSocketProtocol: HeaderCodec[String]       =
+  final val webSocketProtocol: HeaderCodec[String]          =
     header(HeaderNames.webSocketProtocol.toString(), TextCodec.string)
-  final val wwwAuthenticate: HeaderCodec[String]         =
+  final val wwwAuthenticate: HeaderCodec[String]            =
     header(HeaderNames.wwwAuthenticate.toString(), TextCodec.string)
-  final val xFrameOptions: HeaderCodec[String]           =
+  final val xFrameOptions: HeaderCodec[String]              =
     header(HeaderNames.xFrameOptions.toString(), TextCodec.string)
-  final val xRequestedWith: HeaderCodec[String]          =
+  final val xRequestedWith: HeaderCodec[String]             =
     header(HeaderNames.xRequestedWith.toString(), TextCodec.string)
 }

--- a/zio-http/src/main/scala/zio/http/model/headers/values/TransferEncoding.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/TransferEncoding.scala
@@ -1,0 +1,97 @@
+package zio.http.model.headers.values
+
+import zio.Chunk
+
+sealed trait TransferEncoding {
+  val encoding: String
+}
+
+object TransferEncoding {
+
+  /**
+   * InvalidEncoding is represented with ""
+   */
+  case object InvalidEncoding extends TransferEncoding {
+    override val encoding: String = ""
+  }
+
+  /**
+   * Data is sent in a series of chunks.
+   */
+  case object ChunkedEncoding extends TransferEncoding {
+    override val encoding: String = "chunked"
+  }
+
+  /**
+   * A format using the Lempel-Ziv-Welch (LZW) algorithm. The value name was
+   * taken from the UNIX compress program, which implemented this algorithm.
+   * Like the compress program, which has disappeared from most UNIX
+   * distributions, this content-encoding is not used by many browsers today,
+   * partly because of a patent issue (it expired in 2003).
+   */
+  case object CompressEncoding extends TransferEncoding {
+    override val encoding: String = "compress"
+  }
+
+  /**
+   * Using the zlib structure (defined in RFC 1950) with the deflate compression
+   * algorithm (defined in RFC 1951).
+   */
+  case object DeflateEncoding extends TransferEncoding {
+    override val encoding: String = "deflate"
+  }
+
+  /**
+   * A format using the Lempel-Ziv coding (LZ77), with a 32-bit CRC. This is the
+   * original format of the UNIX gzip program. The HTTP/1.1 standard also
+   * recommends that the servers supporting this content-encoding should
+   * recognize x-gzip as an alias, for compatibility purposes.
+   */
+  case object GZipEncoding extends TransferEncoding {
+    override val encoding: String = "gzip"
+  }
+
+  /**
+   * Maintains a list of TransferEncoding values.
+   */
+  final case class MultipleEncodings(encodings: Chunk[TransferEncoding]) extends TransferEncoding {
+    override val encoding: String = encodings.map(_.encoding).mkString(",")
+  }
+
+  private def findEncoding(value: String): TransferEncoding = {
+    value.trim match {
+      case "chunked"  => ChunkedEncoding
+      case "compress" => CompressEncoding
+      case "deflate"  => DeflateEncoding
+      case "gzip"     => GZipEncoding
+      case _          => InvalidEncoding
+    }
+  }
+
+  /**
+   * @param value
+   *   of string , seperated for multiple values
+   * @return
+   *   TransferEncoding
+   *
+   * Note: This implementation ignores the invalid string that might occur in
+   * MultipleEncodings case.
+   */
+  def toTransferEncoding(value: String): TransferEncoding = {
+    val array = value.split(",")
+    array.foldLeft[TransferEncoding](InvalidEncoding)((accum, elem) => {
+      val encoding = findEncoding(elem)
+      (accum, encoding) match {
+        case (InvalidEncoding, InvalidEncoding)              => InvalidEncoding
+        case (InvalidEncoding, other)                        => other
+        case (MultipleEncodings(encodings), InvalidEncoding) => MultipleEncodings(encodings)
+        case (MultipleEncodings(encodings), other)           => MultipleEncodings(encodings ++ Chunk(other))
+        case (other, InvalidEncoding)                        => other
+        case (other, other1)                                 => MultipleEncodings(Chunk(other, other1))
+      }
+    })
+  }
+
+  def fromTransferEncoding(value: TransferEncoding): String = value.encoding
+
+}

--- a/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
@@ -307,4 +307,15 @@ object HttpGen {
 
   def acceptRanges: Gen[Any, AcceptRanges] =
     Gen.elements(AcceptRanges.Bytes, AcceptRanges.None, AcceptRanges.InvalidAcceptRanges)
+
+  def allowTransferEncodingSingleValue: Gen[Any, TransferEncoding] = Gen.fromIterable(
+    List(
+      TransferEncoding.ChunkedEncoding,
+      TransferEncoding.CompressEncoding,
+      TransferEncoding.GZipEncoding,
+      TransferEncoding.MultipleEncodings(Chunk(TransferEncoding.ChunkedEncoding, TransferEncoding.CompressEncoding)),
+      TransferEncoding.DeflateEncoding,
+      TransferEncoding.InvalidEncoding,
+    ),
+  )
 }

--- a/zio-http/src/test/scala/zio/http/model/headers/values/TransferEncodingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/TransferEncodingSpec.scala
@@ -1,0 +1,61 @@
+package zio.http.model.headers.values
+
+import zio.http.internal.HttpGen
+import zio.http.model.headers.values.TransferEncoding.{InvalidEncoding, MultipleEncodings}
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue, check}
+import zio.{Chunk, Scope}
+
+object TransferEncodingSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("TransferEncoding suite")(
+    suite("TransferEncoding header value transformation should be symmetrical")(
+      test("gen single value") {
+        check(HttpGen.allowTransferEncodingSingleValue) { value =>
+          assertTrue(TransferEncoding.toTransferEncoding(TransferEncoding.fromTransferEncoding(value)) == value)
+        }
+      },
+      test("single value") {
+        assertTrue(TransferEncoding.toTransferEncoding("chunked") == TransferEncoding.ChunkedEncoding) &&
+        assertTrue(TransferEncoding.toTransferEncoding("compress") == TransferEncoding.CompressEncoding) &&
+        assertTrue(TransferEncoding.toTransferEncoding("deflate") == TransferEncoding.DeflateEncoding) &&
+        assertTrue(
+          TransferEncoding.toTransferEncoding("deflate, chunked, compress") == TransferEncoding.MultipleEncodings(
+            Chunk(TransferEncoding.DeflateEncoding, TransferEncoding.ChunkedEncoding, TransferEncoding.CompressEncoding),
+          ),
+        ) &&
+        assertTrue(TransferEncoding.toTransferEncoding("garbage") == TransferEncoding.InvalidEncoding)
+
+      },
+      test("edge cases") {
+        assertTrue(
+          TransferEncoding.toTransferEncoding(
+            TransferEncoding.fromTransferEncoding(MultipleEncodings(Chunk())),
+          ) == InvalidEncoding,
+        ) &&
+        assertTrue(
+          TransferEncoding.toTransferEncoding(
+            TransferEncoding.fromTransferEncoding(
+              MultipleEncodings(
+                Chunk(
+                  TransferEncoding.DeflateEncoding,
+                  TransferEncoding.ChunkedEncoding,
+                  TransferEncoding.CompressEncoding,
+                ),
+              ),
+            ),
+          ) == TransferEncoding.MultipleEncodings(
+            Chunk(TransferEncoding.DeflateEncoding, TransferEncoding.ChunkedEncoding, TransferEncoding.CompressEncoding),
+          ),
+        ) &&
+        assertTrue(
+          TransferEncoding.toTransferEncoding(
+            TransferEncoding.fromTransferEncoding(
+              MultipleEncodings(
+                Chunk(TransferEncoding.DeflateEncoding),
+              ),
+            ),
+          ) == TransferEncoding.DeflateEncoding,
+        )
+      },
+    ),
+  )
+}


### PR DESCRIPTION
Added header codec for Transfer-Encoding.   Tried following implementation based on [ContentEncoding](https://github.com/zio/zio-http/blob/c8597a61d7d5d816fd4f68603428f75e94c97e34/zio-http/src/main/scala/zio/http/model/headers/values/ContentEncoding.scala). 

One main difference between Content-Encoding is the value `chunked` instead of `br`

Here is the spec reference related to this this header
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding

