### PR TITLE
Set scheme when setting url/uri to ZClient

### DIFF
--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -416,21 +416,27 @@ trait ZClient[-Env, -In, +Err, +Out] { self =>
   final def ssl(ssl: ClientSSLConfig): ZClient[Env, In, Err, Out] =
     copy(sslConfig = Some(ssl))
 
-  final def uri(uri: URI): ZClient[Env, In, Err, Out] =
+  final def uri(uri: URI): ZClient[Env, In, Err, Out] = {
+    val scheme = Scheme.decode(uri.getScheme)
+
     copy(
       hostOption = Option(uri.getHost),
       pathPrefix = pathPrefix ++ Path.decode(uri.getRawPath),
-      portOption = Option(uri.getPort).filter(_ != -1).orElse(Scheme.decode(uri.getScheme).map(_.port)),
+      portOption = Option(uri.getPort).filter(_ != -1).orElse(scheme.map(_.port)),
       queries = queries ++ QueryParams.decode(uri.getRawQuery),
+      schemeOption = scheme,
     )
+  }
 
-  final def url(url: URL): ZClient[Env, In, Err, Out] =
+  final def url(url: URL): ZClient[Env, In, Err, Out] = {
     copy(
       hostOption = url.host,
       pathPrefix = pathPrefix ++ url.path,
       portOption = url.port,
       queries = queries ++ url.queryParams,
+      schemeOption = url.scheme,
     )
+  }
 
   protected def requestInternal(
     body: In,


### PR DESCRIPTION
the issue comes when setting a uri to the client like this:
```scala
val configuredClient = client.uri(URI("https://example.com"))
```
it sets the port to 443 which is correct, but doesn't set the scheme which results to defaulting it to the `http` value in the `ClientLive.requestInternal` implementation.

I think the client should be completely redesigned and rewritten but it requires much more time, so the PR just fixes the issue