### PR TITLE
Don't run unreadable file test on Windows

### DIFF
--- a/zio-http/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import zio._
 import zio.test.Assertion._
-import zio.test.TestAspect.{timeout, withLiveClock}
+import zio.test.TestAspect.{timeout, unix, withLiveClock}
 import zio.test.assertZIO
 
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, severTestLayer}
@@ -79,7 +79,7 @@ object StaticFileServerSpec extends HttpRunnableSpec {
           tmpFile.setReadable(false)
           val res     = Http.fromFile(tmpFile).deploy.run().map(_.status)
           assertZIO(res)(equalTo(Status.InternalServerError))
-        },
+        } @@ unix,
       ),
       suite("invalid file")(
         test("should respond with 500") {


### PR DESCRIPTION
On Windows you cannot remove read permissions (or at least not easily)