### PR TITLE
Name route codecs

### DIFF
--- a/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/ApiBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/ApiBenchmark.scala
@@ -87,7 +87,7 @@ class ApiBenchmark {
   // API DSL
   val usersPosts =
     EndpointSpec
-      .get(RouteCodec.literal("users") / RouteCodec.int / "posts" / RouteCodec.int)
+      .get(RouteCodec.literal("users") / RouteCodec.int("userId") / "posts" / RouteCodec.int("limit"))
       .in(QueryCodec.query("query"))
       .out[ExampleData]
 
@@ -209,7 +209,11 @@ class ApiBenchmark {
   val deepPathHttpApp = EndpointSpec
     .get(
       RouteCodec.literal("first") /
-        RouteCodec.int / "second" / RouteCodec.int / "third" / RouteCodec.int / "fourth" / RouteCodec.int / "fifth" / RouteCodec.int / "sixth" / RouteCodec.int / "seventh" / RouteCodec.int,
+        RouteCodec.int("id1") / "second" / RouteCodec.int("id2") / "third" / RouteCodec.int(
+          "id3",
+        ) / "fourth" / RouteCodec.int("id4") / "fifth" / RouteCodec.int("id5") / "sixth" / RouteCodec.int(
+          "id5",
+        ) / "seventh" / RouteCodec.int("id5"),
     )
     .implement { _ =>
       ZIO.unit
@@ -325,65 +329,89 @@ class ApiBenchmark {
 
   // API DSL
 
-  val broadUsers        = EndpointSpec.get(RouteCodec.literal("users")).implement { _ => ZIO.unit }
-  val broadUsersId      = EndpointSpec.get(RouteCodec.literal("users") / RouteCodec.int).implement { _ => ZIO.unit }
-  val boardUsersPosts   =
-    EndpointSpec.get(RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts")).implement { _ =>
-      ZIO.unit
+  val broadUsers                       = EndpointSpec.get(RouteCodec.literal("users")).implement { _ => ZIO.unit }
+  val broadUsersId                     =
+    EndpointSpec.get(RouteCodec.literal("users") / RouteCodec.int("userId")).implement { _ => ZIO.unit }
+  val boardUsersPosts                  =
+    EndpointSpec.get(RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts")).implement {
+      _ =>
+        ZIO.unit
     }
-  val boardUsersPostsId =
+  val boardUsersPostsId                =
     EndpointSpec
-      .get(RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts") / RouteCodec.int)
+      .get(
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts") / RouteCodec.int("postId"),
+      )
       .implement { _ =>
         ZIO.unit
       }
-  val boardUsersPostsComments   =
+  val boardUsersPostsComments          =
     EndpointSpec
       .get(
-        RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts") / RouteCodec.int / RouteCodec
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts") / RouteCodec.int(
+          "postId",
+        ) / RouteCodec
           .literal("comments"),
       )
       .implement { _ =>
         ZIO.unit
       }
-  val boardUsersPostsCommentsId =
+  val boardUsersPostsCommentsId        =
     EndpointSpec
       .get(
-        RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts") / RouteCodec.int / RouteCodec
-          .literal("comments") / RouteCodec.int,
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts") / RouteCodec.int(
+          "postId",
+        ) / RouteCodec
+          .literal("comments") / RouteCodec.int("commentId"),
       )
       .implement { _ =>
         ZIO.unit
       }
-  val broadPosts                = EndpointSpec.get(RouteCodec.literal("posts")).implement { _ => ZIO.unit }
-  val broadPostsId         = EndpointSpec.get(RouteCodec.literal("posts") / RouteCodec.int).implement { _ => ZIO.unit }
-  val boardPostsComments   =
-    EndpointSpec.get(RouteCodec.literal("posts") / RouteCodec.int / RouteCodec.literal("comments")).implement { _ =>
-      ZIO.unit
-    }
-  val boardPostsCommentsId =
+  val broadPosts                       = EndpointSpec.get(RouteCodec.literal("posts")).implement { _ => ZIO.unit }
+  val broadPostsId                     =
+    EndpointSpec.get(RouteCodec.literal("posts") / RouteCodec.int("postId")).implement { _ => ZIO.unit }
+  val boardPostsComments               =
     EndpointSpec
-      .get(RouteCodec.literal("posts") / RouteCodec.int / RouteCodec.literal("comments") / RouteCodec.int)
+      .get(RouteCodec.literal("posts") / RouteCodec.int("postId") / RouteCodec.literal("comments"))
       .implement { _ =>
         ZIO.unit
       }
-  val broadComments        = EndpointSpec.get(RouteCodec.literal("comments")).implement { _ => ZIO.unit }
-  val broadCommentsId    = EndpointSpec.get(RouteCodec.literal("comments") / RouteCodec.int).implement { _ => ZIO.unit }
-  val broadUsersComments =
-    EndpointSpec.get(RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("comments")).implement { _ =>
-      ZIO.unit
-    }
+  val boardPostsCommentsId             =
+    EndpointSpec
+      .get(
+        RouteCodec.literal("posts") / RouteCodec.int("postId") / RouteCodec.literal("comments") / RouteCodec.int(
+          "commentId",
+        ),
+      )
+      .implement { _ =>
+        ZIO.unit
+      }
+  val broadComments                    = EndpointSpec.get(RouteCodec.literal("comments")).implement { _ => ZIO.unit }
+  val broadCommentsId                  =
+    EndpointSpec.get(RouteCodec.literal("comments") / RouteCodec.int("commentId")).implement { _ => ZIO.unit }
+  val broadUsersComments               =
+    EndpointSpec
+      .get(RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("comments"))
+      .implement { _ =>
+        ZIO.unit
+      }
   val broadUsersCommentsId             =
     EndpointSpec
-      .get(RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("comments") / RouteCodec.int)
+      .get(
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("comments") / RouteCodec.int(
+          "commentId",
+        ),
+      )
       .implement { _ =>
         ZIO.unit
       }
   val boardUsersPostsCommentsReplies   =
     EndpointSpec
       .get(
-        RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts") / RouteCodec.int / RouteCodec
-          .literal("comments") / RouteCodec.int / RouteCodec.literal(
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts") / RouteCodec.int(
+          "postId",
+        ) / RouteCodec
+          .literal("comments") / RouteCodec.int("commentId") / RouteCodec.literal(
           "replies",
         ),
       )
@@ -393,10 +421,12 @@ class ApiBenchmark {
   val boardUsersPostsCommentsRepliesId =
     EndpointSpec
       .get(
-        RouteCodec.literal("users") / RouteCodec.int / RouteCodec.literal("posts") / RouteCodec.int / RouteCodec
-          .literal("comments") / RouteCodec.int / RouteCodec.literal(
+        RouteCodec.literal("users") / RouteCodec.int("userId") / RouteCodec.literal("posts") / RouteCodec.int(
+          "postId",
+        ) / RouteCodec
+          .literal("comments") / RouteCodec.int("commentId") / RouteCodec.literal(
           "replies",
-        ) / RouteCodec.int,
+        ) / RouteCodec.int("replyId"),
       )
       .implement { _ =>
         ZIO.unit

--- a/zio-http-example/src/main/scala/example/APIExamples.scala
+++ b/zio-http-example/src/main/scala/example/APIExamples.scala
@@ -10,7 +10,7 @@ object APIExamples extends ZIOAppDefault {
 
   // MiddlewareSpec can be added at the service level as well
   val getUsers =
-    EndpointSpec.get("users" / int).out[Int]
+    EndpointSpec.get("users" / int("userId")).out[Int]
 
   val getUserEndpoint =
     getUsers.implement { id =>
@@ -19,7 +19,7 @@ object APIExamples extends ZIOAppDefault {
 
   val getUserPosts =
     EndpointSpec
-      .get("users" / int / "posts" / int)
+      .get("users" / int("userId") / "posts" / int("postId"))
       .in(query("name"))
 
   val getUserPostEndpoint =

--- a/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
+++ b/zio-http-example/src/main/scala/example/BasicAuthAPIExample.scala
@@ -10,7 +10,7 @@ object BasicAuthAPIExample extends ZIOAppDefault {
 
   // MiddlewareSpec can be added at the service level as well
   val getUser =
-    EndpointSpec.get(literal("users") / int).out[Int]
+    EndpointSpec.get(literal("users") / int("id")).out[Int]
 
   val getUserImpl =
     getUser.implement { case (id: Int) =>

--- a/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/api/HttpCodec.scala
@@ -222,7 +222,8 @@ object HttpCodec extends HeaderCodecs with QueryCodecs with RouteCodecs {
   private[api] final case class Status[A](textCodec: TextCodec[A]) extends Atom[CodecType.Status, A] { self =>
     def erase: Status[Any] = self.asInstanceOf[Status[Any]]
   }
-  private[api] final case class Route[A](textCodec: TextCodec[A])  extends Atom[CodecType.Route, A]  { self =>
+  private[api] final case class Route[A](textCodec: TextCodec[A], name: Option[String])
+      extends Atom[CodecType.Route, A] { self =>
     def erase: Route[Any] = self.asInstanceOf[Route[Any]]
   }
   private[api] final case class Body[A](schema: Schema[A])         extends Atom[CodecType.Body, A]

--- a/zio-http/src/main/scala/zio/http/api/RouteCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/api/RouteCodecs.scala
@@ -6,14 +6,14 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 private[api] trait RouteCodecs {
   def literal(string: String): RouteCodec[Unit] =
-    HttpCodec.Route(TextCodec.constant(string))
+    HttpCodec.Route(TextCodec.constant(string), None)
 
-  val int: RouteCodec[Int] =
-    HttpCodec.Route(TextCodec.int)
+  def int(name: String): RouteCodec[Int] =
+    HttpCodec.Route(TextCodec.int, Some(name))
 
-  val string: RouteCodec[String] =
-    HttpCodec.Route(TextCodec.string)
+  def string(name: String): RouteCodec[String] =
+    HttpCodec.Route(TextCodec.string, Some(name))
 
-  val uuid: RouteCodec[UUID] =
-    HttpCodec.Route(TextCodec.uuid)
+  def uuid(name: String): RouteCodec[UUID] =
+    HttpCodec.Route(TextCodec.uuid, Some(name))
 }

--- a/zio-http/src/test/scala/zio/http/api/APISpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/APISpec.scala
@@ -13,13 +13,13 @@ object APISpec extends ZIOSpecDefault {
       test("simple request") {
         val testRoutes = testApi(
           EndpointSpec
-            .get(literal("users") / int)
+            .get(literal("users") / int("userId"))
             .out[String]
             .implement { userId =>
               ZIO.succeed(s"route(users, $userId)")
             } ++
             EndpointSpec
-              .get(literal("users") / int / literal("posts") / int)
+              .get(literal("users") / int("userId") / literal("posts") / int("postId"))
               .in(query("name"))
               .out[String]
               .implement { case (userId, postId, name) =>
@@ -32,15 +32,15 @@ object APISpec extends ZIOSpecDefault {
       test("out of order api") {
         val testRoutes = testApi(
           EndpointSpec
-            .get(literal("users") / int)
+            .get(literal("users") / int("userId"))
             .out[String]
             .implement { userId =>
               ZIO.succeed(s"route(users, $userId)")
             } ++
             EndpointSpec
-              .get(literal("users") / int)
+              .get(literal("users") / int("userId"))
               .in(query("name"))
-              .in(literal("posts") / int)
+              .in(literal("posts") / int("postId"))
               .in(query("age"))
               .out[String]
               .implement { case (userId, name, postId, age) =>
@@ -56,7 +56,7 @@ object APISpec extends ZIOSpecDefault {
       test("fallback") {
         val testRoutes = testApi(
           EndpointSpec
-            .get(literal("users") / (int | string))
+            .get(literal("users") / (int("userId") | string("userId")))
             .out[String]
             .implement { userId =>
               ZIO.succeed(s"route(users, $userId)")
@@ -69,19 +69,19 @@ object APISpec extends ZIOSpecDefault {
         val broadUsers              =
           EndpointSpec.get("users").out[String].implement { _ => ZIO.succeed("route(users)") }
         val broadUsersId            =
-          EndpointSpec.get("users" / RouteCodec.int).out[String].implement { userId =>
+          EndpointSpec.get("users" / RouteCodec.int("userId")).out[String].implement { userId =>
             ZIO.succeed(s"route(users, $userId)")
           }
         val boardUsersPosts         =
           EndpointSpec
-            .get("users" / RouteCodec.int / "posts")
+            .get("users" / RouteCodec.int("userId") / "posts")
             .out[String]
             .implement { userId =>
               ZIO.succeed(s"route(users, $userId, posts)")
             }
         val boardUsersPostsId       =
           EndpointSpec
-            .get("users" / RouteCodec.int / "posts" / RouteCodec.int)
+            .get("users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId"))
             .out[String]
             .implement { case (userId, postId) =>
               ZIO.succeed(s"route(users, $userId, posts, $postId)")
@@ -89,7 +89,7 @@ object APISpec extends ZIOSpecDefault {
         val boardUsersPostsComments =
           EndpointSpec
             .get(
-              "users" / RouteCodec.int / "posts" / RouteCodec.int / RouteCodec
+              "users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId") / RouteCodec
                 .literal("comments"),
             )
             .out[String]
@@ -100,8 +100,8 @@ object APISpec extends ZIOSpecDefault {
         val boardUsersPostsCommentsId        =
           EndpointSpec
             .get(
-              "users" / RouteCodec.int / "posts" / RouteCodec.int / RouteCodec
-                .literal("comments") / RouteCodec.int,
+              "users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId") / RouteCodec
+                .literal("comments") / RouteCodec.int("commentId"),
             )
             .out[String]
             .implement { case (userId, postId, commentId) =>
@@ -110,19 +110,19 @@ object APISpec extends ZIOSpecDefault {
         val broadPosts                       =
           EndpointSpec.get("posts").out[String].implement { _ => ZIO.succeed("route(posts)") }
         val broadPostsId                     =
-          EndpointSpec.get("posts" / RouteCodec.int).out[String].implement { postId =>
+          EndpointSpec.get("posts" / RouteCodec.int("postId")).out[String].implement { postId =>
             ZIO.succeed(s"route(posts, $postId)")
           }
         val boardPostsComments               =
           EndpointSpec
-            .get("posts" / RouteCodec.int / "comments")
+            .get("posts" / RouteCodec.int("postId") / "comments")
             .out[String]
             .implement { postId =>
               ZIO.succeed(s"route(posts, $postId, comments)")
             }
         val boardPostsCommentsId             =
           EndpointSpec
-            .get("posts" / RouteCodec.int / "comments" / RouteCodec.int)
+            .get("posts" / RouteCodec.int("postId") / "comments" / RouteCodec.int("commentId"))
             .out[String]
             .implement { case (postId, commentId) =>
               ZIO.succeed(s"route(posts, $postId, comments, $commentId)")
@@ -130,19 +130,19 @@ object APISpec extends ZIOSpecDefault {
         val broadComments                    =
           EndpointSpec.get("comments").out[String].implement { _ => ZIO.succeed("route(comments)") }
         val broadCommentsId                  =
-          EndpointSpec.get("comments" / RouteCodec.int).out[String].implement { commentId =>
+          EndpointSpec.get("comments" / RouteCodec.int("commentId")).out[String].implement { commentId =>
             ZIO.succeed(s"route(comments, $commentId)")
           }
         val broadUsersComments               =
           EndpointSpec
-            .get("users" / RouteCodec.int / "comments")
+            .get("users" / RouteCodec.int("userId") / "comments")
             .out[String]
             .implement { userId =>
               ZIO.succeed(s"route(users, $userId, comments)")
             }
         val broadUsersCommentsId             =
           EndpointSpec
-            .get("users" / RouteCodec.int / "comments" / RouteCodec.int)
+            .get("users" / RouteCodec.int("userId") / "comments" / RouteCodec.int("commentId"))
             .out[String]
             .implement { case (userId, commentId) =>
               ZIO.succeed(s"route(users, $userId, comments, $commentId)")
@@ -150,8 +150,8 @@ object APISpec extends ZIOSpecDefault {
         val boardUsersPostsCommentsReplies   =
           EndpointSpec
             .get(
-              "users" / RouteCodec.int / "posts" / RouteCodec.int / RouteCodec
-                .literal("comments") / RouteCodec.int / RouteCodec
+              "users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId") / RouteCodec
+                .literal("comments") / RouteCodec.int("commentId") / RouteCodec
                 .literal(
                   "replies",
                 ),
@@ -163,11 +163,11 @@ object APISpec extends ZIOSpecDefault {
         val boardUsersPostsCommentsRepliesId =
           EndpointSpec
             .get(
-              "users" / RouteCodec.int / "posts" / RouteCodec.int / RouteCodec
-                .literal("comments") / RouteCodec.int / RouteCodec
+              "users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId") / RouteCodec
+                .literal("comments") / RouteCodec.int("commentId") / RouteCodec
                 .literal(
                   "replies",
-                ) / RouteCodec.int,
+                ) / RouteCodec.int("replyId"),
             )
             .out[String]
             .implement { case (userId, postId, commentId, replyId) =>

--- a/zio-http/src/test/scala/zio/http/api/HttpCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/HttpCodecSpec.scala
@@ -109,7 +109,7 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("decode route with two path segments") {
           val userCodec = RouteCodec.literal("users")
-          val intCodec  = RouteCodec.int
+          val intCodec  = RouteCodec.int("userId")
 
           // /users/<int id>
           val fullCodec = userCodec ++ intCodec
@@ -120,7 +120,7 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("encode route with two path segments") {
           val userCodec = RouteCodec.literal("users")
-          val intCodec  = RouteCodec.int
+          val intCodec  = RouteCodec.int("userId")
 
           // /users/<int id>
           val fullCodec = userCodec ++ intCodec
@@ -133,7 +133,7 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("decode route with three path segments") {
           val userCodec = RouteCodec.literal("users")
-          val intCodec  = RouteCodec.int
+          val intCodec  = RouteCodec.int("userId")
           val postCodec = RouteCodec.literal("post")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec
@@ -144,7 +144,7 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("encode route with three path segments") {
           val userCodec = RouteCodec.literal("users")
-          val intCodec  = RouteCodec.int
+          val intCodec  = RouteCodec.int("userId")
           val postCodec = RouteCodec.literal("post")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec
@@ -155,9 +155,9 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("decode route with four path segments") {
           val userCodec   = RouteCodec.literal("users")
-          val intCodec    = RouteCodec.int
+          val intCodec    = RouteCodec.int("userId")
           val postCodec   = RouteCodec.literal("post")
-          val postIdCodec = RouteCodec.int
+          val postIdCodec = RouteCodec.int("postId")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec ++ postIdCodec
           for {
@@ -166,9 +166,9 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("encode route with four path segments") {
           val userCodec   = RouteCodec.literal("users")
-          val intCodec    = RouteCodec.int
+          val intCodec    = RouteCodec.int("userId")
           val postCodec   = RouteCodec.literal("post")
-          val postIdCodec = RouteCodec.int
+          val postIdCodec = RouteCodec.int("postId")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec ++ postIdCodec
 
@@ -178,9 +178,9 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("decode route with five path segments") {
           val userCodec       = RouteCodec.literal("users")
-          val intCodec        = RouteCodec.int
+          val intCodec        = RouteCodec.int("userId")
           val postCodec       = RouteCodec.literal("post")
-          val postIdCodec     = RouteCodec.int
+          val postIdCodec     = RouteCodec.int("postId")
           val postIdfontCodec = RouteCodec.literal("fontstyle")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec ++ postIdCodec ++ postIdfontCodec
@@ -190,9 +190,9 @@ object HttpCodecSpec extends ZIOSpecDefault {
         } +
         test("encode route with five path segments") {
           val userCodec       = RouteCodec.literal("users")
-          val intCodec        = RouteCodec.int
+          val intCodec        = RouteCodec.int("userId")
           val postCodec       = RouteCodec.literal("post")
-          val postIdCodec     = RouteCodec.int
+          val postIdCodec     = RouteCodec.int("postId")
           val postIdfontCodec = RouteCodec.literal("fontstyle")
 
           val fullCodec = userCodec ++ intCodec ++ postCodec ++ postIdCodec ++ postIdfontCodec

--- a/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
@@ -20,7 +20,7 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
   }
 
   val usersPostAPI =
-    EndpointSpec.get("users" / RouteCodec.int / "posts" / RouteCodec.int).out[Post]
+    EndpointSpec.get("users" / RouteCodec.int("userId") / "posts" / RouteCodec.int("postId")).out[Post]
 
   val usersPostHandler =
     usersPostAPI.implement { case (userId, postId) =>


### PR DESCRIPTION
For documentation (generators) just a type of a route segment is not
enough. We need a name to generate meaningful docs.
