### PR TITLE
Fail on decoding errors

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -337,8 +337,8 @@ private[zio] final case class ServerInboundHandler(
       ctx.channel().close()
     }.unit.orDie
 
-  private def failOnDecodingError(request: HttpRequest): ZIO[Any, Nothing, Unit] =
-    ZIO.die(request.decoderResult().cause()).when(request.decoderResult().isFailure).unit
+  private def failOnDecodingError(request: HttpRequest): Exit[Nothing, Unit] =
+    if (request.decoderResult().isFailure) Exit.die(request.decoderResult().cause()) else Exit.unit
 }
 
 object ServerInboundHandler {

--- a/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
@@ -1,0 +1,37 @@
+package zio.http
+
+import zio.Scope
+import zio.test._
+
+import zio.http.model._
+
+object NettyMaxHeaderLengthSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    test("should get a failure instead of an empty body") {
+      for {
+        port <- Server.install(
+          Http
+            .collectZIO[Request] { request =>
+              request.body.asString.map { body =>
+                val responseBody = if (body.isEmpty) "<empty>" else body
+                Response.text(responseBody)
+              } // this should not be run, as the request is invalid
+            }
+            .withDefaultErrorResponse,
+        )
+        url = s"http://localhost:$port"
+        headers = Headers(
+          Header.UserAgent.Product("a looooooooooooooooooooooooooooong header", None),
+        )
+
+        res  <- Client.request(url, headers = headers, content = Body.fromString("some-body"))
+        data <- res.body.asString
+      } yield {
+        assertTrue(res.status == Status.InternalServerError && data == "")
+      }
+    }.provide(
+      Client.default,
+      Server.live,
+      ServerConfig.live(ServerConfig(maxHeaderSize = 1)),
+    )
+}

--- a/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
@@ -1,34 +1,32 @@
 package zio.http
 
-import zio.Scope
 import zio.test._
+import zio.{Scope, ZIO}
 
 import zio.http.model._
 
 object NettyMaxHeaderLengthSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     test("should get a failure instead of an empty body") {
+      val app = Handler
+        .fromFunctionZIO[Request] { request =>
+          request.body.asString.map { body =>
+            val responseBody = if (body.isEmpty) "<empty>" else body
+            Response.text(responseBody)
+          } // this should not be run, as the request is invalid
+        }
+        .toHttp
+        .withDefaultErrorResponse
       for {
-        port <- Server.install(
-          Http
-            .collectZIO[Request] { request =>
-              request.body.asString.map { body =>
-                val responseBody = if (body.isEmpty) "<empty>" else body
-                Response.text(responseBody)
-              } // this should not be run, as the request is invalid
-            }
-            .withDefaultErrorResponse,
-        )
-        url = s"http://localhost:$port"
+        port <- Server.install(app)
+        url     = s"http://localhost:$port"
         headers = Headers(
           Header.UserAgent.Product("a looooooooooooooooooooooooooooong header", None),
         )
 
         res  <- Client.request(url, headers = headers, content = Body.fromString("some-body"))
         data <- res.body.asString
-      } yield {
-        assertTrue(res.status == Status.InternalServerError && data == "")
-      }
+      } yield assertTrue(res.status == Status.InternalServerError, data == "")
     }.provide(
       Client.default,
       Server.live,


### PR DESCRIPTION
Resolves #2056 

Note that it is not exactly what the bug report asks for: the decoding error is converted to a `Die` failure which means it gets an internal server error response, and can be observed with the server's error callback, while the bug description asks for running to the `withDefaultErrorResponse` handler in this case. To do so, we would need to model decoding errors in our `Request` class and do the check within the `Http` app which does not sound like a good idea to me.