### PR TITLE
Add local address binding option for clients

### DIFF
--- a/zio-http/src/main/scala/zio/http/ClientConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ClientConfig.scala
@@ -6,6 +6,7 @@ import zio.{Duration, Scope, Trace, ZLayer}
 import zio.http.netty.{ChannelFactories, ChannelType, EventLoopGroups, NettyRuntime}
 import zio.http.socket.SocketApp
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
+import java.net.InetSocketAddress
 
 case class ClientConfig(
   socketApp: Option[SocketApp[Any]] = None,
@@ -17,6 +18,7 @@ case class ClientConfig(
   connectionPool: ConnectionPoolConfig = ConnectionPoolConfig.Disabled,
   maxHeaderSize: Int = 8192,
   requestDecompression: Decompression = Decompression.No,
+  localAddress: Option[InetSocketAddress] = None,
 ) extends EventLoopGroups.Config {
   self =>
   def ssl(ssl: ClientSSLConfig): ClientConfig = self.copy(ssl = Some(ssl))

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -615,6 +615,7 @@ object ZClient {
                         clientConfig.ssl.getOrElse(ClientSSLConfig.Default),
                         clientConfig.maxHeaderSize,
                         clientConfig.requestDecompression,
+                        clientConfig.localAddress,
                       )
                       .provideEnvironment(ZEnvironment(channelScope))
                   }


### PR DESCRIPTION
In case the client has multiple ip addresses it can define a preferred source address to initiate requests from.