### PR TITLE
Pass the entire request for Auth middleware verification

### DIFF
--- a/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -142,8 +142,8 @@ object AuthSpec extends ZIOSpecDefault with HttpAppTestExtensions {
     ),
     suite("custom")(
       test("Providing context from auth middleware") {
-        def auth[R0] = RequestHandlerMiddlewares.customAuthProviding[R0, AuthContext]((headers: Headers) =>
-          headers.header(Header.Authorization).map(auth => AuthContext(auth.renderedValue.toString)),
+        def auth[R0] = RequestHandlerMiddlewares.customAuthProviding[R0, AuthContext]((request: Request) =>
+          request.header(Header.Authorization).map(auth => AuthContext(auth.renderedValue.toString)),
         )
 
         val app1 = Handler.text("ok") @@ auth[Any]
@@ -172,8 +172,8 @@ object AuthSpec extends ZIOSpecDefault with HttpAppTestExtensions {
       }.provideLayer(ZLayer.succeed(BaseService("base"))),
       test("Providing context from auth middleware effectfully") {
         def auth[R0] = RequestHandlerMiddlewares.customAuthProvidingZIO[R0, UserService, Throwable, AuthContext](
-          (headers: Headers) =>
-            headers.header(Header.Authorization) match {
+          (request: Request) =>
+            request.header(Header.Authorization) match {
               case Some(Header.Authorization.Bearer(value)) if value.startsWith("_") =>
                 ZIO.service[UserService].map { usvc => Some(AuthContext(usvc.prefix + value)) }
               case Some(value)                                                       =>


### PR DESCRIPTION
It is not unreasonable for an auth middleware to require more than the headers, for example the `remoteAddress` of the request. This will pass the entire request to verification for auth middlewares, it is still as easy to do `request.header()` but allows doing more if necessary without having to re-implement an entire middleware such as `customAuthProviding*` in user-land.