### PR TITLE
Unprotect ZClient methods

### DIFF
--- a/zio-http-testkit/src/main/scala/zio/http/TestClient.scala
+++ b/zio-http-testkit/src/main/scala/zio/http/TestClient.scala
@@ -77,7 +77,7 @@ final case class TestClient(behavior: Ref[HttpApp[Any, Throwable]], serverSocket
   val schemeOption: Option[Scheme]       = None
   val sslConfig: Option[ClientSSLConfig] = None
 
-  override protected def requestInternal(
+  override def request(
     body: Body,
     headers: Headers,
     hostOption: Option[String],
@@ -105,7 +105,7 @@ final case class TestClient(behavior: Ref[HttpApp[Any, Throwable]], serverSocket
       }
     } yield response
 
-  override protected def socketInternal[Env1](
+  override def socket[Env1](
     app: SocketApp[Env1],
     headers: Headers,
     hostOption: Option[String],

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -71,7 +71,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
       def queries: QueryParams               = self.queries
       def schemeOption: Option[Scheme]       = self.schemeOption
       def sslConfig: Option[ClientSSLConfig] = self.sslConfig
-      def requestInternal(
+      def request(
         body: In2,
         headers: Headers,
         hostOption: Option[String],
@@ -84,7 +84,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env1, Err1, Out] =
         f(body).flatMap { body =>
-          self.requestInternal(
+          self.request(
             body,
             headers,
             hostOption,
@@ -97,7 +97,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
             version,
           )
         }
-      def socketInternal[Env2 <: Env1](
+      def socket[Env2 <: Env1](
         app: SocketApp[Env2],
         headers: Headers,
         hostOption: Option[String],
@@ -107,7 +107,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         schemeOption: Option[Scheme],
         version: Version,
       )(implicit trace: Trace): ZIO[Env2 with Scope, Err1, Out] =
-        self.socketInternal(
+        self.socket(
           app,
           headers,
           hostOption,
@@ -160,7 +160,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
       def queries: QueryParams               = self.queries
       def schemeOption: Option[Scheme]       = self.schemeOption
       def sslConfig: Option[ClientSSLConfig] = self.sslConfig
-      def requestInternal(
+      def request(
         body: In,
         headers: Headers,
         hostOption: Option[String],
@@ -173,7 +173,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env1, Err1, Out2] =
         self
-          .requestInternal(
+          .request(
             body,
             headers,
             hostOption,
@@ -186,7 +186,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
             version,
           )
           .flatMap(f)
-      protected def socketInternal[Env2 <: Env1](
+      def socket[Env2 <: Env1](
         app: SocketApp[Env2],
         headers: Headers,
         hostOption: Option[String],
@@ -197,7 +197,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env2 with Scope, Err1, Out2] =
         self
-          .socketInternal(
+          .socket(
             app,
             headers,
             hostOption,
@@ -239,7 +239,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
       def queries: QueryParams               = self.queries
       def schemeOption: Option[Scheme]       = self.schemeOption
       def sslConfig: Option[ClientSSLConfig] = self.sslConfig
-      def requestInternal(
+      def request(
         body: In,
         headers: Headers,
         hostOption: Option[String],
@@ -252,7 +252,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env, Err2, Out] =
         self
-          .requestInternal(
+          .request(
             body,
             headers,
             hostOption,
@@ -265,7 +265,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
             version,
           )
           .refineOrDie(pf)
-      protected def socketInternal[Env1 <: Env](
+      def socket[Env1 <: Env](
         app: SocketApp[Env1],
         headers: Headers,
         hostOption: Option[String],
@@ -276,7 +276,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env1 with Scope, Err2, Out] =
         self
-          .socketInternal(
+          .socket(
             app,
             headers,
             hostOption,
@@ -290,7 +290,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
     }
 
   final def request(method: Method, pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
-    requestInternal(
+    request(
       body,
       headers,
       hostOption,
@@ -304,7 +304,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
     )
 
   final def request(request: Request)(implicit ev: Body <:< In, trace: Trace): ZIO[Env, Err, Out] = {
-    requestInternal(
+    self.request(
       ev(request.body),
       headers ++ request.headers,
       request.url.host,
@@ -327,7 +327,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
       def queries: QueryParams               = self.queries
       def schemeOption: Option[Scheme]       = self.schemeOption
       def sslConfig: Option[ClientSSLConfig] = self.sslConfig
-      def requestInternal(
+      def request(
         body: In,
         headers: Headers,
         hostOption: Option[String],
@@ -340,7 +340,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env1, Err, Out] =
         self
-          .requestInternal(
+          .request(
             body,
             headers,
             hostOption,
@@ -353,7 +353,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
             version,
           )
           .retry(policy)
-      def socketInternal[Env2 <: Env1](
+      def socket[Env2 <: Env1](
         app: SocketApp[Env2],
         headers: Headers,
         hostOption: Option[String],
@@ -364,7 +364,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
         version: Version,
       )(implicit trace: Trace): ZIO[Env2 with Scope, Err, Out] =
         self
-          .socketInternal(
+          .socket(
             app,
             headers,
             hostOption,
@@ -383,7 +383,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
   final def socket[Env1 <: Env](
     pathSuffix: String,
   )(app: SocketApp[Env1])(implicit trace: Trace): ZIO[Env1 with Scope, Err, Out] =
-    socketInternal(
+    socket(
       app,
       headers,
       hostOption,
@@ -401,7 +401,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
   )(implicit trace: Trace): ZIO[Env1 with Scope, Err, Out] =
     for {
       url <- ZIO.fromEither(URL.fromString(url)).orDie
-      out <- socketInternal(
+      out <- socket(
         app,
         headers,
         url.host,
@@ -432,7 +432,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
       queries = queries ++ url.queryParams,
     )
 
-  protected def requestInternal(
+  def request(
     body: In,
     headers: Headers,
     hostOption: Option[String],
@@ -445,7 +445,7 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
     version: Version,
   )(implicit trace: Trace): ZIO[Env, Err, Out]
 
-  protected def socketInternal[Env1 <: Env](
+  def socket[Env1 <: Env](
     app: SocketApp[Env1],
     headers: Headers,
     hostOption: Option[String],
@@ -490,7 +490,7 @@ object ZClient {
     sslConfig: Option[ClientSSLConfig],
   ) extends ZClient[Env, In, Err, Out] {
 
-    def requestInternal(
+    def request(
       body: In,
       headers: Headers,
       hostOption: Option[String],
@@ -502,7 +502,7 @@ object ZClient {
       sslConfig: Option[ClientSSLConfig],
       version: Version,
     )(implicit trace: Trace): ZIO[Env, Err, Out] =
-      client.requestInternal(
+      client.request(
         body,
         headers,
         hostOption,
@@ -515,7 +515,7 @@ object ZClient {
         version,
       )
 
-    protected def socketInternal[Env1 <: Env](
+    def socket[Env1 <: Env](
       app: SocketApp[Env1],
       headers: Headers,
       hostOption: Option[String],
@@ -525,7 +525,7 @@ object ZClient {
       schemeOption: Option[Scheme],
       version: Version,
     )(implicit trace: Trace): ZIO[Env1 with Scope, Err, Out] =
-      client.socketInternal(app, headers, hostOption, pathPrefix, portOption, queries, schemeOption, version)
+      client.socket(app, headers, hostOption, pathPrefix, portOption, queries, schemeOption, version)
 
   }
 
@@ -544,7 +544,7 @@ object ZClient {
     val schemeOption: Option[Scheme]       = None
     val sslConfig: Option[ClientSSLConfig] = config.ssl
 
-    def requestInternal(
+    def request(
       body: Body,
       headers: Headers,
       hostOption: Option[String],
@@ -576,7 +576,7 @@ object ZClient {
       } yield response
     }
 
-    protected override def socketInternal[R](
+    override def socket[R](
       app: SocketApp[R],
       headers: Headers,
       hostOption: Option[String],


### PR DESCRIPTION
The use case: measure request duration and push it to a metrics service

Possible solution: define a middleware using `ZClientAspect` and wrap a client like
```scala
def apply[Env, In,  Err, Out](client: ZClient[Env, In, Err, Out]): ZClient[Env, In, Err, Out] = 
  new ZClient[Env, In, Err, Out] {
    def request(...) =
       client.request(...).timed.flatMap { case (duration, response) =>  metrics.report(duration).as(response) }
  }
```

The issue: because of the ZClient defines two protected methods, it's impossible to call them on the wrapped client which forces to make a hack. Using `mapZIO` and `contramapZIO` methods complicates the simple task a lot.

The suggested solution is to unprotect the methods, wdyt?

UPD: another use case is to catch request failures and report them somewhere, it's impossible to achieve that with the `mapZIO` method because it's not called in case of an error