### PR TITLE
RichTextCodec.describe now with labels and handles recursive parsers (#1693)

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
@@ -76,15 +76,16 @@ sealed trait RichTextCodec[A] { self =>
   /**
    * Tags the codec with a label used in the documentation
    */
-  final def ??(label: String): RichTextCodec.Tagged[A] = tagged(label)
+  final def ??(label: String): RichTextCodec.Tagged[A]     = tagged(label)
   final def tagged(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self)
 
   /**
    * Tags the codec with a label used in the documentation. The label will be
    * used but not explained
    */
-  final def ?!(label: String): RichTextCodec.Tagged[A] = taggedUnexplained(label)
-  final def taggedUnexplained(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self, descriptionNotNeeded = true)
+  final def ?!(label: String): RichTextCodec.Tagged[A]                = taggedUnexplained(label)
+  final def taggedUnexplained(label: String): RichTextCodec.Tagged[A] =
+    RichTextCodec.Tagged(label, self, descriptionNotNeeded = true)
 
   /**
    * Encodes a value into a string, or if this is not possible, fails with an

--- a/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/RichTextCodec.scala
@@ -76,13 +76,15 @@ sealed trait RichTextCodec[A] { self =>
   /**
    * Tags the codec with a label used in the documentation
    */
-  final def @@(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self)
+  final def ??(label: String): RichTextCodec.Tagged[A] = tagged(label)
+  final def tagged(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self)
 
   /**
    * Tags the codec with a label used in the documentation. The label will be
    * used but not explained
    */
-  final def @!(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self, descriptionNotNeeded = true)
+  final def ?!(label: String): RichTextCodec.Tagged[A] = taggedUnexplained(label)
+  final def taggedUnexplained(label: String): RichTextCodec.Tagged[A] = RichTextCodec.Tagged(label, self, descriptionNotNeeded = true)
 
   /**
    * Encodes a value into a string, or if this is not possible, fails with an
@@ -195,7 +197,7 @@ object RichTextCodec {
   /**
    * A codec that describes a letter character.
    */
-  val letter: RichTextCodec[Char] = filter(_.isLetter) @! "letter"
+  val letter: RichTextCodec[Char] = filter(_.isLetter) ?! "letter"
 
   /**
    * A codec that describes a literal character sequence.

--- a/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
@@ -1,7 +1,5 @@
 package zio.http.api.internal
 
-import zio.Scope
-import zio.http._
 import zio.http.api._
 import zio.test.Assertion.equalTo
 import zio.test._

--- a/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/RichTextCodecSpec.scala
@@ -91,8 +91,8 @@ object RichTextCodecSpec extends ZIOSpecDefault {
         assertTrue(textOf(codec.describe).get == "(“a” | “bb”) (“cc” | “d”)")
       },
       test("describe tagged (non recursive)") {
-        val greeting = (RichTextCodec.literal("hello") | RichTextCodec.literal("hi")) @@ "greeting"
-        val planet   = (RichTextCodec.literal("Earth") | RichTextCodec.literal("Mars")) @@ "planet"
+        val greeting = (RichTextCodec.literal("hello") | RichTextCodec.literal("hi")) ?? "greeting"
+        val planet   = (RichTextCodec.literal("Earth") | RichTextCodec.literal("Mars")) ?? "planet"
         val codec    = greeting ~ planet
         assertTrue(
           textOf(codec.describe).get ==
@@ -107,13 +107,13 @@ object RichTextCodecSpec extends ZIOSpecDefault {
         assertTrue(textOf(codec.describe).get == "«1» ⩴ (“x” «1»)?")
       },
       test("describe tagged simple recursion") {
-        val codec = RichTextCodec.char('x').repeat @@ "xs"
+        val codec = RichTextCodec.char('x').repeat ?? "xs"
         // This would be perhaps nicer as «xs» ⩴ “x”*
         assertTrue(textOf(codec.describe).get == "«xs» ⩴ (“x” «xs»)?")
       },
       test("describe tagged with recursion") {
-        lazy val integer: RichTextCodec[_] = (RichTextCodec.digit ~ (RichTextCodec.empty | integer)) @@ "integer"
-        val decimal                        = (integer | integer ~ RichTextCodec.char('.') ~ integer) @@ "decimal"
+        lazy val integer: RichTextCodec[_] = (RichTextCodec.digit ~ (RichTextCodec.empty | integer)) ?? "integer"
+        val decimal                        = (integer | integer ~ RichTextCodec.char('.') ~ integer) ?? "decimal"
         assertTrue(
           textOf(decimal.describe).get ==
             """|«decimal» ⩴ «integer» | «integer» “.” «integer»
@@ -121,8 +121,8 @@ object RichTextCodecSpec extends ZIOSpecDefault {
         )
       },
       test("describe labelled mutual recursion") {
-        lazy val a: RichTextCodec[_] = (RichTextCodec.char('a') | b) @@ "a"
-        lazy val b: RichTextCodec[_] = (RichTextCodec.char('b') | a) @@ "b"
+        lazy val a: RichTextCodec[_] = (RichTextCodec.char('a') | b) ?? "a"
+        lazy val b: RichTextCodec[_] = (RichTextCodec.char('b') | a) ?? "b"
         assertTrue(
           textOf(a.describe).get ==
             """«a» ⩴ “a” | «b»


### PR DESCRIPTION
- added ability to add labels to codecs to be used in the description (both for recursive and non-recursive case)
- unlabelled recursive codecs are automatically labelled with numeric labels
- resolved some ambiguity in describing alternatives in sequences ( `ab|c` vs `a(b|c)` )
- char sets formatted as in regexps  `[A-Za-z]` instead of `[[A-Z][a-z]]`

Still to do:
- quoting literals, so that to be able to distinguish between `"a" | "b" and "a|b"`
- possibly formatting optional as `x?` instead of `(x | )`