### PR TITLE
feat: add auth and cors middleware

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -40,7 +40,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * method may only be called on header and query codecs.
    */
   def optional(implicit
-    ev: CodecType.Header with CodecType.Query <:< AtomTypes,
+    ev: CodecType.Header with CodecType.Query with CodecType.Method <:< AtomTypes,
   ): HttpCodec[AtomTypes, Option[Value]] =
     HttpCodec.Optional(HttpCodec.updateOptional(self))
 

--- a/zio-http/src/main/scala/zio/http/api/MethodCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/MethodCodecs.scala
@@ -7,6 +7,14 @@ private[api] trait MethodCodecs {
   def method(method: zio.http.model.Method): HttpCodec[CodecType.Method, Unit] =
     HttpCodec.Method(TextCodec.constant(method.toString()))
 
+  def method: HttpCodec[CodecType.Method, zio.http.model.Method] =
+    HttpCodec
+      .Method(TextCodec.string)
+      .transform(
+        methodStr => zio.http.model.Method.fromString(methodStr),
+        method => method.text,
+      )
+
   def get: HttpCodec[Method, Unit]    = method(zio.http.model.Method.GET)
   def put: HttpCodec[Method, Unit]    = method(zio.http.model.Method.PUT)
   def post: HttpCodec[Method, Unit]   = method(zio.http.model.Method.POST)

--- a/zio-http/src/main/scala/zio/http/api/Middleware.scala
+++ b/zio-http/src/main/scala/zio/http/api/Middleware.scala
@@ -1,12 +1,16 @@
 package zio.http.api
 
+import io.netty.handler.codec.http.HttpHeaderNames
 import zio._
 import zio.http._
-import zio.http.api.MiddlewareSpec.CsrfValidate
-import zio.http.model.{Cookie, Status}
-import zio.schema.codec.JsonCodec
+import zio.http.api.MiddlewareSpec.{CsrfValidate, decodeHttpBasic}
+import zio.http.middleware.Auth
+import zio.http.middleware.Cors.CorsConfig
+import zio.http.model.Headers.{BasicSchemeName, BearerSchemeName, Header}
+import zio.http.model.headers.values.Origin
+import zio.http.model.{Cookie, Headers, Method, Status}
 
-import java.util.UUID
+import java.util.{Base64, UUID}
 
 /**
  * A `Middleware` represents the implementation of a `MiddlewareSpec`,
@@ -103,6 +107,158 @@ object Middleware {
 
   def addCookieZIO[R](cookie: ZIO[R, Nothing, Cookie[Response]]): Middleware[R, Unit, Cookie[Response]] =
     fromFunctionZIO(MiddlewareSpec.addCookie)(_ => cookie)
+
+  /**
+   * Creates a middleware for basic authentication
+   */
+  final def basicAuth(f: Auth.Credentials => Boolean)(implicit trace: Trace): Middleware[Any, String, Unit] =
+    basicAuthZIO(credentials => ZIO.succeed(f(credentials)))
+
+  /**
+   * Creates a middleware for basic authentication that checks if the
+   * credentials are same as the ones given
+   */
+  final def basicAuth(u: String, p: String)(implicit trace: Trace): Middleware[Any, String, Unit] =
+    basicAuth { credentials => (credentials.uname == u) && (credentials.upassword == p) }
+
+  /**
+   * Creates a middleware for basic authentication using an effectful
+   * verification function
+   */
+  def basicAuthZIO[R](f: Auth.Credentials => ZIO[R, Nothing, Boolean])(implicit
+    trace: Trace,
+  ): Middleware[R, String, Unit] =
+    customAuthZIO(HeaderCodec.authorization, Headers(HttpHeaderNames.WWW_AUTHENTICATE, BasicSchemeName)) { encoded =>
+      val indexOfBasic = encoded.indexOf(BasicSchemeName)
+      if (indexOfBasic != 0 || encoded.length == BasicSchemeName.length) ZIO.succeed(false)
+      else {
+        // TODO: probably should be part of decodeHttpBasic
+        val readyForDecode = new String(Base64.getDecoder.decode(encoded.substring(BasicSchemeName.length + 1)))
+        decodeHttpBasic(readyForDecode) match {
+          case Some(credentials) => f(credentials)
+          case None              => ZIO.succeed(false)
+        }
+      }
+    }
+
+  /**
+   * Creates a middleware for bearer authentication that checks the token using
+   * the given function
+   *
+   * @param f
+   *   : function that validates the token string inside the Bearer Header
+   */
+  final def bearerAuth(f: String => Boolean)(implicit trace: Trace): Middleware[Any, String, Unit] =
+    bearerAuthZIO(token => ZIO.succeed(f(token)))
+
+  /**
+   * Creates a middleware for bearer authentication that checks the token using
+   * the given effectful function
+   *
+   * @param f
+   *   : function that effectfully validates the token string inside the Bearer
+   *   Header
+   */
+  final def bearerAuthZIO[R](
+    f: String => ZIO[R, Nothing, Boolean],
+  )(implicit trace: Trace): Middleware[R, String, Unit] =
+    customAuthZIO(
+      HeaderCodec.authorization,
+      responseHeaders = Headers(HttpHeaderNames.WWW_AUTHENTICATE, BearerSchemeName),
+    ) { token =>
+      val indexOfBearer = token.indexOf(BearerSchemeName)
+      if (indexOfBearer != 0 || token.length == BearerSchemeName.length)
+        ZIO.succeed(false)
+      else
+        f(token.substring(BearerSchemeName.length + 1))
+    }
+
+  /**
+   * Creates an authentication middleware that only allows authenticated
+   * requests to be passed on to the app.
+   */
+  def customAuth[R, I](headerCodec: HeaderCodec[I])(
+    verify: I => Boolean,
+  ): Middleware[R, I, Unit] =
+    customAuthZIO(headerCodec)(header => ZIO.succeed(verify(header)))
+
+  /**
+   * Creates an authentication middleware that only allows authenticated
+   * requests to be passed on to the app using an effectful verification
+   * function.
+   */
+  def customAuthZIO[R, I](
+    headerCodec: HeaderCodec[I],
+    responseHeaders: Headers = Headers.empty,
+    responseStatus: Status = Status.Unauthorized,
+  )(verify: I => ZIO[R, Nothing, Boolean])(implicit trace: Trace): Middleware[R, I, Unit] =
+    MiddlewareSpec.customAuth(headerCodec).implementIncomingControl { in =>
+      verify(in).map {
+        case true  => Middleware.Control.Continue(())
+        case false => Middleware.Control.Abort((), _.copy(status = responseStatus, headers = responseHeaders))
+      }
+    }
+
+  /**
+   * Creates a middleware for Cross-Origin Resource Sharing (CORS).
+   *
+   * @see
+   *   https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+   */
+  def cors(config: CorsConfig = CorsConfig()) = {
+    def allowCORS(origin: Origin, method: Method): Boolean =
+      (config.anyOrigin, config.anyMethod, Origin.fromOrigin(origin), method) match {
+        case (true, true, _, _)           => true
+        case (true, false, _, acrm)       => config.allowedMethods.exists(_.contains(acrm))
+        case (false, true, origin, _)     => config.allowedOrigins(origin)
+        case (false, false, origin, acrm) =>
+          config.allowedMethods.exists(_.contains(acrm)) && config.allowedOrigins(origin)
+      }
+
+    def corsHeaders(origin: Origin, isPreflight: Boolean): Headers = {
+      def buildHeaders(headerName: String, values: Option[Set[String]]): Headers =
+        values match {
+          case Some(headerValues) =>
+            Headers(headerValues.toList.map(value => Header(headerName, value)))
+          case None               => Headers.empty
+        }
+
+      Headers.ifThenElse(isPreflight)(
+        onTrue = buildHeaders(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(), config.allowedHeaders),
+        onFalse = buildHeaders(HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS.toString(), config.exposedHeaders),
+      ) ++
+        Headers(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), Origin.fromOrigin(origin)) ++
+        buildHeaders(
+          HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(),
+          config.allowedMethods.map(_.map(_.toJava.name())),
+        ) ++
+        Headers.when(config.allowCredentials) {
+          Headers(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, config.allowCredentials.toString)
+        }
+    }
+
+    MiddlewareSpec.cors.implement {
+      case (Method.OPTIONS, Some(origin), Some(acrm)) if allowCORS(origin, Method.fromString(acrm)) =>
+        ZIO
+          .succeed(
+            Middleware.Control.Abort(
+              (),
+              _.copy(status = Status.NoContent, headers = corsHeaders(origin, isPreflight = true)),
+            ),
+          )
+
+      case (method, Some(origin), _) if allowCORS(origin, method) =>
+        ZIO
+          .succeed(
+            Middleware.Control
+              .Abort((), _.copy(headers = corsHeaders(origin, isPreflight = false))),
+          )
+
+      case _ => ZIO.succeed(Middleware.Control.Continue(()))
+    } { case (_, _) =>
+      ZIO.unit
+    }
+  }
 
   /**
    * Generates a new CSRF token that can be validated using the csrfValidate

--- a/zio-http/src/test/scala/zio/http/api/AuthMiddlewareSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/AuthMiddlewareSpec.scala
@@ -1,0 +1,95 @@
+package zio.http.api
+
+import zio._
+import zio.http.internal.HttpAppTestExtensions
+import zio.http.model.{Headers, Status}
+import zio.http.{Http, Request, URL}
+import zio.test.Assertion.{equalTo, isSome}
+import zio.test._
+
+object AuthMiddlewareSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+
+  private val successBasicHeader  = Headers.basicAuthorizationHeader("user", "resu")
+  private val failureBasicHeader  = Headers.basicAuthorizationHeader("user", "user")
+  private val bearerToken         = "dummyBearerToken"
+  private val successBearerHeader = Headers.bearerAuthorizationHeader(bearerToken)
+  private val failureBearerHeader = Headers.bearerAuthorizationHeader(bearerToken + "SomethingElse")
+
+  private val basicAuth     = Middleware.basicAuth { с => с.uname.reverse == с.upassword }
+  private val basicAuthZIO  = Middleware.basicAuthZIO { c => ZIO.succeed(c.uname.reverse == c.upassword) }
+  private val bearerAuth    = Middleware.bearerAuth { _ == bearerToken }
+  private val bearerAuthZIO = Middleware.bearerAuthZIO { c => ZIO.succeed(c == bearerToken) }
+
+  private val allowApp = Http.ok
+    .withMiddleware(Middleware.customAuthZIO(HeaderCodec.authorization)(_ => ZIO.succeed(true)))
+    .status
+
+  private val notAllowApp = Http.ok
+    .withMiddleware(Middleware.customAuthZIO(HeaderCodec.authorization)(_ => ZIO.succeed(false)))
+    .status
+
+  private val basicAuthApp = Http.ok
+    .withMiddleware(Middleware.basicAuthZIO { cred =>
+      ZIO.succeed(cred.uname == "user" && cred.upassword == "password")
+    })
+    .status
+  override def spec        =
+    suite("Auth Middleware Spec")(
+      suite("basicAuth")(
+        test("HttpApp is accepted if the basic authentication succeeds") {
+          val app = Http.ok.withMiddleware(basicAuth).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = successBasicHeader)))(equalTo(Status.Ok))
+        },
+        test("Uses forbidden app if the basic authentication fails") {
+          val app = Http.ok.withMiddleware(basicAuth).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBasicHeader)))(equalTo(Status.Unauthorized))
+        },
+        test("Responses should have WWW-Authentication header if Basic Auth failed") {
+          val app = Http.ok.withMiddleware(basicAuth).header("WWW-AUTHENTICATE")
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBasicHeader)))(isSome)
+        },
+      ),
+      suite("basicAuthZIO")(
+        test("HttpApp is accepted if the basic authentication succeeds") {
+          val app = Http.ok.withMiddleware(basicAuthZIO).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = successBasicHeader)))(equalTo(Status.Ok))
+        },
+        test("Uses forbidden app if the basic authentication fails") {
+          val app = Http.ok.withMiddleware(basicAuthZIO).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBasicHeader)))(equalTo(Status.Unauthorized))
+        },
+        test("Responses should have WWW-Authentication header if Basic Auth failed") {
+          val app = Http.ok.withMiddleware(basicAuthZIO).header("WWW-AUTHENTICATE")
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBasicHeader)))(isSome)
+        },
+      ),
+      suite("bearerAuth")(
+        test("HttpApp is accepted if the bearer authentication succeeds") {
+          val app = Http.ok.withMiddleware(bearerAuth).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = successBearerHeader)))(equalTo(Status.Ok))
+        },
+        test("Uses forbidden app if the bearer authentication fails") {
+          val app = Http.ok.withMiddleware(bearerAuth).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBearerHeader)))(equalTo(Status.Unauthorized))
+        },
+        test("Responses should have WWW-Authentication header if bearer Auth failed") {
+          val app = Http.ok.withMiddleware(bearerAuth).header("WWW-AUTHENTICATE")
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBearerHeader)))(isSome)
+        },
+      ),
+      suite("bearerAuthZIO")(
+        test("HttpApp is accepted if the bearer authentication succeeds") {
+          val app = Http.ok.withMiddleware(bearerAuthZIO).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = successBearerHeader)))(equalTo(Status.Ok))
+        },
+        test("Uses forbidden app if the bearer authentication fails") {
+          val app = Http.ok.withMiddleware(bearerAuthZIO).status
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBearerHeader)))(equalTo(Status.Unauthorized))
+        },
+        test("Responses should have WWW-Authentication header if bearer Auth failed") {
+          val app = Http.ok.withMiddleware(bearerAuthZIO).header("WWW-AUTHENTICATE")
+          assertZIO(app(Request.get(URL.empty).copy(headers = failureBearerHeader)))(isSome)
+        },
+      ),
+    )
+}

--- a/zio-http/src/test/scala/zio/http/api/CorsMiddlewareSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/CorsMiddlewareSpec.scala
@@ -1,0 +1,61 @@
+package zio.http.api
+
+import zio.http._
+import zio.http.api.Middleware.cors
+import zio.http.internal.HttpAppTestExtensions
+import zio.http.middleware.Cors.CorsConfig
+import zio.http.model.{Headers, Method, Status}
+import zio.test.Assertion.hasSubset
+import zio.test._
+
+object CorsMiddlewareSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+  val app = Http.ok.withMiddleware(cors(CorsConfig(allowedMethods = Some(Set(Method.GET)))))
+
+  override def spec =
+    suite("CorsMiddlewares")(
+      test("OPTIONS request") {
+        val request = Request
+          .options(URL(!! / "success"))
+          .copy(
+            headers = Headers.accessControlRequestMethod(Method.GET) ++ Headers.origin("https://domain-a:8080"),
+          )
+
+        val initialHeaders = Headers
+          .accessControlAllowCredentials(true)
+          .withAccessControlAllowMethods(Method.GET)
+          .withAccessControlAllowOrigin("https://domain-a:8080")
+
+        val expected = CorsConfig().allowedHeaders
+          .fold(Headers.empty) { header =>
+            header
+              .map(value => Headers.empty.withAccessControlAllowHeaders(value))
+              .fold(initialHeaders)(_ ++ _)
+          }
+          .toList
+
+        for {
+          res <- app(request)
+        } yield assert(res.headersAsList)(hasSubset(expected)) &&
+          assertTrue(res.status == Status.NoContent)
+      },
+      test("GET request") {
+        val request =
+          Request
+            .get(URL(!! / "success"))
+            .copy(
+              headers = Headers.accessControlRequestMethod(Method.GET) ++ Headers.origin("https://domain-a:8080"),
+            )
+
+        val expected = Headers
+          .accessControlExposeHeaders("*")
+          .withAccessControlAllowOrigin("https://domain-a:8080")
+          .withAccessControlAllowMethods(Method.GET)
+          .withAccessControlAllowCredentials(true)
+          .toList
+
+        for {
+          res <- app(request)
+        } yield assert(res.headersAsList)(hasSubset(expected))
+      },
+    )
+}

--- a/zio-http/src/test/scala/zio/http/model/headers/values/OriginSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/values/OriginSpec.scala
@@ -18,6 +18,10 @@ object OriginSpec extends ZIOSpecDefault {
       assertTrue(Origin.toOrigin("http://:80") == InvalidOriginValue) &&
       assertTrue(Origin.toOrigin("host:80") == InvalidOriginValue)
     },
+    test("parsing of valid without a port ") {
+      assertTrue(Origin.toOrigin("http://domain") == OriginValue("http", "domain", Some(80))) &&
+      assertTrue(Origin.toOrigin("https://domain") == OriginValue("https", "domain", Some(443)))
+    },
     test("parsing of valid Origin values") {
       check(HttpGen.genAbsoluteURL) { url =>
         val justSchemeHostAndPort = url.copy(path = Path.empty, queryParams = QueryParams.empty, fragment = None)


### PR DESCRIPTION
converting existing middleware to the new encoding
tests are adopted from existing implementation

fixes: #1700