### PR TITLE
Fixes #1737: Constructing RichTextCodec.repeat causes stack overflow

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
@@ -35,7 +35,7 @@ sealed trait RichTextCodec[A] { self =>
    * Returns a new codec that is the sequential composition of this codec and
    * the specified codec, producing the values of both as a tuple.
    */
-  final def ~[B](that: RichTextCodec[B])(implicit combiner: Combiner[A, B]): RichTextCodec[combiner.Out] =
+  final def ~[B](that: => RichTextCodec[B])(implicit combiner: Combiner[A, B]): RichTextCodec[combiner.Out] =
     RichTextCodec.Zip(self, RichTextCodec.defer(that), combiner)
 
   /**
@@ -110,7 +110,7 @@ sealed trait RichTextCodec[A] { self =>
     self.transform(a => Some(a), { case None => default; case Some(a) => a })
 
   final def repeat: RichTextCodec[Chunk[A]] =
-    (self ~ RichTextCodec.defer(repeat)).transformOrFailRight(
+    (self ~ repeat).transformOrFailRight(
       t => Chunk(t._1) ++ t._2,
       c =>
         c.headOption match {

--- a/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
@@ -109,7 +109,7 @@ sealed trait RichTextCodec[A] { self =>
   final def optional(default: A): RichTextCodec[Option[A]] =
     self.transform(a => Some(a), { case None => default; case Some(a) => a })
 
-  final def repeat: RichTextCodec[Chunk[A]] =
+  final lazy val repeat: RichTextCodec[Chunk[A]] =
     (self ~ repeat).transformOrFailRight(
       t => Chunk(t._1) ++ t._2,
       c =>

--- a/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
@@ -110,7 +110,7 @@ sealed trait RichTextCodec[A] { self =>
     self.transform(a => Some(a), { case None => default; case Some(a) => a })
 
   final def repeat: RichTextCodec[Chunk[A]] =
-    (self ~ repeat).transformOrFailRight(
+    (self ~ RichTextCodec.defer(repeat)).transformOrFailRight(
       t => Chunk(t._1) ++ t._2,
       c =>
         c.headOption match {

--- a/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
@@ -11,6 +11,11 @@ object RichTextCodecSpec extends ZIOSpecDefault {
   def success[A](a: A): Either[String, A] = Right(a)
 
   override def spec = suite("Rich Text Codec Spec")(
+    test("repeat can be constructed") {
+      // Checks whether the call to repeat causes stack overflow
+      assertTrue(RichTextCodec.whitespaces != null)
+      assertTrue(RichTextCodec.char('x').repeat != null)
+    },
     test("encode empty spec") {
       assert(RichTextCodec.empty.encode(()))(equalTo(Right("")))
     },


### PR DESCRIPTION
Wrapped `repeat` with `defer`:
```
  final def repeat: RichTextCodec[Chunk[A]] =
    (self ~ RichTextCodec.defer(repeat)).transformOrFailRight(
```
(creating double laziness)

Perhaps changing `that` in `~` to by name instead of by value were a better solution. (Similar to `|`)

```
  final def ~[B](that: => RichTextCodec[B])(implicit combiner: Combiner[A, B]): RichTextCodec[combiner.Out] =
    RichTextCodec.Zip(self, RichTextCodec.defer(that), combiner)

```