### PR TITLE
Multi-benchmark Support for CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,8 @@ jobs:
         id: push_codecov
         run: 'bash <(curl -s https://codecov.io/bash)'
 
-  runBenchMarks:
-    name: Benchmarks
+  runBenchmarks-simple:
+    name: Performance Benchmarks (PlainTextBenchmarkServer)
     if: ${{ github.event_name == 'pull_request'}}
     strategy:
       matrix:
@@ -278,10 +278,10 @@ jobs:
           sha: ${{github.event.pull_request.head.sha}}
           body: |
 
-            **🚀 Performance Benchmark:**
+            **🚀 :** Performance Benchmarks (PlainTextBenchmarkServer)
 
-             requests/sec: ${{steps.result.outputs.concurrency}}
-             concurrency:  ${{steps.result.outputs.request_per_second}}
+             concurrency: ${{steps.result.outputs.concurrency}}
+             requests/sec:  ${{steps.result.outputs.request_per_second}}
 
       
       - name: Performance Report
@@ -291,7 +291,77 @@ jobs:
           CONCURRENCY: ${{steps.result.outputs.concurrency}}
           PERFORMANCE_FLOOR: 800000
         run: |
-          echo "** 🚀 Performance Benchmark Report 🚀 **"
+          echo "** 🚀 Performance Benchmarks (PlainTextBenchmarkServer) Report 🚀 **" 
+
+          echo "$REQUESTS_PER_SECOND requests/sec for $CONCURRENCY concurrent requests"
+
+          if (( REQUESTS_PER_SECOND > PERFORMANCE_FLOOR )); then
+            echo "Woohoo! Performance is good! $REQUESTS_PER_SECOND requests/sec exceeds the performance floor of $PERFORMANCE_FLOOR requests/sec."
+          else 
+            echo "Performance benchmark failed with $REQUESTS_PER_SECOND req/sec! Performance must exceed $PERFORMANCE_FLOOR req/sec."
+             exit 1
+          fi
+
+  runBenchmarks-effectful:
+    name: Performance Benchmarks (SimpleEffectBenchmarkServer)
+    if: ${{ github.event_name == 'pull_request'}}
+    strategy:
+      matrix:
+        os: [centos]
+        scala: [2.13.8]
+        java: [temurin@11]
+    runs-on: [ "${{ matrix.os }}", zio-http ]
+    steps:
+      - name: Clean up
+        id: clean_up
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: sudo rm -rf *
+
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/checkout@v2
+        with:
+          repository: zio/FrameworkBenchmarks
+          path: FrameworkBenchMarks
+
+      - id: result
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          mkdir -p ./FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala
+          cp ./zio-http/zio-http-example/src/main/scala/example/SimpleEffectBenchmarkServer.scala ./FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
+          cd ./FrameworkBenchMarks
+          sed -i "s/---COMMIT_SHA---/${{github.event.pull_request.head.repo.owner.login}}\/zio-http.git#${{github.event.pull_request.head.sha}}/g" frameworks/Scala/zio-http/build.sbt
+          ./tfb  --test zio-http | tee result
+          RESULT_REQUEST=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "requests/sec: [0-9]+.[0-9]+" | grep -oiE "[0-9]+" | head -1)
+          RESULT_CONCURRENCY=$(echo $(grep -B 1 -A 17 "Concurrency: 256 for plaintext" result) | grep -oiE "concurrency: [0-9]+" | grep -oiE "[0-9]+")
+          echo "request_per_second=$RESULT_REQUEST" >> $GITHUB_OUTPUT
+          echo "concurrency=$RESULT_CONCURRENCY" >> $GITHUB_OUTPUT
+
+      - if: ${{github.event.pull_request.head.repo.full_name == 'zio/zio-http'}}
+        uses: peter-evans/commit-comment@v2
+        with:
+          sha: ${{github.event.pull_request.head.sha}}
+          body: |
+
+            **🚀 :** Performance Benchmarks (SimpleEffectBenchmarkServer)
+
+             concurrency: ${{steps.result.outputs.concurrency}}
+             requests/sec:  ${{steps.result.outputs.request_per_second}}
+
+      
+      - name: Performance Report
+        id: perf-report
+        env:
+          REQUESTS_PER_SECOND: ${{steps.result.outputs.request_per_second}}
+          CONCURRENCY: ${{steps.result.outputs.concurrency}}
+          PERFORMANCE_FLOOR: 500000
+        run: |
+          echo "** 🚀 Performance Benchmarks (SimpleEffectBenchmarkServer) Report 🚀 **" 
+
           echo "$REQUESTS_PER_SECOND requests/sec for $CONCURRENCY concurrent requests"
 
           if (( REQUESTS_PER_SECOND > PERFORMANCE_FLOOR )); then

--- a/benchmark-zio-http.sh
+++ b/benchmark-zio-http.sh
@@ -1,6 +1,11 @@
-
 COMMIT_SHA=$(git rev-parse --short HEAD)
 ZIO_HTTP="zio/zio-http.git#$COMMIT_SHA"
+
+if [ -z "$1" ]; then
+    SERVER=PlainTextBenchmarkServer
+else
+    SERVER=$1
+fi
 
 if [ ! -e "/var/run/docker.sock" ]; then
     echo "'/var/run/docker.sock' does not exist.  Are you sure Docker is running?"
@@ -12,10 +17,11 @@ if [ ! -d "../FrameworkBenchMarks" ]; then
     git checkout master
 fi
 
+mkdir -p ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala
 rm ../FrameworkBenchMarks/frameworks/Scala/zio-http/build.sbt
 rm ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
 cp ../FrameworkBenchMarks/frameworks/Scala/zio-http/base.build.sbt ../FrameworkBenchMarks/frameworks/Scala/zio-http/build.sbt
-cp ./zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
+cp ./zio-http-example/src/main/scala/example/$SERVER.scala ../FrameworkBenchMarks/frameworks/Scala/zio-http/src/main/scala/Main.scala
 cd ../FrameworkBenchMarks
 sed -i '' "s|---COMMIT_SHA---|${ZIO_HTTP}|g" frameworks/Scala/zio-http/build.sbt
 ./tfb --test zio-http | tee result

--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -8,7 +8,7 @@ import zio.http._
 /**
  * This server is used to run plaintext benchmarks on CI.
  */
-object Main extends ZIOAppDefault {
+object PlainTextBenchmarkServer extends ZIOAppDefault {
 
   private val plainTextMessage: String = "hello, world!"
   private val jsonMessage: String      = """{"message": "hello, world!"}"""

--- a/zio-http-example/src/main/scala/example/SimpleEffectBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/SimpleEffectBenchmarkServer.scala
@@ -1,0 +1,39 @@
+package example
+
+import io.netty.util.AsciiString
+import zio._
+import zio.http.ServerConfig.LeakDetectionLevel
+import zio.http._
+import zio.http.model.Method
+
+/**
+ * This server is used to run plaintext benchmarks on CI.
+ */
+object SimpleEffectBenchmarkServer extends ZIOAppDefault {
+
+  private val plainTextMessage: String = "hello, world!"
+  private val jsonMessage: String      = s"""{"message": "$plainTextMessage"}"""
+
+  private val STATIC_SERVER_NAME = AsciiString.cached("zio-http")
+
+  private val app: HttpApp[Any, Nothing] = Http.collectZIO[Request] {
+    case Method.GET -> !! / "plaintext" =>
+      ZIO.succeed(Response.text(plainTextMessage).withServerTime.withServer(STATIC_SERVER_NAME).freeze)
+    case Method.GET -> !! / "json"      =>
+      ZIO.succeed(Response.json(jsonMessage).withServerTime.withServer(STATIC_SERVER_NAME).freeze)
+  }
+
+  private val config = ServerConfig.default
+    .port(8080)
+    .maxThreads(8)
+    .leakDetection(LeakDetectionLevel.DISABLED)
+    .consolidateFlush(true)
+    .flowControl(false)
+    .objectAggregator(-1)
+
+  private val configLayer = ServerConfig.live(config)
+
+  val run: UIO[ExitCode] =
+    Server.serve(app).provide(configLayer, Server.live).exitCode
+
+}


### PR DESCRIPTION
BenchmarkWorkFlow has been modified to support multiple, customizable benchmarks.

When defining a new benchmark, you supply the following:

- An 'id', this will be how the job is referenced in the generated CI workflow.
- A 'name', this is the name of the benchmark and will be displayed in the final reports.
- The 'performanceFloor' which is the minimum performance threshold for the benchmark.
- The 'server' which is the short name of the server to use for the benchmark.  This scala file must exist under '/zio-http-example/src/main/scala/example'.

Currently there are now two benchmarks defined:

- 'PlainTextBenchmarkServer' this is the same server benchmark that was previously in place.
- 'SimpleEffectBenchmarkServer' this is a new benchmark that uses a simple 'ZIO.succeed' to generate the response.