### PR TITLE
Add methods to `Endpoint` to apply any kind of in/out codec

### DIFF
--- a/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
@@ -16,6 +16,8 @@
 
 package zio.http.codec
 
+import scala.util.Try
+
 import zio.http.Header
 import zio.http.Header.HeaderType
 
@@ -26,6 +28,29 @@ private[codec] trait HeaderCodecs {
   def header(headerType: HeaderType): HeaderCodec[headerType.HeaderValue] =
     headerCodec(headerType.name, TextCodec.string)
       .transformOrFailLeft(headerType.parse(_), headerType.render(_))
+
+  def name[A](name: String)(implicit codec: TextCodec[A]): HeaderCodec[A] =
+    headerCodec(name, codec)
+
+  def nameTransform[A, B](name: String, parse: B => Either[String, A], render: A => B)(implicit
+    codec: TextCodec[B],
+  ): HeaderCodec[A] =
+    headerCodec(name, codec).transformOrFailLeft(parse, render)
+
+  def nameTransformOpt[A, B](name: String, parse: B => Option[A], render: A => B)(implicit
+    codec: TextCodec[B],
+  ): HeaderCodec[A] =
+    headerCodec(name, codec).transformOrFailLeft(parse(_).toRight(s"Failed to parse header $name"), render)
+
+  def nameTransformOrFail[A, B](
+    name: String,
+    parse: B => A,
+    render: A => B,
+  )(implicit codec: TextCodec[B]): HeaderCodec[A] =
+    headerCodec(name, codec).transformOrFailLeft(
+      s => Try(parse(s)).toEither.left.map(e => s"Failed to parse header $name: ${e.getMessage}"),
+      render,
+    )
 
   final val accept: HeaderCodec[Header.Accept]                 = header(Header.Accept)
   final val acceptEncoding: HeaderCodec[Header.AcceptEncoding] = header(Header.AcceptEncoding)

--- a/zio-http/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -28,4 +28,5 @@ private[codec] trait QueryCodecs {
 
   def queryAs[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
     HttpCodec.Query(name, codec)
+
 }

--- a/zio-http/src/main/scala/zio/http/codec/TextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/TextCodec.scala
@@ -45,15 +45,15 @@ sealed trait TextCodec[A] extends PartialFunction[String, A] { self =>
 }
 
 object TextCodec {
-  val boolean: TextCodec[Boolean] = BooleanCodec
+  implicit val boolean: TextCodec[Boolean] = BooleanCodec
 
   def constant(string: String): TextCodec[Unit] = Constant(string)
 
-  val int: TextCodec[Int] = IntCodec
+  implicit val int: TextCodec[Int] = IntCodec
 
-  val string: TextCodec[String] = StringCodec
+  implicit val string: TextCodec[String] = StringCodec
 
-  val uuid: TextCodec[UUID] = UUIDCodec
+  implicit val uuid: TextCodec[UUID] = UUIDCodec
 
   final case class Constant(string: String) extends TextCodec[Unit] {
 


### PR DESCRIPTION
- add some convenience methods for creating header codecs
- make text codecs implicit for easy usage in header and query codec
