### PR TITLE
Fix for #1960 - multiple set-cookie headers when other headers are al…

### DIFF
--- a/zio-http/src/main/scala/zio/http/model/Headers.scala
+++ b/zio-http/src/main/scala/zio/http/model/Headers.scala
@@ -199,7 +199,8 @@ object Headers extends HeaderConstructors {
   def empty: Headers = EmptyHeaders
 
   private[http] def encode(headersList: List[Product2[CharSequence, CharSequence]]): HttpHeaders = {
-    val (exceptions, regularHeaders) = headersList.span(h => h._1.toString.contains(HeaderNames.setCookie.toString))
+    val (exceptions, regularHeaders) =
+      headersList.partition(h => h._1.toString.contains(HeaderNames.setCookie.toString))
     val combinedHeaders              = regularHeaders
       .groupBy(_._1)
       .map { case (key, tuples) =>

--- a/zio-http/src/test/scala/zio/http/model/headers/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/model/headers/HeaderSpec.scala
@@ -246,6 +246,12 @@ object HeaderSpec extends ZIOSpecDefault {
         val result        = cookieHeaders.encode.entries().size()
         assertTrue(result == 2)
       },
+      test("should encode multiple cookie headers as two separate headers also if other headers are present") {
+        val cookieHeaders = Headers(HeaderNames.setCookie, "x1") ++ Headers(HeaderNames.setCookie, "x2")
+        val otherHeaders  = Headers(HeaderNames.contentType, "application/json")
+        val result        = (otherHeaders ++ cookieHeaders).encode.entries().size()
+        assertTrue(result == 3)
+      },
       test("header with multiple values should not be escaped") {
         val headers               = Headers("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
         val expected: HttpHeaders =


### PR DESCRIPTION
`set-cookie` headers should be sent separately, but currently they may be packed together if there are other headers before them.