### PR TITLE
Friendlier Forms in ZIO HTTP

### DIFF
--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -2,18 +2,14 @@ package zio.http
 
 import java.io.FileInputStream
 import java.nio.charset._
-import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 import java.nio.file._
-import zio.http.model.Headers
-
-import zio.http.forms._
-import zio.http.model.MediaType
 
 import zio._
 
 import zio.stream.ZStream
 
-import zio.http.model.HTTP_CHARSET
+import zio.http.forms._
+import zio.http.model.{HTTP_CHARSET, Headers, MediaType}
 
 import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.channel.{Channel => JChannel}
@@ -95,8 +91,10 @@ object Body {
    */
   def fromAsciiString(asciiString: AsciiString): Body = AsciiStringBody(asciiString, Headers.empty)
 
-  private[zio] final case class AsciiStringBody(asciiString: AsciiString, override val requestHeaders: Headers)
-      extends Body
+  private[zio] final case class AsciiStringBody(
+    asciiString: AsciiString,
+    override val requestHeaders: Headers = Headers.empty,
+  ) extends Body
       with UnsafeWriteable
       with UnsafeBytes {
 

--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -3,6 +3,10 @@ package zio.http
 import java.io.FileInputStream
 import java.nio.charset.Charset
 import java.nio.file._
+import zio.http.model.Headers
+
+import zio.http.forms._
+import zio.http.model.MediaType
 
 import zio._
 
@@ -29,6 +33,15 @@ sealed trait Body { self =>
 
   def asChunk(implicit trace: Trace): Task[Chunk[Byte]]
 
+  def asURLEncodedForm(implicit trace: Trace): Task[Form] =
+    asString.flatMap(Form.fromURLEncoded(_, HTTP_CHARSET).mapError(_.asException))
+
+  def asMultipartForm(implicit trace: Trace): Task[Form] =
+    for {
+      bytes <- asChunk
+      form  <- Form.fromMultipartBytes(bytes, HTTP_CHARSET).mapError(_.asException)
+    } yield form
+
   def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte]
 
   /**
@@ -44,6 +57,8 @@ sealed trait Body { self =>
     asArray.map(new String(_, HTTP_CHARSET))
 
   def isComplete: Boolean
+
+  private[zio] def requestHeaders: Headers = Headers.empty
 
 }
 
@@ -77,9 +92,9 @@ object Body {
   /**
    * Helper to create Body from AsciiString
    */
-  def fromAsciiString(asciiString: AsciiString): Body = AsciiStringBody(asciiString)
+  def fromAsciiString(asciiString: AsciiString): Body = AsciiStringBody(asciiString, Headers.empty)
 
-  private[zio] final case class AsciiStringBody(asciiString: AsciiString)
+  private[zio] final case class AsciiStringBody(asciiString: AsciiString, override val requestHeaders: Headers)
       extends Body
       with UnsafeWriteable
       with UnsafeBytes {
@@ -133,7 +148,10 @@ object Body {
    */
   def fromChunk(data: Chunk[Byte]): Body = new ChunkBody(data)
 
-  private[zio] final case class ChunkBody(data: Chunk[Byte]) extends Body with UnsafeWriteable with UnsafeBytes {
+  private[zio] final case class ChunkBody(data: Chunk[Byte], override val requestHeaders: Headers = Headers.empty)
+      extends Body
+      with UnsafeWriteable
+      with UnsafeBytes {
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(data.toArray)
 
@@ -191,6 +209,17 @@ object Body {
     override private[zio] def unsafeAsArray(implicit unsafe: Unsafe): Array[Byte] =
       Files.readAllBytes(file.toPath)
 
+  }
+
+  def fromURLEncodedForm(form: Form, charset: Charset = `UTF-8`): Body = {
+    val contentType = Headers.contentType(MediaType.application.`x-www-form-urlencoded`.fullType)
+    AsciiStringBody(new AsciiString(form.encodeAsURLEncoded(charset), charset), contentType)
+  }
+
+  def fromMultipartForm(form: Form, charset: Charset = `UTF-8`): Body = {
+    val (headers, bytes) = form.encodeAsMultipartBytes(charset)
+
+    ChunkBody(bytes, headers)
   }
 
   /**

--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -1,7 +1,8 @@
 package zio.http
 
 import java.io.FileInputStream
-import java.nio.charset.Charset
+import java.nio.charset._
+import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 import java.nio.file._
 import zio.http.model.Headers
 
@@ -211,12 +212,12 @@ object Body {
 
   }
 
-  def fromURLEncodedForm(form: Form, charset: Charset = `UTF-8`): Body = {
+  def fromURLEncodedForm(form: Form, charset: Charset = StandardCharsets.UTF_8): Body = {
     val contentType = Headers.contentType(MediaType.application.`x-www-form-urlencoded`.fullType)
     AsciiStringBody(new AsciiString(form.encodeAsURLEncoded(charset), charset), contentType)
   }
 
-  def fromMultipartForm(form: Form, charset: Charset = `UTF-8`): Body = {
+  def fromMultipartForm(form: Form, charset: Charset = StandardCharsets.UTF_8): Body = {
     val (headers, bytes) = form.encodeAsMultipartBytes(charset)
 
     ChunkBody(bytes, headers)

--- a/zio-http/src/main/scala/zio/http/Request.scala
+++ b/zio-http/src/main/scala/zio/http/Request.scala
@@ -52,7 +52,7 @@ object Request {
   }
 
   def default(method: Method, url: URL, body: Body = Body.empty) =
-    Request(body, Headers.empty, method, url, Version.`HTTP/1.1`, Option.empty)
+    Request(body, body.requestHeaders, method, url, Version.`HTTP/1.1`, Option.empty)
 
   def delete(url: URL): Request = default(Method.DELETE, url)
 

--- a/zio-http/src/main/scala/zio/http/forms/Boundary.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Boundary.scala
@@ -1,0 +1,68 @@
+package zio.http.forms
+
+import zio.Chunk
+import zio.http.forms.FormAST.Header
+import zio.http.model.{Headers, MediaType}
+
+import java.nio.charset.Charset
+import java.security.SecureRandom
+
+final case class Boundary(id: String, charset: Charset = `UTF-8`) {
+
+  def isEncapsulating(bytes: Chunk[Byte]): Boolean = bytes == encapsulationBoundaryBytes
+
+  def isClosing(bytes: Chunk[Byte]): Boolean = bytes == closingBoundaryBytes
+
+  def contentTypeHeader: Headers = Headers.contentType(s"${MediaType.multipart.`form-data`.fullType}; boundary=$id")
+
+  val encapsulationBoundary: String = s"--$id"
+
+  val closingBoundary: String = s"--$id--"
+
+  private[forms] val encapsulationBoundaryBytes = Chunk.fromArray(encapsulationBoundary.getBytes(charset))
+
+  private[forms] val closingBoundaryBytes = Chunk.fromArray(closingBoundary.getBytes(charset))
+
+}
+
+object Boundary {
+
+  def generate(rng: () => String = () => new SecureRandom().nextLong.toString): Boundary =
+    Boundary(s"(((${rng().toString()})))")
+
+  def fromContent(content: Chunk[Byte], charset: Charset = `UTF-8`): Option[Boundary] = {
+    var i = 0
+    var j = 0
+
+    val boundaryBytes = content.foldWhile(Chunk.empty[Byte])(_ => i < 2) {
+      case (buffer, byte) if byte == '\r' || byte == '\n' =>
+        i = i + 1
+        buffer
+      case (buffer, byte) if byte == '-' && j < 2         =>
+        j = j + 1
+        buffer
+      case (buffer, byte)                                 =>
+        buffer :+ byte
+    }
+    if (i == 2 && j == 2)
+      Some(Boundary(new String(boundaryBytes.toArray, charset)))
+    else Option.empty
+  }
+
+  def fromHeaders(headers: Headers): Option[Boundary] = {
+
+    val charset =
+      headers.contentType
+        .flatMap(value => Header("Content-Type", value.toString()).fields.get("charset"))
+        .map(Charset.forName)
+        .getOrElse(`UTF-8`)
+
+    for {
+      disp     <- headers.contentDisposition
+      boundary <- Header("Content-Disposition", disp.toString()).fields.get("boundary")
+
+    } yield Boundary(boundary, charset)
+
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/forms/Boundary.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Boundary.scala
@@ -4,10 +4,10 @@ import zio.Chunk
 import zio.http.forms.FormAST.Header
 import zio.http.model.{Headers, MediaType}
 
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 import java.security.SecureRandom
 
-final case class Boundary(id: String, charset: Charset = `UTF-8`) {
+final case class Boundary(id: String, charset: Charset = StandardCharsets.UTF_8) {
 
   def isEncapsulating(bytes: Chunk[Byte]): Boolean = bytes == encapsulationBoundaryBytes
 
@@ -30,7 +30,7 @@ object Boundary {
   def generate(rng: () => String = () => new SecureRandom().nextLong.toString): Boundary =
     Boundary(s"(((${rng().toString()})))")
 
-  def fromContent(content: Chunk[Byte], charset: Charset = `UTF-8`): Option[Boundary] = {
+  def fromContent(content: Chunk[Byte], charset: Charset = StandardCharsets.UTF_8): Option[Boundary] = {
     var i = 0
     var j = 0
 
@@ -55,7 +55,7 @@ object Boundary {
       headers.contentType
         .flatMap(value => Header("Content-Type", value.toString()).fields.get("charset"))
         .map(Charset.forName)
-        .getOrElse(`UTF-8`)
+        .getOrElse(StandardCharsets.UTF_8)
 
     for {
       disp     <- headers.contentDisposition

--- a/zio-http/src/main/scala/zio/http/forms/Boundary.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Boundary.scala
@@ -1,11 +1,12 @@
 package zio.http.forms
 
-import zio.Chunk
-import zio.http.forms.FormAST.Header
-import zio.http.model.{Headers, MediaType}
-
 import java.nio.charset.{Charset, StandardCharsets}
 import java.security.SecureRandom
+
+import zio.Chunk
+
+import zio.http.forms.FormAST.Header
+import zio.http.model.{Headers, MediaType}
 
 final case class Boundary(id: String, charset: Charset = StandardCharsets.UTF_8) {
 

--- a/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
+++ b/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
@@ -1,0 +1,39 @@
+package zio.http.forms
+
+import zio.Chunk
+import zio.http.model.Headers
+
+/**
+ * Represents the Content-Transfer-Encoding header.
+ * @SEE:
+ *   https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
+ */
+sealed trait ContentTransferEncoding { self =>
+  val name: String = self match {
+    case ContentTransferEncoding.Binary          => "binary"
+    case ContentTransferEncoding.QuotedPrintable => "quoted-printable"
+    case ContentTransferEncoding.Base64          => "base64"
+    case ContentTransferEncoding.`7bit`          => "7bit"
+    case ContentTransferEncoding.`8bit`          => "8bit"
+  }
+
+  def asHeaders: Headers = Headers.contentTransferEncoding(name)
+}
+
+object ContentTransferEncoding {
+
+  def parse(value: String): Option[ContentTransferEncoding] = value.toLowerCase match {
+    case "binary"           => Some(Binary)
+    case "7bit"             => Some(`7bit`)
+    case "8bit"             => Some(`8bit`)
+    case "quoted-printable" => Some(QuotedPrintable)
+    case "base64"           => Some(Base64)
+    case _                  => None
+  }
+
+  case object Binary          extends ContentTransferEncoding
+  case object `7bit`          extends ContentTransferEncoding
+  case object `8bit`          extends ContentTransferEncoding
+  case object QuotedPrintable extends ContentTransferEncoding
+  case object Base64          extends ContentTransferEncoding
+}

--- a/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
+++ b/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
@@ -6,8 +6,8 @@ import zio.http.model.Headers
 
 /**
  * Represents the Content-Transfer-Encoding header.
- * @SEE:
- *   https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
+ * 
+ * https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
  */
 sealed trait ContentTransferEncoding { self =>
   val name: String = self match {

--- a/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
+++ b/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
@@ -1,6 +1,7 @@
 package zio.http.forms
 
 import zio.Chunk
+
 import zio.http.model.Headers
 
 /**

--- a/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
+++ b/zio-http/src/main/scala/zio/http/forms/ContentTransferEncoding.scala
@@ -6,7 +6,7 @@ import zio.http.model.Headers
 
 /**
  * Represents the Content-Transfer-Encoding header.
- * 
+ *
  * https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
  */
 sealed trait ContentTransferEncoding { self =>

--- a/zio-http/src/main/scala/zio/http/forms/Form.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Form.scala
@@ -1,17 +1,19 @@
 package zio.http.forms
 
+import java.io.UnsupportedEncodingException
+import java.net.{URLDecoder, URLEncoder}
+import java.nio.charset.{Charset, StandardCharsets}
+import java.security.SecureRandom
+
 import zio._
+
+import zio.stream._
+
 import zio.http.forms.FormAST._
 import zio.http.forms.FormData._
 import zio.http.forms.FormDecodingError._
 import zio.http.forms.FormState._
 import zio.http.model.Headers
-import zio.stream._
-
-import java.io.UnsupportedEncodingException
-import java.net.{URLDecoder, URLEncoder}
-import java.nio.charset.{Charset, StandardCharsets}
-import java.security.SecureRandom
 
 /**
  * Represents a form that can be either multipart or url encoded.

--- a/zio-http/src/main/scala/zio/http/forms/Form.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Form.scala
@@ -10,7 +10,7 @@ import zio.stream._
 
 import java.io.UnsupportedEncodingException
 import java.net.{URLDecoder, URLEncoder}
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 import java.security.SecureRandom
 
 /**
@@ -24,7 +24,7 @@ final case class Form(formData: Chunk[FormData]) {
 
   def get(name: String): Option[FormData] = formData.find(_.name == name)
 
-  def encodeAsURLEncoded(charset: Charset = `UTF-8`): String = {
+  def encodeAsURLEncoded(charset: Charset = StandardCharsets.UTF_8): String = {
 
     def makePair(name: String, value: String): String = {
       val encodedName  = URLEncoder.encode(name, charset.name())
@@ -42,7 +42,7 @@ final case class Form(formData: Chunk[FormData]) {
   }
 
   def encodeAsMultipartBytes(
-    charset: Charset = `UTF-8`,
+    charset: Charset = StandardCharsets.UTF_8,
     rng: () => String = () => new SecureRandom().nextLong().toString(),
   ): (Headers, Chunk[Byte]) = {
 
@@ -109,7 +109,7 @@ object Form {
 
   def fromMultipartBytes(
     bytes: Chunk[Byte],
-    charset: Charset = `UTF-8`,
+    charset: Charset = StandardCharsets.UTF_8,
   ): ZIO[Any, FormDecodingError, Form] = {
     def process(boundary: Boundary) = ZStream
       .fromChunk(bytes)

--- a/zio-http/src/main/scala/zio/http/forms/Form.scala
+++ b/zio-http/src/main/scala/zio/http/forms/Form.scala
@@ -1,0 +1,161 @@
+package zio.http.forms
+
+import zio._
+import zio.http.forms.FormAST._
+import zio.http.forms.FormData._
+import zio.http.forms.FormDecodingError._
+import zio.http.forms.FormState._
+import zio.http.model.Headers
+import zio.stream._
+
+import java.io.UnsupportedEncodingException
+import java.net.{URLDecoder, URLEncoder}
+import java.nio.charset.Charset
+import java.security.SecureRandom
+
+/**
+ * Represents a form that can be either multipart or url encoded.
+ */
+final case class Form(formData: Chunk[FormData]) {
+
+  def +(field: FormData): Form = append(field)
+
+  def append(field: FormData): Form = Form(formData :+ field)
+
+  def get(name: String): Option[FormData] = formData.find(_.name == name)
+
+  def encodeAsURLEncoded(charset: Charset = `UTF-8`): String = {
+
+    def makePair(name: String, value: String): String = {
+      val encodedName  = URLEncoder.encode(name, charset.name())
+      val encodedValue = URLEncoder.encode(value, charset.name())
+      s"$encodedName=$encodedValue"
+    }
+
+    val urlEncoded = formData.foldLeft(Chunk.empty[String]) {
+      case (accum, FormData.Text(k, v, _, _)) => accum :+ makePair(k, v)
+      case (accum, FormData.Simple(k, v))     => accum :+ makePair(k, v)
+      case (accum, _)                         => accum
+    }
+
+    urlEncoded.mkString("&")
+  }
+
+  def encodeAsMultipartBytes(
+    charset: Charset = `UTF-8`,
+    rng: () => String = () => new SecureRandom().nextLong().toString(),
+  ): (Headers, Chunk[Byte]) = {
+
+    val boundary              = Boundary.generate(rng)
+    val encapsulatingBoundary = EncapsulatingBoundary(boundary)
+    val closingBoundary       = ClosingBoundary(boundary)
+
+    val ast = formData.flatMap {
+      case fd @ Simple(name, value) =>
+        Chunk(
+          encapsulatingBoundary,
+          EoL,
+          Header.contentDisposition(name),
+          EoL,
+          Header.contentType(fd.contentType),
+          EoL,
+          EoL,
+          Content(Chunk.fromArray(value.getBytes(charset))),
+          EoL,
+        )
+
+      case Text(name, value, contentType, filename)                    =>
+        Chunk(
+          encapsulatingBoundary,
+          EoL,
+          Header.contentDisposition(name, filename),
+          EoL,
+          Header.contentType(contentType),
+          EoL,
+          EoL,
+          Content(Chunk.fromArray(value.getBytes(charset))),
+          EoL,
+        )
+      case Binary(name, data, contentType, transferEncoding, filename) =>
+        val xferEncoding =
+          transferEncoding.map(enc => Chunk(Header.contentTransferEncoding(enc), EoL)).getOrElse(Chunk.empty)
+
+        Chunk(
+          encapsulatingBoundary,
+          EoL,
+          Header.contentDisposition(name, filename),
+          EoL,
+          Header.contentType(contentType),
+          EoL,
+        ) ++ xferEncoding ++
+          Chunk(
+            EoL,
+            Content(data),
+            EoL,
+          )
+    } ++ Chunk(closingBoundary, EoL)
+
+    boundary.contentTypeHeader -> ast.flatMap(_.bytes)
+  }
+}
+
+object Form {
+
+  def apply(formData: FormData*): Form = Form(Chunk.fromIterable(formData))
+
+  def fromStrings(formData: (String, String)*): Form = apply(
+    formData.map(pair => FormData.Simple(pair._1, pair._2)): _*,
+  )
+
+  def fromMultipartBytes(
+    bytes: Chunk[Byte],
+    charset: Charset = `UTF-8`,
+  ): ZIO[Any, FormDecodingError, Form] = {
+    def process(boundary: Boundary) = ZStream
+      .fromChunk(bytes)
+      .mapAccum(FormState.fromBoundary(boundary)) { (state, byte) =>
+        state match {
+          case BoundaryClosed(tree)       => (FormState.fromBoundary(boundary), tree)
+          case BoundaryEncapsulated(tree) => (FormState.fromBoundary(boundary, Some(byte)), tree)
+          case buffer: FormStateBuffer    =>
+            val state = buffer.append(byte)
+            state match {
+              case BoundaryClosed(prevContent) => (state, prevContent)
+              case _                           => (state, Chunk.empty[FormAST])
+            }
+        }
+      }
+      .collectZIO {
+        case chunk if chunk.nonEmpty => FormData.fromFormAST(chunk, charset)
+      }
+      .runCollect
+      .map(apply)
+
+    for {
+      boundary <- ZIO
+        .fromOption(Boundary.fromContent(bytes, charset))
+        .mapError(_ => FormDecodingError.BoundaryNotFoundInContent)
+      form     <- process(boundary)
+    } yield form
+  }
+
+  def fromURLEncoded(encoded: String, encoding: Charset): ZIO[Any, FormDecodingError, Form] = {
+    val fields = ZIO.foreach(encoded.split("&")) { pair =>
+      val array = pair.split("=")
+      if (array.length == 2)
+        ZIO
+          .attempt((URLDecoder.decode(array(0), encoding.name()), URLDecoder.decode(array(1), encoding.name)))
+          .mapError {
+            case e: UnsupportedEncodingException => InvalidCharset(e.getMessage)
+            case e                               => InvalidURLEncodedFormat(e.getMessage)
+          }
+      else
+        ZIO.fail(
+          InvalidURLEncodedFormat(s"Invalid form field.  Expected: '{name}={value}'', Got '$pair' instead."),
+        )
+    }
+
+    fields.map(fields => Form(Chunk.fromArray(fields.map(pair => FormData.Simple(pair._1, pair._2)))))
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/forms/FormAST.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormAST.scala
@@ -1,0 +1,101 @@
+package zio.http.forms
+
+import zio._
+import zio.http.model._
+
+import java.nio.charset.Charset
+
+private[forms] sealed trait FormAST { def bytes: Chunk[Byte] }
+
+private[forms] object FormAST {
+
+  sealed trait DecodingPart1AST extends FormAST
+
+  sealed trait DecodingPart2AST extends DecodingPart1AST
+
+  def makePart1(bytes: Chunk[Byte], boundary: Boundary, encoding: Charset = `UTF-8`): DecodingPart1AST = {
+    val header = Header.fromBytes(bytes.toArray, encoding)
+    header match {
+      case Some(header)                            => header
+      case None if boundary.isEncapsulating(bytes) => EncapsulatingBoundary(boundary)
+      case None if boundary.isClosing(bytes)       => ClosingBoundary(boundary)
+      case None                                    => Content(bytes)
+    }
+  }
+
+  def makePart2(bytes: Chunk[Byte], boundary: Boundary, encoding: Charset = `UTF-8`): DecodingPart2AST = {
+    if (boundary.isEncapsulating(bytes)) EncapsulatingBoundary(boundary)
+    else if (boundary.isClosing(bytes)) ClosingBoundary(boundary)
+    else Content(bytes)
+  }
+
+  case object EoL extends FormAST { val bytes: Chunk[Byte] = Chunk('\r', '\n') }
+
+  case class EncapsulatingBoundary(boundary: Boundary) extends DecodingPart2AST {
+    def bytes: Chunk[Byte] = boundary.encapsulationBoundaryBytes
+  }
+
+  case class ClosingBoundary(boundary: Boundary) extends DecodingPart2AST {
+    def bytes: Chunk[Byte] = boundary.closingBoundaryBytes
+  }
+
+  case class Header(name: String, value: String) extends DecodingPart1AST {
+
+    /**
+     * The preposition is the first part of the header value before the first
+     * semicolon. For example, the preposition of "text/html; charset=utf-8" is
+     * "text/html".
+     *
+     * If there is no semicolon, the entire value is returned.
+     *
+     * @return
+     */
+    def preposition: String = value.split(';').head
+
+    def fields: Map[String, String] =
+      value
+        .split(';')
+        .map(_.trim)
+        .flatMap { field =>
+          val tokens = field.split('=')
+          if (tokens.size > 1)
+            Some(tokens(0) -> tokens.last.stripPrefix("\"").stripSuffix("\""))
+          else Option.empty[(String, String)]
+        }
+        .toMap
+
+    def toHeaders: Headers = Headers(name -> value)
+
+    def bytes: Chunk[Byte] = Chunk.fromArray(s"$name: $value".getBytes(`UTF-8`))
+  }
+
+  object Header {
+
+    private def makeField(name: String, value: String): String = s"""; ${name}="${value}""""
+
+    private def makeField(name: String, value: Option[String]): String =
+      value.map(makeField(name, _)).getOrElse("")
+
+    def contentType(contentType: MediaType, charset: Option[Charset] = None): Header =
+      Header("Content-Type", s"${contentType.fullType}${makeField("charset", charset.map(_.name))}")
+
+    def contentDisposition(name: String, filename: Option[String] = None): Header =
+      Header("Content-Disposition", s"""form-data${makeField("name", name)}${makeField("filename", filename)}""")
+
+    def contentTransferEncoding(xferEncoding: ContentTransferEncoding): Header =
+      Header("Content-Transfer-Encoding", xferEncoding.name)
+
+    def fromBytes(bytes: Array[Byte], encoding: Charset = `UTF-8`): Option[Header] = {
+      val i = bytes.indexOf(':')
+
+      if (i > -1) {
+        bytes.splitAt(i) match {
+          case (nameBytes, valueBytes) =>
+            Some(Header(new String(nameBytes, encoding), new String(valueBytes.splitAt(1)._2, encoding).trim))
+        }
+      } else None
+    }
+  }
+
+  final case class Content(bytes: Chunk[Byte]) extends DecodingPart2AST
+}

--- a/zio-http/src/main/scala/zio/http/forms/FormAST.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormAST.scala
@@ -1,9 +1,10 @@
 package zio.http.forms
 
-import zio._
-import zio.http.model._
-
 import java.nio.charset._
+
+import zio._
+
+import zio.http.model._
 
 private[forms] sealed trait FormAST { def bytes: Chunk[Byte] }
 

--- a/zio-http/src/main/scala/zio/http/forms/FormAST.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormAST.scala
@@ -3,7 +3,7 @@ package zio.http.forms
 import zio._
 import zio.http.model._
 
-import java.nio.charset.Charset
+import java.nio.charset._
 
 private[forms] sealed trait FormAST { def bytes: Chunk[Byte] }
 
@@ -13,7 +13,11 @@ private[forms] object FormAST {
 
   sealed trait DecodingPart2AST extends DecodingPart1AST
 
-  def makePart1(bytes: Chunk[Byte], boundary: Boundary, encoding: Charset = `UTF-8`): DecodingPart1AST = {
+  def makePart1(
+    bytes: Chunk[Byte],
+    boundary: Boundary,
+    encoding: Charset = StandardCharsets.UTF_8,
+  ): DecodingPart1AST = {
     val header = Header.fromBytes(bytes.toArray, encoding)
     header match {
       case Some(header)                            => header
@@ -23,7 +27,11 @@ private[forms] object FormAST {
     }
   }
 
-  def makePart2(bytes: Chunk[Byte], boundary: Boundary, encoding: Charset = `UTF-8`): DecodingPart2AST = {
+  def makePart2(
+    bytes: Chunk[Byte],
+    boundary: Boundary,
+    encoding: Charset = StandardCharsets.UTF_8,
+  ): DecodingPart2AST = {
     if (boundary.isEncapsulating(bytes)) EncapsulatingBoundary(boundary)
     else if (boundary.isClosing(bytes)) ClosingBoundary(boundary)
     else Content(bytes)
@@ -66,7 +74,7 @@ private[forms] object FormAST {
 
     def toHeaders: Headers = Headers(name -> value)
 
-    def bytes: Chunk[Byte] = Chunk.fromArray(s"$name: $value".getBytes(`UTF-8`))
+    def bytes: Chunk[Byte] = Chunk.fromArray(s"$name: $value".getBytes(StandardCharsets.UTF_8))
   }
 
   object Header {
@@ -85,7 +93,7 @@ private[forms] object FormAST {
     def contentTransferEncoding(xferEncoding: ContentTransferEncoding): Header =
       Header("Content-Transfer-Encoding", xferEncoding.name)
 
-    def fromBytes(bytes: Array[Byte], encoding: Charset = `UTF-8`): Option[Header] = {
+    def fromBytes(bytes: Array[Byte], encoding: Charset = StandardCharsets.UTF_8): Option[Header] = {
       val i = bytes.indexOf(':')
 
       if (i > -1) {

--- a/zio-http/src/main/scala/zio/http/forms/FormData.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormData.scala
@@ -5,7 +5,7 @@ import zio.http.forms.FormAST._
 import zio.http.forms.FormDecodingError._
 import zio.http.model.MediaType
 
-import java.nio.charset.Charset
+import java.nio.charset._
 
 sealed trait FormData {
   def name: String
@@ -60,7 +60,10 @@ object FormData {
     override val filename: Option[String] = None
   }
 
-  def fromFormAST(ast: Chunk[FormAST], defaultCharset: Charset = `UTF-8`): ZIO[Any, FormDecodingError, FormData] = {
+  def fromFormAST(
+    ast: Chunk[FormAST],
+    defaultCharset: Charset = StandardCharsets.UTF_8,
+  ): ZIO[Any, FormDecodingError, FormData] = {
     val extract =
       ast.foldLeft((Option.empty[Header], Option.empty[Header], Option.empty[Header], Option.empty[Content])) {
         case (accum, header: Header) if header.name == "Content-Disposition"       =>

--- a/zio-http/src/main/scala/zio/http/forms/FormData.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormData.scala
@@ -1,11 +1,12 @@
 package zio.http.forms
 
+import java.nio.charset._
+
 import zio._
+
 import zio.http.forms.FormAST._
 import zio.http.forms.FormDecodingError._
 import zio.http.model.MediaType
-
-import java.nio.charset._
 
 sealed trait FormData {
   def name: String

--- a/zio-http/src/main/scala/zio/http/forms/FormData.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormData.scala
@@ -1,0 +1,108 @@
+package zio.http.forms
+
+import zio._
+import zio.http.forms.FormAST._
+import zio.http.forms.FormDecodingError._
+import zio.http.model.MediaType
+
+import java.nio.charset.Charset
+
+sealed trait FormData {
+  def name: String
+  def contentType: MediaType
+  def filename: Option[String]
+
+  def valueAsString: Option[String] = this match {
+    case FormData.Text(_, value, _, _) => Some(value)
+    case FormData.Simple(_, value)     => Some(value)
+    case _                             => None
+  }
+}
+
+object FormData {
+
+  /**
+   * A binary form data part.
+   *
+   * @param name
+   *   Name of this form data part. This is the value of the `name` field in the
+   *   `Content-Disposition` within this part.
+   * @param data
+   *   The data of this form data part. This is the data between the headers and
+   *   the boundary.
+   * @param contentType
+   *   The content type of this form data part. This is the value of the
+   *   `Content-Type` with in this part.
+   * @param transferEncoding
+   *   The transfer encoding of this form data part. This is the value of the
+   *   `Content-Transfer-Encoding` within this part. IMPORTANT NOTE: The data is
+   *   not encoded in any way relative to the provided `transferEncoding`. It is
+   *   the responsibility of the user to encode the `data` accordingly.
+   * @param filename
+   */
+  final case class Binary(
+    name: String,
+    data: Chunk[Byte],
+    contentType: MediaType,
+    transferEncoding: Option[ContentTransferEncoding] = None,
+    filename: Option[String] = None,
+  ) extends FormData
+
+  final case class Text(
+    name: String,
+    value: String,
+    contentType: MediaType,
+    filename: Option[String] = None,
+  ) extends FormData
+
+  final case class Simple(name: String, value: String) extends FormData {
+    override val contentType: MediaType   = MediaType.text.plain
+    override val filename: Option[String] = None
+  }
+
+  def fromFormAST(ast: Chunk[FormAST], defaultCharset: Charset = `UTF-8`): ZIO[Any, FormDecodingError, FormData] = {
+    val extract =
+      ast.foldLeft((Option.empty[Header], Option.empty[Header], Option.empty[Header], Option.empty[Content])) {
+        case (accum, header: Header) if header.name == "Content-Disposition"       =>
+          (Some(header), accum._2, accum._3, accum._4)
+        case (accum, content: Content)                                             =>
+          (accum._1, accum._2, accum._3, Some(content))
+        case (accum, header: Header) if header.name == "Content-Type"              =>
+          (accum._1, Some(header), accum._3, accum._4)
+        case (accum, header: Header) if header.name == "Content-Transfer-Encoding" =>
+          (accum._1, accum._2, Some(header), accum._4)
+        case (accum, _)                                                            => accum
+      }
+
+    for {
+      disposition <- ZIO.fromOption(extract._1).mapError(_ => FormDataMissingContentDisposition)
+      name    <- ZIO.fromOption(extract._1.flatMap(_.fields.get("name"))).mapError(_ => ContentDispositionMissingName)
+      charset <- ZIO
+        .attempt(extract._2.flatMap(x => x.fields.get("charset").map(Charset.forName)).getOrElse(defaultCharset))
+        .mapError(e => InvalidCharset(e.getMessage))
+      content          = extract._4.map(_.bytes).getOrElse(Chunk.empty)
+      contentType      = extract._2
+        .flatMap(x => MediaType.forContentType(x.preposition))
+        .getOrElse(MediaType.text.plain)
+      transferEncoding = extract._3
+        .flatMap(x => ContentTransferEncoding.parse(x.preposition))
+
+    } yield
+      if (!contentType.binary)
+        Text(name, new String(content.toArray, charset), contentType, disposition.fields.get("filename"))
+      else Binary(name, content, contentType, transferEncoding, disposition.fields.get("filename"))
+  }
+
+  def textField(name: String, value: String, mediaType: MediaType = MediaType.text.plain): FormData =
+    Text(name, value, mediaType, None)
+
+  def simpleField(name: String, value: String): FormData = Simple(name, value)
+
+  def binaryField(
+    name: String,
+    data: Chunk[Byte],
+    mediaType: MediaType,
+    transferEncoding: Option[ContentTransferEncoding] = None,
+    filename: Option[String] = None,
+  ): FormData = Binary(name, data, mediaType, transferEncoding, filename)
+}

--- a/zio-http/src/main/scala/zio/http/forms/FormDecodingError.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormDecodingError.scala
@@ -1,0 +1,33 @@
+package zio.http.forms
+
+/**
+ * Represents a form decoding error.
+ */
+sealed trait FormDecodingError { self =>
+  import FormDecodingError._
+
+  def message: String = self match {
+    case ContentDispositionMissingName     => "Content-Disposition header is missing 'name' field"
+    case FormDataMissingContentDisposition => "Form data is missing Content-Disposition header"
+    case InvalidCharset(msg)               => s"Invalid charset: $msg"
+    case InvalidURLEncodedFormat(msg)      => s"Invalid URL encoded format: $msg"
+    case BoundaryNotFoundInContent         => "Boundary not found in content or was malformed."
+  }
+
+  def asException: FormDecodingException = FormDecodingException(self)
+}
+
+object FormDecodingError {
+
+  final case class FormDecodingException(error: FormDecodingError) extends Exception
+
+  case object ContentDispositionMissingName extends FormDecodingError
+
+  case object FormDataMissingContentDisposition extends FormDecodingError
+
+  final case class InvalidCharset(msg: String) extends FormDecodingError
+
+  final case class InvalidURLEncodedFormat(msg: String) extends FormDecodingError
+
+  case object BoundaryNotFoundInContent extends FormDecodingError
+}

--- a/zio-http/src/main/scala/zio/http/forms/FormState.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormState.scala
@@ -1,6 +1,7 @@
 package zio.http.forms
 
 import zio._
+
 import zio.http.forms.FormAST._
 
 private[forms] sealed trait FormState

--- a/zio-http/src/main/scala/zio/http/forms/FormState.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormState.scala
@@ -1,0 +1,83 @@
+package zio.http.forms
+
+import zio._
+import zio.http.forms.FormAST._
+
+private[forms] sealed trait FormState
+
+private[forms] object FormState {
+
+  final case class FormStateBuffer(
+    tree: Chunk[FormAST],
+    phase: FormState.Phase,
+    buffer: Chunk[Byte],
+    lastByte: Option[Byte],
+    boundary: Boundary,
+    eols: Int = 0,
+  ) extends FormState { self =>
+
+    def append(byte: Byte): FormState = {
+
+      val crlf = lastByte.contains('\r') && byte == '\n'
+
+      val (eols0, phase0) = (eols, phase, crlf) match {
+        case (_, Phase.Part2, _)    => (0, Phase.Part2)
+        case (0, Phase.Part1, true) => (1, Phase.Part1)
+        case (1, Phase.Part1, true) => (0, Phase.Part2)
+        case _                      => (eols, phase)
+      }
+
+      def flush(ast: FormAST): FormState =
+        self.copy(
+          tree = tree :+ ast,
+          buffer = Chunk.empty,
+          lastByte = None,
+          phase = phase0,
+          eols = eols0,
+        )
+
+      if (crlf && phase == Phase.Part1) {
+        val ast = FormAST.makePart1(buffer, boundary)
+
+        ast match {
+          case content: Content         => flush(content)
+          case header: Header           => flush(header)
+          case EncapsulatingBoundary(_) => BoundaryEncapsulated(tree)
+          case ClosingBoundary(_)       => BoundaryClosed(tree)
+        }
+
+      } else if (crlf && phase == Phase.Part2) {
+        val ast = FormAST.makePart2(buffer, boundary)
+
+        ast match {
+          case content: Content         => flush(content)
+          case EncapsulatingBoundary(_) => BoundaryEncapsulated(tree)
+          case ClosingBoundary(_)       => BoundaryClosed(tree)
+        }
+      } else {
+        self.copy(
+          buffer = lastByte.map(buffer :+ _).getOrElse(buffer),
+          lastByte = Some(byte),
+          eols = 0,
+        )
+      }
+
+    }
+  }
+
+  final case class BoundaryEncapsulated(buffer: Chunk[FormAST]) extends FormState
+
+  final case class BoundaryClosed(buffer: Chunk[FormAST]) extends FormState
+
+  def fromBoundary(boundary: Boundary, lastByte: Option[Byte] = None): FormState =
+    FormStateBuffer(Chunk.empty, Phase.Part1, Chunk.empty, lastByte, boundary)
+
+  sealed trait Phase
+
+  object Phase {
+
+    case object Part1 extends Phase
+    case object Part2 extends Phase
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/forms/package.scala
+++ b/zio-http/src/main/scala/zio/http/forms/package.scala
@@ -1,9 +1,9 @@
 package zio.http
 
-import zio.http.model.Headers
-
 import java.net._
 import java.nio.charset.Charset
+
+import zio.http.model.Headers
 
 package object forms {
   private[forms] val CRLF = "\r\n"

--- a/zio-http/src/main/scala/zio/http/forms/package.scala
+++ b/zio-http/src/main/scala/zio/http/forms/package.scala
@@ -6,8 +6,6 @@ import java.net._
 import java.nio.charset.Charset
 
 package object forms {
-  private[zio] val `UTF-8` = Charset.forName("UTF-8")
-
   private[forms] val CRLF = "\r\n"
 
 }

--- a/zio-http/src/main/scala/zio/http/forms/package.scala
+++ b/zio-http/src/main/scala/zio/http/forms/package.scala
@@ -1,0 +1,13 @@
+package zio.http
+
+import zio.http.model.Headers
+
+import java.net._
+import java.nio.charset.Charset
+
+package object forms {
+  private[zio] val `UTF-8` = Charset.forName("UTF-8")
+
+  private[forms] val CRLF = "\r\n"
+
+}

--- a/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -4,6 +4,7 @@ import zio._
 
 import zio.http.Body
 import zio.http.Body._
+import zio.http.model.Headers
 
 import io.netty.buffer.Unpooled
 import io.netty.channel._

--- a/zio-http/src/main/scala/zio/http/netty/package.scala
+++ b/zio-http/src/main/scala/zio/http/netty/package.scala
@@ -1,4 +1,4 @@
-package zio.http // scalafix:ok;
+package zio.http
 
 package object netty {
 

--- a/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
@@ -4,13 +4,15 @@ import zio._
 import zio.http.forms.Fixtures._
 import zio.test._
 
+import java.nio.charset.StandardCharsets
+
 object BoundarySpec extends ZIOSpecDefault {
 
-  val multipartFormBytes3 = Chunk.fromArray(s"""------heythere--${CRLF}""".getBytes(`UTF-8`))
-  val bad1                = Chunk.fromArray(s"""-heythere${CRLF}""".getBytes(`UTF-8`))
-  val bad2                = Chunk.fromArray(s"""--heythere${CR}""".getBytes(`UTF-8`))
-  val bad3                = Chunk.fromArray(s"--heythere\n".getBytes(`UTF-8`))
-  val bad4                = Chunk.fromArray(s"--heythere".getBytes(`UTF-8`))
+  val multipartFormBytes3 = Chunk.fromArray(s"""------heythere--${CRLF}""".getBytes(StandardCharsets.UTF_8))
+  val bad1                = Chunk.fromArray(s"""-heythere${CRLF}""".getBytes(StandardCharsets.UTF_8))
+  val bad2                = Chunk.fromArray(s"""--heythere${CR}""".getBytes(StandardCharsets.UTF_8))
+  val bad3                = Chunk.fromArray(s"--heythere\n".getBytes(StandardCharsets.UTF_8))
+  val bad4                = Chunk.fromArray(s"--heythere".getBytes(StandardCharsets.UTF_8))
 
   val fromContentSuite = suite("fromContent")(
     test("parse success") {

--- a/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
@@ -1,10 +1,11 @@
 package zio.http.forms
 
+import java.nio.charset.StandardCharsets
+
 import zio._
-import zio.http.forms.Fixtures._
 import zio.test._
 
-import java.nio.charset.StandardCharsets
+import zio.http.forms.Fixtures._
 
 object BoundarySpec extends ZIOSpecDefault {
 

--- a/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/BoundarySpec.scala
@@ -1,0 +1,47 @@
+package zio.http.forms
+
+import zio._
+import zio.http.forms.Fixtures._
+import zio.test._
+
+object BoundarySpec extends ZIOSpecDefault {
+
+  val multipartFormBytes3 = Chunk.fromArray(s"""------heythere--${CRLF}""".getBytes(`UTF-8`))
+  val bad1                = Chunk.fromArray(s"""-heythere${CRLF}""".getBytes(`UTF-8`))
+  val bad2                = Chunk.fromArray(s"""--heythere${CR}""".getBytes(`UTF-8`))
+  val bad3                = Chunk.fromArray(s"--heythere\n".getBytes(`UTF-8`))
+  val bad4                = Chunk.fromArray(s"--heythere".getBytes(`UTF-8`))
+
+  val fromContentSuite = suite("fromContent")(
+    test("parse success") {
+      val boundary1 = Boundary.fromContent(multipartFormBytes1)
+      val boundary2 = Boundary.fromContent(multipartFormBytes2)
+      val boundary3 = Boundary.fromContent(multipartFormBytes3)
+      assertTrue(
+        boundary1.get.id == "AaB03x",
+        boundary2.get.id == "(((AaB03x)))",
+        boundary3.get.id == "----heythere--",
+        boundary3.get.encapsulationBoundary == "------heythere--",
+        boundary3.get.closingBoundary == "------heythere----",
+      )
+    },
+    test("parse failure") {
+
+      val boundary1 = Boundary.fromContent(bad1)
+      val boundary2 = Boundary.fromContent(bad2)
+      val boundary3 = Boundary.fromContent(bad3)
+      val boundary4 = Boundary.fromContent(bad4)
+
+      assertTrue(
+        boundary1.isEmpty,
+        boundary2.isEmpty,
+        boundary3.isEmpty,
+        boundary4.isEmpty,
+      )
+    },
+  )
+
+  val spec = suite("BoundarySpec")(
+    fromContentSuite,
+  )
+}

--- a/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
+++ b/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
@@ -2,6 +2,8 @@ package zio.http.forms
 
 import zio._
 
+import java.nio.charset.StandardCharsets
+
 object Fixtures {
 
   val CR = '\r'
@@ -26,7 +28,7 @@ object Fixtures {
                         |Content-Transfer-Encoding: base64${CR}
                         |${CR}
                         |${base64Corgi}${CR}
-                        |--AaB03x--${CRLF}""".stripMargin.getBytes(`UTF-8`))
+                        |--AaB03x--${CRLF}""".stripMargin.getBytes(StandardCharsets.UTF_8))
 
   val multipartFormBytes2 =
     Chunk.fromArray(

--- a/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
+++ b/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
@@ -1,8 +1,8 @@
 package zio.http.forms
 
-import zio._
-
 import java.nio.charset.StandardCharsets
+
+import zio._
 
 object Fixtures {
 

--- a/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
+++ b/zio-http/src/test/scala/zio/http/forms/Fixtures.scala
@@ -1,0 +1,51 @@
+package zio.http.forms
+
+import zio._
+
+object Fixtures {
+
+  val CR = '\r'
+
+  val base64Corgi =
+    "iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAFDUlEQVR4nO2YfUwbZRzHnzFRcWObQ1rAEDLRGXWZLjBwSwRfSabTUBzjD00kLJAYyXQ6ULJBkQFbZKCyuIUgvpBtKMStYerGENiAwpD2rjDoc9wdoxZaYOOttLAtCD/zFAqM8dIWijTpN/n+0T/ueT6fu6d39xxCjjjiiCPWRCaTObenBesGMl6421EQG4HsLbTkpwP/xLjDkFgIumPPjbQUHngc2VPkhbmleO+jRgHSru8jqpE9RV5dyVa95Ar6RIFRYDDVd0xzRvwYspdQmNNXBa2HG5EbJ69Cx49Rucge0tTU9CDN8FAf7gs1wesmr0Jv9su9yB5Csaw7EWiI2wUVAWtBHe02eRV0aU+O9Zx4vUt99sN4tFIjx9iLCFw/nQGqfVPwM9uZ954UrcRQSv4DIsCX5s4Jb6omPzoBraQUAqymGK6NCPSc3HUfcP9hIUT4bYIvXvMx/u7L2qFHKykKhoswLh/6Ghi+9LpPQB3vCUFP+04KkDbStQMU5qophs+plSk+y0xNjc37NuPZ/0WAYng5EVAVH11w+ZiKpReAHGO8czUqIWynP7zjvxWWHZ5muFATSHduuFnwhmQvaFTUTwqQ/nK2ACLffGN5Bei2tg0U5jtMEP1ZL84JrU/xJs8E6DjzETDVknvgTaUwd255BTCfPx2AAA5NAA+mbybvQqAqPgbK2ougwC2zQk90hMJ8Zo1a7bKc8IdngrSWnAJ92lOgkhwBhZKZDxgohh+kMfcHhfn9dU1tHlZBQAxyvn1IuGk40SN4KFEYqBcLt9yKc3Od7xh58w0fiuF+mA+OnrsaIq5g2W3k1msdNEKrhpM8wg1iocSQJLht7l3DVKayyBpwoDA3puB5gXXQYuSkESGRdo9Tqe7zjV2WQk9vT/aroFDOu55hrsqUKk+L4W+KkKdWhP7ShiHQxU295i6m6qIEqwQUytbdFsH3haP12lDUoBUh6IlyWRL48XpAW/FXlktgLtkiAW0oOk3gSXUHp7Z6SyWhOp9i2f+A4S6YDd/+LtqqCUWjJgFD0vgGY6nb/mucBRJcp9kCGhE6YoLX7lmFbQFvakfBJ+YKDJm/fERISuA1oWig833nLbYUIOVLTpqzhBizBagm5R1yUEN16VFy7zckCe7aUkCf5gsNjfQCf2L+Z7PgMcaupncMGcMYP2sYxELW9lchZ4HbKB9mlgDLsg/RDM9Nf7sbEgt+t62ABzBVv8139vmKiooHkLUZEguP2wq+PysQ+EvfzfsaQbe0voUWk75Mv/3mwHR/7A69B93NX/spPuQBtdAD7BBabLpzQkPmgtAlCEAV5Qb1IeuM33RI6X3PgyY9+M5gmu/oQhJkLzwbuByzcPmavA8tRTqKPt02c+K+eAE0ijbAlcBxaNLy7WvY8oC12WUBj4SIEXKCcLS668TuHV15Eem3Tr19tfeboPaB436DuvTNI4NpT4yS7eFsa7+sjobiK7VwvlyqsYmAIdkTaoJdx8EDXaE8YE3KVf+Hva0Zm2b49JkCknKpsTYT0KU/M3XWX/H+dzFj05iPXBaBgcztoM2PMW79GiovQUnsXvjz61QoPifpWszYFOZ22lxAPvHtcnJz0cwu2SR1SqWbzQVq1GoXGnPD0yepb2bhovTv8cnKqtslZdIga8c37nfv2X2xcLlWtiRjT03SwkXTmBuYPlHddTx1tsqk9daPzYtozN+c8yovYmxHHHEE2Vf+A9E0cuqjrJELAAAAAElFTkSuQmCC"
+
+  val multipartFormBytes1 =
+    Chunk.fromArray(s"""|--AaB03x${CR}
+                        |Content-Disposition: form-data; name="submit-name"${CR}
+                        |Content-Type: text/plain${CR}
+                        |${CR}
+                        |Larry${CR}
+                        |--AaB03x${CR}
+                        |Content-Disposition: form-data; name="files"; filename="file1.txt"${CR}
+                        |Content-Type: image/png${CR}
+                        |${CR}
+                        |PNG${CR}
+                        |--AaB03x${CR}
+                        |Content-Disposition: form-data; name="corgi"; filename="corgi.png"${CR}
+                        |Content-Type: image/png${CR}
+                        |Content-Transfer-Encoding: base64${CR}
+                        |${CR}
+                        |${base64Corgi}${CR}
+                        |--AaB03x--${CRLF}""".stripMargin.getBytes(`UTF-8`))
+
+  val multipartFormBytes2 =
+    Chunk.fromArray(
+      s"""|--(((AaB03x)))${CR}
+          |Content-Disposition: form-data; name="csv-data"${CR}
+          |Content-Type: text/csv${CR}
+          |${CR}
+          |foo,bar,baz${CR}
+          |--(((AaB03x)))${CR}
+          |Content-Disposition: form-data; name="file"${CR}
+          |Content-Type: image/png${CR}
+          |${CR}
+          |PNG${CR}
+          |--(((AaB03x)))${CR}
+          |Content-Disposition: form-data; name="corgi"; filename="corgi.png"${CR}
+          |Content-Type: image/png${CR}
+          |Content-Transfer-Encoding: base64${CR}
+          |${CR}
+          |iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAFDUlEQVR4nO2YfUwbZRzHnzFRcWObQ1rAEDLRGXWZLjBwSwRfSabTUBzjD00kLJAYyXQ6ULJBkQFbZKCyuIUgvpBtKMStYerGENiAwpD2rjDoc9wdoxZaYOOttLAtCD/zFAqM8dIWijTpN/n+0T/ueT6fu6d39xxCjjjiiCPWRCaTObenBesGMl6421EQG4HsLbTkpwP/xLjDkFgIumPPjbQUHngc2VPkhbmleO+jRgHSru8jqpE9RV5dyVa95Ar6RIFRYDDVd0xzRvwYspdQmNNXBa2HG5EbJ69Cx49Rucge0tTU9CDN8FAf7gs1wesmr0Jv9su9yB5Csaw7EWiI2wUVAWtBHe02eRV0aU+O9Zx4vUt99sN4tFIjx9iLCFw/nQGqfVPwM9uZ954UrcRQSv4DIsCX5s4Jb6omPzoBraQUAqymGK6NCPSc3HUfcP9hIUT4bYIvXvMx/u7L2qFHKykKhoswLh/6Ghi+9LpPQB3vCUFP+04KkDbStQMU5qophs+plSk+y0xNjc37NuPZ/0WAYng5EVAVH11w+ZiKpReAHGO8czUqIWynP7zjvxWWHZ5muFATSHduuFnwhmQvaFTUTwqQ/nK2ACLffGN5Bei2tg0U5jtMEP1ZL84JrU/xJs8E6DjzETDVknvgTaUwd255BTCfPx2AAA5NAA+mbybvQqAqPgbK2ougwC2zQk90hMJ8Zo1a7bKc8IdngrSWnAJ92lOgkhwBhZKZDxgohh+kMfcHhfn9dU1tHlZBQAxyvn1IuGk40SN4KFEYqBcLt9yKc3Od7xh58w0fiuF+mA+OnrsaIq5g2W3k1msdNEKrhpM8wg1iocSQJLht7l3DVKayyBpwoDA3puB5gXXQYuSkESGRdo9Tqe7zjV2WQk9vT/aroFDOu55hrsqUKk+L4W+KkKdWhP7ShiHQxU295i6m6qIEqwQUytbdFsH3haP12lDUoBUh6IlyWRL48XpAW/FXlktgLtkiAW0oOk3gSXUHp7Z6SyWhOp9i2f+A4S6YDd/+LtqqCUWjJgFD0vgGY6nb/mucBRJcp9kCGhE6YoLX7lmFbQFvakfBJ+YKDJm/fERISuA1oWig833nLbYUIOVLTpqzhBizBagm5R1yUEN16VFy7zckCe7aUkCf5gsNjfQCf2L+Z7PgMcaupncMGcMYP2sYxELW9lchZ4HbKB9mlgDLsg/RDM9Nf7sbEgt+t62ABzBVv8139vmKiooHkLUZEguP2wq+PysQ+EvfzfsaQbe0voUWk75Mv/3mwHR/7A69B93NX/spPuQBtdAD7BBabLpzQkPmgtAlCEAV5Qb1IeuM33RI6X3PgyY9+M5gmu/oQhJkLzwbuByzcPmavA8tRTqKPt02c+K+eAE0ijbAlcBxaNLy7WvY8oC12WUBj4SIEXKCcLS668TuHV15Eem3Tr19tfeboPaB436DuvTNI4NpT4yS7eFsa7+sjobiK7VwvlyqsYmAIdkTaoJdx8EDXaE8YE3KVf+Hva0Zm2b49JkCknKpsTYT0KU/M3XWX/H+dzFj05iPXBaBgcztoM2PMW79GiovQUnsXvjz61QoPifpWszYFOZ22lxAPvHtcnJz0cwu2SR1SqWbzQVq1GoXGnPD0yepb2bhovTv8cnKqtslZdIga8c37nfv2X2xcLlWtiRjT03SwkXTmBuYPlHddTx1tsqk9daPzYtozN+c8yovYmxHHHEE2Vf+A9E0cuqjrJELAAAAAElFTkSuQmCC${CR}
+          |--(((AaB03x)))--${CRLF}""".stripMargin.getBytes(),
+    )
+}

--- a/zio-http/src/test/scala/zio/http/forms/FormHeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormHeaderSpec.scala
@@ -1,8 +1,9 @@
 package zio.http.forms
 
 import zio.Scope
-import zio.http.forms.FormAST.Header
 import zio.test._
+
+import zio.http.forms.FormAST.Header
 object FormHeaderSpec extends ZIOSpecDefault {
 
   val contentType1 = "Content-Type: text/html; charset=utf-8".getBytes()

--- a/zio-http/src/test/scala/zio/http/forms/FormHeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormHeaderSpec.scala
@@ -1,0 +1,27 @@
+package zio.http.forms
+
+import zio.Scope
+import zio.http.forms.FormAST.Header
+import zio.test._
+object FormHeaderSpec extends ZIOSpecDefault {
+
+  val contentType1 = "Content-Type: text/html; charset=utf-8".getBytes()
+  val contextType2 = "Content-Type: multipart/form-data; boundary=something".getBytes
+
+  def spec = suite("HeaderSpec")(
+    test("Header parsing") {
+
+      val header = Header.fromBytes(contentType1)
+
+      println(header.get.fields)
+
+      assertTrue(
+        header.get.name == "Content-Type",
+        header.get.fields.get("charset").get == "utf-8",
+        header.get.preposition == "text/html",
+      )
+
+    },
+  )
+
+}

--- a/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
@@ -1,12 +1,14 @@
 package zio.http.forms
 
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.nowarn
+
 import zio._
-import zio.http.forms.Fixtures._
-import zio.http.model.MediaType
 import zio.test._
 
-import java.nio.charset.StandardCharsets
-import scala.annotation.nowarn
+import zio.http.forms.Fixtures._
+import zio.http.model.MediaType
 
 object FormSpec extends ZIOSpecDefault {
 

--- a/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
@@ -5,6 +5,7 @@ import zio.http.forms.Fixtures._
 import zio.http.model.MediaType
 import zio.test._
 
+import java.nio.charset.StandardCharsets
 import scala.annotation.nowarn
 
 object FormSpec extends ZIOSpecDefault {
@@ -20,7 +21,7 @@ object FormSpec extends ZIOSpecDefault {
         )
       },
       test("decoding") {
-        val form = Form.fromURLEncoded("name=John&age=30", `UTF-8`)
+        val form = Form.fromURLEncoded("name=John&age=30", StandardCharsets.UTF_8)
         form.map { form =>
           assertTrue(
             form.get("age").get.valueAsString.get == "30",
@@ -57,7 +58,7 @@ object FormSpec extends ZIOSpecDefault {
         assertTrue(
           actualBytes == multipartFormBytes2,
           form2 == form,
-        ).??(new String(actualBytes.toArray, `UTF-8`))
+        ).??(new String(actualBytes.toArray, StandardCharsets.UTF_8))
       }
 
     },

--- a/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormSpec.scala
@@ -1,0 +1,95 @@
+package zio.http.forms
+
+import zio._
+import zio.http.forms.Fixtures._
+import zio.http.model.MediaType
+import zio.test._
+
+import scala.annotation.nowarn
+
+object FormSpec extends ZIOSpecDefault {
+
+  val urlEncodedSuite =
+    suite("application/x-www-form-urlencoded ")(
+      test("encoding") {
+        val form    = Form.fromStrings("name" -> "John", "age" -> "30")
+        val encoded = form.encodeAsURLEncoded()
+        assertTrue(
+          encoded == "name=John&age=30",
+          form.formData.size == 2,
+        )
+      },
+      test("decoding") {
+        val form = Form.fromURLEncoded("name=John&age=30", `UTF-8`)
+        form.map { form =>
+          assertTrue(
+            form.get("age").get.valueAsString.get == "30",
+            form.get("name").get.valueAsString.get == "John",
+          )
+        }
+      },
+    )
+
+  @nowarn
+  val multiFormSuite = suite("multipart/form-data")(
+    test("encoding") {
+
+      val form = Form(
+        FormData.Text("csv-data", "foo,bar,baz", MediaType.text.csv),
+        FormData.Binary(
+          "file",
+          Chunk[Byte](0x50, 0x4e, 0x47),
+          MediaType.image.png,
+        ),
+        FormData.Binary(
+          "corgi",
+          Chunk.fromArray(base64Corgi.getBytes()),
+          MediaType.image.png,
+          Some(ContentTransferEncoding.Base64),
+          Some("corgi.png"),
+        ),
+      )
+
+      val (_, actualBytes) = form.encodeAsMultipartBytes(rng = () => "AaB03x")
+      val form2            = Form.fromMultipartBytes(multipartFormBytes2)
+
+      form2.map { form2 =>
+        assertTrue(
+          actualBytes == multipartFormBytes2,
+          form2 == form,
+        ).??(new String(actualBytes.toArray, `UTF-8`))
+      }
+
+    },
+    test("decoding") {
+      val boundary = Boundary("AaB03x")
+
+      val form = Form.fromMultipartBytes(multipartFormBytes1)
+
+      form.map { form =>
+        val bytes = form.encodeAsMultipartBytes()
+
+        val (text: FormData.Text) :: (image1: FormData.Binary) :: (image2: FormData.Binary) :: Nil =
+          form.formData.toList
+        assertTrue(
+          form.formData.size == 3,
+          text.name == "submit-name",
+          text.value == "Larry",
+          text.contentType == MediaType.text.plain,
+          text.filename.isEmpty,
+          image1.name == "files",
+          image1.data == Chunk[Byte](0x50, 0x4e, 0x47),
+          image1.contentType == MediaType.image.png,
+          image1.transferEncoding.isEmpty,
+          image1.filename.get == "file1.txt",
+          image2.name == "corgi",
+          image2.contentType == MediaType.image.png,
+          image2.transferEncoding.get == ContentTransferEncoding.Base64,
+          image2.data == Chunk.fromArray(base64Corgi.getBytes()),
+        )
+      }
+    },
+  )
+
+  def spec = suite("FormSpec")(urlEncodedSuite, multiFormSuite)
+}

--- a/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
@@ -1,9 +1,9 @@
 package zio.http.forms
 
+import java.nio.charset.StandardCharsets
+
 import zio._
 import zio.test._
-
-import java.nio.charset.StandardCharsets
 
 object FormStateSpec extends ZIOSpecDefault {
 

--- a/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
@@ -1,0 +1,41 @@
+package zio.http.forms
+
+import zio._
+import zio.test._
+
+object FormStateSpec extends ZIOSpecDefault {
+
+  val CR = '\r'
+
+  val formExample1 = s"""|--AaB03x${CR}
+                         |Content-Disposition: form-data; name="submit-name"${CR}
+                         |Content-Type: text/plain${CR}
+                         |${CR}
+                         |Larry${CR}
+                         |--AaB03x${CR}
+                         |Content-Disposition: form-data; name="files"; filename="file1.txt"${CR}
+                         |Content-Type: text/plain${CR}
+                         |${CR}
+                         |... contents of file1.txt ...${CR}
+                         |--AaB03x--${CR}""".stripMargin.getBytes(`UTF-8`)
+  def spec         = suite("FormStateSpec")(
+    test("FormStateAccum") {
+
+      val lastByte = Some('\r')
+
+      def wasNewline(byte: Byte): Boolean = lastByte.contains('\r') && byte == '\n'
+
+      val id       = "AaB03x"
+      val start    = Chunk.fromArray(s"--$id".getBytes())
+      val end      = Chunk.fromArray(s"--$id--".getBytes())
+      val boundary = Boundary(id)
+
+      assertTrue(
+        wasNewline('\n'),
+        boundary.isEncapsulating(start),
+        boundary.isClosing(end),
+      )
+    },
+  )
+
+}

--- a/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/forms/FormStateSpec.scala
@@ -3,6 +3,8 @@ package zio.http.forms
 import zio._
 import zio.test._
 
+import java.nio.charset.StandardCharsets
+
 object FormStateSpec extends ZIOSpecDefault {
 
   val CR = '\r'
@@ -17,7 +19,7 @@ object FormStateSpec extends ZIOSpecDefault {
                          |Content-Type: text/plain${CR}
                          |${CR}
                          |... contents of file1.txt ...${CR}
-                         |--AaB03x--${CR}""".stripMargin.getBytes(`UTF-8`)
+                         |--AaB03x--${CR}""".stripMargin.getBytes(StandardCharsets.UTF_8)
   def spec         = suite("FormStateSpec")(
     test("FormStateAccum") {
 


### PR DESCRIPTION
Friendly Forms MK II
===============

This is pretty much complete rewrite of the previous Friendly Forms API that only initially supported 'application/x-www-form-urlencoded'.

User API: Form
---------------

'zio.http.forms.Form' provides the user the tools they need to:

- Encode 'application/x-www-form-urlencoded' to a 'zio.http.Body'.
- Decode a 'zio.http.Body' that is encoded as 'application/x-www-form-urlencoded' to a 'zio.http.forms.Form'.
- Encode 'multipart/form-data  ' to a 'zio.http.Body'.
- Decode a 'zio.http.Body' that is encoded as 'multipart/form-data' to a 'zio.http.forms.Form'.