### PR TITLE
Fix authentication via middleware (#2159)

### DIFF
--- a/zio-http/src/main/scala/zio/http/RequestHandlerMiddleware.scala
+++ b/zio-http/src/main/scala/zio/http/RequestHandlerMiddleware.scala
@@ -132,13 +132,16 @@ object RequestHandlerMiddleware {
           Http.Static(apply(handler), errorHandler.map(applyToErrorHandler))
         case route: Http.Route[Env, Err, Request, Response] =>
           Http
-            .fromHttpZIO[Request](route.run(_).map(self(_)))
+            .fromHttpZIO[Request] { r =>
+              val x = route.run(r)
+              x.map(self(_))
+            }
             .withErrorHandler(route.errorHandler.map(applyToErrorHandler))
       }
 
     def applyToErrorHandler[Env <: UpperEnv](
       f: Cause[Nothing] => ZIO[Env, Nothing, Response],
-    )(implicit trace: Trace): (Cause[Nothing] => ZIO[Env, Nothing, Response]) =
+    )(implicit trace: Trace): Cause[Nothing] => ZIO[Env, Nothing, Response] =
       f
   }
 


### PR DESCRIPTION
- Only exec. code for authenticated routes
- Only authenticate matching routes

fixes #2159 

I introduced a new method `applicable` on `Http.Routes`. I think this is necessary, to be able to know outside of the constructors, if that routes object is able to handle a given request. 
Why do we care? Because if it does not, we are not allowed to check the authentication attached to this `Http`.
Else `Http.collect[Request](PartialFunction.empty) @@ myAuth` would always return unauthenticated even though it has nothing to authenticate and other apps that a user would combine via `++` would be ignored.
It also enables us, to avoid executing any code on the rhs of path/route matches in the collect methods.

One test is still red. I am not sure why. Sadly the error message is just `Assertion failed:  Exception in thread "zio-fiber-" scala.None$: None` maybe you can give me a hint?

/claim #2159