### PR TITLE
Better client layers without leaking Netty implementation details

### DIFF
--- a/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
+++ b/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
@@ -3,7 +3,7 @@ package example
 import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValues}
 import zio._
 import zio.http.model.Headers
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.NettyConnectionPool
 import zio.http.{Client, ClientConfig}
 
 object ClientWithDecompression extends ZIOAppDefault {
@@ -17,6 +17,6 @@ object ClientWithDecompression extends ZIOAppDefault {
 
   val config       = ClientConfig.empty.requestDecompression(true)
   override val run =
-    program.provide(ClientConfig.live(config), ConnectionPool.disabled, Client.fromConfig)
+    program.provide(ClientConfig.live(config), Client.fromConfig)
 
 }

--- a/zio-http-example/src/main/scala/example/HttpsClient.scala
+++ b/zio-http-example/src/main/scala/example/HttpsClient.scala
@@ -2,7 +2,7 @@ package example
 
 import zio._
 import zio.http.model.Headers
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.http.{Client, ClientConfig, ClientSSLConfig}
 
 object HttpsClient extends ZIOAppDefault {
@@ -22,6 +22,6 @@ object HttpsClient extends ZIOAppDefault {
     _    <- Console.printLine(data)
   } yield ()
 
-  val run = program.provide(ClientConfig.live(clientConfig), Client.live, ConnectionPool.disabled)
+  val run = program.provide(ClientConfig.live(clientConfig), Client.live, NettyClientDriver.fromConfig)
 
 }

--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -1,17 +1,14 @@
 package zio.http
 
-import io.netty.buffer.{ByteBuf, ByteBufUtil, Unpooled}
-import io.netty.channel.{Channel => JChannel, DefaultFileRegion}
-import io.netty.handler.codec.http.LastHttpContent
+import io.netty.buffer.{ByteBuf, ByteBufUtil}
+import io.netty.channel.{Channel => JChannel}
 import io.netty.util.AsciiString
 import zio._
 import zio.http.model.HTTP_CHARSET
-import zio.http.service.Ctx
 import zio.stream.ZStream
 
 import java.io.FileInputStream
 import java.nio.charset.Charset
-import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 import java.nio.file._
 
 /**

--- a/zio-http/src/main/scala/zio/http/ClientConfig.scala
+++ b/zio-http/src/main/scala/zio/http/ClientConfig.scala
@@ -1,11 +1,9 @@
 package zio.http
 
-import io.netty.channel
-import io.netty.channel.{ChannelFactory, EventLoopGroup, _}
-import zio.{Duration, Scope, Trace, ZLayer}
-import zio.http.netty.{ChannelFactories, ChannelType, EventLoopGroups, NettyRuntime}
+import zio.http.netty.{ChannelType, EventLoopGroups}
 import zio.http.socket.SocketApp
-import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
+import zio.{Duration, ZLayer}
+
 import java.net.InetSocketAddress
 
 case class ClientConfig(
@@ -52,23 +50,9 @@ case class ClientConfig(
 object ClientConfig {
   def empty: ClientConfig = ClientConfig()
 
-  val default: ZLayer[
-    Any,
-    Nothing,
-    ClientConfig with EventLoopGroup with ChannelFactory[channel.Channel] with NettyRuntime,
-  ] = {
-    implicit val trace: Trace = Trace.empty
-    ZLayer.succeed(
-      empty,
-    ) >+> EventLoopGroups.fromConfig >+> ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool
-  }
+  val default: ZLayer[Any, Nothing, ClientConfig] =
+    live(empty)
 
-  def live(
-    clientConfig: ClientConfig,
-  )(implicit
-    trace: Trace,
-  ): ZLayer[Any, Nothing, ClientConfig with EventLoopGroup with ChannelFactory[channel.Channel] with NettyRuntime] =
-    ZLayer.succeed(
-      clientConfig,
-    ) >+> EventLoopGroups.fromConfig >+> ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool
+  def live(clientConfig: ClientConfig): ZLayer[Any, Nothing, ClientConfig] =
+    ZLayer.succeed(clientConfig)
 }

--- a/zio-http/src/main/scala/zio/http/ClientDriver.scala
+++ b/zio-http/src/main/scala/zio/http/ClientDriver.scala
@@ -1,0 +1,24 @@
+package zio.http
+
+import zio.http.netty.client.ChannelState
+import zio.http.socket.SocketApp
+import zio.{Promise, Scope, Trace, ZIO}
+
+trait ClientDriver {
+  type Connection
+
+  def requestOnChannel(
+    connection: Connection,
+    location: URL.Location.Absolute,
+    req: Request,
+    onResponse: Promise[Throwable, Response],
+    onComplete: Promise[Throwable, ChannelState],
+    useAggregator: Boolean,
+    enableKeepAlive: Boolean,
+    createSocketApp: () => SocketApp[Any],
+  )(implicit trace: Trace): ZIO[Scope, Throwable, ChannelState]
+
+  def createConnectionPool(config: ConnectionPoolConfig)(implicit
+    trace: Trace,
+  ): ZIO[Scope, Nothing, ConnectionPool[Connection]]
+}

--- a/zio-http/src/main/scala/zio/http/ClientDriver.scala
+++ b/zio-http/src/main/scala/zio/http/ClientDriver.scala
@@ -16,7 +16,7 @@ trait ClientDriver {
     useAggregator: Boolean,
     enableKeepAlive: Boolean,
     createSocketApp: () => SocketApp[Any],
-  )(implicit trace: Trace): ZIO[Scope, Throwable, ChannelState]
+  )(implicit trace: Trace): ZIO[Scope, Throwable, ZIO[Any, Throwable, ChannelState]]
 
   def createConnectionPool(config: ConnectionPoolConfig)(implicit
     trace: Trace,

--- a/zio-http/src/main/scala/zio/http/ConnectionPool.scala
+++ b/zio-http/src/main/scala/zio/http/ConnectionPool.scala
@@ -1,0 +1,21 @@
+package zio.http
+
+import zio.{Scope, Trace, ZIO}
+
+import java.net.InetSocketAddress
+
+trait ConnectionPool[Connection] {
+
+  def get(
+    location: URL.Location.Absolute,
+    proxy: Option[Proxy],
+    sslOptions: ClientSSLConfig,
+    maxHeaderSize: Int,
+    decompression: Decompression,
+    localAddress: Option[InetSocketAddress] = None,
+  )(implicit trace: Trace): ZIO[Scope, Throwable, Connection]
+
+  def invalidate(connection: Connection)(implicit trace: Trace): ZIO[Any, Nothing, Unit]
+
+  def enableKeepAlive: Boolean
+}

--- a/zio-http/src/main/scala/zio/http/Driver.scala
+++ b/zio-http/src/main/scala/zio/http/Driver.scala
@@ -9,4 +9,6 @@ trait Driver {
   def setErrorCallback(newCallback: Option[Server.ErrorCallback])(implicit trace: Trace): UIO[Unit]
 
   def addApp[R](newApp: App[R], env: ZEnvironment[R])(implicit trace: Trace): UIO[Unit]
+
+  def createClientDriver(config: ClientConfig)(implicit trace: Trace): ZIO[Scope, Throwable, ClientDriver]
 }

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -612,20 +612,21 @@ object ZClient {
                         .map(_.asInstanceOf[driver.Connection])
                         .provideEnvironment(ZEnvironment(channelScope))
                     }
-                  resetChannel <- ZIO.attempt {
-                    driver.requestOnChannel(
-                      connection,
-                      location,
-                      req,
-                      onResponse,
-                      onComplete,
-                      clientConfig.useAggregator,
-                      connectionPool.enableKeepAlive,
-                      () => clientConfig.socketApp.getOrElse(SocketApp()),
-                    )
-                  }.tapErrorCause { cause =>
-                    channelScope.close(Exit.failCause(cause))
-                  }
+                  resetChannel <-
+                    driver
+                      .requestOnChannel(
+                        connection,
+                        location,
+                        req,
+                        onResponse,
+                        onComplete,
+                        clientConfig.useAggregator,
+                        connectionPool.enableKeepAlive,
+                        () => clientConfig.socketApp.getOrElse(SocketApp()),
+                      )
+                      .map(_.tapErrorCause { cause =>
+                        channelScope.close(Exit.failCause(cause))
+                      })
                   // If request registration failed we release the channel immediately.
                   // Otherwise we wait for completion signal from netty in a background fiber:
                   _            <-

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -624,9 +624,9 @@ object ZClient {
                         connectionPool.enableKeepAlive,
                         () => clientConfig.socketApp.getOrElse(SocketApp()),
                       )
-                      .map(_.tapErrorCause { cause =>
+                      .tapErrorCause { cause =>
                         channelScope.close(Exit.failCause(cause))
-                      })
+                      }
                   // If request registration failed we release the channel immediately.
                   // Otherwise we wait for completion signal from netty in a background fiber:
                   _            <-

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -1,20 +1,13 @@
 package zio.http
 
-import io.netty.channel.{ChannelHandler, Channel => JChannel}
-import io.netty.handler.codec.http._
-import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler
-import io.netty.handler.flow.FlowControlHandler
 import zio._
 import zio.http.URL.Location
 import zio.http.model._
 import zio.http.netty.client._
-import zio.http.netty.{NettyRuntime, _}
 import zio.http.service._
 import zio.http.socket.SocketApp
 
-import java.net.URI
-import scala.collection.mutable
-import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
+import java.net.URI // scalafix:ok;
 
 trait ZClient[-Env, -In, +Err, +Out] { self =>
 
@@ -499,13 +492,13 @@ object ZClient {
 
   }
 
-  final case class ClientLive(
-    settings: ClientConfig,
-    runtime: Runtime[Any],
-    rtm: NettyRuntime,
-    connectionPool: ConnectionPool,
-  ) extends Client
+  final class ClientLive private (config: ClientConfig, driver: ClientDriver, connectionPool: ConnectionPool[Any])
+      extends Client
       with ClientRequestEncoder {
+
+    def this(driver: ClientDriver)(connectionPool: ConnectionPool[driver.Connection])(settings: ClientConfig) =
+      this(settings, driver, connectionPool.asInstanceOf[ConnectionPool[Any]])
+
     val headers: Headers                   = Headers.empty
     val hostOption: Option[String]         = None
     val pathPrefix: Path                   = Path.empty
@@ -541,7 +534,7 @@ object ZClient {
               version = version,
               headers = headers,
             ),
-          sslConfig.fold(settings)(settings.ssl),
+          sslConfig.fold(config)(config.ssl),
         )
       } yield response
     }
@@ -572,7 +565,7 @@ object ZClient {
               version = version,
               headers = headers,
             ),
-          clientConfig = settings.copy(socketApp = Some(app.provideEnvironment(env))),
+          clientConfig = config.copy(socketApp = Some(app.provideEnvironment(env))),
         ).withFinalizer {
           case resp: Response.CloseableResponse => resp.close.orDie
           case _                                => ZIO.unit
@@ -584,8 +577,7 @@ object ZClient {
     ): ZIO[Any, Throwable, Response] =
       for {
         onResponse <- Promise.make[Throwable, Response]
-        jReq       <- encode(request)
-        _          <- internalRequest(request, jReq, onResponse, clientConfig)(Unsafe.unsafe, trace)
+        _          <- internalRequest(request, onResponse, clientConfig)(Unsafe.unsafe, trace)
           .catchAll(cause => onResponse.fail(cause))
         res        <- onResponse.await
       } yield res
@@ -595,154 +587,70 @@ object ZClient {
      */
     private def internalRequest(
       req: Request,
-      jReq: FullHttpRequest,
       onResponse: Promise[Throwable, Response],
       clientConfig: ClientConfig,
-    )(implicit unsafe: Unsafe, trace: Trace): ZIO[Any, Throwable, Unit] = {
-      req.url.kind match {
-        case location: Location.Absolute =>
-          for {
-            onComplete   <- Promise.make[Throwable, ChannelState]
-            channelScope <- Scope.make
-            _            <- ZIO.uninterruptibleMask { restore =>
-              for {
-                channel      <-
-                  restore {
-                    connectionPool
-                      .get(
-                        location,
-                        clientConfig.proxy,
-                        clientConfig.ssl.getOrElse(ClientSSLConfig.Default),
-                        clientConfig.maxHeaderSize,
-                        clientConfig.requestDecompression,
-                        clientConfig.localAddress,
-                      )
-                      .provideEnvironment(ZEnvironment(channelScope))
+    )(implicit unsafe: Unsafe, trace: Trace): ZIO[Any, Throwable, Unit] =
+      ZIO.scoped {
+        req.url.kind match {
+          case location: Location.Absolute =>
+            for {
+              onComplete   <- Promise.make[Throwable, ChannelState]
+              channelScope <- Scope.make
+              _            <- ZIO.uninterruptibleMask { restore =>
+                for {
+                  connection   <-
+                    restore {
+                      connectionPool
+                        .get(
+                          location,
+                          clientConfig.proxy,
+                          clientConfig.ssl.getOrElse(ClientSSLConfig.Default),
+                          clientConfig.maxHeaderSize,
+                          clientConfig.requestDecompression,
+                          clientConfig.localAddress,
+                        )
+                        .map(_.asInstanceOf[driver.Connection])
+                        .provideEnvironment(ZEnvironment(channelScope))
+                    }
+                  resetChannel <- ZIO.attempt {
+                    driver.requestOnChannel(
+                      connection,
+                      location,
+                      req,
+                      onResponse,
+                      onComplete,
+                      clientConfig.useAggregator,
+                      connectionPool.enableKeepAlive,
+                      () => clientConfig.socketApp.getOrElse(SocketApp()),
+                    )
+                  }.tapErrorCause { cause =>
+                    channelScope.close(Exit.failCause(cause))
                   }
-                resetChannel <- ZIO.attempt {
-                  requestOnChannel(
-                    channel,
-                    location,
-                    req,
-                    jReq,
-                    onResponse,
-                    onComplete,
-                    clientConfig.useAggregator,
-                    connectionPool.enableKeepAlive,
-                    () => clientConfig.socketApp.getOrElse(SocketApp()),
-                  )
-                }.tapErrorCause { cause =>
-                  channelScope.close(Exit.failCause(cause))
-                }
-                // If request registration failed we release the channel immediately.
-                // Otherwise we wait for completion signal from netty in a background fiber:
-                _            <-
-                  onComplete.await.interruptible.exit.flatMap { exit =>
-                    resetChannel
-                      .zip(exit)
-                      .map { case (s1, s2) => s1 && s2 }
-                      .catchAll(_ =>
-                        ZIO.succeed(ChannelState.Invalid),
-                      ) // In case resetting the channel fails we cannot reuse it
-                      .flatMap { channelState =>
-                        connectionPool
-                          .invalidate(channel)
-                          .when(channelState == ChannelState.Invalid)
-                      }
-                      .zipRight(channelScope.close(exit))
-                      .uninterruptible
-                  }.forkDaemon
-              } yield ()
-            }
-          } yield ()
-        case Location.Relative           =>
-          ZIO.fail(throw new IllegalArgumentException("Absolute URL is required"))
-      }
-    }.tapError { _ =>
-      ZIO.attempt {
-        if (jReq.refCnt() > 0) {
-          jReq.release(jReq.refCnt()): Unit
+                  // If request registration failed we release the channel immediately.
+                  // Otherwise we wait for completion signal from netty in a background fiber:
+                  _            <-
+                    onComplete.await.interruptible.exit.flatMap { exit =>
+                      resetChannel
+                        .zip(exit)
+                        .map { case (s1, s2) => s1 && s2 }
+                        .catchAll(_ =>
+                          ZIO.succeed(ChannelState.Invalid),
+                        ) // In case resetting the channel fails we cannot reuse it
+                        .flatMap { channelState =>
+                          connectionPool
+                            .invalidate(connection)
+                            .when(channelState == ChannelState.Invalid)
+                        }
+                        .zipRight(channelScope.close(exit))
+                        .uninterruptible
+                    }.forkDaemon
+                } yield ()
+              }
+            } yield ()
+          case Location.Relative           =>
+            ZIO.fail(throw new IllegalArgumentException("Absolute URL is required"))
         }
       }
-    }
-
-    private def requestOnChannel(
-      channel: JChannel,
-      location: URL.Location.Absolute,
-      req: Request,
-      jReq: FullHttpRequest,
-      onResponse: Promise[Throwable, Response],
-      onComplete: Promise[Throwable, ChannelState],
-      useAggregator: Boolean,
-      enableKeepAlive: Boolean,
-      createSocketApp: () => SocketApp[Any],
-    )(implicit trace: Trace): ZIO[Any, Throwable, ChannelState] = {
-      log.debug(s"Request: [${jReq.method().asciiName()} ${req.url.encode}]")
-
-      val pipeline                              = channel.pipeline()
-      val toRemove: mutable.Set[ChannelHandler] = new mutable.HashSet[ChannelHandler]()
-
-      // ObjectAggregator is used to work with FullHttpRequests and FullHttpResponses
-      // This is also required to make WebSocketHandlers work
-      if (useAggregator) {
-        val httpObjectAggregator = new HttpObjectAggregator(Int.MaxValue)
-        val clientInbound        =
-          new ClientInboundHandler(rtm, jReq, onResponse, onComplete, location.scheme.isWebSocket, enableKeepAlive)
-        pipeline.addLast(HTTP_OBJECT_AGGREGATOR, httpObjectAggregator)
-        pipeline.addLast(CLIENT_INBOUND_HANDLER, clientInbound)
-
-        toRemove.add(httpObjectAggregator)
-        toRemove.add(clientInbound)
-      } else {
-        val flowControl   = new FlowControlHandler()
-        val clientInbound = new ClientInboundStreamingHandler(rtm, req, onResponse, onComplete, enableKeepAlive)
-
-        pipeline.addLast(FLOW_CONTROL_HANDLER, flowControl)
-        pipeline.addLast(CLIENT_INBOUND_HANDLER, clientInbound)
-
-        toRemove.add(flowControl)
-        toRemove.add(clientInbound)
-      }
-
-      // Add WebSocketHandlers if it's a `ws` or `wss` request
-      if (location.scheme.isWebSocket) {
-        val headers = req.headers.encode
-        val app     = createSocketApp()
-        val config  = app.protocol.clientBuilder
-          .customHeaders(headers)
-          .webSocketUri(req.url.encode)
-          .build()
-
-        // Handles the heavy lifting required to upgrade the connection to a WebSocket connection
-
-        val webSocketClientProtocol = new WebSocketClientProtocolHandler(config)
-        val webSocket               = new WebSocketAppHandler(rtm, app, true)
-
-        pipeline.addLast(WEB_SOCKET_CLIENT_PROTOCOL_HANDLER, webSocketClientProtocol)
-        pipeline.addLast(WEB_SOCKET_HANDLER, webSocket)
-
-        toRemove.add(webSocketClientProtocol)
-        toRemove.add(webSocket)
-
-        pipeline.fireChannelRegistered()
-        pipeline.fireChannelActive()
-
-        ZIO.succeed(
-          ChannelState.Invalid,
-        ) // channel becomes invalid - reuse of websocket channels not supported currently
-      } else {
-
-        pipeline.fireChannelRegistered()
-        pipeline.fireChannelActive()
-
-        val frozenToRemove = toRemove.toSet
-
-        ZIO.attempt {
-          frozenToRemove.foreach(pipeline.remove)
-          ChannelState.Reusable // channel can be reused
-        }
-      }
-    }
   }
 
   def request(
@@ -780,30 +688,24 @@ object ZClient {
       ZIO.serviceWithZIO[Client](_.socket(url, app, headers))
     }
 
-  val live: ZLayer[ClientConfig with ConnectionPool with NettyRuntime, Throwable, Client] = {
-    implicit val trace = Trace.empty
-    ZLayer {
+  val live: ZLayer[ClientConfig with ClientDriver, Throwable, Client] = {
+    implicit val trace: Trace = Trace.empty
+    ZLayer.scoped {
       for {
-        settings       <- ZIO.service[ClientConfig]
-        runtime        <- ZIO.runtime[Any]
-        zx             <- ZIO.service[NettyRuntime]
-        connectionPool <- ZIO.service[ConnectionPool]
-      } yield ClientLive(settings, runtime, zx, connectionPool)
+        config         <- ZIO.service[ClientConfig]
+        driver         <- ZIO.service[ClientDriver]
+        connectionPool <- driver.createConnectionPool(config.connectionPool)
+      } yield new ClientLive(driver)(connectionPool)(config)
     }
   }
-
-  val fromConfig: ZLayer[
-    ChannelType.Config with ConnectionPool with ClientConfig,
-    Throwable,
-    Client,
-  ] = {
-    implicit val trace = Trace.empty
-    ChannelFactories.Client.fromConfig >+> NettyRuntime.usingDedicatedThreadPool >>> live
-  }
+  val fromConfig: ZLayer[ClientConfig, Throwable, Client]             = {
+    implicit val trace: Trace = Trace.empty
+    NettyClientDriver.fromConfig >>> live
+  }.fresh
 
   val default: ZLayer[Any, Throwable, Client] = {
-    implicit val trace = Trace.empty
-    ClientConfig.default >+> ConnectionPool.disabled >>> live
+    implicit val trace: Trace = Trace.empty
+    ClientConfig.default >>> fromConfig
   }
 
   val zioHttpVersion: CharSequence           = Client.getClass().getPackage().getImplementationVersion()

--- a/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -139,12 +139,4 @@ object NettyClientDriver {
         } yield NettyClientDriver(channelFactory, eventLoopGroup, nettyRuntime, clientConfig)
       }
 
-  val shared: ZLayer[ClientConfig with Driver, Throwable, ClientDriver] =
-    ZLayer.scoped {
-      for {
-        config       <- ZIO.service[ClientConfig]
-        driver       <- ZIO.service[Driver]
-        clientDriver <- driver.createClientDriver(config)
-      } yield clientDriver
-    }
 }

--- a/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -1,0 +1,150 @@
+package zio.http.netty.client
+
+import io.netty.channel.{Channel, ChannelFactory, ChannelHandler, EventLoopGroup}
+import io.netty.handler.codec.http.HttpObjectAggregator
+import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler
+import io.netty.handler.flow.FlowControlHandler
+import zio._
+import zio.http._
+import zio.http.netty.{ChannelFactories, EventLoopGroups, NettyRuntime, WebSocketAppHandler}
+import zio.http.service._
+import zio.http.socket.SocketApp
+import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
+
+import scala.collection.mutable
+
+private[zio] final case class NettyClientDriver(
+  channelFactory: ChannelFactory[Channel],
+  eventLoopGroup: EventLoopGroup,
+  nettyRuntime: NettyRuntime,
+  clientConfig: ClientConfig,
+) extends ClientDriver
+    with ClientRequestEncoder {
+  import zio.http.ZClient.log
+
+  override type Connection = Channel
+
+  def requestOnChannel(
+    channel: Channel,
+    location: URL.Location.Absolute,
+    req: Request,
+    onResponse: Promise[Throwable, Response],
+    onComplete: Promise[Throwable, ChannelState],
+    useAggregator: Boolean,
+    enableKeepAlive: Boolean,
+    createSocketApp: () => SocketApp[Any],
+  )(implicit trace: Trace): ZIO[Scope, Throwable, ChannelState] = {
+    encode(req).flatMap { jReq =>
+      Scope.addFinalizerExit { exit =>
+        ZIO.attempt {
+          if (jReq.refCnt() > 0) {
+            jReq.release(jReq.refCnt()): Unit
+          }
+        }.ignore.when(exit.isFailure)
+      }.zipRight {
+        log.debug(s"Request: [${jReq.method().asciiName()} ${req.url.encode}]")
+
+        val pipeline                              = channel.pipeline()
+        val toRemove: mutable.Set[ChannelHandler] = new mutable.HashSet[ChannelHandler]()
+
+        // ObjectAggregator is used to work with FullHttpRequests and FullHttpResponses
+        // This is also required to make WebSocketHandlers work
+        if (useAggregator) {
+          val httpObjectAggregator = new HttpObjectAggregator(Int.MaxValue)
+          val clientInbound        =
+            new ClientInboundHandler(
+              nettyRuntime,
+              jReq,
+              onResponse,
+              onComplete,
+              location.scheme.isWebSocket,
+              enableKeepAlive,
+            )
+          pipeline.addLast(HTTP_OBJECT_AGGREGATOR, httpObjectAggregator)
+          pipeline.addLast(CLIENT_INBOUND_HANDLER, clientInbound)
+
+          toRemove.add(httpObjectAggregator)
+          toRemove.add(clientInbound)
+        } else {
+          val flowControl   = new FlowControlHandler()
+          val clientInbound =
+            new ClientInboundStreamingHandler(nettyRuntime, req, onResponse, onComplete, enableKeepAlive)
+
+          pipeline.addLast(FLOW_CONTROL_HANDLER, flowControl)
+          pipeline.addLast(CLIENT_INBOUND_HANDLER, clientInbound)
+
+          toRemove.add(flowControl)
+          toRemove.add(clientInbound)
+        }
+
+        // Add WebSocketHandlers if it's a `ws` or `wss` request
+        if (location.scheme.isWebSocket) {
+          val headers = req.headers.encode
+          val app     = createSocketApp()
+          val config  = app.protocol.clientBuilder
+            .customHeaders(headers)
+            .webSocketUri(req.url.encode)
+            .build()
+
+          // Handles the heavy lifting required to upgrade the connection to a WebSocket connection
+
+          val webSocketClientProtocol = new WebSocketClientProtocolHandler(config)
+          val webSocket               = new WebSocketAppHandler(nettyRuntime, app, true)
+
+          pipeline.addLast(WEB_SOCKET_CLIENT_PROTOCOL_HANDLER, webSocketClientProtocol)
+          pipeline.addLast(WEB_SOCKET_HANDLER, webSocket)
+
+          toRemove.add(webSocketClientProtocol)
+          toRemove.add(webSocket)
+
+          pipeline.fireChannelRegistered()
+          pipeline.fireChannelActive()
+
+          ZIO.succeed(
+            ChannelState.Invalid,
+          ) // channel becomes invalid - reuse of websocket channels not supported currently
+        } else {
+
+          pipeline.fireChannelRegistered()
+          pipeline.fireChannelActive()
+
+          val frozenToRemove = toRemove.toSet
+
+          ZIO.attempt {
+            frozenToRemove.foreach(pipeline.remove)
+            ChannelState.Reusable // channel can be reused
+          }
+        }
+      }
+    }
+  }
+
+  override def createConnectionPool(config: ConnectionPoolConfig)(implicit
+    trace: Trace,
+  ): ZIO[Scope, Nothing, ConnectionPool[Channel]] =
+    NettyConnectionPool.fromConfig(config).provideSomeEnvironment[Scope](_ ++ ZEnvironment(this))
+}
+
+object NettyClientDriver {
+  private implicit val trace: Trace = Trace.empty
+
+  val fromConfig: ZLayer[ClientConfig, Throwable, ClientDriver] =
+    (EventLoopGroups.fromConfig ++ ChannelFactories.Client.fromConfig ++ NettyRuntime.usingDedicatedThreadPool) >>>
+      ZLayer {
+        for {
+          eventLoopGroup <- ZIO.service[EventLoopGroup]
+          channelFactory <- ZIO.service[ChannelFactory[Channel]]
+          nettyRuntime   <- ZIO.service[NettyRuntime]
+          clientConfig   <- ZIO.service[ClientConfig]
+        } yield NettyClientDriver(channelFactory, eventLoopGroup, nettyRuntime, clientConfig)
+      }
+
+  val shared: ZLayer[ClientConfig with Driver, Throwable, ClientDriver] =
+    ZLayer.scoped {
+      for {
+        config       <- ZIO.service[ClientConfig]
+        driver       <- ZIO.service[Driver]
+        clientDriver <- driver.createClientDriver(config)
+      } yield clientDriver
+    }
+}

--- a/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -13,7 +13,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace // scalafix:ok;
 
 import scala.collection.mutable
 
-private[zio] final case class NettyClientDriver(
+final case class NettyClientDriver private (
   channelFactory: ChannelFactory[Channel],
   eventLoopGroup: EventLoopGroup,
   nettyRuntime: NettyRuntime,

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -3,7 +3,7 @@ package zio.http
 import io.netty.handler.codec.DecoderException
 import zio.http._
 import zio.http.model._
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{ignore, timeout}
 import zio.test.{Gen, ZIOSpecDefault, assertZIO, check}
@@ -39,9 +39,9 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.Ok))
           }.provide(
-            ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),
+            NettyClientDriver.fromConfig,
           ),
           test("fail with DecoderException when client doesn't have the server certificate") {
             val actual = Client
@@ -51,9 +51,9 @@ object SSLSpec extends ZIOSpecDefault {
               }
             assertZIO(actual)(equalTo("DecoderException"))
           }.provide(
-            ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL2)),
+            NettyClientDriver.fromConfig,
           ),
           test("succeed when client has default SSL") {
             val actual = Client
@@ -61,9 +61,9 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.Ok))
           }.provide(
-            ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(ClientSSLConfig.Default)),
+            NettyClientDriver.fromConfig,
           ),
           test("Https Redirect when client makes http request") {
             val actual = Client
@@ -71,9 +71,9 @@ object SSLSpec extends ZIOSpecDefault {
               .map(_.status)
             assertZIO(actual)(equalTo(Status.PermanentRedirect))
           }.provide(
-            ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),
+            NettyClientDriver.fromConfig,
           ),
           test("Https request with a large payload should respond with 413") {
             check(payload) { payload =>
@@ -87,9 +87,9 @@ object SSLSpec extends ZIOSpecDefault {
               assertZIO(actual)(equalTo(Status.RequestEntityTooLarge))
             }
           }.provide(
-            ConnectionPool.disabled,
             Client.live,
             ClientConfig.live(ClientConfig.empty.ssl(clientSSL1)),
+            NettyClientDriver.fromConfig,
           ),
         ),
       ),

--- a/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/api/ServerClientIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package zio.http.api
 
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.http.{Client, ClientConfig, Server, ServerConfig, URL}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test.{ZIOSpecDefault, assertTrue}
@@ -57,9 +57,9 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
       Server.live,
       ServerConfig.live,
       Client.live,
-      ConnectionPool.disabled,
       executorLayer,
       // TODO: [Ergonomics] Server.default is a value and ClientConfig.default is a Layer
       ClientConfig.default,
+      NettyClientDriver.fromConfig,
     )
 }

--- a/zio-http/src/test/scala/zio/http/service/ClientHttpsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientHttpsSpec.scala
@@ -2,7 +2,7 @@ package zio.http.service
 
 import io.netty.handler.codec.DecoderException
 import zio.http.model.Status
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.http.{Client, ClientConfig, ClientSSLConfig}
 import zio.test.Assertion.{anything, equalTo, fails, isSubtype}
 import zio.test.TestAspect.{ignore, timeout}
@@ -44,7 +44,7 @@ object ClientHttpsSpec extends ZIOSpecDefault {
   ).provide(
     ClientConfig.live(ClientConfig.empty.ssl(sslConfig)),
     Client.live,
-    ConnectionPool.disabled,
+    NettyClientDriver.fromConfig,
   ) @@ timeout(
     30 seconds,
   ) @@ ignore

--- a/zio-http/src/test/scala/zio/http/service/ClientProxySpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientProxySpec.scala
@@ -4,7 +4,7 @@ import zio.http._
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, severTestLayer}
 import zio.http.middleware.Auth.Credentials
 import zio.http.model._
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.test.Assertion._
 import zio.test.TestAspect.{sequential, timeout}
 import zio.test._
@@ -26,9 +26,9 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = serverUrl),
             )
             .provideSome(
-              ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(Proxy(proxyUrl))),
+              NettyClientDriver.fromConfig,
             )
         } yield out
       assertZIO(res.either)(isLeft(isSubtype[ConnectException](anything)))
@@ -45,9 +45,9 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = url),
             )
             .provideSome(
-              ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(proxy)),
+              NettyClientDriver.fromConfig,
             )
         } yield out
       assertZIO(res.either)(isRight)
@@ -76,9 +76,9 @@ object ClientProxySpec extends HttpRunnableSpec {
               Request.get(url = url),
             )
             .provideSome(
-              ConnectionPool.disabled,
               Client.live,
               ClientConfig.live(ClientConfig.empty.proxy(proxy)),
+              NettyClientDriver.fromConfig,
             )
         } yield out
       assertZIO(res.either)(isRight)

--- a/zio-http/src/test/scala/zio/http/service/ClientStreamingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/ClientStreamingSpec.scala
@@ -3,7 +3,7 @@ package zio.http.service
 import zio.http._
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, severTestLayer}
 import zio.http.model.Method
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.{NettyClientDriver, NettyConnectionPool}
 import zio.stream.ZStream
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{sequential, timeout}
@@ -28,9 +28,9 @@ object ClientStreamingSpec extends HttpRunnableSpec {
   }.provideShared(
     DynamicServer.live,
     severTestLayer,
-    ConnectionPool.disabled,
     Client.live,
     ClientConfig.live(ClientConfig.empty.useObjectAggregator(false)),
+    NettyClientDriver.fromConfig,
   ) @@
     timeout(5 seconds) @@ sequential
 }

--- a/zio-http/src/test/scala/zio/http/service/NettyConnectionPoolSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/NettyConnectionPoolSpec.scala
@@ -9,7 +9,7 @@ import zio.http.netty.NettyRuntime
 import zio.http.netty.client.NettyClientDriver
 import zio.stream.ZStream
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.{diagnose, nonFlaky, sequential, timeout}
+import zio.test.TestAspect.{diagnose, nonFlaky, sequential, timeout, withLiveClock}
 import zio.test._
 
 object NettyConnectionPoolSpec extends HttpRunnableSpec {
@@ -151,7 +151,7 @@ object NettyConnectionPoolSpec extends HttpRunnableSpec {
     )
 
   override def spec: Spec[Scope, Throwable] = {
-    connectionPoolSpec @@ timeout(30.seconds) @@ diagnose(30.seconds) @@ sequential
+    connectionPoolSpec @@ timeout(30.seconds) @@ diagnose(30.seconds) @@ sequential @@ withLiveClock
   }
 
 }

--- a/zio-http/src/test/scala/zio/http/service/NettyConnectionPoolSpec.scala
+++ b/zio-http/src/test/scala/zio/http/service/NettyConnectionPoolSpec.scala
@@ -6,13 +6,13 @@ import zio.http._
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, severTestLayer}
 import zio.http.model.{Headers, Method, Version}
 import zio.http.netty.NettyRuntime
-import zio.http.netty.client.ConnectionPool
+import zio.http.netty.client.NettyClientDriver
 import zio.stream.ZStream
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{diagnose, nonFlaky, sequential, timeout}
 import zio.test._
 
-object ConnectionPoolSpec extends HttpRunnableSpec {
+object NettyConnectionPoolSpec extends HttpRunnableSpec {
 
   private val app = Http.collectZIO[Request] {
     case req @ Method.POST -> !! / "streaming" => ZIO.succeed(Response(body = Body.fromStream(req.body.asStream)))
@@ -100,8 +100,7 @@ object ConnectionPoolSpec extends HttpRunnableSpec {
       },
     )
 
-  def connectionPoolSpec
-    : Spec[Scope with ClientConfig with EventLoopGroup with ChannelFactory with NettyRuntime, Throwable] =
+  def connectionPoolSpec: Spec[Scope, Throwable] =
     suite("ConnectionPool")(
       suite("fixed")(
         connectionPoolTests(
@@ -118,12 +117,13 @@ object ConnectionPoolSpec extends HttpRunnableSpec {
             "with keep-alive"    -> keepAliveHeader,
           ),
         ),
-      ).provideSomeShared[Scope with ClientConfig with EventLoopGroup with ChannelFactory with NettyRuntime](
+      ).provideSome[Scope](
         ZLayer(appKeepAliveEnabled.unit),
         DynamicServer.live,
         severTestLayer,
         Client.live,
-        ConnectionPool.fixed(2),
+        ClientConfig.live(ClientConfig.empty.withFixedConnectionPool(2)),
+        NettyClientDriver.fromConfig,
       ),
       suite("dynamic")(
         connectionPoolTests(
@@ -140,21 +140,18 @@ object ConnectionPoolSpec extends HttpRunnableSpec {
             "with keep-alive"    -> keepAliveHeader,
           ),
         ),
-      ).provideSomeShared[Scope with ClientConfig with EventLoopGroup with ChannelFactory with NettyRuntime](
+      ).provideSome[Scope](
         ZLayer(appKeepAliveEnabled.unit),
         DynamicServer.live,
         severTestLayer,
         Client.live,
-        ConnectionPool.dynamic(4, 16, 100.millis),
+        ClientConfig.live(ClientConfig.empty.withDynamicConnectionPool(4, 16, 100.millis)),
+        NettyClientDriver.fromConfig,
       ),
     )
 
-  override def spec: Spec[Any, Throwable] = {
-    connectionPoolSpec
-      .provideShared(
-        ClientConfig.default,
-        Scope.default,
-      ) @@ timeout(30.seconds) @@ diagnose(30.seconds) @@ sequential
+  override def spec: Spec[Scope, Throwable] = {
+    connectionPoolSpec @@ timeout(30.seconds) @@ diagnose(30.seconds) @@ sequential
   }
 
 }


### PR DESCRIPTION
- Hides Netty specific initialization for the client, similar to how it's already done for the `Server` (related to #1453)
- `ZClient` no longer contains netty specific code
- Connection pools are part of the client driver, always initialized from the client config
- Ability to share the `EventLoopGroup` with the server (`ClientDriver.shared`)
- `Client.fromConfig` is `fresh` by default to avoid confusion like https://github.com/zio/zio-http/issues/1877
- `ClientConfig` layers now only construct `ClientConfig`