### PR TITLE
HttpCodec fallback

### DIFF
--- a/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/HeaderCodecs.scala
@@ -7,7 +7,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 trait HeaderCodecs {
   private[api] def header[A](name: String, value: TextCodec[A]): HeaderCodec[A] =
-    HttpCodec.Header(name, value, optional = false)
+    HttpCodec.Header(name, value)
 
   final val accept: HeaderCodec[Accept] =
     header(HeaderNames.accept.toString(), TextCodec.string)

--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -143,13 +143,12 @@ sealed trait HttpCodec[-AtomTypes, Value] {
     encoderDecoder.encodeWith(value)(f)
 
   /**
-   * Returns a new codec, where the value produced by this one is optional. This
-   * method may only be called on header and query codecs.
+   * Returns a new codec, where the value produced by this one is optional.
    */
-  final def optional(implicit
-    ev: CodecType.Header with CodecType.Query with CodecType.Method <:< AtomTypes,
-  ): HttpCodec[AtomTypes, Option[Value]] =
-    HttpCodec.Optional(HttpCodec.updateOptional(self))
+  final def optional: HttpCodec[AtomTypes, Option[Value]] =
+    self
+      .orElse(HttpCodec.empty)
+      .transform[Option[Value]](_.swap.toOption, _.fold[Either[Unit, Value]](Left(()))(Right(_)).swap)
 
   final def orElse[AtomTypes1 <: AtomTypes, Value2](
     that: HttpCodec[AtomTypes1, Value2],
@@ -229,8 +228,7 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
   private[api] final case class Body[A](schema: Schema[A])         extends Atom[CodecType.Body, A]
   private[api] final case class BodyStream[A](schema: Schema[A])
       extends Atom[CodecType.Body, ZStream[Any, Throwable, A]]
-  private[api] final case class Query[A](name: String, textCodec: TextCodec[A], optional: Boolean)
-      extends Atom[CodecType.Query, A] {
+  private[api] final case class Query[A](name: String, textCodec: TextCodec[A]) extends Atom[CodecType.Query, A] {
     self =>
     def erase: Query[Any] = self.asInstanceOf[Query[Any]]
   }
@@ -239,16 +237,9 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
     def erase: Method[Any] = self.asInstanceOf[Method[Any]]
   }
 
-  private[api] final case class Header[A](name: String, textCodec: TextCodec[A], optional: Boolean)
-      extends Atom[CodecType.Header, A] {
+  private[api] final case class Header[A](name: String, textCodec: TextCodec[A]) extends Atom[CodecType.Header, A] {
     self =>
     def erase: Header[Any] = self.asInstanceOf[Header[Any]]
-  }
-
-  private[api] final case class Optional[AtomType, A](in: HttpCodec[AtomType, A])
-      extends HttpCodec[AtomType, Option[A]] {
-    type In  = A
-    type Out = Option[A]
   }
 
   private[api] final case class IndexedAtom[AtomType, A](atom: Atom[AtomType, A], index: Int) extends Atom[AtomType, A]
@@ -286,35 +277,6 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
     type Out   = Either[A, B]
   }
 
-  private[api] def updateOptional[AtomTypes, A](api: HttpCodec[AtomTypes, A]): HttpCodec[AtomTypes, A] = {
-    def loop[B](api: HttpCodec[AtomTypes, B]): HttpCodec[AtomTypes, B] =
-      api match {
-        case atom: HttpCodec.Atom[AtomTypes, B] =>
-          atom match {
-            case HttpCodec.Header(name, textCodec, _) => HttpCodec.Header(name, textCodec, optional = true)
-            case HttpCodec.Query(name, codec, _)      => HttpCodec.Query(name, codec, optional = true)
-            case body: HttpCodec.Body[_]              => body
-            case method: HttpCodec.Method[_]          => method
-            case route: HttpCodec.Route[_]            => route
-            case status: HttpCodec.Status[_]          => status
-            case bodyStream: HttpCodec.BodyStream[_]  => bodyStream
-            case i: HttpCodec.IndexedAtom[_, _]       =>
-              val result: HttpCodec[_, _] = loop(i.atom)
-              HttpCodec.IndexedAtom(result.asInstanceOf[Atom[AtomTypes, B]], i.index)
-          }
-
-        case empty: HttpCodec.Empty.type                   => empty
-        case HttpCodec.WithDoc(in, doc)                    => HttpCodec.WithDoc(updateOptional(in), doc)
-        case HttpCodec.TransformOrFail(api, f, g)          => HttpCodec.TransformOrFail(updateOptional(api), f, g)
-        case optional: HttpCodec.Optional[_, _]            => HttpCodec.Optional(updateOptional(optional.in))
-        case HttpCodec.Combine(left, right, inputCombiner) =>
-          HttpCodec.Combine(loop(left), loop(right), inputCombiner)
-        case HttpCodec.Fallback(left, right)               => HttpCodec.Fallback(loop(left), loop(right))
-      }
-
-    loop(api)
-  }
-
   private[api] def flattenFallbacks[AtomTypes, A](api: HttpCodec[AtomTypes, A]): Chunk[HttpCodec[AtomTypes, A]] = {
     def rewrite[T, B](api: HttpCodec[T, B]): Chunk[HttpCodec[T, B]] =
       api match {
@@ -332,8 +294,6 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
           } yield HttpCodec.Combine(l, r, combiner)
 
         case HttpCodec.WithDoc(in, doc) => rewrite[T, B](in).map(_ ?? doc)
-
-        case optional @ HttpCodec.Optional(codec) => rewrite[T, optional.In](codec).map(HttpCodec.Optional(_))
 
         case HttpCodec.Empty => Chunk.single(HttpCodec.Empty)
 

--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -147,10 +147,10 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    */
   final def optional: HttpCodec[AtomTypes, Option[Value]] =
     self
-      .orElse(HttpCodec.empty)
+      .orElseEither(HttpCodec.empty)
       .transform[Option[Value]](_.swap.toOption, _.fold[Either[Unit, Value]](Left(()))(Right(_)).swap)
 
-  final def orElse[AtomTypes1 <: AtomTypes, Value2](
+  final def orElseEither[AtomTypes1 <: AtomTypes, Value2](
     that: HttpCodec[AtomTypes1, Value2],
   ): HttpCodec[AtomTypes1, Either[Value, Value2]] =
     self | that

--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -33,23 +33,19 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Returns a new codec that is the same as this one, but has attached docs,
    * which will render whenever docs are generated from the codec.
    */
-  def ??(doc: Doc): HttpCodec[AtomTypes, Value] = HttpCodec.WithDoc(self, doc)
+  final def ??(doc: Doc): HttpCodec[AtomTypes, Value] = HttpCodec.WithDoc(self, doc)
 
-  /**
-   * Returns a new codec, where the value produced by this one is optional. This
-   * method may only be called on header and query codecs.
-   */
-  def optional(implicit
-    ev: CodecType.Header with CodecType.Query with CodecType.Method <:< AtomTypes,
-  ): HttpCodec[AtomTypes, Option[Value]] =
-    HttpCodec.Optional(HttpCodec.updateOptional(self))
+  final def |[AtomTypes1 <: AtomTypes, Value2](
+    that: HttpCodec[AtomTypes1, Value2],
+  ): HttpCodec[AtomTypes1, Either[Value, Value2]] =
+    HttpCodec.Fallback(self, that)
 
   /**
    * Returns a new codec that is the composition of this codec and the specified
    * codec. For codecs that include route codecs, the routes will be decoded
    * sequentially from left to right.
    */
-  def ++[AtomTypes1 <: AtomTypes, Value2](that: HttpCodec[AtomTypes1, Value2])(implicit
+  final def ++[AtomTypes1 <: AtomTypes, Value2](that: HttpCodec[AtomTypes1, Value2])(implicit
     combiner: Combiner[Value, Value2],
   ): HttpCodec[AtomTypes1, combiner.Out] =
     HttpCodec.Combine[AtomTypes1, AtomTypes1, Value, Value2, combiner.Out](self, that, combiner)
@@ -57,7 +53,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Combines two query codecs into another query codec.
    */
-  def &[Value2](
+  final def &[Value2](
     that: QueryCodec[Value2],
   )(implicit
     combiner: Combiner[Value, Value2],
@@ -68,13 +64,20 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Combines two route codecs into another route codec.
    */
-  def /[Value2](
+  final def /[Value2](
     that: RouteCodec[Value2],
   )(implicit
     combiner: Combiner[Value, Value2],
     ev: CodecType.Route <:< AtomTypes,
   ): RouteCodec[combiner.Out] =
     self.asRoute ++ that
+
+  /**
+   * Produces a flattened collection of alternatives. Once flattened, each codec
+   * inside the returned collection is guaranteed to contain no nested
+   * alternatives.
+   */
+  final def alternatives: Chunk[HttpCodec[AtomTypes, Value]] = HttpCodec.flattenFallbacks(self)
 
   /**
    * Reinterprets this codec as a query codec assuming evidence that this
@@ -140,6 +143,32 @@ sealed trait HttpCodec[-AtomTypes, Value] {
     encoderDecoder.encodeWith(value)(f)
 
   /**
+   * Returns a new codec, where the value produced by this one is optional. This
+   * method may only be called on header and query codecs.
+   */
+  final def optional(implicit
+    ev: CodecType.Header with CodecType.Query with CodecType.Method <:< AtomTypes,
+  ): HttpCodec[AtomTypes, Option[Value]] =
+    HttpCodec.Optional(HttpCodec.updateOptional(self))
+
+  final def orElse[AtomTypes1 <: AtomTypes, Value2](
+    that: HttpCodec[AtomTypes1, Value2],
+  ): HttpCodec[AtomTypes1, Either[Value, Value2]] =
+    self | that
+
+  final def toLeft[R]: HttpCodec[AtomTypes, Either[Value, R]] =
+    self.transformOrFail[Either[Value, R]](
+      value => Right(Left(value)),
+      either => either.swap.left.map(_ => "Error!"),
+    ) // TODO: Solve with partiality
+
+  final def toRight[L]: HttpCodec[AtomTypes, Either[L, Value]] =
+    self.transformOrFail[Either[L, Value]](
+      value => Right(Right(value)),
+      either => either.left.map(_ => "Error!"),
+    ) // TODO: Solve with partiality
+
+  /**
    * Transforms the type parameter of this HttpCodec from `Value` to `Value2`.
    * Due to the fact that HttpCodec is invariant in its type parameter, the
    * transformation requires not just a function from `Value` to `Value2`, but
@@ -150,22 +179,22 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * used in encoding, for example, when a client calls the endpoint on the
    * server.
    */
-  def transform[Value2](f: Value => Value2, g: Value2 => Value): HttpCodec[AtomTypes, Value2] =
+  final def transform[Value2](f: Value => Value2, g: Value2 => Value): HttpCodec[AtomTypes, Value2] =
     HttpCodec.TransformOrFail[AtomTypes, Value, Value2](self, in => Right(f(in)), output => Right(g(output)))
 
-  def transformOrFail[Value2](
+  final def transformOrFail[Value2](
     f: Value => Either[String, Value2],
     g: Value2 => Either[String, Value],
   ): HttpCodec[AtomTypes, Value2] =
     HttpCodec.TransformOrFail[AtomTypes, Value, Value2](self, f, g)
 
-  def transformOrFailLeft[Value2](
+  final def transformOrFailLeft[Value2](
     f: Value => Either[String, Value2],
     g: Value2 => Value,
   ): HttpCodec[AtomTypes, Value2] =
     HttpCodec.TransformOrFail[AtomTypes, Value, Value2](self, f, output => Right(g(output)))
 
-  def transformOrFailRight[Value2](
+  final def transformOrFailRight[Value2](
     f: Value => Value2,
     g: Value2 => Either[String, Value],
   ): HttpCodec[AtomTypes, Value2] =
@@ -179,7 +208,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Note: You should NOT use this method on any codec which can decode
    * semantically distinct values.
    */
-  def unit(canonical: Value): HttpCodec[AtomTypes, Unit] =
+  final def unit(canonical: Value): HttpCodec[AtomTypes, Unit] =
     self.transform(_ => (), _ => canonical)
 }
 
@@ -216,7 +245,11 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
     def erase: Header[Any] = self.asInstanceOf[Header[Any]]
   }
 
-  private[api] final case class Optional[AtomType, A](in: HttpCodec[AtomType, A]) extends HttpCodec[AtomType, Option[A]]
+  private[api] final case class Optional[AtomType, A](in: HttpCodec[AtomType, A])
+      extends HttpCodec[AtomType, Option[A]] {
+    type In  = A
+    type Out = Option[A]
+  }
 
   private[api] final case class IndexedAtom[AtomType, A](atom: Atom[AtomType, A], index: Int) extends Atom[AtomType, A]
 
@@ -227,7 +260,10 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
     api: HttpCodec[AtomType, X],
     f: X => Either[String, A],
     g: A => Either[String, X],
-  ) extends HttpCodec[AtomType, A]
+  ) extends HttpCodec[AtomType, A] {
+    type In  = X
+    type Out = A
+  }
 
   private[api] case object Empty extends HttpCodec[Any, Unit]
 
@@ -235,7 +271,20 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
     left: HttpCodec[AtomType1, A1],
     right: HttpCodec[AtomType2, A2],
     inputCombiner: Combiner.WithOut[A1, A2, A],
-  ) extends HttpCodec[AtomType1 with AtomType2, A]
+  ) extends HttpCodec[AtomType1 with AtomType2, A] {
+    type Left  = A1
+    type Right = A2
+    type Out   = A
+  }
+
+  private[api] final case class Fallback[AtomType, A, B](
+    left: HttpCodec[AtomType, A],
+    right: HttpCodec[AtomType, B],
+  ) extends HttpCodec[AtomType, Either[A, B]] {
+    type Left  = A
+    type Right = B
+    type Out   = Either[A, B]
+  }
 
   private[api] def updateOptional[AtomTypes, A](api: HttpCodec[AtomTypes, A]): HttpCodec[AtomTypes, A] = {
     def loop[B](api: HttpCodec[AtomTypes, B]): HttpCodec[AtomTypes, B] =
@@ -260,8 +309,37 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
         case optional: HttpCodec.Optional[_, _]            => HttpCodec.Optional(updateOptional(optional.in))
         case HttpCodec.Combine(left, right, inputCombiner) =>
           HttpCodec.Combine(loop(left), loop(right), inputCombiner)
+        case HttpCodec.Fallback(left, right)               => HttpCodec.Fallback(loop(left), loop(right))
       }
 
     loop(api)
+  }
+
+  private[api] def flattenFallbacks[AtomTypes, A](api: HttpCodec[AtomTypes, A]): Chunk[HttpCodec[AtomTypes, A]] = {
+    def rewrite[T, B](api: HttpCodec[T, B]): Chunk[HttpCodec[T, B]] =
+      api match {
+        case fallback @ HttpCodec.Fallback(left, right) =>
+          rewrite[T, fallback.Left](left).map(_.toLeft[fallback.Right]) ++ rewrite[T, fallback.Right](right)
+            .map(_.toRight[fallback.Left])
+
+        case transform @ HttpCodec.TransformOrFail(codec, f, g) =>
+          rewrite[T, transform.In](codec).map(HttpCodec.TransformOrFail(_, f, g))
+
+        case combine @ HttpCodec.Combine(left, right, combiner) =>
+          for {
+            l <- rewrite[T, combine.Left](left)
+            r <- rewrite[T, combine.Right](right)
+          } yield HttpCodec.Combine(l, r, combiner)
+
+        case HttpCodec.WithDoc(in, doc) => rewrite[T, B](in).map(_ ?? doc)
+
+        case optional @ HttpCodec.Optional(codec) => rewrite[T, optional.In](codec).map(HttpCodec.Optional(_))
+
+        case HttpCodec.Empty => Chunk.single(HttpCodec.Empty)
+
+        case atom: Atom[_, _] => Chunk.single(atom)
+      }
+
+    rewrite(api)
   }
 }

--- a/zio-http/src/main/scala/zio/http/api/QueryCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/QueryCodecs.scala
@@ -5,14 +5,14 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 private[api] trait QueryCodecs {
   def query(name: String): QueryCodec[String] =
-    HttpCodec.Query(name, TextCodec.string, optional = false)
+    HttpCodec.Query(name, TextCodec.string)
 
   def queryBool(name: String): QueryCodec[Boolean] =
-    HttpCodec.Query(name, TextCodec.boolean, optional = false)
+    HttpCodec.Query(name, TextCodec.boolean)
 
   def queryInt(name: String): QueryCodec[Int] =
-    HttpCodec.Query(name, TextCodec.int, optional = false)
+    HttpCodec.Query(name, TextCodec.int)
 
   def queryAs[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
-    HttpCodec.Query(name, codec, optional = false)
+    HttpCodec.Query(name, codec)
 }

--- a/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
@@ -152,9 +152,7 @@ private[api] object EncoderDecoder                   {
           case Some(value) =>
             inputs(i) = value
           case None        =>
-            if (query.optional) {
-              inputs(i) = Undefined
-            } else throw EndpointError.MissingQueryParam(query.name)
+            throw EndpointError.MissingQueryParam(query.name)
         }
 
         i = i + 1
@@ -196,9 +194,7 @@ private[api] object EncoderDecoder                   {
               .getOrElse(throw EndpointError.MalformedHeader(header.name, header.textCodec))
 
           case None =>
-            if (header.optional) {
-              inputs(i) = Undefined
-            } else throw EndpointError.MissingHeader(header.name)
+            throw EndpointError.MissingHeader(header.name)
         }
 
         i = i + 1

--- a/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
@@ -8,222 +8,279 @@ import zio.schema.codec._
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
-private[api] final case class EncoderDecoder[-AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value]) {
-  private val constructor   = Mechanic.makeConstructor(httpCodec)
-  private val deconstructor = Mechanic.makeDeconstructor(httpCodec)
-
-  private val flattened: Mechanic.FlattenedAtoms = Mechanic.flatten(httpCodec)
-
-  private val jsonEncoders = flattened.bodies.map(bodyCodec => bodyCodec.erase.encodeToBody(_, JsonCodec))
-  private val jsonDecoders = flattened.bodies.map(bodyCodec => bodyCodec.decodeFromBody(_, JsonCodec))
-
+private[api] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
     trace: Trace,
-  ): Task[Value] = {
-    val inputsBuilder = flattened.makeInputsBuilder()
+  ): Task[Value]
 
-    decodeRoutes(url.path, inputsBuilder.routes)
-    decodeQuery(url.queryParams, inputsBuilder.queries)
-    decodeStatus(status, inputsBuilder.statuses)
-    decodeMethod(method, inputsBuilder.methods)
-    decodeHeaders(headers, inputsBuilder.headers)
-    decodeBody(body, inputsBuilder.bodies).as(constructor(inputsBuilder))
+  def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z
+}
+private[api] object EncoderDecoder                   {
+  def apply[AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value]): EncoderDecoder[AtomTypes, Value] = {
+    val flattened = httpCodec.alternatives
+
+    if (flattened.length == 1) Single(flattened.head)
+    else Multiple(flattened)
   }
 
-  final def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z = {
-    val inputs = deconstructor(value)
+  private final case class Multiple[-AtomTypes, Value](httpCodecs: Chunk[HttpCodec[AtomTypes, Value]])
+      extends EncoderDecoder[AtomTypes, Value] {
+    val singles = httpCodecs.map(Single(_))
+    val head    = singles.head
+    val tail    = singles.tail
 
-    val route   = encodeRoute(inputs.routes)
-    val query   = encodeQuery(inputs.queries)
-    val status  = encodeStatus(inputs.statuses)
-    val method  = encodeMethod(inputs.methods)
-    val headers = encodeHeaders(inputs.headers)
-    val body    = encodeBody(inputs.bodies)
+    def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
+      trace: Trace,
+    ): Task[Value] =
+      ZIO.firstSuccessOf(
+        head.decode(url, status, method, headers, body),
+        tail.map(_.decode(url, status, method, headers, body)),
+      )
 
-    f(URL(route, queryParams = query), status, method, headers, body)
-  }
+    def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z = {
+      var i         = 0
+      var encoded   = null.asInstanceOf[Z]
+      var lastError = null.asInstanceOf[Throwable]
 
-  private def decodeRoutes(path: Path, inputs: Array[Any]): Unit = {
-    assert(flattened.routes.length == inputs.length)
+      while (i < singles.length) {
+        val current = singles(i)
 
-    var i        = 0
-    var j        = 0
-    val segments = path.segments
-    while (i < inputs.length) {
-      val textCodec = flattened.routes(i).erase
+        try {
+          encoded = current.encodeWith(value)(f)
 
-      if (j >= segments.length) throw EndpointError.PathTooShort(path, textCodec)
-      else {
-        val segment = segments(j)
-
-        if (segment.text.length != 0) {
-          val textCodec = flattened.routes(i).erase
-
-          inputs(i) =
-            textCodec.decode(segment.text).getOrElse(throw EndpointError.MalformedRoute(path, segment, textCodec))
-
-          i = i + 1
+          i = singles.length // break
+        } catch {
+          case error: EndpointError =>
+            // TODO: Aggregate all errors in disjunction:
+            lastError = error
         }
-        j = j + 1
-      }
-    }
-  }
 
-  private def decodeQuery(queryParams: QueryParams, inputs: Array[Any]): Unit = {
-    var i       = 0
-    val queries = flattened.queries
-    while (i < queries.length) {
-      val query = queries(i).erase
-
-      val queryParamValue =
-        queryParams
-          .getOrElse(query.name, Nil)
-          .collectFirst(query.textCodec)
-
-      queryParamValue match {
-        case Some(value) =>
-          inputs(i) = value
-        case None        =>
-          if (query.optional) {
-            inputs(i) = Undefined
-          } else throw EndpointError.MissingQueryParam(query.name)
+        i = i + 1
       }
 
-      i = i + 1
+      encoded
     }
   }
 
-  private def decodeStatus(status: Status, inputs: Array[Any]): Unit = {
-    var i = 0
-    while (i < inputs.length) {
-      val textCodec = flattened.statuses(i).erase
+  private final case class Single[-AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value])
+      extends EncoderDecoder[AtomTypes, Value] {
+    private val constructor   = Mechanic.makeConstructor(httpCodec)
+    private val deconstructor = Mechanic.makeDeconstructor(httpCodec)
 
-      inputs(i) = textCodec.decode(status.text).getOrElse(throw EndpointError.MalformedStatus("200", textCodec))
+    private val flattened: Mechanic.FlattenedAtoms = Mechanic.flatten(httpCodec)
 
-      i = i + 1
+    private val jsonEncoders = flattened.bodies.map(bodyCodec => bodyCodec.erase.encodeToBody(_, JsonCodec))
+    private val jsonDecoders = flattened.bodies.map(bodyCodec => bodyCodec.decodeFromBody(_, JsonCodec))
+
+    def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
+      trace: Trace,
+    ): Task[Value] = {
+      val inputsBuilder = flattened.makeInputsBuilder()
+
+      decodeRoutes(url.path, inputsBuilder.routes)
+      decodeQuery(url.queryParams, inputsBuilder.queries)
+      decodeStatus(status, inputsBuilder.statuses)
+      decodeMethod(method, inputsBuilder.methods)
+      decodeHeaders(headers, inputsBuilder.headers)
+      decodeBody(body, inputsBuilder.bodies).as(constructor(inputsBuilder))
     }
-  }
 
-  private def decodeMethod(method: Method, inputs: Array[Any]): Unit = {
-    var i = 0
-    while (i < inputs.length) {
-      val textCodec = flattened.methods(i)
+    final def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z = {
+      val inputs = deconstructor(value)
 
-      inputs(i) =
-        textCodec.decode(method.text).getOrElse(throw EndpointError.MalformedMethod(method.toString(), textCodec))
+      val route   = encodeRoute(inputs.routes)
+      val query   = encodeQuery(inputs.queries)
+      val status  = encodeStatus(inputs.statuses)
+      val method  = encodeMethod(inputs.methods)
+      val headers = encodeHeaders(inputs.headers)
+      val body    = encodeBody(inputs.bodies)
 
-      i = i + 1
+      f(URL(route, queryParams = query), status, method, headers, body)
     }
-  }
 
-  private def decodeHeaders(headers: Headers, inputs: Array[Any]): Unit = {
-    var i = 0
-    while (i < flattened.headers.length) {
-      val header = flattened.headers(i).erase
+    private def decodeRoutes(path: Path, inputs: Array[Any]): Unit = {
+      assert(flattened.routes.length == inputs.length)
 
-      headers.get(header.name) match {
-        case Some(value) =>
-          inputs(i) =
-            header.textCodec.decode(value).getOrElse(throw EndpointError.MalformedHeader(header.name, header.textCodec))
+      var i        = 0
+      var j        = 0
+      val segments = path.segments
+      while (i < inputs.length) {
+        val textCodec = flattened.routes(i).erase
 
-        case None =>
-          if (header.optional) {
-            inputs(i) = Undefined
-          } else throw EndpointError.MissingHeader(header.name)
-      }
+        if (j >= segments.length) throw EndpointError.PathTooShort(path, textCodec)
+        else {
+          val segment = segments(j)
 
-      i = i + 1
-    }
-  }
+          if (segment.text.length != 0) {
+            val textCodec = flattened.routes(i).erase
 
-  private def decodeBody(body: Body, inputs: Array[Any])(implicit trace: Trace): Task[Unit] =
-    if (jsonDecoders.length == 0) ZIO.unit
-    else if (jsonDecoders.length == 1) {
-      jsonDecoders(0)(body).map { result => inputs(0) = result }
-    } else {
-      ZIO.foreachDiscard(jsonDecoders.zipWithIndex) { case (decoder, index) =>
-        decoder(body).map { result => inputs(index) = result }
+            inputs(i) =
+              textCodec.decode(segment.text).getOrElse(throw EndpointError.MalformedRoute(path, segment, textCodec))
+
+            i = i + 1
+          }
+          j = j + 1
+        }
       }
     }
 
-  private def encodeRoute(inputs: Array[Any]): Path = {
-    var path = Path.empty
+    private def decodeQuery(queryParams: QueryParams, inputs: Array[Any]): Unit = {
+      var i       = 0
+      val queries = flattened.queries
+      while (i < queries.length) {
+        val query = queries(i).erase
 
-    var i = 0
-    while (i < inputs.length) {
-      val textCodec = flattened.routes(i).erase
-      val input     = inputs(i)
+        val queryParamValue =
+          queryParams
+            .getOrElse(query.name, Nil)
+            .collectFirst(query.textCodec)
 
-      val segment = textCodec.encode(input)
+        queryParamValue match {
+          case Some(value) =>
+            inputs(i) = value
+          case None        =>
+            if (query.optional) {
+              inputs(i) = Undefined
+            } else throw EndpointError.MissingQueryParam(query.name)
+        }
 
-      path = path / segment
-      i = i + 1
+        i = i + 1
+      }
     }
 
-    path
-  }
+    private def decodeStatus(status: Status, inputs: Array[Any]): Unit = {
+      var i = 0
+      while (i < inputs.length) {
+        val textCodec = flattened.statuses(i).erase
 
-  private def encodeQuery(inputs: Array[Any]): QueryParams = {
-    var queryParams = QueryParams.empty
+        inputs(i) = textCodec.decode(status.text).getOrElse(throw EndpointError.MalformedStatus("200", textCodec))
 
-    var i = 0
-    while (i < inputs.length) {
-      val query = flattened.queries(i).erase
-      val input = inputs(i)
-
-      val value = query.textCodec.encode(input)
-
-      queryParams = queryParams.add(query.name, value)
-
-      i = i + 1
+        i = i + 1
+      }
     }
 
-    queryParams
-  }
+    private def decodeMethod(method: Method, inputs: Array[Any]): Unit = {
+      var i = 0
+      while (i < inputs.length) {
+        val textCodec = flattened.methods(i)
 
-  private def encodeStatus(inputs: Array[Any]): Option[Status] = {
-    if (flattened.statuses.length == 0) {
-      None
-    } else {
-      val statusString = flattened.statuses(0).erase.encode(inputs(0))
+        inputs(i) =
+          textCodec.decode(method.text).getOrElse(throw EndpointError.MalformedMethod(method.toString(), textCodec))
 
-      Some(Status.fromInt(statusString.toInt).getOrElse(Status.Ok))
-    }
-  }
-
-  private def encodeHeaders(inputs: Array[Any]): Headers = {
-    var headers = Headers.contentType("application/json")
-
-    var i = 0
-    while (i < inputs.length) {
-      val header = flattened.headers(i).erase
-      val input  = inputs(i)
-
-      val value = header.textCodec.encode(input)
-
-      headers = headers ++ Headers(header.name, value)
-
-      i = i + 1
+        i = i + 1
+      }
     }
 
-    headers
-  }
+    private def decodeHeaders(headers: Headers, inputs: Array[Any]): Unit = {
+      var i = 0
+      while (i < flattened.headers.length) {
+        val header = flattened.headers(i).erase
 
-  private def encodeMethod(inputs: Array[Any]): Option[zio.http.model.Method] = {
-    if (flattened.methods.nonEmpty) {
-      val method = flattened.methods.head.erase
-      Some(zio.http.model.Method.fromString(method.encode(inputs(0))))
-    } else {
-      None
+        headers.get(header.name) match {
+          case Some(value) =>
+            inputs(i) = header.textCodec
+              .decode(value)
+              .getOrElse(throw EndpointError.MalformedHeader(header.name, header.textCodec))
+
+          case None =>
+            if (header.optional) {
+              inputs(i) = Undefined
+            } else throw EndpointError.MissingHeader(header.name)
+        }
+
+        i = i + 1
+      }
     }
-  }
 
-  private def encodeBody(inputs: Array[Any]): Body = {
-    if (jsonEncoders.length == 0) Body.empty
-    else if (jsonEncoders.length == 1) {
-      val encoder = jsonEncoders(0)
+    private def decodeBody(body: Body, inputs: Array[Any])(implicit trace: Trace): Task[Unit] =
+      if (jsonDecoders.length == 0) ZIO.unit
+      else if (jsonDecoders.length == 1) {
+        jsonDecoders(0)(body).map { result => inputs(0) = result }
+      } else {
+        ZIO.foreachDiscard(jsonDecoders.zipWithIndex) { case (decoder, index) =>
+          decoder(body).map { result => inputs(index) = result }
+        }
+      }
 
-      encoder(inputs(0))
-    } else throw new IllegalStateException("A request on a REST endpoint should have at most one body")
+    private def encodeRoute(inputs: Array[Any]): Path = {
+      var path = Path.empty
+
+      var i = 0
+      while (i < inputs.length) {
+        val textCodec = flattened.routes(i).erase
+        val input     = inputs(i)
+
+        val segment = textCodec.encode(input)
+
+        path = path / segment
+        i = i + 1
+      }
+
+      path
+    }
+
+    private def encodeQuery(inputs: Array[Any]): QueryParams = {
+      var queryParams = QueryParams.empty
+
+      var i = 0
+      while (i < inputs.length) {
+        val query = flattened.queries(i).erase
+        val input = inputs(i)
+
+        val value = query.textCodec.encode(input)
+
+        queryParams = queryParams.add(query.name, value)
+
+        i = i + 1
+      }
+
+      queryParams
+    }
+
+    private def encodeStatus(inputs: Array[Any]): Option[Status] = {
+      if (flattened.statuses.length == 0) {
+        None
+      } else {
+        val statusString = flattened.statuses(0).erase.encode(inputs(0))
+
+        Some(Status.fromInt(statusString.toInt).getOrElse(Status.Ok))
+      }
+    }
+
+    private def encodeHeaders(inputs: Array[Any]): Headers = {
+      var headers = Headers.contentType("application/json")
+
+      var i = 0
+      while (i < inputs.length) {
+        val header = flattened.headers(i).erase
+        val input  = inputs(i)
+
+        val value = header.textCodec.encode(input)
+
+        headers = headers ++ Headers(header.name, value)
+
+        i = i + 1
+      }
+
+      headers
+    }
+
+    private def encodeMethod(inputs: Array[Any]): Option[zio.http.model.Method] = {
+      if (flattened.methods.nonEmpty) {
+        val method = flattened.methods.head.erase
+        Some(zio.http.model.Method.fromString(method.encode(inputs(0))))
+      } else {
+        None
+      }
+    }
+
+    private def encodeBody(inputs: Array[Any]): Body = {
+      if (jsonEncoders.length == 0) Body.empty
+      else if (jsonEncoders.length == 1) {
+        val encoder = jsonEncoders(0)
+
+        encoder(inputs(0))
+      } else throw new IllegalStateException("A request on a REST endpoint should have at most one body")
+    }
   }
 }

--- a/zio-http/src/main/scala/zio/http/api/internal/Mechanic.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/Mechanic.scala
@@ -26,6 +26,7 @@ private[api] object Mechanic {
       case WithDoc(api, _)               => flattenedAtoms(api)
       case optional: Optional[_, _]      => flattenedAtoms(optional.in)
       case Empty                         => Chunk.empty
+      case Fallback(_, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
 
   private def indexed[R, A](api: HttpCodec[R, A]): HttpCodec[R, A] =
@@ -48,6 +49,7 @@ private[api] object Mechanic {
       case opt: Optional[_, _] =>
         val (api2, resultIndices) = indexedImpl(opt.in, indices)
         (Optional(api2).asInstanceOf[HttpCodec[R, A]], resultIndices)
+      case Fallback(_, _)      => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
 
   def makeConstructor[R, A](
@@ -130,6 +132,8 @@ private[api] object Mechanic {
 
       case atom: Atom[_, _] =>
         throw new RuntimeException(s"Atom $atom should have been wrapped in IndexedAtom")
+
+      case Fallback(_, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
   }
 
@@ -188,6 +192,8 @@ private[api] object Mechanic {
 
       case atom: Atom[_, _] =>
         throw new RuntimeException(s"Atom $atom should have been wrapped in IndexedAtom")
+
+      case Fallback(_, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
   }
 

--- a/zio-http/src/main/scala/zio/http/api/internal/package.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/package.scala
@@ -1,5 +1,0 @@
-package zio.http.api
-
-package object internal {
-  private[api] case object Undefined
-}

--- a/zio-http/src/main/scala/zio/http/model/headers/values/RetryAfter.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/values/RetryAfter.scala
@@ -34,7 +34,7 @@ object RetryAfter {
     (Try(dateOrSeconds.toLong) orElse Try(ZonedDateTime.parse(dateOrSeconds, formatter)) map {
       case long: Long if long > -1 => RetryAfterByDuration(Duration.ofSeconds(long))
       case date: ZonedDateTime     => RetryAfterByDate(date)
-    } recover { case e: Throwable =>
+    } recover { case _: Throwable =>
       InvalidRetryAfter
     }).getOrElse(InvalidRetryAfter)
   }

--- a/zio-http/src/test/scala/zio/http/api/APISpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/APISpec.scala
@@ -53,6 +53,18 @@ object APISpec extends ZIOSpecDefault {
           "route(users, 123, posts, 555) query(name=adam, age=9000)",
         )
       },
+      test("fallback") {
+        val testRoutes = testApi(
+          EndpointSpec
+            .get(literal("users") / (int | string))
+            .out[String]
+            .implement { userId =>
+              ZIO.succeed(s"route(users, $userId)")
+            },
+        ) _
+        testRoutes("/users/123", "route(users, Left(123))") &&
+        testRoutes("/users/foo", "route(users, Right(foo))")
+      },
       test("broad api") {
         val broadUsers              =
           EndpointSpec.get("users").out[String].implement { _ => ZIO.succeed("route(users)") }


### PR DESCRIPTION
Adds a fallback operator, `|` (`orElseEither`) to `HttpCodec`. Due to the efficient way construction, deconstruction, and route lookup occurs, this is not a simple operator to support.

All `HttpCodec` are rewritten by progressively pulling out fallback to the top level. Thus, something like `A & (C * (D | E))` would be rewritten to `A & C & D | A & C & E`. In this rewritten form, in which there are no more fallback nodes, just a list of alternatives, it becomes possible to create the prefix tree, as well as avoid fallback as much as possible in the encoder/decoder.

This functionality turns out to be required for adding typed errors to endpoints, because typed errors (where there is more than one) must compose using fallback.