### PR TITLE
Docs appendable to Endpoint, no name req. for out methods in Endpoint

### DIFF
--- a/zio-http/src/main/scala/zio/http/endpoint/EndpointMiddleware.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/EndpointMiddleware.scala
@@ -47,6 +47,9 @@ sealed trait EndpointMiddleware { self =>
       self.doc + that.doc,
     )
 
+  def ??(doc: Doc): EndpointMiddleware.Typed[In, Err, Out] =
+    EndpointMiddleware.Spec(input, output, error, doc)
+
   def implement[R, S](incoming: In => ZIO[R, Err, S])(
     outgoing: S => ZIO[R, Err, Out],
   ): RoutesMiddleware[R, S, this.type] =

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -531,7 +531,7 @@ object EndpointSpec extends ZIOSpecDefault {
             route =
               Endpoint
                 .get(literal("test-byte-stream"))
-                .outStream[Byte]("response", Status.Ok, MediaType.image.png)
+                .outStream[Byte](Status.Ok, MediaType.image.png)
                 .implement { _ =>
                   ZIO.succeed(ZStream.fromChunk(bytes).rechunk(16))
                 }


### PR DESCRIPTION
Also add method to append doc to `EndpointMiddleware`

fixes #2193 
/claim #2193

fixes #2195
/claim #2195