### PR TITLE
octet-stream as default multipart form contentType

### DIFF
--- a/zio-http/src/main/scala/zio/http/forms/FormField.scala
+++ b/zio-http/src/main/scala/zio/http/forms/FormField.scala
@@ -125,7 +125,7 @@ object FormField {
       content          = contentParts.foldLeft(Chunk.empty[Byte])(_ ++ _.bytes)
       contentType      = extract._2
         .flatMap(x => MediaType.forContentType(x.preposition))
-        .getOrElse(MediaType.text.plain)
+        .getOrElse(MediaType.application.`octet-stream`)
       transferEncoding = extract._3
         .flatMap(x => ContentTransferEncoding.parse(x.preposition).toOption)
 


### PR DESCRIPTION
In many clients, `content-type` in `multipart/form-data` is not specified, for best compatibility, we should use `application/octet-stream` as `content-type` when not specified in body.