### PR TITLE
Remove Scope From Input Type Of Layers

### DIFF
--- a/zio-http-example/src/main/scala/example/AuthenticationClient.scala
+++ b/zio-http-example/src/main/scala/example/AuthenticationClient.scala
@@ -22,6 +22,6 @@ object AuthenticationClient extends ZIOAppDefault {
     _        <- Console.printLine(body)
   } yield ()
 
-  override val run = program.provide(Client.default, Scope.default)
+  override val run = program.provide(Client.default)
 
 }

--- a/zio-http-example/src/main/scala/example/ClientServer.scala
+++ b/zio-http-example/src/main/scala/example/ClientServer.scala
@@ -16,6 +16,6 @@ object ClientServer extends ZIOAppDefault {
   }
 
   val run = {
-    Server.serve(app).provide(Server.default, Client.default, Scope.default).exitCode
+    Server.serve(app).provide(Server.default, Client.default).exitCode
   }
 }

--- a/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
+++ b/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
@@ -17,6 +17,6 @@ object ClientWithDecompression extends ZIOAppDefault {
 
   val config       = ClientConfig.empty.requestDecompression(true)
   override val run =
-    program.provide(ClientConfig.live(config), ConnectionPool.disabled, Client.fromConfig, Scope.default)
+    program.provide(ClientConfig.live(config), ConnectionPool.disabled, Client.fromConfig)
 
 }

--- a/zio-http-example/src/main/scala/example/HttpsClient.scala
+++ b/zio-http-example/src/main/scala/example/HttpsClient.scala
@@ -22,6 +22,6 @@ object HttpsClient extends ZIOAppDefault {
     _    <- Console.printLine(data)
   } yield ()
 
-  val run = program.provide(ClientConfig.live(clientConfig), Client.live, ConnectionPool.disabled, Scope.default)
+  val run = program.provide(ClientConfig.live(clientConfig), Client.live, ConnectionPool.disabled)
 
 }

--- a/zio-http-example/src/main/scala/example/SimpleClient.scala
+++ b/zio-http-example/src/main/scala/example/SimpleClient.scala
@@ -12,6 +12,6 @@ object SimpleClient extends ZIOAppDefault {
     _    <- Console.printLine(data)
   } yield ()
 
-  override val run = program.provide(Client.default, Scope.default)
+  override val run = program.provide(Client.default)
 
 }

--- a/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
@@ -104,7 +104,8 @@ object SocketContractSpec extends ZIOSpecDefault {
           )
           _        <- promise.await.timeout(10.seconds)
         } yield assertTrue(response.status == Status.SwitchingProtocols)
-      }.provide(Client.default, Scope.default, TestServer.layer, NettyDriver.default, ServerConfig.liveOnOpenPort),
+      }.provideSome[Client](TestServer.layer, NettyDriver.default, ServerConfig.liveOnOpenPort, Scope.default)
+        .provide(Client.default),
       test("Test") {
         for {
           portAndPromise <- testServerSetup(serverApp)

--- a/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
@@ -82,7 +82,7 @@ object TestServerSpec extends ZIOSpecDefault {
       .provideSome[Client with Driver](
         TestServer.layer,
       ),
-  ).provideSome[Scope](
+  ).provide(
     ServerConfig.liveOnOpenPort,
     Client.default,
     NettyDriver.default,

--- a/zio-http/src/main/scala/zio/http/ClientConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ClientConfig.scala
@@ -53,7 +53,7 @@ object ClientConfig {
   def empty: ClientConfig = ClientConfig()
 
   val default: ZLayer[
-    Scope,
+    Any,
     Nothing,
     ClientConfig with EventLoopGroup with ChannelFactory[channel.Channel] with NettyRuntime,
   ] = {
@@ -67,7 +67,7 @@ object ClientConfig {
     clientConfig: ClientConfig,
   )(implicit
     trace: Trace,
-  ): ZLayer[Scope, Nothing, ClientConfig with EventLoopGroup with ChannelFactory[channel.Channel] with NettyRuntime] =
+  ): ZLayer[Any, Nothing, ClientConfig with EventLoopGroup with ChannelFactory[channel.Channel] with NettyRuntime] =
     ZLayer.succeed(
       clientConfig,
     ) >+> EventLoopGroups.fromConfig >+> ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -792,15 +792,15 @@ object ZClient {
   }
 
   val fromConfig: ZLayer[
-    Scope with EventLoopGroups.Config with ChannelType.Config with ConnectionPool with ClientConfig,
+    ChannelType.Config with ConnectionPool with ClientConfig,
     Throwable,
     Client,
   ] = {
     implicit val trace = Trace.empty
-    EventLoopGroups.fromConfig >+> ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool >>> live
+    ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool >>> live
   }
 
-  val default: ZLayer[Scope, Throwable, Client] = {
+  val default: ZLayer[Any, Throwable, Client] = {
     implicit val trace = Trace.empty
     ClientConfig.default >+> ConnectionPool.disabled >>> live
   }

--- a/zio-http/src/main/scala/zio/http/netty/NettyRuntime.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyRuntime.scala
@@ -77,7 +77,7 @@ private[zio] object NettyRuntime {
   /**
    * Creates a runtime that uses a separate thread pool for ZIO operations.
    */
-  val usingDedicatedThreadPool = {
+  val usingDedicatedThreadPool: ZLayer[Any, Nothing, NettyRuntime] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.fromZIO {
       ZIO
@@ -95,7 +95,7 @@ private[zio] object NettyRuntime {
    * event loop. This should be the preferred way of creating the runtime for
    * the server.
    */
-  val usingSharedThreadPool = {
+  val usingSharedThreadPool: ZLayer[EventLoopGroup, Nothing, NettyRuntime] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.fromZIO {
       for {

--- a/zio-http/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -85,9 +85,9 @@ object NettyDriver {
 
     val serverChannelFactory: ZLayer[ServerConfig, Nothing, ChannelFactory[ServerChannel]] =
       ChannelFactories.Server.fromConfig
-    val eventLoopGroup: ZLayer[Scope with ServerConfig, Nothing, EventLoopGroup]           = EventLoopGroups.fromConfig
+    val eventLoopGroup: ZLayer[ServerConfig, Nothing, EventLoopGroup]                      = EventLoopGroups.fromConfig
 
-    Scope.default >>> eventLoopGroup >+> serverChannelFactory >>> manual
+    eventLoopGroup >+> serverChannelFactory >>> manual
   }
 
   val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & ServerConfig, Nothing, Driver] =

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -39,7 +39,6 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.Ok))
           }.provide(
-            Scope.default,
             ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),
@@ -52,7 +51,6 @@ object SSLSpec extends ZIOSpecDefault {
               }
             assertZIO(actual)(equalTo("DecoderException"))
           }.provide(
-            Scope.default,
             ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL2)),
@@ -63,7 +61,6 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.Ok))
           }.provide(
-            Scope.default,
             ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(ClientSSLConfig.Default)),
@@ -74,7 +71,6 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.PermanentRedirect))
           }.provide(
-            Scope.default,
             ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -87,7 +87,6 @@ object SSLSpec extends ZIOSpecDefault {
               assertZIO(actual)(equalTo(Status.RequestEntityTooLarge))
             }
           }.provide(
-            Scope.default,
             ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),

--- a/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
@@ -53,7 +53,7 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
           _        <- ZIO.debug(s"Result: $result")
         } yield assertTrue(result == Post(20, "title", "body", 10))
       },
-    ).provideSome[Scope](
+    ).provide(
       Server.live,
       ServerConfig.live,
       Client.live,

--- a/zio-http/src/test/scala/zio/http/service/ClientHttpsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientHttpsSpec.scala
@@ -45,7 +45,6 @@ object ClientHttpsSpec extends ZIOSpecDefault {
     ClientConfig.live(ClientConfig.empty.ssl(sslConfig)),
     Client.live,
     ConnectionPool.disabled,
-    Scope.default,
   ) @@ timeout(
     30 seconds,
   ) @@ ignore

--- a/zio-http/src/test/scala/zio/http/service/ClientProxySpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientProxySpec.scala
@@ -26,7 +26,6 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = serverUrl),
             )
             .provideSome(
-              Scope.default,
               ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(Proxy(proxyUrl))),
@@ -46,7 +45,6 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = url),
             )
             .provideSome(
-              Scope.default,
               ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(proxy)),
@@ -76,7 +74,6 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = url),
             )
             .provideSome(
-              Scope.default,
               ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(proxy)),

--- a/zio-http/src/test/scala/zio/http/service/ClientStreamingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientStreamingSpec.scala
@@ -26,7 +26,6 @@ object ClientStreamingSpec extends HttpRunnableSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ClientProxy") {
     serve(DynamicServer.app).as(List(clientStreamingSpec))
   }.provideShared(
-    Scope.default,
     DynamicServer.live,
     severTestLayer,
     ConnectionPool.disabled,


### PR DESCRIPTION
Since layers are resourceful they should not depend on a `Scope`.