### PR TITLE
withContentType to add a new header

### DIFF
--- a/zio-http/src/main/scala/zio/http/model/headers/HeaderModifierZIO.scala
+++ b/zio-http/src/main/scala/zio/http/model/headers/HeaderModifierZIO.scala
@@ -131,7 +131,7 @@ trait HeaderModifierZIO[+A] { self =>
     addHeaders(Headers.contentTransferEncoding(value))
 
   final def withContentType(value: CharSequence)(implicit trace: Trace): A =
-    setHeaders(Headers.contentType(value))
+    addHeaders(Headers.contentType(value))
 
   final def withCookie(value: CharSequence)(implicit trace: Trace): A =
     addHeaders(Headers.cookie(value))


### PR DESCRIPTION
Changed the behavior of `withContentType` to add a header, not to replace them.

closes https://github.com/zio/zio-http/issues/1922