### PR TITLE
Multipart/from file input implementation and some refactoring

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -3,646 +3,128 @@ package zio.http.endpoint.cli
 import scala.util.Try
 
 import zio.cli._
-import zio.json.ast._
 
 import zio.schema._
 
 import zio.http._
 import zio.http.codec._
+import zio.http.codec.internal._
 import zio.http.endpoint._
 
-private[cli] final case class CliEndpoint[A](
-  embed: (A, CliRequest) => CliRequest,
-  options: Options[A],
-  commandNameSegments: List[Either[Method, String]],
-  doc: Doc,
+
+private[cli] final case class CliEndpoint(
+  body: List[HttpOptions.Body[_]] = List.empty,
+  headers: List[HttpOptions.HeaderOptions] = List.empty,
+  methods: Method = Method.GET,
+  url: List[HttpOptions.URLOptions] = List.empty,
+  commandNameSegments: List[String] = List.empty,
+  doc: Doc = Doc.empty,
 ) {
   self =>
-  type Type = A
 
-  def ++[B](that: CliEndpoint[B]): CliEndpoint[(A, B)] =
+  def ++(that: CliEndpoint): CliEndpoint =
     CliEndpoint(
-      { case ((a, b), request) =>
-        that.embed(b, self.embed(a, request))
-      },
-      self.options ++ that.options,
+      self.body ++ that.body,
+      self.headers ++ that.headers,
+      if(that.methods == Method.GET) self.methods else that.methods,
+      self.url ++ that.url,
       self.commandNameSegments ++ that.commandNameSegments,
-      self.doc,
+      self.doc, // TODO add doc
     )
 
-  def ??(doc: Doc): CliEndpoint[A] = self.copy(doc = doc)
+  def ??(doc: Doc): CliEndpoint = self.copy(doc = doc)
 
   lazy val commandName: String = {
-    self.commandNameSegments
-      .sortBy(_.isRight)
-      .map {
-        case Right(pathSegment) => pathSegment
-        case Left(Method.POST)  => "create"
-        case Left(Method.PUT)   => "update"
-        case Left(method)       => method.name.toLowerCase
-      }
-      .mkString("-")
+    {methods match {
+        case Method.POST  => "create"
+        case Method.PUT   => "update"
+        case method       => method.name.toLowerCase
+      }} + " " + url.map(_.tag).fold("")(_ + _)
   }
 
-  def describeOptions(description: String) = self.copy(options = options ?? description)
+  lazy val getOptions: List[HttpOptions] = url ++ headers ++ body
 
-  lazy val optional: CliEndpoint[Option[A]] =
+  def describeOptions(description: Doc) = self.copy(doc = doc + description)
+
+  lazy val optional: CliEndpoint =
     CliEndpoint(
-      {
-        case (Some(a), request) => self.embed(a, request)
-        case (None, request)    => request
-      },
-      self.options.optional,
-      self.commandNameSegments,
-      self.doc,
+      //{
+      //  case (Some(a), request) => self.embed(a, request)
+      //  case (None, request)    => request
+      //},
+      //self.options.optional
     )
-
-  def transform[B](f: A => B, g: B => A): CliEndpoint[B] =
+/*
+  def transform[B](f: A => B, g: B => A): CliEndpoint =
     CliEndpoint(
-      (b, request) => self.embed(g(b), request),
+      //(b, request) => self.embed(g(b), request),
       self.options.map(f),
       self.commandNameSegments,
       self.doc,
-    )
+    )*/
+
 }
+
 private[cli] object CliEndpoint {
-  def fromEndpoint[In, Err, Out, M <: EndpointMiddleware](endpoint: Endpoint[In, Err, Out, M]): Set[CliEndpoint[_]] =
-    fromInput(endpoint.input).map(_ ?? endpoint.doc)
 
-  private def fromInput[Input](input: HttpCodec[_, Input]): Set[CliEndpoint[_]] =
-    input.asInstanceOf[HttpCodec[_, _]] match {
-      case HttpCodec.Combine(left, right, _) =>
-        val leftCliEndpoints  = fromInput(left)
-        val rightCliEndpoints = fromInput(right)
+  def empty: CliEndpoint = CliEndpoint()
 
-        if (leftCliEndpoints.isEmpty) rightCliEndpoints
-        else
-          for {
-            l <- fromInput(left)
-            r <- fromInput(right)
-          } yield l ++ r
+  def fromEndpoint[In, Err, Out, M <: EndpointMiddleware](endpoint: Endpoint[In, Err, Out, M]): CliEndpoint =
+    fromInput(endpoint.input) ?? endpoint.doc
 
-      case HttpCodec.Content(schema, _, _, _)       => fromSchema(schema)
-      case HttpCodec.ContentStream(schema, _, _, _) => fromSchema(schema)
-      case HttpCodec.Empty                          => Set.empty
+  def fromInput[Input](input: HttpCodec[_, Input]): CliEndpoint = {
+    input match {
+      case atom: HttpCodec.Atom[_, _]               => fromAtom(atom)
+      case HttpCodec.TransformOrFail(api, _, _)     => fromInput(api)
+      case HttpCodec.WithDoc(in, doc)               => fromInput(in) describeOptions doc
+      case HttpCodec.WithExamples(in, _)            => fromInput(in)
       case HttpCodec.Fallback(left, right)          => fromInput(left) ++ fromInput(right)
-      case HttpCodec.Halt                           => Set.empty
-      case HttpCodec.Header(name, textCodec, _)     =>
-        textCodec.asInstanceOf[TextCodec[_]] match {
-          case TextCodec.UUIDCodec        =>
-            Set(
-              CliEndpoint[java.util.UUID](
-                (uuid, request) => request.addHeader(name, uuid.toString),
-                Options
-                  .text(name)
-                  .mapOrFail(str =>
-                    Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
-                      ValidationError(
-                        ValidationErrorType.InvalidValue,
-                        HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
-                      )
-                    },
-                  ),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.StringCodec      =>
-            Set(
-              CliEndpoint[String](
-                (str, request) => request.addHeader(name, str),
-                Options.text(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.IntCodec         =>
-            Set(
-              CliEndpoint[BigInt](
-                (int, request) => request.addHeader(name, int.toString),
-                Options.integer(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.BooleanCodec     =>
-            Set(
-              CliEndpoint[Boolean](
-                (bool, request) => request.addHeader(name, bool.toString),
-                Options.boolean(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.Constant(string) =>
-            Set(
-              CliEndpoint[Unit](
-                (_, request) => request.addHeader(name, string),
-                Options.Empty,
-                List.empty,
-                Doc.empty,
-              ),
-            )
+      case HttpCodec.Combine(left, right, _)        => fromInput(left) ++ fromInput(right)
+      case _                                        => CliEndpoint.empty          
+    }
+  }
+
+  private def fromAtom[Input](input: HttpCodec.Atom[_, Input]): CliEndpoint = {
+    input match {
+      case HttpCodec.Content(schema, mediaType, nameOption, _)       => {
+        val name = nameOption match {
+          case Some(x) => x
+          case None => ""
         }
+        CliEndpoint(body = HttpOptions.Body(name, mediaType, schema) :: List())
+      }
+        
+      case HttpCodec.ContentStream(schema, mediaType, nameOption, _) => {
+        val name = nameOption match {
+          case Some(x) => x
+          case None => ""
+        }
+        CliEndpoint(body = HttpOptions.Body(name, mediaType, schema) :: List())
+      }
+
+      case HttpCodec.Header(name, textCodec, _)     =>
+        CliEndpoint(headers = HttpOptions.Header(name, textCodec) :: List())
       case HttpCodec.Method(codec, _)               =>
         codec.asInstanceOf[SimpleCodec[_, _]] match {
-          case SimpleCodec.Specified(method) =>
-            Set(
-              CliEndpoint[Unit](
-                (_, request) => request.withMethod(method.asInstanceOf[Method]),
-                Options.none,
-                List(Left(method.asInstanceOf[Method])),
-                Doc.empty,
-              ),
-            )
-          case SimpleCodec.Unspecified()     =>
-            Set.empty
+          case SimpleCodec.Specified(method: Method)  =>
+            CliEndpoint(methods = method)
+          case _     => CliEndpoint.empty
         }
+      
       case HttpCodec.Path(textCodec, Some(name), _) =>
-        textCodec.asInstanceOf[TextCodec[_]] match {
-          case TextCodec.UUIDCodec        =>
-            Set(
-              CliEndpoint[java.util.UUID](
-                (uuid, request) => request.addPathParam(uuid.toString),
-                Options
-                  .text(name)
-                  .mapOrFail(str =>
-                    Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
-                      ValidationError(
-                        ValidationErrorType.InvalidValue,
-                        HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
-                      )
-                    },
-                  ),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.StringCodec      =>
-            Set(
-              CliEndpoint[String](
-                (str, request) => request.addPathParam(str),
-                Options.text(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.IntCodec         =>
-            Set(
-              CliEndpoint[BigInt](
-                (int, request) => request.addPathParam(int.toString),
-                Options.integer(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.BooleanCodec     =>
-            Set(
-              CliEndpoint[Boolean](
-                (bool, request) => request.addPathParam(bool.toString),
-                Options.boolean(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.Constant(string) =>
-            Set(
-              CliEndpoint[Unit](
-                (_, request) => request.addPathParam(string),
-                Options.Empty,
-                List(Right(string)),
-                Doc.empty,
-              ),
-            )
-        }
+        CliEndpoint(url = HttpOptions.Path(name, textCodec) :: List())
       case HttpCodec.Path(textCodec, None, _)       =>
         textCodec.asInstanceOf[TextCodec[_]] match {
           case TextCodec.Constant(string) =>
-            Set(
-              CliEndpoint[Unit](
-                (_, request) => request.addPathParam(string),
-                Options.Empty,
-                List(Right(string)),
-                Doc.empty,
-              ),
-            )
-          case _                          => Set.empty
+            CliEndpoint(url = HttpOptions.PathConstant(string) :: List())
+          case _                          => CliEndpoint.empty
         }
+      
       case HttpCodec.Query(name, textCodec, _)      =>
-        textCodec.asInstanceOf[TextCodec[_]] match {
-          case TextCodec.UUIDCodec        =>
-            Set(
-              CliEndpoint[java.util.UUID](
-                (uuid, request) => request.addQueryParam(name, uuid.toString),
-                Options
-                  .text(name)
-                  .mapOrFail(str =>
-                    Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
-                      ValidationError(
-                        ValidationErrorType.InvalidValue,
-                        HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
-                      )
-                    },
-                  ),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.StringCodec      =>
-            Set(
-              CliEndpoint[String](
-                (str, request) => request.addQueryParam(name, str),
-                Options.text(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.IntCodec         =>
-            Set(
-              CliEndpoint[BigInt](
-                (int, request) => request.addQueryParam(name, int.toString),
-                Options.integer(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.BooleanCodec     =>
-            Set(
-              CliEndpoint[Boolean](
-                (bool, request) => request.addQueryParam(name, bool.toString),
-                Options.boolean(name),
-                List.empty,
-                Doc.empty,
-              ),
-            )
-          case TextCodec.Constant(string) =>
-            Set(
-              CliEndpoint[Unit](
-                (_, request) => request.addQueryParam(name, string),
-                Options.Empty,
-                List.empty,
-                Doc.empty,
-              ),
-            )
-        }
-      case HttpCodec.Status(_, _)                   => Set.empty
-      case HttpCodec.TransformOrFail(api, _, _)     => fromInput(api)
-      case HttpCodec.WithDoc(in, doc)               => fromInput(in).map(_ describeOptions doc.toPlaintext())
-      case HttpCodec.WithExamples(in, _)            => fromInput(in)
+        CliEndpoint(url = HttpOptions.Query(name, textCodec) :: List())
+        
+      case HttpCodec.Status(_, _)                   => CliEndpoint.empty
+
     }
-
-  private def fromSchema(schema: zio.schema.Schema[_]): Set[CliEndpoint[_]] = {
-    def loop(prefix: List[String], schema: zio.schema.Schema[_]): Set[CliEndpoint[_]] =
-      schema match {
-        case record: Schema.Record[_]             =>
-          Set(
-            record.fields
-              .foldLeft(Set.empty[CliEndpoint[_]]) { (cliEndpoints, field) =>
-                cliEndpoints ++ loop(prefix :+ field.name, field.schema).map { cliEndpoint =>
-                  field.annotations.headOption match {
-                    case Some(description) => cliEndpoint describeOptions description.asInstanceOf[description].text
-                    case None              => cliEndpoint
-                  }
-                }
-              }
-              .reduce(_ ++ _), // TODO review the case of nested sealed trait inside case class
-          )
-        case enumeration: Schema.Enum[_]          =>
-          enumeration.cases.foldLeft(Set.empty[CliEndpoint[_]]) { (cliEndpoints, enumCase) =>
-            cliEndpoints ++ loop(prefix, enumCase.schema)
-          }
-        case Schema.Primitive(standardType, _)    =>
-          standardType match {
-            case StandardType.InstantType        =>
-              Set(
-                CliEndpoint[java.time.Instant](
-                  (instant, request) => request.addFieldToBody(prefix, Json.Str(instant.toString())),
-                  Options.instant(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.UnitType           => Set.empty
-            case StandardType.PeriodType         =>
-              Set(
-                CliEndpoint[java.time.Period](
-                  (period, request) => request.addFieldToBody(prefix, Json.Str(period.toString())),
-                  Options.period(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.LongType           =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    long,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(long))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.StringType         =>
-              Set(
-                CliEndpoint[String](
-                  (str, request) => request.addFieldToBody(prefix, Json.Str(str)),
-                  Options.text(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.UUIDType           =>
-              Set(
-                CliEndpoint[String](
-                  (uuid, request) => request.addFieldToBody(prefix, Json.Str(uuid.toString())),
-                  Options.text(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.ByteType           =>
-              Set(
-                CliEndpoint[BigInt](
-                  (byte, request) => request.addFieldToBody(prefix, Json.Num(BigDecimal(byte))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.OffsetDateTimeType =>
-              Set(
-                CliEndpoint[java.time.OffsetDateTime](
-                  (
-                    offsetDateTime,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(offsetDateTime.toString())),
-                  Options.offsetDateTime(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.LocalDateType      =>
-              Set(
-                CliEndpoint[java.time.LocalDate](
-                  (
-                    localDate,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(localDate.toString())),
-                  Options.localDate(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.OffsetTimeType     =>
-              Set(
-                CliEndpoint[java.time.OffsetTime](
-                  (
-                    offsetTime,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(offsetTime.toString())),
-                  Options.offsetTime(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.FloatType          =>
-              Set(
-                CliEndpoint[BigDecimal](
-                  (float, request) => request.addFieldToBody(prefix, Json.Num(float)),
-                  Options.decimal(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.BigDecimalType     =>
-              Set(
-                CliEndpoint[BigDecimal](
-                  (bigDecimal, request) => request.addFieldToBody(prefix, Json.Num(bigDecimal)),
-                  Options.decimal(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.BigIntegerType     =>
-              Set(
-                CliEndpoint[BigInt](
-                  (bigInt, request) => request.addFieldToBody(prefix, Json.Num(BigDecimal(bigInt))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.DoubleType         =>
-              Set(
-                CliEndpoint[BigDecimal](
-                  (double, request) => request.addFieldToBody(prefix, Json.Num(double)),
-                  Options.decimal(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.BoolType           =>
-              Set(
-                CliEndpoint[Boolean](
-                  (bool, request) => request.addFieldToBody(prefix, Json.Bool(bool)),
-                  Options.boolean(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.CharType           =>
-              Set(
-                CliEndpoint[String](
-                  (char, request) => request.addFieldToBody(prefix, Json.Str(char.toString())),
-                  Options.text(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.ZoneOffsetType     =>
-              Set(
-                CliEndpoint[java.time.ZoneOffset](
-                  (
-                    zoneOffset,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(zoneOffset.toString())),
-                  Options.zoneOffset(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.YearMonthType      =>
-              Set(
-                CliEndpoint[java.time.YearMonth](
-                  (
-                    yearMonth,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(yearMonth.toString())),
-                  Options.yearMonth(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.BinaryType         =>
-              Set(
-                CliEndpoint[java.nio.file.Path](
-                  ???, // TODO modify CliRequest so it can store a binary body and not just Json
-                  Options.file(prefix.mkString("."), Exists.Yes),
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.LocalTimeType      =>
-              Set(
-                CliEndpoint[java.time.LocalTime](
-                  (
-                    localTime,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(localTime.toString())),
-                  Options.localTime(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.ZoneIdType         =>
-              Set(
-                CliEndpoint[java.time.ZoneId](
-                  (
-                    zoneId,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(zoneId.toString())),
-                  Options.zoneId(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.ZonedDateTimeType  =>
-              Set(
-                CliEndpoint[java.time.ZonedDateTime](
-                  (
-                    zonedDateTime,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(zonedDateTime.toString())),
-                  Options.zonedDateTime(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.DayOfWeekType      =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    dayOfWeek,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(dayOfWeek))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.DurationType       =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    duration,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(duration))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.IntType            =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    int,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(int))), // FIXME
-                  Options.integer(prefix.mkString(".")),                          // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.MonthDayType       =>
-              Set(
-                CliEndpoint[java.time.MonthDay](
-                  (
-                    monthDay,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(monthDay.toString())),
-                  Options.monthDay(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.ShortType          =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    short,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(short))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.LocalDateTimeType  =>
-              Set(
-                CliEndpoint[java.time.LocalDateTime](
-                  (
-                    localDateTime,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(localDateTime.toString())),
-                  Options.localDateTime(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.MonthType          =>
-              Set(
-                CliEndpoint[String](
-                  (
-                    month,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Str(month)),
-                  Options.text(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-            case StandardType.YearType           =>
-              Set(
-                CliEndpoint[BigInt](
-                  (
-                    year,
-                    request,
-                  ) => request.addFieldToBody(prefix, Json.Num(BigDecimal(year))),
-                  Options.integer(prefix.mkString(".")), // FIXME
-                  List.empty,
-                  Doc.empty,
-                ),
-              )
-          }
-        case Schema.Fail(_, _)                    => Set.empty
-        case Schema.Map(_, _, _)                  => ??? // TODO
-        case Schema.Sequence(_, _, _, _, _)       => ??? // TODO
-        case Schema.Set(_, _)                     => ??? // TODO
-        case Schema.Lazy(schema0)                 => loop(prefix, schema0())
-        case Schema.Dynamic(_)                    => Set.empty
-        case Schema.Either(left, right, _)        => loop(prefix, left) ++ loop(prefix, right)
-        case Schema.Optional(schema, _)           => loop(prefix, schema).map(_.optional)
-        case Schema.Tuple2(left, right, _)        =>
-          for {
-            l <- loop(prefix, left)
-            r <- loop(prefix, right)
-          } yield l ++ r
-        case Schema.Transform(schema, _, _, _, _) => loop(prefix, schema)
-      }
-
-    loop(List.empty, schema)
   }
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -34,7 +34,7 @@ private[cli] final case class CliEndpoint(
       self.doc + that.doc,
     )
 
-  def ??(doc: Doc): CliEndpoint = self.copy(doc = self.doc + doc)
+  def ??(doc: Doc): CliEndpoint = self.copy(doc = doc)
 
   def commandName(cliStyle: Boolean): String = 
     if(cliStyle){
@@ -44,7 +44,13 @@ private[cli] final case class CliEndpoint(
           case Method.PUT   => "update"
           case method       => method.name.toLowerCase
         }
-      } + "-" + url.map(_.name).mkString("-")
+      } + "-" + url.filter(
+        _ match {
+          case _: URLOptions.PathConstant  => false
+          case _: URLOptions.QueryConstant => false
+          case _                           => true
+        }
+      ).map(_.name).mkString("-")
     } else {
       {
         methods match {
@@ -57,7 +63,12 @@ private[cli] final case class CliEndpoint(
 
   lazy val getOptions: List[HttpOptions] = url ++ headers ++ body
 
-  def describeOptions(description: Doc) = self.copy(doc = doc + description)
+  def describeOptions(description: Doc) = 
+    self.copy(
+      body = self.body.map(_ ?? description),
+      headers = self.headers.map(_ ?? description),
+      url = self.url.map(_ ?? description),
+    )
 
 }
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -46,9 +46,9 @@ private[cli] final case class CliEndpoint(
         }
       } + "-" + url.filter(
         _ match {
-          case _: URLOptions.PathConstant  => false
-          case _: URLOptions.QueryConstant => false
-          case _                           => true
+          case _: HttpOptions.PathConstant  => true
+          case _: HttpOptions.QueryConstant => true
+          case _                           => false
         }
       ).map(_.name).mkString("-")
     } else {

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliRequest.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliRequest.scala
@@ -1,23 +1,22 @@
 package zio.http.endpoint.cli
 
-import zio._
-import zio.json.ast._
+import java.io.{File, IOException}
+import java.nio.channels.FileChannel
 import java.nio.file.Path
 
-import zio.http._
+import scala.io.Source
+
+import zio._
 import zio.cli._
-import java.nio.channels.FileChannel
+import zio.json.ast._
 
 import zio.stream.{ZSink, ZStream}
 
-import java.io.File
-import scala.io.Source
-import java.io.IOException
-
+import zio.http._
 
 /**
- * Represents a Request. The body parameter allows implementation of multipart form data and the retrieval of a body
- * from a file or an URL.
+ * Represents a Request. The body parameter allows implementation of multipart
+ * form data and the retrieval of a body from a file or an URL.
  */
 
 private[cli] final case class CliRequest(
@@ -26,7 +25,7 @@ private[cli] final case class CliRequest(
   method: Method,
   url: URL,
   outputResponse: Boolean = true,
-  saveResponse: Boolean = false
+  saveResponse: Boolean = false,
 ) { self =>
 
   def addBody(value: Retriever) =
@@ -34,7 +33,6 @@ private[cli] final case class CliRequest(
 
   def addHeader(name: String, value: String): CliRequest =
     self.copy(headers = self.headers.addHeader(name, value))
-    
 
   def addPathParam(value: String) =
     self.copy(url = self.url.copy(path = self.url.path / value))
@@ -50,15 +48,15 @@ private[cli] final case class CliRequest(
    */
   def toRequest(host: String, port: Int): Task[Request] = for {
     formFields <- ZIO.foreach(body)(_.retrieve())
-    finalBody <- Body.fromMultipartFormUUID(Form(formFields))
+    finalBody  <- Body.fromMultipartFormUUID(Form(formFields))
   } yield Request
-      .default(
-        method,
-        url.withHost(host).withPort(port),
-        finalBody,
-        )
-      .setHeaders(headers)
-  
+    .default(
+      method,
+      url.withHost(host).withPort(port),
+      finalBody,
+    )
+    .setHeaders(headers)
+
 }
 
 private[cli] object CliRequest {

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliRequest.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliRequest.scala
@@ -2,27 +2,35 @@ package zio.http.endpoint.cli
 
 import zio._
 import zio.json.ast._
+import java.nio.file.Path
 
 import zio.http._
+import zio.cli._
+import java.nio.channels.FileChannel
+
+import zio.stream.{ZSink, ZStream}
+
+import java.io.File
+import scala.io.Source
+import java.io.IOException
+
+
 
 private[cli] final case class CliRequest(
-  url: URL,
-  method: Method,
+  body: Chunk[Either[Either[(String, Path, MediaType), String], FormField]],
   headers: Headers,
-  body: Json,
+  method: Method,
+  url: URL,
+  printResponse: Boolean = false,
+  saveResponse: Boolean = false
 ) { self =>
-  def addFieldToBody(prefix: List[String], value: Json) = {
-    def sparseJson(prefix: List[String], json: Json): Json =
-      prefix match {
-        case Nil          => json
-        case head :: tail => Json.Obj(Chunk(head -> sparseJson(tail, json)))
-      }
 
-    self.copy(body = self.body.merge(sparseJson(prefix, value)))
-  }
+  def addBody(value: Either[Either[(String, Path, MediaType), String], FormField]) =
+    self.copy(body = self.body ++ Chunk(value))
 
   def addHeader(name: String, value: String): CliRequest =
     self.copy(headers = self.headers.addHeader(name, value))
+    
 
   def addPathParam(value: String) =
     self.copy(url = self.url.copy(path = self.url.path / value))
@@ -32,7 +40,28 @@ private[cli] final case class CliRequest(
 
   def withMethod(method: Method): CliRequest =
     self.copy(method = method)
+
+  def toRequest(host: String, port: Int): Task[Request] = for {
+    formFields <- ZIO.foreach(body)( _ match {
+        case Left(Left((name, file, mediaType))) => for {
+          chunk <- Body.fromFile(new File(file.toUri())).asChunk
+        } yield FormField.binaryField(name, chunk, mediaType)
+        case Left(Right(url)) => ???
+        case Right(formField) => ZIO.succeed(formField)
+      })
+    finalBody <- Body.fromMultipartFormUUID(Form(formFields))
+  } yield Request
+      .default(
+        method,
+        url.withHost(host).withPort(port),
+        finalBody,
+        )
+      .setHeaders(headers)
+  
 }
+
 private[cli] object CliRequest {
-  val empty = CliRequest(URL.empty, Method.GET, Headers.empty, Json.Obj(Chunk.empty))
+
+  val empty = CliRequest(Chunk.empty, Headers.empty, Method.GET, URL.empty)
+
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliResponse.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliResponse.scala
@@ -1,0 +1,3 @@
+package zio.http.endpoint.cli
+
+private[cli] final case class CliResponse()

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliResponse.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliResponse.scala
@@ -1,3 +1,0 @@
-package zio.http.endpoint.cli
-
-private[cli] final case class CliResponse()

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
@@ -35,6 +35,8 @@ object HttpCliApp {
    *   Configuration of the generated CLI
    * @param figFont
    *   FigFont to use for man pages of the generated CLI
+   * @param cliStyle
+   *   Style of commands of the generated CLI: true for CLI idiomatic interface, false for HTTP-like interface
    * @return
    *   a [[HttpCliApp]]
    */
@@ -48,6 +50,7 @@ object HttpCliApp {
     footer: HelpDoc = HelpDoc.Empty,
     config: CliConfig = CliConfig.default,
     figFont: FigFont = FigFont.Default,
+    cliStyle: Boolean = true 
   ): HttpCliApp[Any, Throwable, CliRequest] = {
     HttpCliApp {
       CliApp.make(
@@ -57,7 +60,7 @@ object HttpCliApp {
         footer = footer,
         config = config,
         figFont = figFont,
-        command = HttpCommand.fromEndpoints(name, endpoints),
+        command = HttpCommand.fromEndpoints(name, endpoints, cliStyle),
       ) { 
         case req @ CliRequest(_, _, _, _, mustPrint, mustSave) =>
           for {

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
@@ -1,7 +1,6 @@
 package zio.http.endpoint.cli
 
 import zio._
-import zio.ZIOAppDefault
 import zio.cli._
 import zio.cli.figlet.FigFont
 
@@ -36,7 +35,8 @@ object HttpCliApp {
    * @param figFont
    *   FigFont to use for man pages of the generated CLI
    * @param cliStyle
-   *   Style of commands of the generated CLI: true for CLI idiomatic interface, false for HTTP-like interface
+   *   Style of commands of the generated CLI: true for CLI idiomatic interface,
+   *   false for HTTP-like interface
    * @return
    *   a [[HttpCliApp]]
    */
@@ -50,7 +50,7 @@ object HttpCliApp {
     footer: HelpDoc = HelpDoc.Empty,
     config: CliConfig = CliConfig.default,
     figFont: FigFont = FigFont.Default,
-    cliStyle: Boolean = true 
+    cliStyle: Boolean = true,
   ): HttpCliApp[Any, Throwable, CliRequest] = {
     HttpCliApp {
       CliApp.make(
@@ -61,28 +61,26 @@ object HttpCliApp {
         config = config,
         figFont = figFont,
         command = HttpCommand.fromEndpoints(name, endpoints, cliStyle),
-      ) { 
-        case req @ CliRequest(_, _, _, _, mustPrint, mustSave) =>
-          for {
-            request <- req.toRequest(host, port)
-            response <- Client
-              .request(request)
-              .provide(Client.default)
-            _        <- Console.printLine(s"Got response")
-            _        <- Console.printLine(s"Status: ${response.status}")
-            _        <- ZIO.when(mustPrint)(printResponse(response))
-            _        <- ZIO.when(mustSave)(saveResponse(response))
-          } yield ()
+      ) { case req @ CliRequest(_, _, _, _, mustPrint, mustSave) =>
+        for {
+          request  <- req.toRequest(host, port)
+          response <- Client
+            .request(request)
+            .provide(Client.default)
+          _        <- Console.printLine(s"Got response")
+          _        <- Console.printLine(s"Status: ${response.status}")
+          _        <- ZIO.when(mustPrint)(printResponse(response))
+          _        <- ZIO.when(mustSave)(saveResponse(response))
+        } yield ()
       }
     }
   }
 
   private def printResponse(response: Response): Task[Unit] = for {
-    body     <- response.body.asString
-    _        <- Console.printLine(s"""Body: ${if (body.nonEmpty) body else "<empty>"}""")
+    body <- response.body.asString
+    _    <- Console.printLine(s"""Body: ${if (body.nonEmpty) body else "<empty>"}""")
   } yield ()
 
   private def saveResponse(response: Response): Task[Unit] = ???
-
 
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
@@ -83,15 +83,3 @@ object HttpCliApp {
 
 
 }
-
-
-
-object Prueba extends ZIOCliDefault {
-
-  val endpoints = Chunk.empty[Endpoint[Any, Nothing, Any, EndpointMiddleware]]
-
-  val cli2 =
-    HttpCliApp.fromEndpoints("a", "0", HelpDoc.Span.empty, endpoints, "dummy.restapiexample.com", 443)
-
-  def cliApp: CliApp[Environment with ZIOAppArgs with Scope,Any,Any] = cli2.cliApp
-}

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
@@ -1,8 +1,8 @@
 package zio.http.endpoint.cli
 
-import zio.cli._
-import zio.http.endpoint._
 import zio._
+import zio.cli._
+
 import zio.http._
 import zio.http.endpoint._
 
@@ -12,44 +12,48 @@ import zio.http.endpoint._
 
 object HttpCommand {
 
-    /*
-     * Transforms an Endpoint in its corresponding Command[CliRequest].
-     */
-    def getCommand[M <: EndpointMiddleware](endpoint: Endpoint[_, _, _, M], cliStyle: Boolean): Command[CliRequest] = {
-        val cliEndpoint = CliEndpoint.fromEndpoint(endpoint, true)
+  /*
+   * Transforms an Endpoint in its corresponding Command[CliRequest].
+   */
+  def getCommand[M <: EndpointMiddleware](endpoint: Endpoint[_, _, _, M], cliStyle: Boolean): Command[CliRequest] = {
+    val cliEndpoint = CliEndpoint.fromEndpoint(endpoint, true)
 
-        val doc = cliEndpoint.doc.toPlaintext()
+    val doc = cliEndpoint.doc.toPlaintext()
 
-        val emptyOptions = Options.Empty.map(_ => CliRequest.empty)
-        
-	    /*
-         * Adds the HttpOptions from options to an empty CliRequest.
-         */
-        def addOptionsTo(options: List[HttpOptions]): Options[CliRequest] =
-            options
-                .map(option => option.transform _)
-                .foldLeft(emptyOptions) {
-                    case(options, f) => f(options)
-                }
-
-        val cliRequest: Options[CliRequest] = addOptionsTo(cliEndpoint.getOptions).map(_.withMethod(cliEndpoint.methods))
-
-        val subcommands: Command[CliRequest] = Command(cliEndpoint.commandName(cliStyle), cliRequest).withHelp(doc)
-
-        subcommands     
-    } 
+    val emptyOptions = Options.Empty.map(_ => CliRequest.empty)
 
     /*
-     * Transforms a chunk of Endpoints in a Command to use directly in the CliApp.
+     * Adds the HttpOptions from options to an empty CliRequest.
      */
-    def fromEndpoints[M <: EndpointMiddleware](name: String, endpoints: Chunk[Endpoint[_, _, _, M]], cliStyle: Boolean): Command[CliRequest] = {
+    def addOptionsTo(options: List[HttpOptions]): Options[CliRequest] =
+      options
+        .map(option => option.transform _)
+        .foldLeft(emptyOptions) { case (options, f) =>
+          f(options)
+        }
 
-        val subcommands = endpoints.map(getCommand(_, cliStyle)).reduceOption(_ orElse _)
+    val cliRequest: Options[CliRequest] = addOptionsTo(cliEndpoint.getOptions).map(_.withMethod(cliEndpoint.methods))
 
-        subcommands match {
-                case Some(subcommands) => Command(name).subcommands(subcommands)
-                case None             => Command(name).map(_ => CliRequest.empty)
-            }
+    val subcommands: Command[CliRequest] = Command(cliEndpoint.commandName(cliStyle), cliRequest).withHelp(doc)
+
+    subcommands
+  }
+
+  /*
+   * Transforms a chunk of Endpoints in a Command to use directly in the CliApp.
+   */
+  def fromEndpoints[M <: EndpointMiddleware](
+    name: String,
+    endpoints: Chunk[Endpoint[_, _, _, M]],
+    cliStyle: Boolean,
+  ): Command[CliRequest] = {
+
+    val subcommands = endpoints.map(getCommand(_, cliStyle)).reduceOption(_ orElse _)
+
+    subcommands match {
+      case Some(subcommands) => Command(name).subcommands(subcommands)
+      case None              => Command(name).map(_ => CliRequest.empty)
     }
-    
+  }
+
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
@@ -1,0 +1,80 @@
+package zio.http.endpoint.cli
+
+import zio.cli._
+import zio.http.endpoint._
+import zio._
+import zio.http._
+import zio.http.endpoint._
+
+object HttpCommand {
+
+    def getCommand[M <: EndpointMiddleware](endpoint: Endpoint[_, _, _, M]): Command[CliRequest] = {
+        val cliEndpoint = CliEndpoint.fromEndpoint(endpoint)
+
+        val doc = cliEndpoint.doc.toPlaintext()
+
+        val emptyOptions = Options.Empty.map(_ => CliRequest.empty)
+        
+        def addOptionsTo(options: List[HttpOptions]): Options[CliRequest] =
+            options
+                .map(option => option.transform _)
+                .foldLeft(emptyOptions) {
+                    case(options, f) => f(options)
+                }
+
+        val cliRequest: Options[CliRequest] = addOptionsTo(cliEndpoint.getOptions).map(_.withMethod(cliEndpoint.methods))
+
+        val subcommands: Command[CliRequest] = Command(cliEndpoint.commandName, cliRequest).withHelp(doc)
+
+        subcommands     
+    } 
+
+    def fromEndpoints[M <: EndpointMiddleware](name: String, endpoints: Chunk[Endpoint[_, _, _, M]]): Command[CliRequest] = {
+
+        val subcommands = endpoints.map(getCommand(_)).reduceOption(_ orElse _)
+
+        subcommands match {
+                case Some(subcommands) => Command(name).subcommands(subcommands)
+                case None             => Command(name).map(_ => CliRequest.empty)
+            }
+    }
+/*
+    def fromEndpoints[M <: EndpointMiddleware](name: String, endpoints: Chunk[Endpoint[_, _, _, M]]): HttpCommand = {
+
+        val cliEndpoints: Chunk[CliEndpoint[_]]   = endpoints.flatMap(CliEndpoint.fromEndpoint(_))
+
+        val subcommand: Option[Command[CliRequest]] = cliEndpoints
+            .groupBy(_.commandName)
+            .map { case (name, cliEndpoints) =>
+                val doc     = cliEndpoints.map(_.doc).map(_.toPlaintext()).mkString("\n\n")
+                val options: Options[(Int, Any)] =
+                cliEndpoints
+                    .map(_.options)
+                    .zipWithIndex
+                    .map { case (options, index) => options.map(index -> _) }
+                    .reduceOption(_ orElse _)
+                    .getOrElse(Options.none.map(_ => (-1, CliRequest.empty)))
+
+                val c: Command[CliRequest] = Command(name, options).withHelp(doc).map { case (index, any) =>
+                val cliEndpoint = cliEndpoints(index)
+                cliEndpoint
+                    .asInstanceOf[CliEndpoint[cliEndpoint.Type]]
+                    .embed(any.asInstanceOf[cliEndpoint.Type], CliRequest.empty)
+                }
+                c
+            }
+            .reduceOption(_ orElse _)
+
+        val command =
+            subcommand match {
+                case Some(subcommand) => Command(name).subcommands(subcommand)
+                case None             => Command(name).map(_ => CliRequest.empty)
+            }
+
+        HttpCommand(command)
+    }
+*/
+    
+
+    
+}

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCommand.scala
@@ -15,7 +15,7 @@ object HttpCommand {
     /*
      * Transforms an Endpoint in its corresponding Command[CliRequest].
      */
-    def getCommand[M <: EndpointMiddleware](endpoint: Endpoint[_, _, _, M]): Command[CliRequest] = {
+    def getCommand[M <: EndpointMiddleware](endpoint: Endpoint[_, _, _, M], cliStyle: Boolean): Command[CliRequest] = {
         val cliEndpoint = CliEndpoint.fromEndpoint(endpoint, true)
 
         val doc = cliEndpoint.doc.toPlaintext()
@@ -34,7 +34,7 @@ object HttpCommand {
 
         val cliRequest: Options[CliRequest] = addOptionsTo(cliEndpoint.getOptions).map(_.withMethod(cliEndpoint.methods))
 
-        val subcommands: Command[CliRequest] = Command(cliEndpoint.commandName, cliRequest).withHelp(doc)
+        val subcommands: Command[CliRequest] = Command(cliEndpoint.commandName(cliStyle), cliRequest).withHelp(doc)
 
         subcommands     
     } 
@@ -42,9 +42,9 @@ object HttpCommand {
     /*
      * Transforms a chunk of Endpoints in a Command to use directly in the CliApp.
      */
-    def fromEndpoints[M <: EndpointMiddleware](name: String, endpoints: Chunk[Endpoint[_, _, _, M]]): Command[CliRequest] = {
+    def fromEndpoints[M <: EndpointMiddleware](name: String, endpoints: Chunk[Endpoint[_, _, _, M]], cliStyle: Boolean): Command[CliRequest] = {
 
-        val subcommands = endpoints.map(getCommand(_)).reduceOption(_ orElse _)
+        val subcommands = endpoints.map(getCommand(_, cliStyle)).reduceOption(_ orElse _)
 
         subcommands match {
                 case Some(subcommands) => Command(name).subcommands(subcommands)

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -3,11 +3,8 @@ package zio.http.endpoint.cli
 import scala.util.Try
 import scala.language.implicitConversions
 
-import zio.cli.Options
-
-import zio.http.codec.TextCodec
-import zio.http.MediaType
-import zio.http.Body
+import zio.http.codec._
+import zio.http._
 import zio.schema._
 import zio.json.ast._
 import java.nio.file.Path
@@ -25,121 +22,117 @@ private[cli] sealed trait HttpOptions {
 
   val name: String
 
-  val doc: Doc = Doc.empty
-
   def transform(request: Options[CliRequest]): Options[CliRequest]
 
-  def ??(doc: Doc): HttpOptions = self.copy(doc = self.doc + doc)
+  def ??(doc: Doc): HttpOptions
 
 }
 
 private[cli] object HttpOptions {
 
-  
   /*
    * Subclass for Body
    * It is possible to specify a body writing directly on the terminal, from a file or the body of the response from another Request.
    * TODO implementation for getting body from URL.
    */
-  final case class Body[A](override val name: String, mediaType: Option[MediaType], schema: Schema[A]) extends HttpOptions {
+  final case class Body[A](override val name: String, mediaType: Option[MediaType], schema: Schema[A], doc: Doc = Doc.empty) extends HttpOptions {
+    self =>
 
-    
     lazy val options: Options[Retriever] = {
       val written: Options[Json] = fromSchema(schema)
-      val fromFile = Options.file("f:"+name)
-      val fromUrl = Options.text("url:"+name)
+      val fromFile               = Options.file("f:" + name)
+      val fromUrl                = Options.text("url:" + name)
 
       val retriever = fromFile orElseEither fromUrl orElseEither written
       retriever.map {
         _ match {
           case Left(Left(file)) => Retriever.File(name, file, mediaType)
           case Left(Right(url)) => Retriever.URL(url)
-          case Right(json)   => Retriever.Content(FormField.textField(name, json.toString()))
+          case Right(json)      => Retriever.Content(FormField.textField(name, json.toString()))
         }
       }
     }
 
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-      (request ++ options).map {
-        case (cliRequest, retriever) => cliRequest.addBody(retriever)
+    override def ??(doc: Doc): Body[A] = self.copy(doc = self.doc + doc)
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
+      (request ++ options).map { case (cliRequest, retriever) =>
+        cliRequest.addBody(retriever)
       }
 
-  
-  
-
-    /* 
-    * Allows to specify the body with given schema using Json.
-    * It does not support schemas with Binary Primitive. This can be added in a ContentCodec
-    */
+    /*
+     * Allows to specify the body with given schema using Json.
+     * It does not support schemas with Binary Primitive. This can be added in a ContentCodec
+     */
     private def fromSchema(schema: zio.schema.Schema[_]): Options[Json] = {
 
-      implicit def toJson[A](options: Options[A]): Options[Json] = options.map( value => Json.Str(value.toString()))
+      implicit def toJson[A](options: Options[A]): Options[Json] = options.map(value => Json.Str(value.toString()))
 
       lazy val emptyJson: Options[Json] = Options.Empty.map(_ => Json.Obj())
 
       def loop(prefix: List[String], schema: zio.schema.Schema[_]): Options[Json] =
         schema match {
-          case record: Schema.Record[_]             =>
-              record.fields
-                .foldLeft(emptyJson) { (options, field) =>
-                  val fieldOptions: Options[Json] = field.annotations.headOption match {
-                      case Some(description) => loop(prefix :+ field.name, field.schema) ?? description.asInstanceOf[description].text
-                      case None              => loop(prefix :+ field.name, field.schema)
-                    } 
-                  merge(options, fieldOptions)
-                } // TODO review the case of nested sealed trait inside case class
-          case enumeration: Schema.Enum[_]          =>
-            enumeration.cases.foldLeft(emptyJson) {
-              case (options, enumCase) => merge(options, loop(prefix, enumCase.schema))
+          case record: Schema.Record[_]    =>
+            record.fields
+              .foldLeft(emptyJson) { (options, field) =>
+                val fieldOptions: Options[Json] = field.annotations.headOption match {
+                  case Some(description) =>
+                    loop(prefix :+ field.name, field.schema) ?? description.asInstanceOf[description].text
+                  case None              => loop(prefix :+ field.name, field.schema)
+                }
+                merge(options, fieldOptions)
+              } // TODO review the case of nested sealed trait inside case class
+          case enumeration: Schema.Enum[_] =>
+            enumeration.cases.foldLeft(emptyJson) { case (options, enumCase) =>
+              merge(options, loop(prefix, enumCase.schema))
             }
 
-          case Schema.Primitive(standardType, _)    => fromPrimitive(prefix, standardType)
-            
+          case Schema.Primitive(standardType, _) => fromPrimitive(prefix, standardType)
+
           case Schema.Fail(_, _)                    => emptyJson
           case Schema.Map(_, _, _)                  => ??? // TODO
           case Schema.Sequence(_, _, _, _, _)       => ??? // TODO
           case Schema.Set(_, _)                     => ??? // TODO
           case Schema.Lazy(schema0)                 => loop(prefix, schema0())
           case Schema.Dynamic(_)                    => emptyJson
-          case Schema.Either(left, right, _)        => 
+          case Schema.Either(left, right, _)        =>
             (loop(prefix, left) orElseEither loop(prefix, right)).map(_.merge)
-          case Schema.Optional(schema, _)           => loop(prefix, schema).optional.map {
-            case Some(json) => json
-            case None => Json.Obj()
-          }
+          case Schema.Optional(schema, _)           =>
+            loop(prefix, schema).optional.map {
+              case Some(json) => json
+              case None       => Json.Obj()
+            }
           case Schema.Tuple2(left, right, _)        =>
             merge(loop(prefix, left), loop(prefix, right))
           case Schema.Transform(schema, _, _, _, _) => loop(prefix, schema)
         }
 
       def merge(opt1: Options[Json], opt2: Options[Json]): Options[Json] =
-        (opt1 ++ opt2).map{ case (a, b) => Json.Arr(a,b) }
-
-          
+        (opt1 ++ opt2).map { case (a, b) => Json.Arr(a, b) }
 
       def fromPrimitive(prefix: List[String], standardType: StandardType[_]): Options[Json] = standardType match {
         case StandardType.InstantType        => Options.instant(prefix.mkString("."))
         case StandardType.UnitType           => emptyJson
         case StandardType.PeriodType         => Options.period(prefix.mkString("."))
         case StandardType.LongType           =>
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
         case StandardType.StringType         => Options.text(prefix.mkString("."))
         case StandardType.UUIDType           => Options.text(prefix.mkString("."))
         case StandardType.ByteType           =>
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
         case StandardType.OffsetDateTimeType => Options.offsetDateTime(prefix.mkString("."))
         case StandardType.LocalDateType      => Options.localDate(prefix.mkString("."))
         case StandardType.OffsetTimeType     => Options.decimal(prefix.mkString("."))
-        case StandardType.FloatType    =>
-          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+        case StandardType.FloatType          =>
+          Options.decimal(prefix.mkString(".")).map(value => Json.Num(value))
         case StandardType.BigDecimalType     =>
-          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+          Options.decimal(prefix.mkString(".")).map(value => Json.Num(value))
         case StandardType.BigIntegerType     =>
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
         case StandardType.DoubleType         =>
-          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+          Options.decimal(prefix.mkString(".")).map(value => Json.Num(value))
         case StandardType.BoolType           =>
-          Options.boolean(prefix.mkString(".")).map( value => Json.Bool(value))
+          Options.boolean(prefix.mkString(".")).map(value => Json.Bool(value))
         case StandardType.CharType           => Options.text(prefix.mkString("."))
         case StandardType.ZoneOffsetType     => Options.zoneOffset(prefix.mkString("."))
         case StandardType.YearMonthType      => Options.yearMonth(prefix.mkString("."))
@@ -147,15 +140,15 @@ private[cli] object HttpOptions {
         case StandardType.LocalTimeType      => Options.localTime(prefix.mkString("."))
         case StandardType.ZoneIdType         => Options.zoneId(prefix.mkString("."))
         case StandardType.ZonedDateTimeType  => Options.zonedDateTime(prefix.mkString("."))
-        case StandardType.DayOfWeekType      => 
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-        case StandardType.DurationType       => 
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-        case StandardType.IntType            => 
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.DayOfWeekType      =>
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
+        case StandardType.DurationType       =>
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
+        case StandardType.IntType            =>
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
         case StandardType.MonthDayType       => Options.monthDay(prefix.mkString("."))
-        case StandardType.ShortType          => 
-          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.ShortType          =>
+          Options.integer(prefix.mkString(".")).map(value => Json.Num(BigDecimal(value)))
         case StandardType.LocalDateTimeType  => Options.localDateTime(prefix.mkString("."))
         case StandardType.MonthType          => Options.text(prefix.mkString("."))
         case StandardType.YearType           => Options.integer(prefix.mkString("."))
@@ -164,34 +157,37 @@ private[cli] object HttpOptions {
       loop(List.empty, schema)
     }
 
-    
   }
-
-  
 
   /*
    * Subclasses for headers
    */
-  sealed trait HeaderOptions extends HttpOptions
-  final case class Header(override val name: String, textCodec: TextCodec[_]) extends HeaderOptions {
+  sealed trait HeaderOptions extends HttpOptions {
+    override def ??(doc: Doc): HeaderOptions
+  }
+  final case class Header(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty) extends HeaderOptions {
+    self =>
 
     lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
-    
-    
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-      (request ++ options).map {
-        case (cliRequest, value) =>
-          if(true) cliRequest.addHeader(name, value.toString())
-          else cliRequest
+
+    override def ??(doc: Doc): Header = self.copy(doc = self.doc + doc)
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
+      (request ++ options).map { case (cliRequest, value) =>
+        if (true) cliRequest.addHeader(name, value.toString())
+        else cliRequest
       }
 
   }
 
-  final case class HeaderConstant(override val name: String, value: String) extends HeaderOptions {
+  final case class HeaderConstant(override val name: String, value: String, doc: Doc = Doc.empty) extends HeaderOptions {
+    self =>
 
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+    override def ??(doc: Doc): HeaderConstant = self.copy(doc = self.doc + doc)
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
       request.map(_.addHeader(name, value))
-    
+
   }
 
   /*
@@ -199,66 +195,81 @@ private[cli] object HttpOptions {
    */
   sealed trait URLOptions extends HttpOptions {
     val tag: String
+    
+    override def ??(doc: Doc): URLOptions
   }
 
-  final case class Path(override val name: String, textCodec: TextCodec[_]) extends URLOptions {
+  final case class Path(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty) extends URLOptions {
+    self =>
 
     lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
 
-    override val tag = "/"+name
-  
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-      (request ++ options).map {
-        case (cliRequest, value) =>
-          if(true) cliRequest.addPathParam(value.toString())
-          else cliRequest
+    override def ??(doc: Doc): Path = self.copy(doc = self.doc + doc)
+
+    override val tag = "/" + name
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
+      (request ++ options).map { case (cliRequest, value) =>
+        if (true) cliRequest.addPathParam(value.toString())
+        else cliRequest
       }
 
   }
 
-  final case class PathConstant(override val name: String) extends URLOptions {
+  final case class PathConstant(override val name: String, doc: Doc = Doc.empty) extends URLOptions {
+    self =>
+
     override val tag = "/" + name
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+
+    override def ??(doc: Doc): PathConstant = self.copy(doc = self.doc + doc)
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
       request.map(_.addPathParam(name))
 
   }
 
-  final case class Query(override val name: String, textCodec: TextCodec[_]) extends URLOptions {
-    override val tag = "?" + name
+  final case class Query(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty) extends URLOptions {
+    self =>
+
+    override val tag             = "?" + name
     lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
-  
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-      (request ++ options).map {
-        case (cliRequest, value) =>
-          if(true) cliRequest.addQueryParam(name, value.toString())
-          else cliRequest
+
+    override def ??(doc: Doc): Query = self.copy(doc = self.doc + doc)
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
+      (request ++ options).map { case (cliRequest, value) =>
+        if (true) cliRequest.addQueryParam(name, value.toString())
+        else cliRequest
       }
 
   }
 
-  final case class QueryConstant(override val name: String, value: String) extends URLOptions {
-    override val tag = "?"+name+"="+value
-    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+  final case class QueryConstant(override val name: String, value: String, doc: Doc = Doc.empty) extends URLOptions {
+    self =>
+
+    override val tag = "?" + name + "=" + value
+    override def ??(doc: Doc): QueryConstant = self.copy(doc = self.doc + doc)
+    override def transform(request: Options[CliRequest]): Options[CliRequest] =
       request.map(_.addQueryParam(name, value))
 
   }
 
-
   private def optionsFromCodec[A](textCodec: TextCodec[A]): (String => Options[_]) =
     textCodec.asInstanceOf[TextCodec[_]] match {
-      case TextCodec.UUIDCodec        => 
-        Options.text(_)
+      case TextCodec.UUIDCodec    =>
+        Options
+          .text(_)
           .mapOrFail(str =>
             Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
               ValidationError(
                 ValidationErrorType.InvalidValue,
                 HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
               )
-            }
+            },
           )
-      case TextCodec.StringCodec      => Options.text(_)
-      case TextCodec.IntCodec         => Options.integer(_)
-      case TextCodec.BooleanCodec     => Options.boolean(_)
-      case _                          => ( _ => Options.Empty)
+      case TextCodec.StringCodec  => Options.text(_)
+      case TextCodec.IntCodec     => Options.integer(_)
+      case TextCodec.BooleanCodec => Options.boolean(_)
+      case _                      => _ => Options.Empty
     }
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -1,0 +1,244 @@
+package zio.http.endpoint.cli
+
+import scala.util.Try
+
+import zio.cli.Options
+
+import zio.http.codec.TextCodec
+import zio.http.MediaType
+import zio.http.Body
+import zio.schema._
+import zio.json.ast._
+import java.nio.file.Path
+import zio.http.FormField
+import zio.cli._
+
+private[cli] sealed trait HttpOptions {
+
+  def transform(request: Options[CliRequest]): Options[CliRequest]
+
+}
+
+private[cli] object HttpOptions {
+
+    /*
+     * It is possible to specify a body writing directly on the terminal, from a file or the body of the response from another CliRequest.
+     */
+
+    case class Body[A](name: String, mediaType: Option[MediaType], schema: Schema[A]) extends HttpOptions {
+
+      
+      lazy val options: Options[Either[Either[java.nio.file.Path, String], Json]] = {
+        val written: Options[Json] = fromSchema(schema)
+        val fromFile = Options.file("f:"+name)
+        val fromUrl = Options.text("url:"+name)
+
+        fromFile orElseEither fromUrl orElseEither written
+        
+      }
+
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        (request ++ options).map {
+          case (cliRequest, value) => {
+            val formField: Either[Either[(String, java.nio.file.Path, MediaType), String], FormField] = 
+              value match {
+                case Left(Left(file)) => mediaType match {
+                  case Some(mediaType) => Left(Left((name, file, mediaType)))
+                  case None => Right(FormField.simpleField("foo", "foo"))
+                }
+                case Left(Right(url)) => Left(Right(url))
+                case Right(a) => Right(FormField.textField(name, a.toString()))
+              }
+              value match {
+                case Left(Left(file)) => mediaType match {
+                  case Some(mediaType) => cliRequest.addBody(formField)
+                  case None => cliRequest
+                }
+                case _ => cliRequest.addBody(formField)
+              }
+          }
+        }
+
+        lazy val emptyJson: Options[Json] = Options.Empty.map(_ => Json.Obj())
+  
+
+  private def fromSchema(schema: zio.schema.Schema[_]): Options[Json] = {
+
+    
+
+    def loop(prefix: List[String], schema: zio.schema.Schema[_]): Options[Json] =
+      schema match {
+        case record: Schema.Record[_]             =>
+            record.fields
+              .foldLeft(emptyJson) { (options, field) =>
+                val fieldOptions: Options[Json] = field.annotations.headOption match {
+                    case Some(description) => loop(prefix :+ field.name, field.schema) ?? description.asInstanceOf[description].text
+                    case None              => loop(prefix :+ field.name, field.schema)
+                  } 
+                merge(options, fieldOptions)
+              } // TODO review the case of nested sealed trait inside case class
+        case enumeration: Schema.Enum[_]          =>
+          enumeration.cases.foldLeft(emptyJson) {
+            case (options, enumCase) => merge(options, loop(prefix, enumCase.schema))
+          }
+
+        case Schema.Primitive(standardType, _)    => fromPrimitive(prefix, standardType)
+          
+        case Schema.Fail(_, _)                    => emptyJson
+        case Schema.Map(_, _, _)                  => ??? // TODO
+        case Schema.Sequence(_, _, _, _, _)       => ??? // TODO
+        case Schema.Set(_, _)                     => ??? // TODO
+        case Schema.Lazy(schema0)                 => loop(prefix, schema0())
+        case Schema.Dynamic(_)                    => emptyJson
+        case Schema.Either(left, right, _)        => 
+          (loop(prefix, left) orElseEither loop(prefix, right)).map(_.merge)
+        case Schema.Optional(schema, _)           => loop(prefix, schema).optional.map {
+          case Some(json) => json
+          case None => Json.Obj()
+        }
+        case Schema.Tuple2(left, right, _)        =>
+          merge(loop(prefix, left), loop(prefix, right))
+        case Schema.Transform(schema, _, _, _, _) => loop(prefix, schema)
+      }
+
+      def merge(opt1: Options[Json], opt2: Options[Json]): Options[Json] =
+        (opt1 ++ opt2).map{ case (a, b) => Json.Arr(a,b) }
+
+    loop(List.empty, schema)
+  }
+
+  implicit def toJson[A](options: Options[A]): Options[Json] = options.map( value => Json.Str(value.toString()))
+
+  def fromPrimitive(prefix: List[String], standardType: StandardType[_]): Options[Json] = standardType match {
+            case StandardType.InstantType        => Options.instant(prefix.mkString("."))
+            case StandardType.UnitType           => emptyJson
+            case StandardType.PeriodType         => Options.period(prefix.mkString("."))
+            case StandardType.LongType           =>
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.StringType         => Options.text(prefix.mkString("."))
+            case StandardType.UUIDType           => Options.text(prefix.mkString("."))
+            case StandardType.ByteType           =>
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.OffsetDateTimeType => Options.offsetDateTime(prefix.mkString("."))
+            case StandardType.LocalDateType      => Options.localDate(prefix.mkString("."))
+            case StandardType.OffsetTimeType     => Options.decimal(prefix.mkString("."))
+            case StandardType.FloatType    =>
+              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+            case StandardType.BigDecimalType     =>
+              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+            case StandardType.BigIntegerType     =>
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.DoubleType         =>
+              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+            case StandardType.BoolType           =>
+              Options.boolean(prefix.mkString(".")).map( value => Json.Bool(value))
+            case StandardType.CharType           => Options.text(prefix.mkString("."))
+            case StandardType.ZoneOffsetType     => Options.zoneOffset(prefix.mkString("."))
+            case StandardType.YearMonthType      => Options.yearMonth(prefix.mkString("."))
+            case StandardType.BinaryType         => emptyJson
+            case StandardType.LocalTimeType      => Options.localTime(prefix.mkString("."))
+            case StandardType.ZoneIdType         => Options.zoneId(prefix.mkString("."))
+            case StandardType.ZonedDateTimeType  => Options.zonedDateTime(prefix.mkString("."))
+            case StandardType.DayOfWeekType      => 
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.DurationType       => 
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.IntType            => 
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.MonthDayType       => Options.monthDay(prefix.mkString("."))
+            case StandardType.ShortType          => 
+              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+            case StandardType.LocalDateTimeType  => Options.localDateTime(prefix.mkString("."))
+            case StandardType.MonthType          => Options.text(prefix.mkString("."))
+            case StandardType.YearType           => Options.integer(prefix.mkString("."))
+          }
+
+    }
+
+
+    sealed trait HeaderOptions extends HttpOptions
+    case class Header(name: String, textCodec: TextCodec[_]) extends HeaderOptions {
+
+      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+    
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        (request ++ options).map {
+          case (cliRequest, value) =>
+            if(true) cliRequest.addHeader(name, value.toString())
+            else cliRequest
+        }
+
+    }
+
+    case class HeaderConstant(name: String, value: String) extends HeaderOptions {
+
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        request.map(_.addHeader(name, value))
+      
+    }
+
+    sealed trait URLOptions extends HttpOptions {
+      val tag: String
+    }
+    case class Path(name: String, textCodec: TextCodec[_]) extends URLOptions {
+
+      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+
+      override val tag = "/"+name
+    
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        (request ++ options).map {
+          case (cliRequest, value) =>
+            if(true) cliRequest.addPathParam(name)
+            else cliRequest
+        }
+
+    }
+
+    case class PathConstant(name: String) extends URLOptions {
+      override val tag = "/"+name
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        request.map(_.addPathParam(name))
+
+    }
+
+    case class Query(name: String, textCodec: TextCodec[_]) extends URLOptions {
+      override val tag = "/"+name+"?"
+      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+    
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        (request ++ options).map {
+          case (cliRequest, value) =>
+            if(true) cliRequest.addQueryParam(name, value.toString())
+            else cliRequest
+        }
+
+    }
+
+    case class QueryConstant(name: String, value: String) extends URLOptions {
+      override val tag = "/"+name+"?"+value
+      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+        request.map(_.addQueryParam(name, value))
+
+    }
+
+    def optionsFromCodec[A](textCodec: TextCodec[A]): (String => Options[_]) =
+      textCodec.asInstanceOf[TextCodec[_]] match {
+        case TextCodec.UUIDCodec        => 
+          Options.text(_)
+            .mapOrFail(str =>
+              Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
+                ValidationError(
+                  ValidationErrorType.InvalidValue,
+                  HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
+                )
+              }
+            )
+        case TextCodec.StringCodec      => Options.text(_)
+        case TextCodec.IntCodec         => Options.integer(_)
+        case TextCodec.BooleanCodec     => Options.boolean(_)
+        case _                          => ( _ => Options.Empty)
+      }
+
+}
+

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -1,15 +1,17 @@
 package zio.http.endpoint.cli
 
-import scala.util.Try
-import scala.language.implicitConversions
-
-import zio.http.codec._
-import zio.http._
-import zio.schema._
-import zio.json.ast._
 import java.nio.file.Path
-import zio.http.FormField
+
+import scala.language.implicitConversions
+import scala.util.Try
+
 import zio.cli._
+import zio.json.ast._
+
+import zio.schema._
+
+import zio.http._
+import zio.http.codec._
 
 /*
  * HttpOptions is a wrapper of a transformation Options[CliRequest] => Options[CliRequest].
@@ -35,7 +37,12 @@ private[cli] object HttpOptions {
    * It is possible to specify a body writing directly on the terminal, from a file or the body of the response from another Request.
    * TODO implementation for getting body from URL.
    */
-  final case class Body[A](override val name: String, mediaType: Option[MediaType], schema: Schema[A], doc: Doc = Doc.empty) extends HttpOptions {
+  final case class Body[A](
+    override val name: String,
+    mediaType: Option[MediaType],
+    schema: Schema[A],
+    doc: Doc = Doc.empty,
+  ) extends HttpOptions {
     self =>
 
     lazy val options: Options[Retriever] = {
@@ -165,7 +172,8 @@ private[cli] object HttpOptions {
   sealed trait HeaderOptions extends HttpOptions {
     override def ??(doc: Doc): HeaderOptions
   }
-  final case class Header(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty) extends HeaderOptions {
+  final case class Header(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty)
+      extends HeaderOptions {
     self =>
 
     lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
@@ -180,7 +188,8 @@ private[cli] object HttpOptions {
 
   }
 
-  final case class HeaderConstant(override val name: String, value: String, doc: Doc = Doc.empty) extends HeaderOptions {
+  final case class HeaderConstant(override val name: String, value: String, doc: Doc = Doc.empty)
+      extends HeaderOptions {
     self =>
 
     override def ??(doc: Doc): HeaderConstant = self.copy(doc = self.doc + doc)
@@ -195,7 +204,7 @@ private[cli] object HttpOptions {
    */
   sealed trait URLOptions extends HttpOptions {
     val tag: String
-    
+
     override def ??(doc: Doc): URLOptions
   }
 
@@ -247,8 +256,8 @@ private[cli] object HttpOptions {
   final case class QueryConstant(override val name: String, value: String, doc: Doc = Doc.empty) extends URLOptions {
     self =>
 
-    override val tag = "?" + name + "=" + value
-    override def ??(doc: Doc): QueryConstant = self.copy(doc = self.doc + doc)
+    override val tag                                                          = "?" + name + "=" + value
+    override def ??(doc: Doc): QueryConstant                                  = self.copy(doc = self.doc + doc)
     override def transform(request: Options[CliRequest]): Options[CliRequest] =
       request.map(_.addQueryParam(name, value))
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -25,7 +25,11 @@ private[cli] sealed trait HttpOptions {
 
   val name: String
 
+  val doc: Doc = Doc.empty
+
   def transform(request: Options[CliRequest]): Options[CliRequest]
+
+  def ??(doc: Doc): HttpOptions = self.copy(doc = self.doc + doc)
 
 }
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -228,7 +228,7 @@ private[cli] object HttpOptions {
   }
 
   final case class Query(name: String, textCodec: TextCodec[_]) extends URLOptions {
-    override val tag = "/"+name+"?"
+    override val tag = "?"+name
     lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
   
     override def transform(request: Options[CliRequest]): Options[CliRequest] = 
@@ -241,7 +241,7 @@ private[cli] object HttpOptions {
   }
 
   final case class QueryConstant(name: String, value: String) extends URLOptions {
-    override val tag = "/"+name+"?"+value
+    override val tag = "?"+name+"="+value
     override def transform(request: Options[CliRequest]): Options[CliRequest] = 
       request.map(_.addQueryParam(name, value))
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -13,6 +13,13 @@ import java.nio.file.Path
 import zio.http.FormField
 import zio.cli._
 
+/*
+ * HttpOptions is a wrapper of a transformation Options[CliRequest] => Options[CliRequest].
+ * The defined HttpOptions subclasses store an information about a request (body, header and url)
+ * and the transformation adds this information to a generic CliRequest wrapped in Options.
+ *
+ */
+
 private[cli] sealed trait HttpOptions {
 
   def transform(request: Options[CliRequest]): Options[CliRequest]
@@ -21,224 +28,241 @@ private[cli] sealed trait HttpOptions {
 
 private[cli] object HttpOptions {
 
-    /*
-     * It is possible to specify a body writing directly on the terminal, from a file or the body of the response from another CliRequest.
-     */
-
-    case class Body[A](name: String, mediaType: Option[MediaType], schema: Schema[A]) extends HttpOptions {
-
-      
-      lazy val options: Options[Either[Either[java.nio.file.Path, String], Json]] = {
-        val written: Options[Json] = fromSchema(schema)
-        val fromFile = Options.file("f:"+name)
-        val fromUrl = Options.text("url:"+name)
-
-        fromFile orElseEither fromUrl orElseEither written
-        
-      }
-
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        (request ++ options).map {
-          case (cliRequest, value) => {
-            val formField: Either[Either[(String, java.nio.file.Path, MediaType), String], FormField] = 
-              value match {
-                case Left(Left(file)) => mediaType match {
-                  case Some(mediaType) => Left(Left((name, file, mediaType)))
-                  case None => Right(FormField.simpleField("foo", "foo"))
-                }
-                case Left(Right(url)) => Left(Right(url))
-                case Right(a) => Right(FormField.textField(name, a.toString()))
-              }
-              value match {
-                case Left(Left(file)) => mediaType match {
-                  case Some(mediaType) => cliRequest.addBody(formField)
-                  case None => cliRequest
-                }
-                case _ => cliRequest.addBody(formField)
-              }
-          }
-        }
-
-        lazy val emptyJson: Options[Json] = Options.Empty.map(_ => Json.Obj())
   
-
-  private def fromSchema(schema: zio.schema.Schema[_]): Options[Json] = {
+  /*
+   * Subclass for Body
+   * It is possible to specify a body writing directly on the terminal, from a file or the body of the response from another Request.
+   * TODO implementation for getting body from URL.
+   */
+  final case class Body[A](name: String, mediaType: Option[MediaType], schema: Schema[A]) extends HttpOptions {
 
     
+    lazy val options: Options[Either[Either[java.nio.file.Path, String], Json]] = {
+      val written: Options[Json] = fromSchema(schema)
+      val fromFile = Options.file("f:"+name)
+      val fromUrl = Options.text("url:"+name)
 
-    def loop(prefix: List[String], schema: zio.schema.Schema[_]): Options[Json] =
-      schema match {
-        case record: Schema.Record[_]             =>
-            record.fields
-              .foldLeft(emptyJson) { (options, field) =>
-                val fieldOptions: Options[Json] = field.annotations.headOption match {
-                    case Some(description) => loop(prefix :+ field.name, field.schema) ?? description.asInstanceOf[description].text
-                    case None              => loop(prefix :+ field.name, field.schema)
-                  } 
-                merge(options, fieldOptions)
-              } // TODO review the case of nested sealed trait inside case class
-        case enumeration: Schema.Enum[_]          =>
-          enumeration.cases.foldLeft(emptyJson) {
-            case (options, enumCase) => merge(options, loop(prefix, enumCase.schema))
-          }
+      fromFile orElseEither fromUrl orElseEither written
+      
+    }
 
-        case Schema.Primitive(standardType, _)    => fromPrimitive(prefix, standardType)
-          
-        case Schema.Fail(_, _)                    => emptyJson
-        case Schema.Map(_, _, _)                  => ??? // TODO
-        case Schema.Sequence(_, _, _, _, _)       => ??? // TODO
-        case Schema.Set(_, _)                     => ??? // TODO
-        case Schema.Lazy(schema0)                 => loop(prefix, schema0())
-        case Schema.Dynamic(_)                    => emptyJson
-        case Schema.Either(left, right, _)        => 
-          (loop(prefix, left) orElseEither loop(prefix, right)).map(_.merge)
-        case Schema.Optional(schema, _)           => loop(prefix, schema).optional.map {
-          case Some(json) => json
-          case None => Json.Obj()
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      (request ++ options).map {
+        case (cliRequest, value) => {
+          val formField: Either[Either[(String, java.nio.file.Path, MediaType), String], FormField] = 
+            value match {
+              case Left(Left(file)) => mediaType match {
+                case Some(mediaType) => Left(Left((name, file, mediaType)))
+                case None => Right(FormField.simpleField("foo", "foo"))
+              }
+              case Left(Right(url)) => Left(Right(url))
+              case Right(a) => Right(FormField.textField(name, a.toString()))
+            }
+            value match {
+              case Left(Left(file)) => mediaType match {
+                case Some(mediaType) => cliRequest.addBody(formField)
+                case None => cliRequest
+              }
+              case _ => cliRequest.addBody(formField)
+            }
         }
-        case Schema.Tuple2(left, right, _)        =>
-          merge(loop(prefix, left), loop(prefix, right))
-        case Schema.Transform(schema, _, _, _, _) => loop(prefix, schema)
       }
+
+  
+  
+
+    /* 
+    * Allows to specify the body with given schema using Json.
+    * It does not support schemas with Binary Primitive. This can be added in a ContentCodec
+    */
+    private def fromSchema(schema: zio.schema.Schema[_]): Options[Json] = {
+
+      implicit def toJson[A](options: Options[A]): Options[Json] = options.map( value => Json.Str(value.toString()))
+
+      lazy val emptyJson: Options[Json] = Options.Empty.map(_ => Json.Obj())
+
+      def loop(prefix: List[String], schema: zio.schema.Schema[_]): Options[Json] =
+        schema match {
+          case record: Schema.Record[_]             =>
+              record.fields
+                .foldLeft(emptyJson) { (options, field) =>
+                  val fieldOptions: Options[Json] = field.annotations.headOption match {
+                      case Some(description) => loop(prefix :+ field.name, field.schema) ?? description.asInstanceOf[description].text
+                      case None              => loop(prefix :+ field.name, field.schema)
+                    } 
+                  merge(options, fieldOptions)
+                } // TODO review the case of nested sealed trait inside case class
+          case enumeration: Schema.Enum[_]          =>
+            enumeration.cases.foldLeft(emptyJson) {
+              case (options, enumCase) => merge(options, loop(prefix, enumCase.schema))
+            }
+
+          case Schema.Primitive(standardType, _)    => fromPrimitive(prefix, standardType)
+            
+          case Schema.Fail(_, _)                    => emptyJson
+          case Schema.Map(_, _, _)                  => ??? // TODO
+          case Schema.Sequence(_, _, _, _, _)       => ??? // TODO
+          case Schema.Set(_, _)                     => ??? // TODO
+          case Schema.Lazy(schema0)                 => loop(prefix, schema0())
+          case Schema.Dynamic(_)                    => emptyJson
+          case Schema.Either(left, right, _)        => 
+            (loop(prefix, left) orElseEither loop(prefix, right)).map(_.merge)
+          case Schema.Optional(schema, _)           => loop(prefix, schema).optional.map {
+            case Some(json) => json
+            case None => Json.Obj()
+          }
+          case Schema.Tuple2(left, right, _)        =>
+            merge(loop(prefix, left), loop(prefix, right))
+          case Schema.Transform(schema, _, _, _, _) => loop(prefix, schema)
+        }
 
       def merge(opt1: Options[Json], opt2: Options[Json]): Options[Json] =
         (opt1 ++ opt2).map{ case (a, b) => Json.Arr(a,b) }
 
-    loop(List.empty, schema)
-  }
+          
 
-  implicit def toJson[A](options: Options[A]): Options[Json] = options.map( value => Json.Str(value.toString()))
-
-  def fromPrimitive(prefix: List[String], standardType: StandardType[_]): Options[Json] = standardType match {
-            case StandardType.InstantType        => Options.instant(prefix.mkString("."))
-            case StandardType.UnitType           => emptyJson
-            case StandardType.PeriodType         => Options.period(prefix.mkString("."))
-            case StandardType.LongType           =>
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.StringType         => Options.text(prefix.mkString("."))
-            case StandardType.UUIDType           => Options.text(prefix.mkString("."))
-            case StandardType.ByteType           =>
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.OffsetDateTimeType => Options.offsetDateTime(prefix.mkString("."))
-            case StandardType.LocalDateType      => Options.localDate(prefix.mkString("."))
-            case StandardType.OffsetTimeType     => Options.decimal(prefix.mkString("."))
-            case StandardType.FloatType    =>
-              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
-            case StandardType.BigDecimalType     =>
-              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
-            case StandardType.BigIntegerType     =>
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.DoubleType         =>
-              Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
-            case StandardType.BoolType           =>
-              Options.boolean(prefix.mkString(".")).map( value => Json.Bool(value))
-            case StandardType.CharType           => Options.text(prefix.mkString("."))
-            case StandardType.ZoneOffsetType     => Options.zoneOffset(prefix.mkString("."))
-            case StandardType.YearMonthType      => Options.yearMonth(prefix.mkString("."))
-            case StandardType.BinaryType         => emptyJson
-            case StandardType.LocalTimeType      => Options.localTime(prefix.mkString("."))
-            case StandardType.ZoneIdType         => Options.zoneId(prefix.mkString("."))
-            case StandardType.ZonedDateTimeType  => Options.zonedDateTime(prefix.mkString("."))
-            case StandardType.DayOfWeekType      => 
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.DurationType       => 
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.IntType            => 
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.MonthDayType       => Options.monthDay(prefix.mkString("."))
-            case StandardType.ShortType          => 
-              Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
-            case StandardType.LocalDateTimeType  => Options.localDateTime(prefix.mkString("."))
-            case StandardType.MonthType          => Options.text(prefix.mkString("."))
-            case StandardType.YearType           => Options.integer(prefix.mkString("."))
-          }
-
-    }
-
-
-    sealed trait HeaderOptions extends HttpOptions
-    case class Header(name: String, textCodec: TextCodec[_]) extends HeaderOptions {
-
-      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
-    
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        (request ++ options).map {
-          case (cliRequest, value) =>
-            if(true) cliRequest.addHeader(name, value.toString())
-            else cliRequest
-        }
-
-    }
-
-    case class HeaderConstant(name: String, value: String) extends HeaderOptions {
-
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        request.map(_.addHeader(name, value))
-      
-    }
-
-    sealed trait URLOptions extends HttpOptions {
-      val tag: String
-    }
-    case class Path(name: String, textCodec: TextCodec[_]) extends URLOptions {
-
-      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
-
-      override val tag = "/"+name
-    
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        (request ++ options).map {
-          case (cliRequest, value) =>
-            if(true) cliRequest.addPathParam(name)
-            else cliRequest
-        }
-
-    }
-
-    case class PathConstant(name: String) extends URLOptions {
-      override val tag = "/"+name
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        request.map(_.addPathParam(name))
-
-    }
-
-    case class Query(name: String, textCodec: TextCodec[_]) extends URLOptions {
-      override val tag = "/"+name+"?"
-      lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
-    
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        (request ++ options).map {
-          case (cliRequest, value) =>
-            if(true) cliRequest.addQueryParam(name, value.toString())
-            else cliRequest
-        }
-
-    }
-
-    case class QueryConstant(name: String, value: String) extends URLOptions {
-      override val tag = "/"+name+"?"+value
-      override def transform(request: Options[CliRequest]): Options[CliRequest] = 
-        request.map(_.addQueryParam(name, value))
-
-    }
-
-    def optionsFromCodec[A](textCodec: TextCodec[A]): (String => Options[_]) =
-      textCodec.asInstanceOf[TextCodec[_]] match {
-        case TextCodec.UUIDCodec        => 
-          Options.text(_)
-            .mapOrFail(str =>
-              Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
-                ValidationError(
-                  ValidationErrorType.InvalidValue,
-                  HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
-                )
-              }
-            )
-        case TextCodec.StringCodec      => Options.text(_)
-        case TextCodec.IntCodec         => Options.integer(_)
-        case TextCodec.BooleanCodec     => Options.boolean(_)
-        case _                          => ( _ => Options.Empty)
+      def fromPrimitive(prefix: List[String], standardType: StandardType[_]): Options[Json] = standardType match {
+        case StandardType.InstantType        => Options.instant(prefix.mkString("."))
+        case StandardType.UnitType           => emptyJson
+        case StandardType.PeriodType         => Options.period(prefix.mkString("."))
+        case StandardType.LongType           =>
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.StringType         => Options.text(prefix.mkString("."))
+        case StandardType.UUIDType           => Options.text(prefix.mkString("."))
+        case StandardType.ByteType           =>
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.OffsetDateTimeType => Options.offsetDateTime(prefix.mkString("."))
+        case StandardType.LocalDateType      => Options.localDate(prefix.mkString("."))
+        case StandardType.OffsetTimeType     => Options.decimal(prefix.mkString("."))
+        case StandardType.FloatType    =>
+          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+        case StandardType.BigDecimalType     =>
+          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+        case StandardType.BigIntegerType     =>
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.DoubleType         =>
+          Options.decimal(prefix.mkString(".")).map( value => Json.Num(value))
+        case StandardType.BoolType           =>
+          Options.boolean(prefix.mkString(".")).map( value => Json.Bool(value))
+        case StandardType.CharType           => Options.text(prefix.mkString("."))
+        case StandardType.ZoneOffsetType     => Options.zoneOffset(prefix.mkString("."))
+        case StandardType.YearMonthType      => Options.yearMonth(prefix.mkString("."))
+        case StandardType.BinaryType         => emptyJson
+        case StandardType.LocalTimeType      => Options.localTime(prefix.mkString("."))
+        case StandardType.ZoneIdType         => Options.zoneId(prefix.mkString("."))
+        case StandardType.ZonedDateTimeType  => Options.zonedDateTime(prefix.mkString("."))
+        case StandardType.DayOfWeekType      => 
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.DurationType       => 
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.IntType            => 
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.MonthDayType       => Options.monthDay(prefix.mkString("."))
+        case StandardType.ShortType          => 
+          Options.integer(prefix.mkString(".")).map( value => Json.Num(BigDecimal(value)))
+        case StandardType.LocalDateTimeType  => Options.localDateTime(prefix.mkString("."))
+        case StandardType.MonthType          => Options.text(prefix.mkString("."))
+        case StandardType.YearType           => Options.integer(prefix.mkString("."))
       }
 
-}
+      loop(List.empty, schema)
+    }
 
+    
+  }
+
+  
+
+  /*
+   * Subclasses for headers
+   */
+  sealed trait HeaderOptions extends HttpOptions
+  final case class Header(name: String, textCodec: TextCodec[_]) extends HeaderOptions {
+
+    lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+    
+    
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      (request ++ options).map {
+        case (cliRequest, value) =>
+          if(true) cliRequest.addHeader(name, value.toString())
+          else cliRequest
+      }
+
+  }
+
+  final case class HeaderConstant(name: String, value: String) extends HeaderOptions {
+
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      request.map(_.addHeader(name, value))
+    
+  }
+
+  /*
+   * Subclasses for path
+   */
+  sealed trait URLOptions extends HttpOptions {
+    val tag: String
+  }
+
+  final case class Path(name: String, textCodec: TextCodec[_]) extends URLOptions {
+
+    lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+
+    override val tag = "/"+name
+  
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      (request ++ options).map {
+        case (cliRequest, value) =>
+          if(true) cliRequest.addPathParam(name)
+          else cliRequest
+      }
+
+  }
+
+  final case class PathConstant(name: String) extends URLOptions {
+    override val tag = "/"+name
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      request.map(_.addPathParam(name))
+
+  }
+
+  final case class Query(name: String, textCodec: TextCodec[_]) extends URLOptions {
+    override val tag = "/"+name+"?"
+    lazy val options: Options[_] = optionsFromCodec(textCodec)(name)
+  
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      (request ++ options).map {
+        case (cliRequest, value) =>
+          if(true) cliRequest.addQueryParam(name, value.toString())
+          else cliRequest
+      }
+
+  }
+
+  final case class QueryConstant(name: String, value: String) extends URLOptions {
+    override val tag = "/"+name+"?"+value
+    override def transform(request: Options[CliRequest]): Options[CliRequest] = 
+      request.map(_.addQueryParam(name, value))
+
+  }
+
+
+  private def optionsFromCodec[A](textCodec: TextCodec[A]): (String => Options[_]) =
+    textCodec.asInstanceOf[TextCodec[_]] match {
+      case TextCodec.UUIDCodec        => 
+        Options.text(_)
+          .mapOrFail(str =>
+            Try(java.util.UUID.fromString(str)).toEither.left.map { error =>
+              ValidationError(
+                ValidationErrorType.InvalidValue,
+                HelpDoc.p(HelpDoc.Span.code(error.getMessage())),
+              )
+            }
+          )
+      case TextCodec.StringCodec      => Options.text(_)
+      case TextCodec.IntCodec         => Options.integer(_)
+      case TextCodec.BooleanCodec     => Options.boolean(_)
+      case _                          => ( _ => Options.Empty)
+    }
+}

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
@@ -1,0 +1,43 @@
+package zio.http.endpoint.cli
+
+import zio.http._
+import zio._
+
+import java.nio.file.Path
+
+/**
+ * Represents a sealed trait that can retrieve a FormField. It allows to specify different methods to obtain parts of a body:
+ * from an URL, from a file, from JSON...
+ */
+
+private[cli] sealed trait Retriever {
+
+    def retrieve(): Task[FormField]
+  
+}
+
+private[cli] object Retriever {
+
+    final case class URL(url: String) extends Retriever {
+        override def retrieve(): Task[FormField] = ???
+    }
+
+    final case class File(name: String, path: Path, mediaType: Option[MediaType]) extends Retriever {
+
+        override def retrieve(): Task[FormField] = {
+            val media = mediaType match {
+                case Some(media) => media
+                case None        => MediaType.any
+            }
+            for {
+                chunk <- Body.fromFile(new java.io.File(path.toUri())).asChunk
+            } yield FormField.binaryField(name, chunk, media)
+        }
+                  
+    }
+
+    final case class Content(formField: FormField) extends Retriever {
+        override def retrieve(): UIO[FormField] = ZIO.succeed(formField)
+    }
+
+}

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
@@ -1,43 +1,45 @@
 package zio.http.endpoint.cli
 
-import zio.http._
-import zio._
-
 import java.nio.file.Path
 
+import zio._
+
+import zio.http._
+
 /**
- * Represents a sealed trait that can retrieve a FormField. It allows to specify different methods to obtain parts of a body:
- * from an URL, from a file, from JSON...
+ * Represents a sealed trait that can retrieve a FormField. It allows to specify
+ * different methods to obtain parts of a body: from an URL, from a file, from
+ * JSON...
  */
 
 private[cli] sealed trait Retriever {
 
-    def retrieve(): Task[FormField]
-  
+  def retrieve(): Task[FormField]
+
 }
 
 private[cli] object Retriever {
 
-    final case class URL(url: String) extends Retriever {
-        override def retrieve(): Task[FormField] = ???
+  final case class URL(url: String) extends Retriever {
+    override def retrieve(): Task[FormField] = ???
+  }
+
+  final case class File(name: String, path: Path, mediaType: Option[MediaType]) extends Retriever {
+
+    override def retrieve(): Task[FormField] = {
+      val media = mediaType match {
+        case Some(media) => media
+        case None        => MediaType.any
+      }
+      for {
+        chunk <- Body.fromFile(new java.io.File(path.toUri())).asChunk
+      } yield FormField.binaryField(name, chunk, media)
     }
 
-    final case class File(name: String, path: Path, mediaType: Option[MediaType]) extends Retriever {
+  }
 
-        override def retrieve(): Task[FormField] = {
-            val media = mediaType match {
-                case Some(media) => media
-                case None        => MediaType.any
-            }
-            for {
-                chunk <- Body.fromFile(new java.io.File(path.toUri())).asChunk
-            } yield FormField.binaryField(name, chunk, media)
-        }
-                  
-    }
-
-    final case class Content(formField: FormField) extends Retriever {
-        override def retrieve(): UIO[FormField] = ZIO.succeed(formField)
-    }
+  final case class Content(formField: FormField) extends Retriever {
+    override def retrieve(): UIO[FormField] = ZIO.succeed(formField)
+  }
 
 }

--- a/zio-http-example/src/main/scala/example/CliExamples.scala
+++ b/zio-http-example/src/main/scala/example/CliExamples.scala
@@ -70,6 +70,7 @@ object TestCliApp extends zio.cli.ZIOCliDefault with TestCliEndpoints {
         host = "localhost",
         port = 8080,
         endpoints = Chunk(getUser, getUserPosts, createUser),
+        cliStyle = true,
       )
       .cliApp
 }


### PR DESCRIPTION
/claim #2160

It is a big refactoring, but a lot of changes are just deleting boilerplate code and implementing multipart/from file input:

- 	 Instead of having Options[A] as a parameter of CliEndpoint, we have different subclasses of HttpOptions to deal with URL, body and headers (URLOptions, BodyOptions, HeadersOptions).

- The functionality of the method embed of CliEndpoint is done now by the method transform of HttpOptions. The benefit is that instead of having to define embed for each case, we can use the same transform method for each subclass of HttpOptions. It allows also to reconstruct easily URL.
- The commands are different, we would have "method url options":
Before: "-get-users --user-id integer ..."
Now:  " get /users/user-id? --user-id integer..."
It exposes more of the HTTP API. I don't know if that is better, but it can be easily changed to the first version (or allow the possibility of choosing between both when making the CliApp). What should we do?

- Each BodyOptions would represent a FormField, implementing multipart inputs. Each FormField can be specified written in the command, by a file path or by a URL
(URL not implemented yet and might not be desired, but maybe useful). If the schema of a FormField is more complex and hides a Schema.Primitive[BinaryType] it would not be valid to specify
writing everything else and specifying the binary data as a file path. It mustn't be difficult to implement this behaviour. Is it desired?

- For the multipart output, I think that it would be better to define what it should do. Should we allow options for each FormField if we wish to save or print a FormField or
do it automatically depending on the type of data? Do we do something with the headers?