### PR TITLE
[#1813] Add QoL to NettyDriver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "files.watcherExclude": {
-    "**/target": true
-  }
-}


### PR DESCRIPTION
------------------------------

'NettyDriver' now supports a layer constructor that additionally requires Netty's 'EventLoopGroup' and 'ChannelFactory'.  This is layer provided via 'NettyDriver.manual'.

The reason for this addition is that under certain circumstances e.g. integration testing, it is beneficial to be able to share Netty dependencies across multiple Http app servers and test specs.

Housekeeping
------------

Remove 'settings.json', it shouldn't be here.