### PR TITLE
Update zio-schema to 0.4.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val NettyIncubatorVersion         = "0.0.15.Final"
   val ScalaCompactCollectionVersion = "2.8.1"
   val ZioVersion                    = "2.0.6"
-  val ZioSchemaVersion              = "0.2.1"
+  val ZioSchemaVersion              = "0.4.2"
   val SttpVersion                   = "3.3.18"
 
   val `jwt-core`                 = "com.github.jwt-scala"   %% "jwt-core"                % JwtCoreVersion

--- a/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/api/internal/EncoderDecoder.scala
@@ -82,8 +82,15 @@ private[api] object EncoderDecoder                   {
 
     private val flattened: Mechanic.FlattenedAtoms = Mechanic.flatten(httpCodec)
 
-    private val jsonEncoders = flattened.bodies.map(bodyCodec => bodyCodec.erase.encodeToBody(_, JsonCodec))
-    private val jsonDecoders = flattened.bodies.map(bodyCodec => bodyCodec.decodeFromBody(_, JsonCodec))
+    private val jsonEncoders = flattened.bodies.map { bodyCodec =>
+      val erased    = bodyCodec.erase
+      val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+      erased.encodeToBody(_, jsonCodec)
+    }
+    private val jsonDecoders = flattened.bodies.map { bodyCodec =>
+      val jsonCodec = JsonCodec.schemaBasedBinaryCodec(bodyCodec.schema)
+      bodyCodec.decodeFromBody(_, jsonCodec)
+    }
 
     def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
       trace: Trace,


### PR DESCRIPTION
Resolves #1913 

This is just the minimal changes to update to the latest zio-schema version. It generates the JSON codec from `Schema` in place where it used to use the `JsonCodec` instance. This results in the same behavior.

A separate issue could be created to allow the user to inject their own codecs instead of always generating them from the schema.