### PR TITLE
Support for multipart/form-data in endpoint API

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -82,8 +82,8 @@ private[cli] object CliEndpoint {
             r <- fromInput(right)
           } yield l ++ r
 
-      case HttpCodec.Content(schema, _, _)          => fromSchema(schema)
-      case HttpCodec.ContentStream(schema, _, _)    => fromSchema(schema)
+      case HttpCodec.Content(schema, _, _, _)       => fromSchema(schema)
+      case HttpCodec.ContentStream(schema, _, _, _) => fromSchema(schema)
       case HttpCodec.Empty                          => Set.empty
       case HttpCodec.Fallback(left, right)          => fromInput(left) ++ fromInput(right)
       case HttpCodec.Halt                           => Set.empty

--- a/zio-http/src/main/scala/zio/http/codec/ContentCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/ContentCodecs.scala
@@ -23,15 +23,31 @@ import zio.schema.Schema
 import zio.http.MediaType
 
 private[codec] trait ContentCodecs {
+  def content[A](name: String)(implicit schema: Schema[A]): ContentCodec[A] =
+    HttpCodec.Content(schema, mediaType = None, Some(name))
+
   def content[A](implicit schema: Schema[A]): ContentCodec[A] =
-    HttpCodec.Content(schema, mediaType = None)
+    HttpCodec.Content(schema, mediaType = None, None)
+
+  def content[A](name: String, mediaType: MediaType)(implicit schema: Schema[A]): ContentCodec[A] =
+    HttpCodec.Content(schema, mediaType = Some(mediaType), Some(name))
 
   def content[A](mediaType: MediaType)(implicit schema: Schema[A]): ContentCodec[A] =
-    HttpCodec.Content(schema, mediaType = Some(mediaType))
+    HttpCodec.Content(schema, mediaType = Some(mediaType), None)
+
+  def contentStream[A](name: String)(implicit schema: Schema[A]): ContentCodec[ZStream[Any, Nothing, A]] =
+    HttpCodec.ContentStream(schema, mediaType = None, Some(name))
 
   def contentStream[A](implicit schema: Schema[A]): ContentCodec[ZStream[Any, Nothing, A]] =
-    HttpCodec.ContentStream(schema, mediaType = None)
+    HttpCodec.ContentStream(schema, mediaType = None, None)
 
-  def contentStream[A](mediaType: MediaType)(implicit schema: Schema[A]): ContentCodec[ZStream[Any, Nothing, A]] =
-    HttpCodec.ContentStream(schema, mediaType = Some(mediaType))
+  def contentStream[A](name: String, mediaType: MediaType)(implicit
+    schema: Schema[A],
+  ): ContentCodec[ZStream[Any, Nothing, A]] =
+    HttpCodec.ContentStream(schema, mediaType = Some(mediaType), Some(name))
+
+  def contentStream[A](mediaType: MediaType)(implicit
+    schema: Schema[A],
+  ): ContentCodec[ZStream[Any, Nothing, A]] =
+    HttpCodec.ContentStream(schema, mediaType = Some(mediaType), None)
 }

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -288,7 +288,7 @@ object HttpCodec
   def error[Body](status: zio.http.Status)(implicit
     schema: Schema[Body],
   ): HttpCodec[HttpCodecType.Status with HttpCodecType.Content, Body] =
-    content[Body] ++ this.status(status)
+    content[Body]("error-response") ++ this.status(status)
 
   private[http] sealed trait AtomTag
   private[http] object AtomTag {
@@ -502,7 +502,7 @@ object HttpCodec
   }
 
   private[http] final case class Status[A](codec: SimpleCodec[zio.http.Status, A], index: Int = 0)
-      extends Atom[HttpCodecType.Status, A]                         {
+      extends Atom[HttpCodecType.Status, A] {
     self =>
     def erase: Status[Any] = self.asInstanceOf[Status[Any]]
 
@@ -511,28 +511,36 @@ object HttpCodec
     def withIndex(index: Int): Status[A] = copy(index = index)
   }
   private[http] final case class Path[A](textCodec: TextCodec[A], name: Option[String], index: Int = 0)
-      extends Atom[HttpCodecType.Path, A]                           { self =>
+      extends Atom[HttpCodecType.Path, A]   { self =>
     def erase: Path[Any] = self.asInstanceOf[Path[Any]]
 
     def tag: AtomTag = AtomTag.Path
 
     def withIndex(index: Int): Path[A] = copy(index = index)
   }
-  private[http] final case class Content[A](schema: Schema[A], mediaType: Option[MediaType], index: Int = 0)
-      extends Atom[HttpCodecType.Content, A]                        {
+  private[http] final case class Content[A](
+    schema: Schema[A],
+    mediaType: Option[MediaType],
+    name: Option[String],
+    index: Int = 0,
+  ) extends Atom[HttpCodecType.Content, A] {
     self =>
     def tag: AtomTag = AtomTag.Content
 
     def withIndex(index: Int): Content[A] = copy(index = index)
   }
-  private[http] final case class ContentStream[A](schema: Schema[A], mediaType: Option[MediaType], index: Int = 0)
-      extends Atom[HttpCodecType.Content, ZStream[Any, Nothing, A]] {
+  private[http] final case class ContentStream[A](
+    schema: Schema[A],
+    mediaType: Option[MediaType],
+    name: Option[String],
+    index: Int = 0,
+  ) extends Atom[HttpCodecType.Content, ZStream[Any, Nothing, A]] {
     def tag: AtomTag = AtomTag.Content
 
     def withIndex(index: Int): ContentStream[A] = copy(index = index)
   }
   private[http] final case class Query[A](name: String, textCodec: TextCodec[A], index: Int = 0)
-      extends Atom[HttpCodecType.Query, A]                          {
+      extends Atom[HttpCodecType.Query, A]  {
     self =>
     def erase: Query[Any] = self.asInstanceOf[Query[Any]]
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
@@ -30,14 +30,15 @@ private[http] final case class AtomizedCodecs(
   status: Chunk[SimpleCodec[zio.http.Status, _]],
 ) { self =>
   def append(atom: Atom[_, _]): AtomizedCodecs = atom match {
-    case path0: Path[_]       => self.copy(path = path :+ path0.textCodec)
-    case method0: Method[_]   => self.copy(method = method :+ method0.codec)
-    case query0: Query[_]     => self.copy(query = query :+ query0)
-    case header0: Header[_]   => self.copy(header = header :+ header0)
-    case content0: Content[_] => self.copy(content = content :+ BodyCodec.Single(content0.schema, content0.mediaType))
-    case status0: Status[_]   => self.copy(status = status :+ status0.codec)
+    case path0: Path[_]            => self.copy(path = path :+ path0.textCodec)
+    case method0: Method[_]        => self.copy(method = method :+ method0.codec)
+    case query0: Query[_]          => self.copy(query = query :+ query0)
+    case header0: Header[_]        => self.copy(header = header :+ header0)
+    case content0: Content[_]      =>
+      self.copy(content = content :+ BodyCodec.Single(content0.schema, content0.mediaType, content0.name))
+    case status0: Status[_]        => self.copy(status = status :+ status0.codec)
     case stream0: ContentStream[_] =>
-      self.copy(content = content :+ BodyCodec.Multiple(stream0.schema, stream0.mediaType))
+      self.copy(content = content :+ BodyCodec.Multiple(stream0.schema, stream0.mediaType, stream0.name))
   }
 
   def makeInputsBuilder(): Mechanic.InputsBuilder = {

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -16,14 +16,18 @@
 
 package zio.http.codec.internal
 
+import java.nio.charset.CharacterCodingException
+import java.time._
+import java.util.UUID
+
 import scala.collection.mutable
 
 import zio._
 
-import zio.stream.ZStream
+import zio.stream.{ZPipeline, ZStream}
 
-import zio.schema.Schema
 import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
 
 import zio.http._
 import zio.http.codec._
@@ -112,9 +116,6 @@ private[codec] object EncoderDecoder                   {
       {
         val erased = bodyCodec.erase
         erased.schema match {
-          case schema if schema == Schema[String] =>
-            FormField.simpleField(name, value.asInstanceOf[String])
-
           case Schema.Primitive(_, _) =>
             FormField.simpleField(name, value.toString)
           case _                      =>
@@ -130,6 +131,75 @@ private[codec] object EncoderDecoder                   {
     private val jsonDecoders      = flattened.content.map { bodyCodec =>
       val jsonCodec = JsonCodec.schemaBasedBinaryCodec(bodyCodec.schema)
       bodyCodec.decodeFromBody(_, jsonCodec)
+    }
+    private val formFieldDecoders = flattened.content.map { bodyCodec => (field: FormField) =>
+      {
+        def fieldAsText = field match {
+          case FormField.Text(_, value, _, _)                =>
+            ZIO.succeed(value)
+          case FormField.Binary(_, value, _, _, _)           =>
+            ZIO.succeed(new String(value.toArray, Charsets.Utf8))
+          case FormField.StreamingBinary(_, _, _, _, stream) =>
+            stream.via(ZPipeline.utf8Decode).runFold("")(_ ++ _)
+          case FormField.Simple(_, value)                    =>
+            ZIO.succeed(value)
+        }
+
+        def fieldAsChunk: ZIO[Any, Nothing, Chunk[Byte]] = field match {
+          case FormField.Text(_, value, _, _)                =>
+            ZIO.succeed(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
+          case FormField.Binary(_, value, _, _, _)           =>
+            ZIO.succeed(value)
+          case FormField.StreamingBinary(_, _, _, _, stream) =>
+            stream.runCollect
+          case FormField.Simple(_, value)                    =>
+            ZIO.succeed(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
+        }
+
+        val erased = bodyCodec.erase
+        erased.schema match {
+          case Schema.Primitive(standardType, _) =>
+            fieldAsText.flatMap { text =>
+              standardType.asInstanceOf[StandardType[_]] match {
+                case StandardType.UnitType           => ZIO.succeed(())
+                case StandardType.StringType         => ZIO.succeed(text)
+                case StandardType.BoolType           => ZIO.attempt(text.toBoolean)
+                case StandardType.ByteType           => ZIO.attempt(text.toByte)
+                case StandardType.ShortType          => ZIO.attempt(text.toShort)
+                case StandardType.IntType            => ZIO.attempt(text.toInt)
+                case StandardType.LongType           => ZIO.attempt(text.toLong)
+                case StandardType.FloatType          => ZIO.attempt(text.toFloat)
+                case StandardType.DoubleType         => ZIO.attempt(text.toDouble)
+                case StandardType.BinaryType         => ZIO.die(new IllegalStateException("Binary is not supported"))
+                case StandardType.CharType           => ZIO.attempt(text.charAt(0))
+                case StandardType.UUIDType           => ZIO.attempt(UUID.fromString(text))
+                case StandardType.BigDecimalType     => ZIO.attempt(BigDecimal(text))
+                case StandardType.BigIntegerType     => ZIO.attempt(BigInt(text))
+                case StandardType.DayOfWeekType      => ZIO.attempt(DayOfWeek.valueOf(text))
+                case StandardType.MonthType          => ZIO.attempt(Month.valueOf(text))
+                case StandardType.MonthDayType       => ZIO.attempt(MonthDay.parse(text))
+                case StandardType.PeriodType         => ZIO.attempt(Period.parse(text))
+                case StandardType.YearType           => ZIO.attempt(Year.parse(text))
+                case StandardType.YearMonthType      => ZIO.attempt(YearMonth.parse(text))
+                case StandardType.ZoneIdType         => ZIO.attempt(ZoneId.of(text))
+                case StandardType.ZoneOffsetType     => ZIO.attempt(ZoneOffset.of(text))
+                case StandardType.DurationType       => ZIO.attempt(java.time.Duration.parse(text))
+                case StandardType.InstantType        => ZIO.attempt(Instant.parse(text))
+                case StandardType.LocalDateType      => ZIO.attempt(LocalDate.parse(text))
+                case StandardType.LocalTimeType      => ZIO.attempt(LocalTime.parse(text))
+                case StandardType.LocalDateTimeType  => ZIO.attempt(LocalDateTime.parse(text))
+                case StandardType.OffsetTimeType     => ZIO.attempt(OffsetTime.parse(text))
+                case StandardType.OffsetDateTimeType => ZIO.attempt(OffsetDateTime.parse(text))
+                case StandardType.ZonedDateTimeType  => ZIO.attempt(ZonedDateTime.parse(text))
+              }
+            }
+          case _                                 =>
+            val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+            fieldAsChunk.flatMap { chunk =>
+              ZIO.fromEither(jsonCodec.decode(chunk))
+            }
+        }
+      }
     }
     private val formBoundary      = Boundary("----zio-http-boundary-D4792A5C-93E0-43B5-9A1F-48E38FDE5714")
 
@@ -265,8 +335,40 @@ private[codec] object EncoderDecoder                   {
       } else if (jsonDecoders.length == 1) {
         jsonDecoders(0)(body).map { result => inputs(0) = result }
       } else {
-        ZIO.foreachDiscard(jsonDecoders.zipWithIndex) { case (decoder, index) =>
-          decoder(body).map { result => inputs(index) = result }
+        val indexByName = flattened.content.zipWithIndex.map { case (codec, idx) =>
+          codec.name.getOrElse("field" + idx.toString) -> idx
+        }.toMap
+        body.asMultipartFormStream.flatMap { form =>
+          form.fields.runForeach { field =>
+            indexByName.get(field.name) match {
+              case Some(idx) =>
+                flattened.content(idx) match {
+                  case BodyCodec.Multiple(schema, _, _) if schema == Schema[Byte] =>
+                    field match {
+                      case FormField.Binary(_, data, _, _, _)          =>
+                        ZIO.succeed {
+                          inputs(idx) = ZStream.fromChunk(data)
+                        }
+                      case FormField.StreamingBinary(_, _, _, _, data) =>
+                        ZIO.succeed {
+                          inputs(idx) = data
+                        }
+                      case FormField.Text(_, value, _, _)              =>
+                        ZIO.succeed {
+                          inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
+                        }
+                      case FormField.Simple(_, value)                  =>
+                        ZIO.succeed {
+                          inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
+                        }
+                    }
+                  case _                                                          =>
+                    formFieldDecoders(idx)(field).map { result => inputs(idx) = result }
+                }
+              case None      =>
+                ZIO.fail(HttpCodecError.MalformedBody(s"Unexpected multipart/form-data field: ${field.name}"))
+            }
+          }
         }
       }
     }

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -20,8 +20,6 @@ import java.nio.charset.CharacterCodingException
 import java.time._
 import java.util.UUID
 
-import scala.collection.mutable
-
 import zio._
 
 import zio.stream.{ZPipeline, ZStream}
@@ -107,101 +105,86 @@ private[codec] object EncoderDecoder                   {
 
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
-    private val jsonEncoders      = flattened.content.map { bodyCodec =>
-      val erased    = bodyCodec.erase
-      val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
-      erased.encodeToBody(_, jsonCodec)
-    }
-    private val formFieldEncoders = flattened.content.map { bodyCodec => (name: String, value: Any) =>
-      {
-        val erased = bodyCodec.erase
-        erased.schema match {
-          case Schema.Primitive(_, _) =>
-            FormField.simpleField(name, value.toString)
-          case _                      =>
-            val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
-            FormField.textField(
-              name,
-              new String(jsonCodec.encode(value.asInstanceOf[erased.Element]).toArray, Charsets.Utf8),
-              MediaType.application.json,
-            )
+    private val jsonEncoders: Chunk[Any => Body]                          =
+      flattened.content.map { bodyCodec =>
+        val erased    = bodyCodec.erase
+        val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+        erased.encodeToBody(_, jsonCodec)
+      }
+    private val formFieldEncoders: Chunk[(String, Any) => FormField]      =
+      flattened.content.map { bodyCodec => (name: String, value: Any) =>
+        {
+          val erased = bodyCodec.erase
+          erased.schema match {
+            case Schema.Primitive(_, _) =>
+              FormField.simpleField(name, value.toString)
+            case _                      =>
+              val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+              FormField.textField(
+                name,
+                new String(jsonCodec.encode(value.asInstanceOf[erased.Element]).toArray, Charsets.Utf8),
+                MediaType.application.json,
+              )
+          }
         }
       }
-    }
-    private val jsonDecoders      = flattened.content.map { bodyCodec =>
-      val jsonCodec = JsonCodec.schemaBasedBinaryCodec(bodyCodec.schema)
-      bodyCodec.decodeFromBody(_, jsonCodec)
-    }
-    private val formFieldDecoders = flattened.content.map { bodyCodec => (field: FormField) =>
-      {
-        def fieldAsText = field match {
-          case FormField.Text(_, value, _, _)                =>
-            ZIO.succeed(value)
-          case FormField.Binary(_, value, _, _, _)           =>
-            ZIO.succeed(new String(value.toArray, Charsets.Utf8))
-          case FormField.StreamingBinary(_, _, _, _, stream) =>
-            stream.via(ZPipeline.utf8Decode).runFold("")(_ ++ _)
-          case FormField.Simple(_, value)                    =>
-            ZIO.succeed(value)
-        }
-
-        def fieldAsChunk: ZIO[Any, Nothing, Chunk[Byte]] = field match {
-          case FormField.Text(_, value, _, _)                =>
-            ZIO.succeed(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
-          case FormField.Binary(_, value, _, _, _)           =>
-            ZIO.succeed(value)
-          case FormField.StreamingBinary(_, _, _, _, stream) =>
-            stream.runCollect
-          case FormField.Simple(_, value)                    =>
-            ZIO.succeed(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
-        }
-
-        val erased = bodyCodec.erase
-        erased.schema match {
-          case Schema.Primitive(standardType, _) =>
-            fieldAsText.flatMap { text =>
-              standardType.asInstanceOf[StandardType[_]] match {
-                case StandardType.UnitType           => ZIO.succeed(())
-                case StandardType.StringType         => ZIO.succeed(text)
-                case StandardType.BoolType           => ZIO.attempt(text.toBoolean)
-                case StandardType.ByteType           => ZIO.attempt(text.toByte)
-                case StandardType.ShortType          => ZIO.attempt(text.toShort)
-                case StandardType.IntType            => ZIO.attempt(text.toInt)
-                case StandardType.LongType           => ZIO.attempt(text.toLong)
-                case StandardType.FloatType          => ZIO.attempt(text.toFloat)
-                case StandardType.DoubleType         => ZIO.attempt(text.toDouble)
-                case StandardType.BinaryType         => ZIO.die(new IllegalStateException("Binary is not supported"))
-                case StandardType.CharType           => ZIO.attempt(text.charAt(0))
-                case StandardType.UUIDType           => ZIO.attempt(UUID.fromString(text))
-                case StandardType.BigDecimalType     => ZIO.attempt(BigDecimal(text))
-                case StandardType.BigIntegerType     => ZIO.attempt(BigInt(text))
-                case StandardType.DayOfWeekType      => ZIO.attempt(DayOfWeek.valueOf(text))
-                case StandardType.MonthType          => ZIO.attempt(Month.valueOf(text))
-                case StandardType.MonthDayType       => ZIO.attempt(MonthDay.parse(text))
-                case StandardType.PeriodType         => ZIO.attempt(Period.parse(text))
-                case StandardType.YearType           => ZIO.attempt(Year.parse(text))
-                case StandardType.YearMonthType      => ZIO.attempt(YearMonth.parse(text))
-                case StandardType.ZoneIdType         => ZIO.attempt(ZoneId.of(text))
-                case StandardType.ZoneOffsetType     => ZIO.attempt(ZoneOffset.of(text))
-                case StandardType.DurationType       => ZIO.attempt(java.time.Duration.parse(text))
-                case StandardType.InstantType        => ZIO.attempt(Instant.parse(text))
-                case StandardType.LocalDateType      => ZIO.attempt(LocalDate.parse(text))
-                case StandardType.LocalTimeType      => ZIO.attempt(LocalTime.parse(text))
-                case StandardType.LocalDateTimeType  => ZIO.attempt(LocalDateTime.parse(text))
-                case StandardType.OffsetTimeType     => ZIO.attempt(OffsetTime.parse(text))
-                case StandardType.OffsetDateTimeType => ZIO.attempt(OffsetDateTime.parse(text))
-                case StandardType.ZonedDateTimeType  => ZIO.attempt(ZonedDateTime.parse(text))
+    private val jsonDecoders: Chunk[Body => IO[Throwable, _]]             =
+      flattened.content.map { bodyCodec =>
+        val jsonCodec = JsonCodec.schemaBasedBinaryCodec(bodyCodec.schema)
+        bodyCodec.decodeFromBody(_, jsonCodec)
+      }
+    private val formFieldDecoders: Chunk[FormField => IO[Throwable, Any]] =
+      flattened.content.map { bodyCodec => (field: FormField) =>
+        {
+          val erased = bodyCodec.erase
+          erased.schema match {
+            case Schema.Primitive(standardType, _) =>
+              field.asText.flatMap { text =>
+                standardType.asInstanceOf[StandardType[_]] match {
+                  case StandardType.UnitType           => ZIO.succeed(())
+                  case StandardType.StringType         => ZIO.succeed(text)
+                  case StandardType.BoolType           => ZIO.attempt(text.toBoolean)
+                  case StandardType.ByteType           => ZIO.attempt(text.toByte)
+                  case StandardType.ShortType          => ZIO.attempt(text.toShort)
+                  case StandardType.IntType            => ZIO.attempt(text.toInt)
+                  case StandardType.LongType           => ZIO.attempt(text.toLong)
+                  case StandardType.FloatType          => ZIO.attempt(text.toFloat)
+                  case StandardType.DoubleType         => ZIO.attempt(text.toDouble)
+                  case StandardType.BinaryType         => ZIO.die(new IllegalStateException("Binary is not supported"))
+                  case StandardType.CharType           => ZIO.attempt(text.charAt(0))
+                  case StandardType.UUIDType           => ZIO.attempt(UUID.fromString(text))
+                  case StandardType.BigDecimalType     => ZIO.attempt(BigDecimal(text))
+                  case StandardType.BigIntegerType     => ZIO.attempt(BigInt(text))
+                  case StandardType.DayOfWeekType      => ZIO.attempt(DayOfWeek.valueOf(text))
+                  case StandardType.MonthType          => ZIO.attempt(Month.valueOf(text))
+                  case StandardType.MonthDayType       => ZIO.attempt(MonthDay.parse(text))
+                  case StandardType.PeriodType         => ZIO.attempt(Period.parse(text))
+                  case StandardType.YearType           => ZIO.attempt(Year.parse(text))
+                  case StandardType.YearMonthType      => ZIO.attempt(YearMonth.parse(text))
+                  case StandardType.ZoneIdType         => ZIO.attempt(ZoneId.of(text))
+                  case StandardType.ZoneOffsetType     => ZIO.attempt(ZoneOffset.of(text))
+                  case StandardType.DurationType       => ZIO.attempt(java.time.Duration.parse(text))
+                  case StandardType.InstantType        => ZIO.attempt(Instant.parse(text))
+                  case StandardType.LocalDateType      => ZIO.attempt(LocalDate.parse(text))
+                  case StandardType.LocalTimeType      => ZIO.attempt(LocalTime.parse(text))
+                  case StandardType.LocalDateTimeType  => ZIO.attempt(LocalDateTime.parse(text))
+                  case StandardType.OffsetTimeType     => ZIO.attempt(OffsetTime.parse(text))
+                  case StandardType.OffsetDateTimeType => ZIO.attempt(OffsetDateTime.parse(text))
+                  case StandardType.ZonedDateTimeType  => ZIO.attempt(ZonedDateTime.parse(text))
+                }
               }
-            }
-          case _                                 =>
-            val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
-            fieldAsChunk.flatMap { chunk =>
-              ZIO.fromEither(jsonCodec.decode(chunk))
-            }
+            case _                                 =>
+              val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+              field.asChunk.flatMap { chunk =>
+                ZIO.fromEither(jsonCodec.decode(chunk))
+              }
+          }
         }
       }
-    }
-    private val formBoundary      = Boundary("----zio-http-boundary-D4792A5C-93E0-43B5-9A1F-48E38FDE5714")
+    private val formBoundary = Boundary("----zio-http-boundary-D4792A5C-93E0-43B5-9A1F-48E38FDE5714")
+    private val indexByName  = flattened.content.zipWithIndex.map { case (codec, idx) =>
+      codec.name.getOrElse("field" + idx.toString) -> idx
+    }.toMap
 
     def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
       trace: Trace,
@@ -335,9 +318,6 @@ private[codec] object EncoderDecoder                   {
       } else if (jsonDecoders.length == 1) {
         jsonDecoders(0)(body).map { result => inputs(0) = result }
       } else {
-        val indexByName = flattened.content.zipWithIndex.map { case (codec, idx) =>
-          codec.name.getOrElse("field" + idx.toString) -> idx
-        }.toMap
         body.asMultipartFormStream.flatMap { form =>
           form.fields.runForeach { field =>
             indexByName.get(field.name) match {
@@ -346,27 +326,29 @@ private[codec] object EncoderDecoder                   {
                   case BodyCodec.Multiple(schema, _, _) if schema == Schema[Byte] =>
                     field match {
                       case FormField.Binary(_, data, _, _, _)          =>
-                        ZIO.succeed {
-                          inputs(idx) = ZStream.fromChunk(data)
-                        }
+                        inputs(idx) = ZStream.fromChunk(data)
                       case FormField.StreamingBinary(_, _, _, _, data) =>
-                        ZIO.succeed {
-                          inputs(idx) = data
-                        }
+                        inputs(idx) = data
                       case FormField.Text(_, value, _, _)              =>
-                        ZIO.succeed {
-                          inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
-                        }
+                        inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
                       case FormField.Simple(_, value)                  =>
-                        ZIO.succeed {
-                          inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
-                        }
+                        inputs(idx) = ZStream.fromChunk(Chunk.fromArray(value.getBytes(Charsets.Utf8)))
                     }
+                    ZIO.unit
                   case _                                                          =>
                     formFieldDecoders(idx)(field).map { result => inputs(idx) = result }
                 }
               case None      =>
                 ZIO.fail(HttpCodecError.MalformedBody(s"Unexpected multipart/form-data field: ${field.name}"))
+            }
+          }.zipRight {
+            ZIO.attempt {
+              for (idx <- inputs.indices) {
+                if (inputs(idx) == null)
+                  throw HttpCodecError.MalformedBody(
+                    s"Missing multipart/form-data field (${flattened.content(idx).name.getOrElse("field" + idx.toString)}",
+                  )
+              }
             }
           }
         }
@@ -452,12 +434,11 @@ private[codec] object EncoderDecoder                   {
         if (inputs.length > 1) {
           Body.fromMultipartForm(encodeMultipartFormData(inputs), formBoundary)
         } else {
-          if (jsonEncoders.length == 0) Body.empty
-          else if (jsonEncoders.length == 1) {
+          if (jsonEncoders.length < 1) Body.empty
+          else {
             val encoder = jsonEncoders(0)
-
             encoder(inputs(0))
-          } else throw new IllegalStateException("A request on a REST endpoint should have at most one body")
+          }
         }
       }
     }
@@ -489,11 +470,11 @@ private[codec] object EncoderDecoder                   {
         if (inputs.length > 1) {
           Headers(Header.ContentType(MediaType.multipart.`form-data`))
         } else {
-          if (jsonEncoders.length == 0) Headers.empty
-          else if (jsonEncoders.length == 1) {
+          if (jsonEncoders.length < 1) Headers.empty
+          else {
             val mediaType = flattened.content(0).mediaType.getOrElse(MediaType.application.json)
             Headers(Header.ContentType(mediaType))
-          } else throw new IllegalStateException("A request on a REST endpoint should have at most one body")
+          }
         }
       }
     }

--- a/zio-http/src/test/scala/zio/http/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FormSpec.scala
@@ -44,8 +44,8 @@ object FormSpec extends ZIOSpecDefault {
         val form = ZIO.fromEither(Form.fromURLEncoded("name=John&age=30", StandardCharsets.UTF_8))
         form.map { form =>
           assertTrue(
-            form.get("age").get.valueAsString.get == "30",
-            form.get("name").get.valueAsString.get == "John",
+            form.get("age").get.stringValue.get == "30",
+            form.get("name").get.stringValue.get == "John",
           )
         }
       },
@@ -113,7 +113,7 @@ object FormSpec extends ZIOSpecDefault {
       Form.fromMultipartBytes(multipartFormBytes3).map { form =>
         assertTrue(
           form.get("file").get.filename.get == "test.jsonl",
-          form.get("file").get.valueAsString.isEmpty,
+          form.get("file").get.stringValue.isEmpty,
           form.get("file").get.asInstanceOf[FormField.Binary].data.size == 69,
         )
       }
@@ -201,7 +201,7 @@ object FormSpec extends ZIOSpecDefault {
             new String(form.get("file").get.asInstanceOf[FormField.Binary].data.toArray, StandardCharsets.UTF_8)
           assertTrue(
             form.get("file").get.filename.get == "test.jsonl",
-            form.get("file").get.valueAsString.isEmpty,
+            form.get("file").get.stringValue.isEmpty,
             form.get("file").get.asInstanceOf[FormField.Binary].data.size == 69,
             contents == """{"prompt": "<prompt text>", "completion": "<ideal generated text>"}""" + "\r\n",
           )


### PR DESCRIPTION
Resolves #2140 
/claim #2140 

- [x] Naming body codecs
- [x] Multipart encoding for output
- [x] Multipart encoding for input
