### PR TITLE
rework styles and classes

### DIFF
--- a/zio-http-example/src/main/scala/example/HtmlTemplating.scala
+++ b/zio-http-example/src/main/scala/example/HtmlTemplating.scala
@@ -21,11 +21,11 @@ object HtmlTemplating extends ZIOAppDefault {
         body(
           div(
             // Support for css class names
-            css := "container" :: "text-align-left" :: Nil,
+            classAttrs("container", "text-align-left"),
             h1("Hello World"),
             ul(
               // Support for inline css
-              styles := Seq("list-style" -> "none"),
+              styleAttrs("list-style" -> "none", "color" -> "blue"),
               li(
                 // Support for attributes
                 a(href := "/hello/world", "Hello World"),

--- a/zio-http/src/main/scala/zio/http/codec/Doc.scala
+++ b/zio-http/src/main/scala/zio/http/codec/Doc.scala
@@ -351,7 +351,7 @@ object Doc {
       self match {
         case Span.Text(value)           => value
         case Span.Code(value)           => code(value)
-        case Span.Error(value)          => span(styleAttr := ("color", "red") :: Nil, value)
+        case Span.Error(value)          => span(styleAttrs("color" -> "red"), value)
         case Span.Bold(value)           => b(value.toHtml)
         case Span.Italic(value)         => i(value.toHtml)
         case Span.Link(value, text)     =>

--- a/zio-http/src/main/scala/zio/http/html/Attributes.scala
+++ b/zio-http/src/main/scala/zio/http/html/Attributes.scala
@@ -49,7 +49,11 @@ trait Attributes {
 
   final def citeAttr: PartialAttribute[String] = PartialAttribute("cite")
 
-  final def classAttr: PartialAttribute[List[String]] = PartialAttribute("class")
+  final def classAttrs: PartialAttribute[Seq[String]] = PartialAttribute("class")
+
+  final def classAttrs(names: String*): Html = classAttrs := names
+
+  final def classAttr: PartialAttribute[String] = PartialAttribute("class")
 
   final def colSpanAttr: PartialAttribute[String] = PartialAttribute("colspan")
 
@@ -65,7 +69,8 @@ trait Attributes {
 
   final def coordsAttr: PartialAttribute[String] = PartialAttribute("coords")
 
-  final def css: PartialAttribute[List[String]] = classAttr
+  @deprecated("instead use `classAttr` or `classAttrs`", "3.0.0")
+  final def css: PartialAttribute[List[String]] = PartialAttribute("class")
 
   final def dataAttr(name: String): PartialAttribute[String] = PartialAttribute("data-" + name)
 
@@ -337,9 +342,13 @@ trait Attributes {
 
   final def stepAttr: PartialAttribute[String] = PartialAttribute("step")
 
-  final def styleAttr: PartialAttribute[Seq[(String, String)]] = PartialAttribute("style")
+  final def styleAttrs: PartialAttribute[Seq[(String, String)]] = PartialAttribute("style")
 
-  final def styles: PartialAttribute[Seq[(String, String)]] = styleAttr
+  final def styleAttrs(styles: (String, String)*): Html = styleAttrs := styles
+
+  final def styleAttr: PartialAttribute[String] = PartialAttribute("style")
+
+  final def styles: PartialAttribute[Seq[(String, String)]] = PartialAttribute("style")
 
   final def tabIndexAttr: PartialAttribute[String] = PartialAttribute("tabindex")
 
@@ -362,7 +371,6 @@ trait Attributes {
   final def xmlnsAttr: PartialAttribute[String] = PartialAttribute("xmlns")
 
   final def cellpaddingAttr: PartialAttribute[String] = PartialAttribute("cellpadding")
-
   final def cellspacingAttr: PartialAttribute[String] = PartialAttribute("cellspacing")
 
 }

--- a/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
+++ b/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
@@ -61,6 +61,30 @@ case object HtmlSpec extends ZIOSpecDefault {
         val expected = """<div class="container">Hello!</div>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
+      test("classAttr(s) attributes") {
+        val view1     = div("Hello!", classAttr := "container")
+        val view2     = div("Hello!", classAttrs := "container" :: Nil)
+        val view3     = div("Hello!", classAttrs("container"))
+        val expected1 = """<div class="container">Hello!</div>"""
+        assert(view1.encode)(equalTo(expected1.stripMargin)) &&
+        assert(view2.encode)(equalTo(expected1.stripMargin)) &&
+        assert(view3.encode)(equalTo(expected1.stripMargin))
+
+        val view4     = div("Hello!", classAttrs("container1", "container2"))
+        val view5     = div("Hello!", classAttrs := "container1" :: "container2" :: Nil)
+        val expected2 = """<div class="container1 container2">Hello!</div>"""
+        assert(view4.encode)(equalTo(expected2.stripMargin)) &&
+        assert(view5.encode)(equalTo(expected2.stripMargin))
+      },
+      test("styleAttr(s) attributes") {
+        val view1     = div("Hello!", styleAttr := "color:red;text-align:right")
+        val view2     = div("Hello!", styleAttrs := "color" -> "red" :: "text-align" -> "right" :: Nil)
+        val view3     = div("Hello!", styleAttrs("color" -> "red", "text-align" -> "right"))
+        val expected1 = """<div style="color:red;text-align:right">Hello!</div>"""
+        assert(view1.encode)(equalTo(expected1.stripMargin)) &&
+        assert(view2.encode)(equalTo(expected1.stripMargin)) &&
+        assert(view3.encode)(equalTo(expected1.stripMargin))
+      },
       suite("implicit conversions")(
         test("from unit") {
           val view: Html = {}


### PR DESCRIPTION
I changed a few things I found a bit rough when using `zio.http.html`. With these changes I hope it is more friendly to add classes (`classAttr` / `classAttrs`) and styles (`styleAttr` / `styleAttrs`). 

Besides that I deprecated `css` as I think it is not entirely clear (at least for me) what it does (does it add a class attribute or a style attribute?). 

But maybe people are already satisfied with how it works, I want to see if these changes provide value - I think they do.