### PR TITLE
Check file readability in `Http.fromFile` / `Http.fromFileZIO` (#2167)

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/NettyResponseEncoder.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyResponseEncoder.scala
@@ -28,7 +28,7 @@ import io.netty.handler.codec.http._
 
 private[zio] object NettyResponseEncoder {
 
-  private val frozenCache    = new ConcurrentHashMap[Response, HttpResponse]()
+  private val frozenCache    = new ConcurrentHashMap[Response, FullHttpResponse]()
   private val frozenZioCache = new ConcurrentHashMap[Response, UIO[HttpResponse]]()
 
   def encode(response: Response): ZIO[Any, Throwable, HttpResponse] = {
@@ -47,7 +47,7 @@ private[zio] object NettyResponseEncoder {
     }
   }
 
-  def fastEncode(response: Response, bytes: Array[Byte])(implicit unsafe: Unsafe): HttpResponse =
+  def fastEncode(response: Response, bytes: Array[Byte])(implicit unsafe: Unsafe): FullHttpResponse =
     if (response.frozen) {
       val encodedResponse = frozenCache.get(response)
 
@@ -62,7 +62,7 @@ private[zio] object NettyResponseEncoder {
       }
     } else doEncode(response, bytes)
 
-  private def doEncode(response: Response, bytes: Array[Byte]): HttpResponse = {
+  private def doEncode(response: Response, bytes: Array[Byte]): FullHttpResponse = {
     val jHeaders         = Conversions.headersToNetty(response.headers)
     val hasContentLength = jHeaders.contains(HttpHeaderNames.CONTENT_LENGTH)
 

--- a/zio-http/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -18,10 +18,10 @@ package zio.http
 
 import java.io.File
 
-import zio.test.Assertion.{equalTo, isSome}
+import zio._
+import zio.test.Assertion._
 import zio.test.TestAspect.{timeout, withLiveClock}
 import zio.test.assertZIO
-import zio.{Scope, ZIO, durationInt}
 
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, severTestLayer}
 
@@ -70,6 +70,14 @@ object StaticFileServerSpec extends HttpRunnableSpec {
       suite("failure on construction")(
         test("should respond with 500") {
           val res = Http.fromFile(throw new Error("Wut happened?")).deploy.run().map(_.status)
+          assertZIO(res)(equalTo(Status.InternalServerError))
+        },
+      ),
+      suite("unreadable file")(
+        test("should respond with 500") {
+          val tmpFile = File.createTempFile("test", "txt")
+          tmpFile.setReadable(false)
+          val res     = Http.fromFile(tmpFile).deploy.run().map(_.status)
           assertZIO(res)(equalTo(Status.InternalServerError))
         },
       ),


### PR DESCRIPTION
This PR contains 2 fixes.

The first one is a check in Http.fromFileZIO that ensures that the file is readable. This is a very specific fix, but reasonable as well.

The second fix, is a more general behaviour for errors happening during encoding netty responses.
This happens after the Http already created a zio-http Responseobject. But like in this case, translating it to the netty response, more explicitly reading the byte to send over the wire, can fail as well.

I added code that ensures that in this case, we send the defaultErrorResponse instead of just failing. This graceful behaviour seems more fitting to me.

But there is one important thing left to say: While the first fix enables the user to map the error, the second error can't be handled by the user within the Http at all. mapError is executed before we reach this point, which makes sense, since it is for the typed errors. But also error handlers can't catch this. I tried using the error handler of app in the ServerInboundHandler to hand over the cause of the failure, but the handler was always None idk why.


fixes #2167
/claim #2167
