### PR TITLE
Enhance ClientLive constructor

### DIFF
--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -521,12 +521,12 @@ object ZClient {
       this(settings, driver, connectionPool.asInstanceOf[ConnectionPool[Any]])
 
     val headers: Headers                   = Headers.empty
-    val hostOption: Option[String]         = None
+    val hostOption: Option[String]         = config.localAddress.map(_.getHostString)
     val pathPrefix: Path                   = Path.empty
-    val portOption: Option[Int]            = None
+    val portOption: Option[Int]            = config.localAddress.map(_.getPort)
     val queries: QueryParams               = QueryParams.empty
     val schemeOption: Option[Scheme]       = None
-    val sslConfig: Option[ClientSSLConfig] = None
+    val sslConfig: Option[ClientSSLConfig] = config.ssl
 
     def requestInternal(
       body: Body,


### PR DESCRIPTION
At this moment ClientLive constructor sets 'empty' values for host, port and ssl config. Even when ClientConfig defines `localAddress` and `ssl` fields.

So today's experience looks like this

```scala
  val live: ZLayer[ClientConfig, Throwable, MyGitHubSdk] =
    Client.fromConfig >>>
      ZLayer.fromZIO {
        for {
          clientConfig <- ZIO.service[ClientConfig]
          client <- ZIO.service[Client]
        } yield {
          val patchedClient = // set host, port, ssl, scheme...

          new MyGitHubSdk(patchedClient)
        }
      }
      
  // inside MyGitHubSdk
      
  def getRepoInfo(userName: String, repoName: String) = {
    client.get(s"/$userName/$repoName")
    // etc...
  }
```

After this changes experience

```scala
  val live: ZLayer[ClientConfig, Throwable, MyGitHubSdk] =
    Client.fromConfig >>>
      ZLayer.fromZIO {
        for {
          client <- ZIO.service[Client]
        } yield new MyGitHubSdk(patchedClient)
      }
      
  // inside MyGitHubSdk stuff remains untouched
```