### PR TITLE
Change withContentType to add the header instead of replacing it

### DIFF
--- a/zio-http/src/main/scala/zio/http/model/headers/HeaderModifier.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/HeaderModifier.scala
@@ -126,7 +126,7 @@ trait HeaderModifier[+A] { self =>
     addHeaders(Headers.contentTransferEncoding(value))
 
   final def withContentType(value: CharSequence): A =
-    setHeaders(Headers.contentType(value))
+    addHeaders(Headers.contentType(value))
 
   final def withCookie(value: CharSequence): A =
     addHeaders(Headers.cookie(value))

--- a/zio-http/src/main/scala/zio/http/model/headers/HeaderModifierZIO.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/HeaderModifierZIO.scala
@@ -131,7 +131,7 @@ trait HeaderModifierZIO[+A] { self =>
     addHeaders(Headers.contentTransferEncoding(value))
 
   final def withContentType(value: CharSequence)(implicit trace: Trace): A =
-    setHeaders(Headers.contentType(value))
+    addHeaders(Headers.contentType(value))
 
   final def withCookie(value: CharSequence)(implicit trace: Trace): A =
     addHeaders(Headers.cookie(value))


### PR DESCRIPTION
This seems like a bug to me, bug calling `withContentType` basically replaces all the headers with the content type header 💀