### PR TITLE
Sketching WS API redesign (WIP)

### DIFF
--- a/zio-http-example/src/main/scala/example/WebSocketSimpleClient.scala
+++ b/zio-http-example/src/main/scala/example/WebSocketSimpleClient.scala
@@ -2,34 +2,24 @@ package example
 
 import zio._
 import zio.http.ChannelEvent.{ChannelRead, UserEvent, UserEventTriggered}
-import zio.http.socket.{WebSocketChannelEvent, WebSocketFrame}
+import zio.http.socket.{SocketApp, SocketAppAction, SocketAppEvent, WebSocketChannelEvent, WebSocketFrame}
 import zio.http.{ChannelEvent, Client, Http, Response}
 
 object WebSocketSimpleClient extends ZIOAppDefault {
 
   val url = "ws://ws.vi-server.org/mirror"
 
-  val httpSocket: Http[Any, Throwable, WebSocketChannelEvent, Unit] =
-    Http
+  val socketApp = SocketApp {
+    case SocketAppEvent.Connected(_) => ZIO.succeed(SocketAppAction.SendFrame(WebSocketFrame.text("foo")).withFlush)
+    case SocketAppEvent.FrameReceived(WebSocketFrame.Text("foo")) => ZIO.succeed(SocketAppAction.SendFrame(WebSocketFrame.text("bar")).withFlush)
+    case SocketAppEvent.FrameReceived(WebSocketFrame.Text("bar")) =>
+      println("Goodbye!")
+      ZIO.succeed(SocketAppAction.SendFrame(WebSocketFrame.close(1000)).withFlush)
+  }
 
-      // Listen for all websocket channel events
-      .collectZIO[WebSocketChannelEvent] {
-
-        // Send a "foo" message to the server once the connection is established
-        case ChannelEvent(ch, UserEventTriggered(UserEvent.HandshakeComplete)) =>
-          ch.writeAndFlush(WebSocketFrame.text("foo"))
-
-        // Send a "bar" if the server sends a "foo"
-        case ChannelEvent(ch, ChannelRead(WebSocketFrame.Text("foo")))         =>
-          ch.writeAndFlush(WebSocketFrame.text("bar"))
-
-        // Close the connection if the server sends a "bar"
-        case ChannelEvent(ch, ChannelRead(WebSocketFrame.Text("bar")))         =>
-          ZIO.succeed(println("Goodbye!")) *> ch.writeAndFlush(WebSocketFrame.close(1000))
-      }
-
-  val app: ZIO[Any with Client with Scope, Throwable, Response] =
-    httpSocket.toSocketApp.connect(url) *> ZIO.never
+  val app: ZIO[Any with Client with Scope, Throwable, Response] = {
+    Client.socket(url, socketApp)
+  }
 
   val run = app.provide(Client.default, Scope.default)
 

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -130,13 +130,13 @@ object Response {
 
   def fromHttpError(error: HttpError): Response = Response(status = error.status, httpError = Some(error))
 
-  /**
-   * Creates a new response for the provided socket
-   */
-  def fromSocket[R](
-    http: Http[R, Throwable, ChannelEvent[WebSocketFrame, WebSocketFrame], Unit],
-  )(implicit trace: Trace): ZIO[R, Nothing, Response] =
-    fromSocketApp(http.toSocketApp)
+//  /**
+//   * Creates a new response for the provided socket
+//   */
+//  def fromSocket[R](
+//    http: Http[R, Throwable, ChannelEvent[WebSocketFrame, WebSocketFrame], Unit],
+//  )(implicit trace: Trace): ZIO[R, Nothing, Response] =
+//    fromSocketApp(http.toSocketApp)
 
   /**
    * Creates a new response for the provided socket app

--- a/zio-http/src/main/scala/zio/http/socket/SocketApp.scala
+++ b/zio-http/src/main/scala/zio/http/socket/SocketApp.scala
@@ -1,14 +1,15 @@
 package zio.http.socket
 
-import zio._
+import zio.{ZIO, _}
 import zio.http._
 import zio.http.model.Headers
+import zio.http.socket.SocketApp.{SocketAppHandler, SocketHandler}
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 final case class SocketApp[-R](
   decoder: SocketDecoder = SocketDecoder.default,
   protocol: SocketProtocol = SocketProtocol.default,
-  message: Option[ChannelEvent[WebSocketFrame, WebSocketFrame] => ZIO[R, Throwable, Any]] = None,
+  message: SocketAppEvent => Option[ZIO[R, Throwable, SocketAppAction]] = SocketAppHandler.noOp.lift
 ) { self =>
 
   /**
@@ -26,7 +27,7 @@ final case class SocketApp[-R](
    * dependency on `R`.
    */
   def provideEnvironment(env: ZEnvironment[R])(implicit trace: Trace): SocketApp[Any] =
-    self.copy(message = self.message.map(cb => event => cb(event).provideEnvironment(env)))
+    self.copy(message = self.message.andThen(_.map(_.provideEnvironment(env))))
 
   /**
    * Converts the socket app to a HTTP app.
@@ -52,10 +53,67 @@ final case class SocketApp[-R](
    */
   def withProtocol(protocol: SocketProtocol): SocketApp[R] =
     copy(protocol = protocol)
+
+  def || [R1](that: SocketApp[R1]): SocketApp[R with R1] = copy(message = e => message(e).orElse(that.message(e)))
+  def && [R1](that: SocketApp[R1])(implicit trace: Trace): SocketApp[R with R1] = copy(message = { e =>
+    val effects = message(e) ++ that.message(e)
+    if(effects.isEmpty) None else Some (
+      ZIO.collectAll(effects).map(_.foldLeft(SocketAppAction.NoOp: SocketAppAction)((a, b) => a + b))
+    )
+  })
 }
 
 object SocketApp {
 
-  def apply[R](socket: ChannelEvent[WebSocketFrame, WebSocketFrame] => ZIO[R, Throwable, Any]): SocketApp[R] =
-    SocketApp(message = Option(socket))
+  type SocketHandler[-R] = PartialFunction[SocketAppEvent, ZIO[R, Throwable, SocketAppAction]]
+
+  object SocketAppHandler {
+    val noOp: SocketHandler[Any] = { case _ => ZIO.succeed(SocketAppAction.NoOp)(Trace.empty) }
+  }
+
 }
+
+trait SocketAppChannel {
+  def action(socketAction: SocketAppAction)(implicit trace: Trace): Task[Unit]
+}
+
+object SocketAppChannel {
+  def apply(channel: Channel[WebSocketFrame]): SocketAppChannel =
+    new SocketAppChannel {
+      override def action(socketAction: SocketAppAction)(implicit trace: Trace): Task[Unit] =
+        socketAction match {
+          case SocketAppAction.CloseSocket => channel.close()
+          case SocketAppAction.SendFrame(message) => channel.write(message)
+          case SocketAppAction.NoOp => ZIO.unit
+          case SocketAppAction.Multiple(actions) => ZIO.foreachDiscard(actions)(action)
+          case SocketAppAction.Flush => channel.flush
+        }
+    }
+}
+
+sealed trait SocketAppEvent
+object SocketAppEvent {
+  final case class Connected(channel: SocketAppChannel) extends SocketAppEvent
+  case object Disconnected extends SocketAppEvent
+  final case class FrameReceived(frame: WebSocketFrame) extends SocketAppEvent
+  final case class Error(cause: Throwable) extends SocketAppEvent
+}
+
+sealed trait SocketAppAction {
+  def + (other: SocketAppAction): SocketAppAction = SocketAppAction.Multiple(Seq(this, other))
+  def withFlush: SocketAppAction = this + SocketAppAction.Flush
+}
+object SocketAppAction {
+  case object NoOp extends SocketAppAction
+  case object CloseSocket extends SocketAppAction
+  final case class SendFrame(frame: WebSocketFrame) extends SocketAppAction
+  final case class Multiple(actions: Seq[SocketAppAction]) extends SocketAppAction {
+    override def + (other: SocketAppAction): SocketAppAction = SocketAppAction.Multiple(actions :+ other)
+  }
+  case object Flush extends SocketAppAction
+  object Multiple {
+    def apply(action: SocketAppAction, actions: SocketAppAction*): Multiple = Multiple(action +: actions)
+  }
+}
+
+


### PR DESCRIPTION
Very rough draft - WIP, doesn't yet compile :)
 * Switch to a new SocketAppEvent ADT for socket app to handle
 * Socket app function returns SocketAppAction instead of manipulating Channel
 * SocketApp can use SocketAppChannel to send messages directly (e.g. from another fiber)