### PR TITLE
feature: retrieve repeatable headers from response

### DIFF
--- a/zio-http/src/main/scala/zio/http/Headers.scala
+++ b/zio-http/src/main/scala/zio/http/Headers.scala
@@ -44,7 +44,7 @@ sealed trait Headers extends HeaderOps[Headers] with Iterable[Header] {
 
   final def get(headerType: Header.HeaderType): Option[headerType.HeaderValue] = header(headerType)
 
-  final def getAll(headerType: Header.HeaderType): Iterable[headerType.HeaderValue] = headers(headerType)
+  final def getAll(headerType: Header.HeaderType): Chunk[headerType.HeaderValue] = headers(headerType)
 
   /**
    * @return

--- a/zio-http/src/main/scala/zio/http/Headers.scala
+++ b/zio-http/src/main/scala/zio/http/Headers.scala
@@ -44,6 +44,8 @@ sealed trait Headers extends HeaderOps[Headers] with Iterable[Header] {
 
   final def get(headerType: Header.HeaderType): Option[headerType.HeaderValue] = header(headerType)
 
+  final def getAll(headerType: Header.HeaderType): Iterable[headerType.HeaderValue] = headers(headerType)
+
   /**
    * @return
    *   null if header is not found

--- a/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
+++ b/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
@@ -16,6 +16,8 @@
 
 package zio.http.internal
 
+import zio.Chunk
+
 import zio.http.Header.HeaderType
 import zio.http.Headers
 import zio.http.internal.{CaseMode, CharSequenceExtensions}
@@ -38,17 +40,18 @@ trait HeaderGetters { self =>
       parsed.toOption
     }
 
-  final def headers(headerType: HeaderType): Seq[headerType.HeaderValue] =
-    headers.iterator
-      .filter(header =>
-        CharSequenceExtensions
-          .equals(header.headerNameAsCharSequence, headerType.name, CaseMode.Insensitive),
-      )
-      .flatMap { raw =>
-        val parsed = headerType.parse(raw.renderedValue)
-        parsed.toOption
-      }
-      .toSeq
+  final def headers(headerType: HeaderType): Chunk[headerType.HeaderValue] =
+    Chunk.from(
+      headers.iterator
+        .filter(header =>
+          CharSequenceExtensions
+            .equals(header.headerNameAsCharSequence, headerType.name, CaseMode.Insensitive),
+        )
+        .flatMap { raw =>
+          val parsed = headerType.parse(raw.renderedValue)
+          parsed.toOption
+        },
+    )
 
   /**
    * Gets a header. If the header is not present, returns None. If the header

--- a/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
+++ b/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
@@ -18,6 +18,7 @@ package zio.http.internal
 
 import zio.http.Header.HeaderType
 import zio.http.Headers
+import zio.http.internal.{CaseMode, CharSequenceExtensions}
 
 /**
  * Maintains a list of operators that parse and extract data from the headers.
@@ -36,6 +37,18 @@ trait HeaderGetters { self =>
       val parsed = headerType.parse(raw)
       parsed.toOption
     }
+
+  final def headers(headerType: HeaderType): Seq[headerType.HeaderValue] =
+    headers.iterator
+      .filter(header =>
+        CharSequenceExtensions
+          .equals(header.headerNameAsCharSequence, headerType.name, CaseMode.Insensitive),
+      )
+      .flatMap { raw =>
+        val parsed = headerType.parse(raw.renderedValue)
+        parsed.toOption
+      }
+      .toSeq
 
   /**
    * Gets a header. If the header is not present, returns None. If the header

--- a/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
+++ b/zio-http/src/main/scala/zio/http/internal/HeaderGetters.scala
@@ -41,7 +41,7 @@ trait HeaderGetters { self =>
     }
 
   final def headers(headerType: HeaderType): Chunk[headerType.HeaderValue] =
-    Chunk.from(
+    Chunk.fromIterator(
       headers.iterator
         .filter(header =>
           CharSequenceExtensions

--- a/zio-http/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HeaderSpec.scala
@@ -84,6 +84,24 @@ object HeaderSpec extends ZIOSpecDefault {
         assert(actual)(isFalse)
       },
     ),
+    suite("cookie")(
+      test("should be able to extract more than one header with the same name") {
+        val firstCookie  = Cookie.Response("first", "value")
+        val secondCookie = Cookie.Response("second", "value2")
+        val headers      = Headers(
+          Header.SetCookie(firstCookie),
+          Header.SetCookie(secondCookie),
+        )
+
+        assert(headers.getAll(Header.SetCookie))(
+          hasSameElements(Seq(Header.SetCookie(firstCookie), Header.SetCookie(secondCookie))),
+        )
+      },
+      test("should return an empty sequence if no headers in the response") {
+        val headers = Headers()
+        assert(headers.getAll(Header.SetCookie))(hasSameElements(Seq.empty))
+      },
+    ),
     suite("hasMediaType")(
       test("should return true if content-type is application/json") {
         val actual = contentTypeJson.hasMediaType(MediaType.application.json)

--- a/zio-http/src/test/scala/zio/http/ResponseSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseSpec.scala
@@ -48,6 +48,19 @@ object ResponseSpec extends ZIOSpecDefault {
         )
       },
     ),
+    suite("cookie")(
+      test("should include multiple SetCookie") {
+        val firstCookie  = Cookie.Response("first", "value")
+        val secondCookie = Cookie.Response("second", "value2")
+        val res          =
+          Response.ok.addCookie(firstCookie).addCookie(secondCookie)
+        assert(res.headers(Header.SetCookie))(
+          hasSameElements(
+            Seq(Header.SetCookie(firstCookie), Header.SetCookie(secondCookie)),
+          ),
+        )
+      },
+    ),
     suite("json")(
       test("Json should set content type to ApplicationJson") {
         val x = Response.json("""{"message": "Hello"}""")


### PR DESCRIPTION
I'm not sure about the name of the method yet, but I would like to avoid `getHeaders` and `headers` is already taken.
Should we keep `Seq` as the return type ?