### PR TITLE
Fix rendering of content type boundary

### DIFF
--- a/zio-http/src/main/scala/zio/http/Header.scala
+++ b/zio-http/src/main/scala/zio/http/Header.scala
@@ -2516,8 +2516,8 @@ object Header {
       (contentType.charset, contentType.boundary) match {
         case (None, None)                    => contentType.mediaType.fullType
         case (Some(charset), None)           => contentType.mediaType.fullType + "; charset=" + charset.toString
-        case (None, Some(boundary))          => contentType.mediaType.fullType + "; boundary=" + boundary
-        case (Some(charset), Some(boundary)) => contentType.mediaType.fullType + "; charset=" + charset.toString + "; boundary=" + boundary
+        case (None, Some(boundary))          => contentType.mediaType.fullType + "; boundary=" + boundary.id
+        case (Some(charset), Some(boundary)) => contentType.mediaType.fullType + "; charset=" + charset.toString + "; boundary=" + boundary.id
       }
   }
 


### PR DESCRIPTION
Fixes boundary not being rendered properly for content type headers.

```
println(Header.ContentType(MediaType.multipart.`form-data`, Some(Boundary("zio"))).renderedValue)
// before: multipart/form-data; boundary=Boundary(zio,UTF-8)
// after:  multipart/form-data; boundary=zio
```