### PR TITLE
Add mapErrorZIO to Handler and Http

### DIFF
--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -318,6 +318,14 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     self >>> Handler.fromFunctionZIO(f)
 
   /**
+   * Transforms the failure of the handler effectfully
+   */
+  final def mapErrorZIO[R1 <: R, Err1 >: Err, Out1 >: Out](f: Err => ZIO[R1, Err1, Out1])(implicit
+    trace: Trace,
+  ): Handler[R1, Err1, In, Out1] =
+    self.foldHandler(err => Handler.fromZIO(f(err)), Handler.succeed)
+
+  /**
    * Returns a new handler where the error channel has been merged into the
    * success channel to their common combined type.
    */

--- a/zio-http/src/test/scala/zio/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpSpec.scala
@@ -16,9 +16,9 @@
 
 package zio.http
 
-import zio.test.Assertion.{dies, equalTo, fails, succeeds, isLeft, isNone}
+import zio.test.Assertion._
 import zio.test.{Spec, ZIOSpecDefault, assert, assertTrue, assertZIO}
-import zio.{Cause, Exit, Unsafe, ZIO, Ref}
+import zio.{Cause, Exit, Ref, Unsafe, ZIO}
 
 object HttpSpec extends ZIOSpecDefault with ExitAssertion {
   implicit val allowUnsafe: Unsafe = Unsafe.unsafe

--- a/zio-http/src/test/scala/zio/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpSpec.scala
@@ -16,9 +16,9 @@
 
 package zio.http
 
-import zio.test.Assertion.{dies, equalTo, fails, isLeft, isNone}
+import zio.test.Assertion.{dies, equalTo, fails, succeeds, isLeft, isNone}
 import zio.test.{Spec, ZIOSpecDefault, assert, assertTrue, assertZIO}
-import zio.{Cause, Exit, Unsafe, ZIO}
+import zio.{Cause, Exit, Unsafe, ZIO, Ref}
 
 object HttpSpec extends ZIOSpecDefault with ExitAssertion {
   implicit val allowUnsafe: Unsafe = Unsafe.unsafe
@@ -150,6 +150,55 @@ object HttpSpec extends ZIOSpecDefault with ExitAssertion {
           val app    = Http.collectHandler[Int](Map.empty)
           val actual = app.runZIO(1)
           assertZIO(actual.exit)(fails(isNone))
+        },
+      ),
+      suite("map")(
+        test("should execute http only when condition applies") {
+          val app    = Handler.succeed(1).toHttp.map(_ + 1)
+          val actual = app.runZIOOrNull(0)
+          assertZIO(actual.exit)(succeeds(equalTo(2)))
+        },
+      ),
+      suite("mapZIO")(
+        test("should map the result of a success") {
+          for {
+            _ <- ZIO.unit
+            app = Handler.succeed(1).toHttp.mapZIO(in => ZIO.succeed(in + 1))
+            actual <- app.runZIOOrNull(0)
+          } yield assert(actual)(equalTo(2))
+        },
+      ),
+      suite("mapError")(
+        test("should map in the http in an error") {
+          for {
+            _ <- ZIO.unit
+            app = Handler.fail(1).toHttp.mapError(_ + 1)
+            actual <- app.runZIOOrNull(0).exit
+          } yield assert(actual)(isFailure(equalTo(2)))
+        },
+      ),
+      suite("mapErrorZIO")(
+        test("should not be executed in case of success") {
+          for {
+            ref <- Ref.make(1)
+            app = Handler.succeed(1).toHttp.mapErrorZIO(_ => ref.set(2))
+            actual <- app.runZIOOrNull(0)
+            res    <- ref.get
+          } yield assert(actual)(equalTo(1)) && assert(res)(equalTo(1))
+        },
+        test("should remain an error in case of error") {
+          for {
+            _ <- ZIO.unit
+            app = Handler.fail(1).toHttp.mapErrorZIO(_ => ZIO.fail(2))
+            actual <- app.runZIOOrNull(0).exit
+          } yield assert(actual)(isFailure(equalTo(2)))
+        },
+        test("should become a success") {
+          for {
+            _ <- ZIO.unit
+            app = Handler.fail(1).toHttp.mapErrorZIO(in => ZIO.succeed(in + 1))
+            actual <- app.runZIOOrNull(0).exit
+          } yield assert(actual)(isSuccess(equalTo(2)))
         },
       ),
       suite("when")(


### PR DESCRIPTION
Feel free to discard this PR but I was confused when migrating to 0.0.5 as those methods were missing.

I have included some tests that I used to understand the changes between 2.X and 0.0.5. 

I am a bit confused about `errorHandler` and how to deal with it in the `mapErrorZIO` case.