### PR TITLE
Make the example snippet work, fix default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Check out the full documentation here: [Documentation]
 A simple Http server can be built using a few lines of code.
 
 ```scala
-import zio.http._
-import zio.http.Server
 import zio._
+import zio.http._
+import zio.http.model.Method
 
 object HelloWorld extends ZIOAppDefault {
 
@@ -39,7 +39,7 @@ object HelloWorld extends ZIOAppDefault {
   }
 
   override val run =
-    Server.start(8090, app)
+    Server.serve(app).provide(Server.default)
 }
 ```
 #### Examples
@@ -59,8 +59,8 @@ You can checkout more examples in the [example](https://github.com/zio/zio-http/
 #### Steps to run an example
 
 1. Edit the [RunSettings](https://github.com/zio/zio-http/blob/main/project/BuildHelper.scala#L109) - modify `className` to the example you'd like to run.
-2. From sbt shell, run `~example/reStart`. You should see `Server started on port: 8090`.
-3. Send curl request for defined `http Routes`, for eg : `curl -i "http://localhost:8090/text"` for `example.HelloWorld`.
+2. From sbt shell, run `~example/reStart`. You should see `Server started on port: 8080`.
+3. Send curl request for defined `http Routes`, for eg : `curl -i "http://localhost:8080/text"` for `example.HelloWorld`.
 
 # Installation
 


### PR DESCRIPTION
- Updated the example snippet to work with zio-http 0.0.3
- Changed port to 8080, as `Server.default` uses that: https://github.com/zio/zio-http/blob/10dfcd2abdae2d0ebdee18a225084b93ed8407cb/zio-http/src/main/scala/zio/http/ServerConfig.scala#L15-L15