### PR TITLE
Make Http.collect safe

### DIFF
--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -140,12 +140,12 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   final def catchAll[R1 <: R, Err1, In1 <: In, Out1 >: Out](f: Err => Handler[R1, Err1, In1, Out1])(implicit
     trace: Trace,
   ): Handler[R1, Err1, In1, Out1] =
-    self.foldHandler(f, Handler.succeed)
+    self.foldHandler(f, Handler.succeed(_))
 
   final def catchAllCause[R1 <: R, Err1, In1 <: In, Out1 >: Out](f: Cause[Err] => Handler[R1, Err1, In1, Out1])(implicit
     trace: Trace,
   ): Handler[R1, Err1, In1, Out1] =
-    self.foldCauseHandler(f, Handler.succeed)
+    self.foldCauseHandler(f, Handler.succeed(_))
 
   /**
    * Recovers from all defects with provided function.
@@ -160,7 +160,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   ): Handler[R1, Err1, In1, Out1] =
     self.foldCauseHandler(
       cause => cause.dieOption.fold[Handler[R1, Err1, In1, Out1]](Handler.failCause(cause))(f),
-      Handler.succeed,
+      Handler.succeed(_),
     )
 
   /**
@@ -328,7 +328,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
    * Transforms the failure of the handler
    */
   final def mapError[Err1](f: Err => Err1)(implicit trace: Trace): Handler[R, Err1, In, Out] =
-    self.foldHandler(err => Handler.fail(f(err)), Handler.succeed)
+    self.foldHandler(err => Handler.fail(f(err)), Handler.succeed(_))
 
   /**
    * Transforms the output of the handler effectfully
@@ -344,7 +344,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   final def mapErrorZIO[R1 <: R, Err1, Out1 >: Out](f: Err => ZIO[R1, Err1, Out1])(implicit
     trace: Trace,
   ): Handler[R1, Err1, In, Out1] =
-    self.foldHandler(err => Handler.fromZIO(f(err)), Handler.succeed)
+    self.foldHandler(err => Handler.fromZIO(f(err)), Handler.succeed(_))
 
   /**
    * Returns a new handler where the error channel has been merged into the
@@ -394,7 +394,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
    * specified function to convert the `E` into a `Throwable`.
    */
   final def orDieWith(f: Err => Throwable)(implicit ev: CanFail[Err], trace: Trace): Handler[R, Nothing, In, Out] =
-    self.foldHandler(err => Handler.die(f(err)), Handler.succeed)
+    self.foldHandler(err => Handler.die(f(err)), Handler.succeed(_))
 
   /**
    * Named alias for `<>`
@@ -490,7 +490,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   )(f: Err => Throwable)(implicit ev: CanFail[Err], trace: Trace): Handler[R, Err1, In, Out] =
     self.foldHandler(
       err => pf.andThen(Handler.fail(_)).applyOrElse(err, (e: Err) => Handler.die(f(e))),
-      Handler.succeed,
+      Handler.succeed(_),
     )
 
   final def runZIO(in: In): ZIO[R, Err, Out] =
@@ -638,7 +638,7 @@ object Handler {
   /**
    * Creates a handler which always responds with a 400 status code.
    */
-  def badRequest(message: String): Handler[Any, Nothing, Any, Response] =
+  def badRequest(message: => String): Handler[Any, Nothing, Any, Response] =
     error(HttpError.BadRequest(message))
 
   /**
@@ -661,13 +661,13 @@ object Handler {
   /**
    * Creates a handler with HttpError.
    */
-  def error(error: HttpError): Handler[Any, Nothing, Any, Response] =
+  def error(error: => HttpError): Handler[Any, Nothing, Any, Response] =
     response(Response.fromHttpError(error))
 
   /**
    * Creates a handler that responds with 500 status code
    */
-  def error(message: String): Handler[Any, Nothing, Any, Response] =
+  def errorMessage(message: => String): Handler[Any, Nothing, Any, Response] =
     error(HttpError.InternalServerError(message))
 
   /**
@@ -682,20 +682,20 @@ object Handler {
   /**
    * Creates a handler that responds with 403 - Forbidden status code
    */
-  def forbidden(message: String): Handler[Any, Nothing, Any, Response] =
+  def forbidden(message: => String): Handler[Any, Nothing, Any, Response] =
     error(HttpError.Forbidden(message))
 
   /**
    * Creates a handler which always responds the provided data and a 200 status
    * code
    */
-  def fromBody(body: Body): Handler[Any, Nothing, Any, Response] =
+  def fromBody(body: => Body): Handler[Any, Nothing, Any, Response] =
     response(Response(body = body))
 
   /**
    * Lifts an `Either` into a `Handler` alue.
    */
-  def fromEither[Err, Out](either: Either[Err, Out]): Handler[Any, Err, Any, Out] =
+  def fromEither[Err, Out](either: => Either[Err, Out]): Handler[Any, Err, Any, Out] =
     either.fold(Handler.fail(_), Handler.succeed(_))
 
   def fromExit[Err, Out](exit: => Exit[Err, Out]): Handler[Any, Err, Any, Out] =
@@ -779,7 +779,7 @@ object Handler {
   /**
    * Creates a handler which always responds with the provided Html page.
    */
-  def html(view: Html): Handler[Any, Nothing, Any, Response] =
+  def html(view: => Html): Handler[Any, Nothing, Any, Response] =
     response(Response.html(view))
 
   /**
@@ -793,7 +793,7 @@ object Handler {
   /**
    * Creates a handler which always responds with a 405 status code.
    */
-  def methodNotAllowed(message: String): Handler[Any, Nothing, Any, Response] =
+  def methodNotAllowed(message: => String): Handler[Any, Nothing, Any, Response] =
     error(HttpError.MethodNotAllowed(message))
 
   /**
@@ -814,7 +814,7 @@ object Handler {
   /**
    * Creates a handler which always responds with the same value.
    */
-  def response(response: Response): Handler[Any, Nothing, Any, Response] =
+  def response(response: => Response): Handler[Any, Nothing, Any, Response] =
     succeed(response)
 
   /**
@@ -830,26 +830,26 @@ object Handler {
    * Creates a handler which always responds with the same status code and empty
    * data.
    */
-  def status(code: Status): Handler[Any, Nothing, Any, Response] =
+  def status(code: => Status): Handler[Any, Nothing, Any, Response] =
     succeed(Response(code))
 
   /**
    * Creates a Handler that always returns the same response and never fails.
    */
-  def succeed[Out](out: Out): Handler[Any, Nothing, Any, Out] =
+  def succeed[Out](out: => Out): Handler[Any, Nothing, Any, Out] =
     fromExit(Exit.succeed(out))
 
   /**
    * Creates a handler which responds with an Html page using the built-in
    * template.
    */
-  def template(heading: CharSequence)(view: Html): Handler[Any, Nothing, Any, Response] =
+  def template(heading: => CharSequence)(view: Html): Handler[Any, Nothing, Any, Response] =
     response(Response.html(Template.container(heading)(view)))
 
   /**
    * Creates a handler which always responds with the same plain text.
    */
-  def text(text: CharSequence): Handler[Any, Nothing, Any, Response] =
+  def text(text: => CharSequence): Handler[Any, Nothing, Any, Response] =
     response(Response.text(text))
 
   /**

--- a/zio-http/src/main/scala/zio/http/Http.scala
+++ b/zio-http/src/main/scala/zio/http/Http.scala
@@ -491,7 +491,7 @@ object Http {
   def collect[In]: Collect[In] = new Collect[In](())
 
   /**
-   * Create an HTTP app from a partial function from A to HExit[R,E,B]
+   * Create an HTTP app from a partial function from A to Exit[R,E,B]
    */
   def collectExit[In]: CollectExit[In] = new CollectExit[In](())
 
@@ -608,7 +608,10 @@ object Http {
 
   final class Collect[In](val self: Unit) extends AnyVal {
     def apply[Out](pf: PartialFunction[In, Out]): Http[Any, Nothing, In, Out] =
-      Http.collectHandler[In].apply(pf.andThen(Handler.succeed(_)))
+      Http.collectZIO[In] {
+        case in if pf.isDefinedAt(in) =>
+          ZIO.succeed(pf(in))
+      }
   }
 
   final class CollectHandler[In](val self: Unit) extends AnyVal {

--- a/zio-http/src/test/scala/zio/http/HttpSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpSpec.scala
@@ -53,19 +53,19 @@ object HttpSpec extends ZIOSpecDefault with ExitAssertion {
           val a      = Http.collect[Int] { case 1 => "A" }
           val b      = Http.collect[Int] { case 2 => "B" }
           val actual = (a ++ b).runZIOOrNull(1)
-          assert(actual)(isSuccess(equalTo("A")))
+          assertZIO(actual)(equalTo("A"))
         },
         test("should resolve second") {
           val a      = Http.empty
           val b      = Handler.succeed("A").toHttp
           val actual = (a ++ b).runZIOOrNull(())
-          assert(actual)(isSuccess(equalTo("A")))
+          assertZIO(actual)(equalTo("A"))
         },
         test("should resolve second") {
           val a      = Http.collect[Int] { case 1 => "A" }
           val b      = Http.collect[Int] { case 2 => "B" }
           val actual = (a ++ b).runZIOOrNull(2)
-          assert(actual)(isSuccess(equalTo("B")))
+          assertZIO(actual)(equalTo("B"))
         },
         test("should not resolve") {
           val a      = Http.collect[Int] { case 1 => "A" }
@@ -111,7 +111,7 @@ object HttpSpec extends ZIOSpecDefault with ExitAssertion {
         test("should succeed") {
           val a      = Http.collect[Int] { case 1 => "OK" }
           val actual = a.runZIOOrNull(1)
-          assert(actual)(isSuccess(equalTo("OK")))
+          assertZIO(actual)(equalTo("OK"))
         },
         test("should fail") {
           val a      = Http.collect[Int] { case 1 => "OK" }

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
@@ -302,12 +302,12 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
     ),
     suite("prettify error")(
       test("should not add anything to the body  as request do not have an accept header") {
-        val app = (Handler.error("Error !!!") @@ beautifyErrors) rawHeader "content-type"
+        val app = (Handler.errorMessage("Error !!!") @@ beautifyErrors) rawHeader "content-type"
         assertZIO(app.runZIO(Request.get(URL.empty)))(isNone)
       },
       test("should return a html body as the request has accept header set to text/html.") {
         val app = (Handler
-          .error("Error !!!") @@ beautifyErrors) rawHeader "content-type"
+          .errorMessage("Error !!!") @@ beautifyErrors) rawHeader "content-type"
         assertZIO(
           app.runZIO(
             Request.get(URL.empty).copy(headers = Headers(Header.Accept(MediaType.text.`html`))),
@@ -316,7 +316,7 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
       },
       test("should return a plain body as the request has accept header set to */*.") {
         val app = (Handler
-          .error("Error !!!") @@ beautifyErrors) rawHeader "content-type"
+          .errorMessage("Error !!!") @@ beautifyErrors) rawHeader "content-type"
         assertZIO(
           app.runZIO(
             Request
@@ -327,7 +327,7 @@ object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
       },
       test("should not add anything to the body as the request has accept header set to application/json.") {
         val app = (Handler
-          .error("Error !!!") @@ beautifyErrors) rawHeader "content-type"
+          .errorMessage("Error !!!") @@ beautifyErrors) rawHeader "content-type"
         assertZIO(
           app.runZIO(
             Request.get(URL.empty).copy(headers = Headers(Header.Accept(MediaType.application.json))),


### PR DESCRIPTION
The `Http.collect` constructor executed the partial function eagerly as part of the routing logic which makes its behavior unexpected in context of request handler middlewares, as described in https://github.com/zio/zio-http/pull/2165 