### PR TITLE
Fail with 400 if request to endpoint is malformed

### DIFF
--- a/zio-http/src/main/scala/zio/http/endpoint/Routes.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/Routes.scala
@@ -63,8 +63,10 @@ sealed trait Routes[-R, +E, M <: EndpointMiddleware] { self =>
       index: Int,
       cause: Cause[Nothing],
     )(implicit trace: Trace): ZIO[R, Nothing, Response] =
-      if (index >= alternatives.length) ZIO.refailCause(cause)
-      else {
+      if (index >= alternatives.length) {
+        if (HttpCodecError.isHttpCodecError(cause)) ZIO.succeed(Response(Status.BadRequest))
+        else ZIO.refailCause(cause)
+      } else {
         val alternative = alternatives(index)
 
         requestHandlers

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
@@ -17,6 +17,7 @@
 package zio.http.endpoint.internal
 
 import zio._
+
 import zio.http._
 import zio.http.codec.HttpCodecError
 import zio.http.endpoint.{EndpointMiddleware, Routes}
@@ -38,7 +39,7 @@ private[endpoint] final case class EndpointServer[R, E, I, O, M <: EndpointMiddl
       .catchSomeCause {
         case Cause.Fail(underlying: HttpCodecError, _) =>
           ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
-        case Cause.Die(underlying: HttpCodecError, _) =>
+        case Cause.Die(underlying: HttpCodecError, _)  =>
           ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
       }
       .orDie

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
@@ -19,7 +19,6 @@ package zio.http.endpoint.internal
 import zio._
 
 import zio.http._
-import zio.http.codec.HttpCodecError
 import zio.http.endpoint.{EndpointMiddleware, Routes}
 
 private[endpoint] final case class EndpointServer[R, E, I, O, M <: EndpointMiddleware](
@@ -29,19 +28,10 @@ private[endpoint] final case class EndpointServer[R, E, I, O, M <: EndpointMiddl
   private val handler  = single.handler
 
   def handle(request: Request)(implicit trace: Trace): ZIO[R, Nothing, Response] = {
-    endpoint.input
-      .decodeRequest(request)
-      .flatMap { value =>
-        handler(value).map(endpoint.output.encodeResponse(_)).catchAll { error =>
-          ZIO.succeed(single.endpoint.error.encodeResponse(error))
-        }
+    endpoint.input.decodeRequest(request).orDie.flatMap { value =>
+      handler(value).map(endpoint.output.encodeResponse(_)).catchAll { error =>
+        ZIO.succeed(single.endpoint.error.encodeResponse(error))
       }
-      .catchSomeCause {
-        case Cause.Fail(underlying: HttpCodecError, _) =>
-          ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
-        case Cause.Die(underlying: HttpCodecError, _)  =>
-          ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
-      }
-      .orDie
+    }
   }
 }

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointServer.scala
@@ -17,8 +17,8 @@
 package zio.http.endpoint.internal
 
 import zio._
-
 import zio.http._
+import zio.http.codec.HttpCodecError
 import zio.http.endpoint.{EndpointMiddleware, Routes}
 
 private[endpoint] final case class EndpointServer[R, E, I, O, M <: EndpointMiddleware](
@@ -28,10 +28,19 @@ private[endpoint] final case class EndpointServer[R, E, I, O, M <: EndpointMiddl
   private val handler  = single.handler
 
   def handle(request: Request)(implicit trace: Trace): ZIO[R, Nothing, Response] = {
-    endpoint.input.decodeRequest(request).orDie.flatMap { value =>
-      handler(value).map(endpoint.output.encodeResponse(_)).catchAll { error =>
-        ZIO.succeed(single.endpoint.error.encodeResponse(error))
+    endpoint.input
+      .decodeRequest(request)
+      .flatMap { value =>
+        handler(value).map(endpoint.output.encodeResponse(_)).catchAll { error =>
+          ZIO.succeed(single.endpoint.error.encodeResponse(error))
+        }
       }
-    }
+      .catchSomeCause {
+        case Cause.Fail(underlying: HttpCodecError, _) =>
+          ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
+        case Cause.Die(underlying: HttpCodecError, _) =>
+          ZIO.succeed(Response(Status.BadRequest, body = Body.fromString(underlying.getMessage())))
+      }
+      .orDie
   }
 }

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -17,11 +17,15 @@
 package zio.http.endpoint
 
 import java.time.Instant
+
 import zio._
 import zio.test._
+
 import zio.stream.ZStream
+
 import zio.schema.codec.{DecodeError, JsonCodec}
 import zio.schema.{DeriveSchema, Schema, StandardType}
+
 import zio.http.Header.ContentType
 import zio.http._
 import zio.http.codec.HttpCodec.{int, literal, query, queryInt, string}
@@ -83,8 +87,6 @@ object EndpointSpec extends ZIOSpecDefault {
         testRoutes("/users/123?key=X&value=Y", "path(users, 123, Some(X), Some(Y))")
       },
       test("bad request for failed codec") {
-        implicit val newPostSchema: Schema[NewPost] = DeriveSchema.gen[NewPost]
-
         val endpoint =
           Endpoint
             .get(literal("posts"))
@@ -101,7 +103,7 @@ object EndpointSpec extends ZIOSpecDefault {
             Request(
               Body.empty,
               Headers.empty,
-              Method.POST,
+              Method.GET,
               URL
                 .decode("/posts?id=notanid")
                 .toOption


### PR DESCRIPTION
Malformed requests seem to turn into internal server errors instead of bad requests