### PR TITLE
rename html to html5

### DIFF
--- a/zio-http-example/src/main/scala/example/HtmlTemplating.scala
+++ b/zio-http-example/src/main/scala/example/HtmlTemplating.scala
@@ -3,7 +3,7 @@ package example
 import zio._
 import zio.http._
 
-// Importing everything from `zio.html`
+// Importing everything from `zio.http.html`
 import zio.http.html._
 
 object HtmlTemplating extends ZIOAppDefault {

--- a/zio-http-example/src/main/scala/example/HtmlTemplating.scala
+++ b/zio-http-example/src/main/scala/example/HtmlTemplating.scala
@@ -1,19 +1,18 @@
 package example
 
 import zio._
-
 import zio.http._
 
-object HtmlTemplating extends ZIOAppDefault {
-  // Importing everything from `zio.html`
-  import zio.http.html._
+// Importing everything from `zio.html`
+import zio.http.html._
 
+object HtmlTemplating extends ZIOAppDefault {
   def app: Handler[Any, Nothing, Any, Response] = {
     // Html response takes in a `Html` instance.
     Handler.html {
 
       // Support for default Html tags
-      html(
+      html5(
         // Support for child nodes
         head(
           title("ZIO Http"),

--- a/zio-http/src/main/scala/zio/http/html/Elements.scala
+++ b/zio-http/src/main/scala/zio/http/html/Elements.scala
@@ -131,7 +131,7 @@ trait Elements {
 
   final def hr: PartialElement = PartialElement("hr")
 
-  final def html: PartialElement = PartialElement("html")
+  final def html5: PartialElement = PartialElement("html")
 
   final def i: PartialElement = PartialElement("i")
 

--- a/zio-http/src/main/scala/zio/http/html/Template.scala
+++ b/zio-http/src/main/scala/zio/http/html/Template.scala
@@ -22,7 +22,7 @@ package zio.http.html
 object Template {
 
   def container(heading: CharSequence)(element: Html): Html = {
-    html(
+    html5(
       head(
         title(s"ZIO Http - ${heading}"),
         style("""

--- a/zio-http/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ServerSpec.scala
@@ -303,11 +303,11 @@ object ServerSpec extends HttpRunnableSpec {
     suite("html")(
       test("body") {
         val res =
-          Handler.html(zio.http.html.html(body(div(id := "foo", "bar")))).toHttp.deploy.body.mapZIO(_.asString).run()
+          Handler.html(zio.http.html.html5(body(div(id := "foo", "bar")))).toHttp.deploy.body.mapZIO(_.asString).run()
         assertZIO(res)(equalTo("""<!DOCTYPE html><html><body><div id="foo">bar</div></body></html>"""))
       },
       test("content-type") {
-        val app = Handler.html(zio.http.html.html(body(div(id := "foo", "bar")))).toHttp
+        val app = Handler.html(zio.http.html.html5(body(div(id := "foo", "bar")))).toHttp
         val res = app.deploy.header(Header.ContentType).run()
         assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.text.html))))
       },

--- a/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
+++ b/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
@@ -23,35 +23,35 @@ case object HtmlSpec extends ZIOSpecDefault {
   def spec = {
     suite("HtmlSpec")(
       test("tags") {
-        val view     = html(head(), body(div()))
+        val view     = html5(head(), body(div()))
         val expected = """<html><head></head><body><div></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!")))
+        val view     = html5(body(div(css := "container" :: Nil, "Hello!")))
         val expected = """<html><body><div class="container">Hello!</div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html5(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html5(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html5(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html5(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))


### PR DESCRIPTION
A top level import in a e.g. `UserRoutes.scala` like
```scala
import zio.http._
import zio.http.html._

case class UserRoutes(userService:IUserService) {
    private def withLayout(content: Dom) = 
        html(
            head(
                title("User")
            ), 
...

```
results in a: 

```scala
[error] /tmp/aaa/blupp/src/main/scala/com/example/blupp/UserRoutes.scala:13:9: reference to html is ambiguous;
[error] it is imported twice in the same scope by
[error] import zio.http.html._
[error] and import zio.http._
[error]         html(
[error]         ^
[error] one error found
```

A possible workaround would be `import zio.http.html.{html => html5, _}`. Otherwise, in order to improve DX, I think it's worthwhile to rename the element `html` to `html5`. With that change both toplevel imports shown above would work without any surprises. 
