### PR TITLE
fix: zio-http-logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ lazy val zioHttpBenchmarks = (project in file("zio-http-benchmarks"))
 
 lazy val zioHttpLogging = (project in file("zio-http-logging"))
   .settings(stdSettings("zio-http-logging"))
-  .settings(publishSetting(false))
+  .settings(publishSetting(true))
   .settings(
     libraryDependencies ++= {
       if (isScala3(scalaVersion.value)) Seq.empty

--- a/zio-http-logging/src/main/scala-2/zio/logging/macros/LoggerMacroExtensions.scala
+++ b/zio-http-logging/src/main/scala-2/zio/logging/macros/LoggerMacroExtensions.scala
@@ -1,6 +1,6 @@
-package zio.logging.macros
+package zio.http.logging.macros
 
-import zio.logging.macros.LoggerMacroImpl._
+import zio.http.logging.macros.LoggerMacroImpl._
 
 trait LoggerMacroExtensions { self =>
   import scala.language.experimental.macros

--- a/zio-http-logging/src/main/scala-2/zio/logging/macros/LoggerMacroImpl.scala
+++ b/zio-http-logging/src/main/scala-2/zio/logging/macros/LoggerMacroImpl.scala
@@ -1,6 +1,6 @@
-package zio.logging.macros
+package zio.http.logging.macros
 
-import zio.logging.{LogLevel, Logger}
+import zio.http.logging.{LogLevel, Logger}
 
 import scala.reflect.macros.whitebox
 
@@ -25,11 +25,11 @@ private[zio] object LoggerMacroImpl {
     val lno: Tree            = q"${c.enclosingPosition.line}"
     val sourceLocation: Tree =
       if (logLevel == LogLevel.Trace)
-        q"Some(_root_.zio.logging.Logger.SourcePos($cname, $lno))"
+        q"Some(_root_.zio.http.logging.Logger.SourcePos($cname, $lno))"
       else
         q"None"
     val logLevelName         = logLevel.name.toLowerCase.capitalize
-    val level: Tree          = q"_root_.zio.logging.LogLevel.${TermName(logLevelName)}"
+    val level: Tree          = q"_root_.zio.http.logging.LogLevel.${TermName(logLevelName)}"
     val isEnabled: Tree      = q"""${c.prefix.tree}.${TermName(s"is${logLevelName}Enabled")}"""
 
     // LogLevel Hierarchy: Trace < Debug < Info < Warn < Error

--- a/zio-http-logging/src/main/scala-3/zio/logging/macros/LoggerMacroExtensions.scala
+++ b/zio-http-logging/src/main/scala-3/zio/logging/macros/LoggerMacroExtensions.scala
@@ -1,7 +1,7 @@
-package zio.logging.macros
+package zio.http.logging.macros
 
-import zio.logging.Logger
-import zio.logging.macros.LoggerMacroImpl._
+import zio.http.logging.Logger
+import zio.http.logging.macros.LoggerMacroImpl._
 
 /**
  * Core Logger class.

--- a/zio-http-logging/src/main/scala-3/zio/logging/macros/LoggerMacroImpl.scala
+++ b/zio-http-logging/src/main/scala-3/zio/logging/macros/LoggerMacroImpl.scala
@@ -1,7 +1,7 @@
-package zio.logging.macros
+package zio.http.logging.macros
 
-import zio.logging.Logger.SourcePos
-import zio.logging.{LogLevel, Logger}
+import zio.http.logging.Logger.SourcePos
+import zio.http.logging.{LogLevel, Logger}
 
 import scala.language.experimental.macros
 import scala.quoted._

--- a/zio-http-logging/src/main/scala/zio/logging/Font.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/Font.scala
@@ -1,6 +1,6 @@
-package zio.logging
+package zio.http.logging
 
-import zio.logging.Font._
+import zio.http.logging.Font._
 
 private[logging] sealed trait Font { self =>
   def toAnsiColor: String = self match {

--- a/zio-http-logging/src/main/scala/zio/logging/LogFormat.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LogFormat.scala
@@ -1,4 +1,4 @@
-package zio.logging
+package zio.http.logging
 
 import java.time.format.DateTimeFormatter
 

--- a/zio-http-logging/src/main/scala/zio/logging/LogLevel.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LogLevel.scala
@@ -1,4 +1,4 @@
-package zio.logging
+package zio.http.logging
 
 sealed abstract class LogLevel(val id: Int) extends Product with Serializable { self =>
   final def >(other: LogLevel): Boolean = self.id > other.id

--- a/zio-http-logging/src/main/scala/zio/logging/LogLine.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LogLine.scala
@@ -1,6 +1,6 @@
-package zio.logging
+package zio.http.logging
 
-import zio.logging.Logger.SourcePos
+import zio.http.logging.Logger.SourcePos
 
 import java.time.LocalDateTime
 

--- a/zio-http-logging/src/main/scala/zio/logging/Logger.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/Logger.scala
@@ -1,7 +1,7 @@
-package zio.logging
+package zio.http.logging
 
-import zio.logging.Logger.SourcePos
-import zio.logging.macros.LoggerMacroExtensions
+import zio.http.logging.Logger.SourcePos
+import zio.http.logging.macros.LoggerMacroExtensions
 
 import java.nio.file.Path
 

--- a/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
+++ b/zio-http-logging/src/main/scala/zio/logging/LoggerTransport.scala
@@ -1,6 +1,6 @@
-package zio.logging
+package zio.http.logging
 
-import zio.logging.Logger.SourcePos
+import zio.http.logging.Logger.SourcePos
 import zio.{LogLevel => _, _}
 
 import java.io.{PrintWriter, StringWriter}

--- a/zio-http-logging/src/test/scala/zio/logging/LogLevelSpec.scala
+++ b/zio-http-logging/src/test/scala/zio/logging/LogLevelSpec.scala
@@ -1,4 +1,4 @@
-package zio.logging
+package zio.http.logging
 
 import zio.test._
 

--- a/zio-http-logging/src/test/scala/zio/logging/LoggerSpec.scala
+++ b/zio-http-logging/src/test/scala/zio/logging/LoggerSpec.scala
@@ -1,5 +1,5 @@
-package zio.logging
-import zio.logging.LoggerTransport.DefaultLoggerTransport
+package zio.http.logging
+import zio.http.logging.LoggerTransport.DefaultLoggerTransport
 import zio.test._
 
 import scala.collection.mutable.ListBuffer

--- a/zio-http/src/main/scala/zio/http/netty/WebSocketAppHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/WebSocketAppHandler.scala
@@ -9,7 +9,7 @@ import zio.http.ChannelEvent
 import zio.http.ChannelEvent.UserEvent
 import zio.http.service.Log
 import zio.http.socket.{SocketApp, WebSocketFrame}
-import zio.logging.Logger
+import zio.http.logging.Logger
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 /**

--- a/zio-http/src/main/scala/zio/http/netty/client/ConnectionPool.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ConnectionPool.scala
@@ -15,7 +15,7 @@ import zio.http._
 import zio.http.netty.NettyFutureExecutor
 import zio.http.service._
 import zio.http.service.logging.LogLevelTransform.LogLevelWrapper
-import zio.logging.LogLevel
+import zio.http.logging.LogLevel
 import zio.{Duration, Scope, ZIO, ZKeyedPool, ZLayer}
 
 import java.net.InetSocketAddress

--- a/zio-http/src/main/scala/zio/http/netty/client/ConnectionPool.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ConnectionPool.scala
@@ -12,10 +12,10 @@ import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.proxy.HttpProxyHandler
 import zio.http.URL.Location
 import zio.http._
+import zio.http.logging.LogLevel
 import zio.http.netty.NettyFutureExecutor
 import zio.http.service._
 import zio.http.service.logging.LogLevelTransform.LogLevelWrapper
-import zio.http.logging.LogLevel
 import zio.{Duration, Scope, ZIO, ZKeyedPool, ZLayer}
 
 import java.net.InetSocketAddress

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerChannelInitializer.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerChannelInitializer.scala
@@ -17,7 +17,7 @@ import zio.http.netty.Names
 import zio.http.netty.server.ServerChannelInitializer.log
 import zio.http.service.Log
 import zio.http.service.logging.LogLevelTransform._
-import zio.logging.LogLevel
+import zio.http.logging.LogLevel
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 /**

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -6,7 +6,7 @@ import io.netty.handler.codec.http._
 import zio._
 import zio.http._
 import zio.http.netty.{NettyRuntime, _}
-import zio.logging.Logger
+import zio.http.logging.Logger
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 import zio.http.model._
 import io.netty.util.AttributeKey

--- a/zio-http/src/main/scala/zio/http/service/Logging.scala
+++ b/zio-http/src/main/scala/zio/http/service/Logging.scala
@@ -1,6 +1,6 @@
 package zio.http.service
 
-import zio.logging.{LogFormat, Logger}
+import zio.http.logging.{LogFormat, Logger}
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 /**

--- a/zio-http/src/main/scala/zio/http/service/logging/LogLevelTransform.scala
+++ b/zio-http/src/main/scala/zio/http/service/logging/LogLevelTransform.scala
@@ -1,16 +1,16 @@
 package zio.http.service.logging
 
-import zio.logging.LogLevel
+import zio.http.logging.LogLevel
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 object LogLevelTransform {
   implicit class LogLevelWrapper(level: LogLevel) {
     def toNettyLogLevel: io.netty.handler.logging.LogLevel = level match {
-      case zio.logging.LogLevel.Trace => io.netty.handler.logging.LogLevel.TRACE
-      case zio.logging.LogLevel.Debug => io.netty.handler.logging.LogLevel.DEBUG
-      case zio.logging.LogLevel.Info  => io.netty.handler.logging.LogLevel.INFO
-      case zio.logging.LogLevel.Warn  => io.netty.handler.logging.LogLevel.WARN
-      case zio.logging.LogLevel.Error => io.netty.handler.logging.LogLevel.ERROR
+      case zio.http.logging.LogLevel.Trace => io.netty.handler.logging.LogLevel.TRACE
+      case zio.http.logging.LogLevel.Debug => io.netty.handler.logging.LogLevel.DEBUG
+      case zio.http.logging.LogLevel.Info  => io.netty.handler.logging.LogLevel.INFO
+      case zio.http.logging.LogLevel.Warn  => io.netty.handler.logging.LogLevel.WARN
+      case zio.http.logging.LogLevel.Error => io.netty.handler.logging.LogLevel.ERROR
     }
   }
 }

--- a/zio-http/src/main/scala/zio/http/service/logging/NettyLoggerFactory.scala
+++ b/zio-http/src/main/scala/zio/http/service/logging/NettyLoggerFactory.scala
@@ -2,7 +2,7 @@ package zio.http.service.logging
 
 import io.netty.util.internal.logging.{AbstractInternalLogger, InternalLogger, InternalLoggerFactory}
 import zio.http.service.logging.NettyLoggerFactory.Live
-import zio.logging.{LogLevel, Logger}
+import zio.http.logging.{LogLevel, Logger}
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 /**


### PR DESCRIPTION
Hey!

When trying https://github.com/zio/zio-http/releases/tag/v0.0.1 (🙏) I realized that zio-http-logging wasn't published as part of the release process.

There also seems to be some package conflicts between zio-http-logging and zio-logging (see #1766), hopefully this fixes both!