### PR TITLE
Scope Requests

### DIFF
--- a/docs/dsl/body.md
+++ b/docs/dsl/body.md
@@ -30,7 +30,7 @@ On the client-side, `ZIO-HTTP` models content in `ClientRequest` as `Body` with 
 To add content while making a request using ZIO HTTP you can use the `Client.request` method:
 
 ```scala mdoc:silent
-  val actual: ZIO[Client, Throwable, Response] = 
+  val actual: ZIO[Client with Scope, Throwable, Response] = 
     Client.request("https://localhost:8073/success", content = Body.fromString("Some string"))
 ```
 

--- a/docs/dsl/headers.md
+++ b/docs/dsl/headers.md
@@ -175,7 +175,7 @@ object SimpleClientJson extends ZIOAppDefault {
   } yield ()
 
   override def run =
-    program.provide(Client.default)
+    program.provide(Client.default, Scope.default)
 
 }
 ```

--- a/docs/examples/basic/http-client.md
+++ b/docs/examples/basic/http-client.md
@@ -18,7 +18,7 @@ object SimpleClient extends ZIOAppDefault {
     _    <- Console.printLine(data)
   } yield ()
 
-  override val run = program.provide(Client.default)
+  override val run = program.provide(Client.default, Scope.default)
 
 }
 

--- a/docs/examples/basic/https-client.md
+++ b/docs/examples/basic/https-client.md
@@ -35,6 +35,7 @@ object HttpsClient extends ZIOAppDefault {
       NettyClientDriver.live,
       DnsResolver.default,
       ZLayer.succeed(NettyConfig.default),
+      Scope.default,
     )
 
 }

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpCliApp.scala
@@ -98,7 +98,7 @@ object HttpCliApp {
                 )
                 .setHeaders(headers),
             )
-            .provide(Client.default)
+            .provide(Client.default, Scope.default)
           _        <- Console.printLine(s"Got response")
           _        <- Console.printLine(s"Status: ${response.status}")
           body     <- response.body.asString

--- a/zio-http-example/src/main/scala/example/AuthenticationClient.scala
+++ b/zio-http-example/src/main/scala/example/AuthenticationClient.scala
@@ -22,6 +22,6 @@ object AuthenticationClient extends ZIOAppDefault {
     _        <- Console.printLine(body)
   } yield ()
 
-  override val run = program.provide(Client.default)
+  override val run = program.provide(Client.default, Scope.default)
 
 }

--- a/zio-http-example/src/main/scala/example/CliExamples.scala
+++ b/zio-http-example/src/main/scala/example/CliExamples.scala
@@ -101,9 +101,10 @@ object TestCliClient extends zio.ZIOAppDefault with TestCliEndpoints {
       .provide(
         EndpointExecutor.make(serviceName = "test"),
         Client.default,
+        Scope.default,
       )
 
-  lazy val clientExample: URIO[EndpointExecutor[Unit], Unit] =
+  lazy val clientExample: URIO[EndpointExecutor[Unit] & Scope, Unit] =
     for {
       executor <- ZIO.service[EndpointExecutor[Unit]]
       _        <- executor(getUser(42, Location.parse("some-location").toOption.get)).debug("result1")

--- a/zio-http-example/src/main/scala/example/ClientServer.scala
+++ b/zio-http-example/src/main/scala/example/ClientServer.scala
@@ -1,6 +1,6 @@
 package example
 
-import zio.{ZIO, ZIOAppDefault}
+import zio.{Scope, ZIO, ZIOAppDefault}
 
 import zio.http._
 
@@ -16,6 +16,6 @@ object ClientServer extends ZIOAppDefault {
   }
 
   val run = {
-    Server.serve(app.withDefaultErrorResponse).provide(Server.default, Client.default).exitCode
+    Server.serve(app.withDefaultErrorResponse).provide(Server.default, Client.default, Scope.default).exitCode
   }
 }

--- a/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
+++ b/zio-http-example/src/main/scala/example/ClientWithDecompression.scala
@@ -22,6 +22,7 @@ object ClientWithDecompression extends ZIOAppDefault {
       Client.live,
       ZLayer.succeed(NettyConfig.default),
       DnsResolver.default,
+      Scope.default,
     )
 
 }

--- a/zio-http-example/src/main/scala/example/EndpointExamples.scala
+++ b/zio-http-example/src/main/scala/example/EndpointExamples.scala
@@ -51,8 +51,8 @@ object EndpointExamples extends ZIOAppDefault {
       val x1 = getUser(42)
       val x2 = getUserPosts(42, 200, "adam")
 
-      val result1: UIO[Int]          = executor(x1)
-      val result2: UIO[List[String]] = executor(x2)
+      val result1: ZIO[Scope, Nothing, Int]          = executor(x1)
+      val result2: ZIO[Scope, Nothing, List[String]] = executor(x2)
 
       result1.zip(result2).debug
     }

--- a/zio-http-example/src/main/scala/example/GracefulShutdown.scala
+++ b/zio-http-example/src/main/scala/example/GracefulShutdown.scala
@@ -52,5 +52,6 @@ object GracefulShutdown extends ZIOAppDefault {
       _        <- Console.printLine(body)
     } yield ()).provide(
       Client.default,
+      Scope.default,
     )
 }

--- a/zio-http-example/src/main/scala/example/HttpsClient.scala
+++ b/zio-http-example/src/main/scala/example/HttpsClient.scala
@@ -30,6 +30,7 @@ object HttpsClient extends ZIOAppDefault {
       NettyClientDriver.live,
       DnsResolver.default,
       ZLayer.succeed(NettyConfig.default),
+      Scope.default,
     )
 
 }

--- a/zio-http-example/src/main/scala/example/Interrupt.scala
+++ b/zio-http-example/src/main/scala/example/Interrupt.scala
@@ -45,6 +45,7 @@ object MyClient extends ZIOAppDefault {
         ZLayer.succeed(ZClient.Config.default.withFixedConnectionPool(2)),
         ZLayer.succeed(NettyConfig.default),
         DnsResolver.default,
+        Scope.default,
       )
       // .provide(Client.live, NettyClientDriver.fromConfig, ClientConfig.live(ClientConfig().withFixedConnectionPool(2)))
       .debug("EXIT")

--- a/zio-http-example/src/main/scala/example/MultipartFormData.scala
+++ b/zio-http-example/src/main/scala/example/MultipartFormData.scala
@@ -38,7 +38,7 @@ object MultipartFormData extends ZIOAppDefault {
         } yield response
     }
 
-  private def program: ZIO[Client with Server, Throwable, Unit] =
+  private def program: ZIO[Client with Server with Scope, Throwable, Unit] =
     for {
       port         <- Server.install(app)
       _            <- ZIO.logInfo(s"Server started on port $port")
@@ -70,5 +70,6 @@ object MultipartFormData extends ZIOAppDefault {
       .provide(
         Server.default,
         Client.default,
+        Scope.default,
       )
 }

--- a/zio-http-example/src/main/scala/example/SimpleClient.scala
+++ b/zio-http-example/src/main/scala/example/SimpleClient.scala
@@ -13,6 +13,6 @@ object SimpleClient extends ZIOAppDefault {
     _    <- Console.printLine(data)
   } yield ()
 
-  override val run = program.provide(Client.default)
+  override val run = program.provide(Client.default, Scope.default)
 
 }

--- a/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
@@ -32,7 +32,7 @@ object TestServerSpec extends ZIOSpecDefault {
           )
       } yield assertTrue(response1.status == Status.Ok) &&
         assertTrue(response2.status == Status.InternalServerError)
-    }.provideSome[Client with Driver](
+    }.provideSome[Client with Driver with Scope](
       TestServer.layer,
     ),
     suite("Exact Request=>Response version")(
@@ -79,13 +79,14 @@ object TestServerSpec extends ZIOSpecDefault {
         } yield assertTrue(finalResponse.status == Status.NotFound)
       },
     )
-      .provideSome[Client with Driver](
+      .provideSome[Client with Driver with Scope](
         TestServer.layer,
       ),
   ).provide(
     ZLayer.succeed(Server.Config.default.onAnyOpenPort),
     Client.default,
     NettyDriver.live,
+    Scope.default,
   )
 
   private def requestToCorrectPort =

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -54,7 +54,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env, Err, Out] =
+      )(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
         self.request(
           version,
           method,
@@ -113,7 +113,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In2,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env1, Err1, Out] =
+      )(implicit trace: Trace): ZIO[Env1 & Scope, Err1, Out] =
         f(body).flatMap { body =>
           self.request(
             version,
@@ -134,13 +134,13 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         self.socket(version, url, headers, app)
     }
 
-  final def delete(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def delete(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.DELETE, pathSuffix, body)
 
-  final def delete(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def delete(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     delete(pathSuffix, ev(Body.empty))
 
-  final def delete(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def delete(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     delete("")
 
   final def dieOn(
@@ -148,22 +148,22 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
   )(implicit ev1: Err IsSubtypeOfError Throwable, ev2: CanFail[Err], trace: Trace): ZClient[Env, In, Err, Out] =
     refineOrDie { case e if !f(e) => e }
 
-  final def get(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def get(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.GET, pathSuffix, body)
 
-  final def get(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def get(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     get(pathSuffix, ev(Body.empty))
 
-  final def get(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def get(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     get("")
 
-  final def head(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def head(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.HEAD, pathSuffix, body)
 
-  final def head(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def head(pathSuffix: String)(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     head(pathSuffix, Body.empty)
 
-  final def head(implicit trace: Trace, ev: Body <:< In): ZIO[Env, Err, Out] =
+  final def head(implicit trace: Trace, ev: Body <:< In): ZIO[Env & Scope, Err, Out] =
     head("")
 
   final def host(host: String): ZClient[Env, In, Err, Out] =
@@ -186,7 +186,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env, Err2, Out] =
+      )(implicit trace: Trace): ZIO[Env & Scope, Err2, Out] =
         self.request(version, method, url, headers, body, sslConfig).mapError(f)
 
       def socket[Env1 <: Env](
@@ -217,7 +217,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env1, Err1, Out2] =
+      )(implicit trace: Trace): ZIO[Env1 & Scope, Err1, Out2] =
         self
           .request(
             version,
@@ -244,13 +244,13 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
   final def port(port: Int): ZClient[Env, In, Err, Out] =
     copy(url = url.withPort(port))
 
-  final def patch(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def patch(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.PATCH, pathSuffix, body)
 
-  final def post(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def post(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.POST, pathSuffix, body)
 
-  final def put(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def put(pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(Method.PUT, pathSuffix, body)
 
   def query(key: String, value: String): ZClient[Env, In, Err, Out] =
@@ -277,7 +277,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env, Err2, Out] =
+      )(implicit trace: Trace): ZIO[Env & Scope, Err2, Out] =
         self
           .request(
             version,
@@ -298,7 +298,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         self.socket(version, url, headers, app).refineOrDie(pf)
     }
 
-  final def request(method: Method, pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env, Err, Out] =
+  final def request(method: Method, pathSuffix: String, body: In)(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
     request(
       version,
       method,
@@ -308,7 +308,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
       sslConfig,
     )
 
-  final def request(request: Request)(implicit ev: Body <:< In, trace: Trace): ZIO[Env, Err, Out] = {
+  final def request(request: Request)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & Scope, Err, Out] = {
     self.request(
       request.version,
       request.method,
@@ -338,7 +338,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
         headers: Headers,
         body: In,
         sslConfig: Option[ClientSSLConfig],
-      )(implicit trace: Trace): ZIO[Env1, Err, Out] =
+      )(implicit trace: Trace): ZIO[Env1 & Scope, Err, Out] =
         self
           .request(
             version,
@@ -388,7 +388,7 @@ trait ZClient[-Env, -In, +Err, +Out] extends HeaderOps[ZClient[Env, In, Err, Out
     headers: Headers,
     body: In,
     sslConfig: Option[ClientSSLConfig],
-  )(implicit trace: Trace): ZIO[Env, Err, Out]
+  )(implicit trace: Trace): ZIO[Env & Scope, Err, Out]
 
   def socket[Env1 <: Env](
     version: Version = Version.Http_1_1,
@@ -539,7 +539,7 @@ object ZClient {
       headers: Headers,
       body: In,
       sslConfig: Option[ClientSSLConfig],
-    )(implicit trace: Trace): ZIO[Env, Err, Out] =
+    )(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
       client.request(
         version,
         method,
@@ -578,7 +578,7 @@ object ZClient {
       headers: Headers,
       body: Body,
       sslConfig: Option[ClientSSLConfig],
-    )(implicit trace: Trace): ZIO[Any, Throwable, Response] = {
+    )(implicit trace: Trace): ZIO[Scope, Throwable, Response] = {
       val request = Request(body, headers, method, url, version, None)
       val cfg     = sslConfig.fold(config)(config.ssl)
 
@@ -626,7 +626,7 @@ object ZClient {
       outerScope: Option[Scope],
     )(implicit
       trace: Trace,
-    ): ZIO[Any, Throwable, Response] =
+    ): ZIO[Scope, Throwable, Response] =
       request.url.kind match {
         case location: Location.Absolute =>
           ZIO.uninterruptibleMask { restore =>
@@ -688,6 +688,7 @@ object ZClient {
                     }
                 } yield ()
               }.forkDaemon // Needs to live as long as the channel is alive, as the response body may be streaming
+              _ <- ZIO.addFinalizer(onComplete.interrupt)
               response <- restore(onResponse.await.onInterrupt {
                 onComplete.interrupt *> channelFiber.join.orDie
               })
@@ -703,7 +704,7 @@ object ZClient {
     method: Method = Method.GET,
     headers: Headers = Headers.empty,
     content: Body = Body.empty,
-  )(implicit trace: Trace): ZIO[Client, Throwable, Response] = {
+  )(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] = {
     for {
       uri      <- ZIO.fromEither(URL.decode(url))
       response <- ZIO.serviceWithZIO[Client](
@@ -715,45 +716,45 @@ object ZClient {
 
   }
 
-  def delete(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def delete(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.delete(pathSuffix, body))
 
-  def delete(pathSuffix: String)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def delete(pathSuffix: String)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.delete(pathSuffix))
 
-  def delete(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def delete(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.delete)
 
-  def get(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def get(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.get(pathSuffix, body))
 
-  def get(pathSuffix: String)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def get(pathSuffix: String)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.get(pathSuffix))
 
-  def get(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def get(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.get)
 
-  def head(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def head(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.head(pathSuffix, body))
 
-  def head(pathSuffix: String)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def head(pathSuffix: String)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.head(pathSuffix))
 
-  def head(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def head(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.head)
 
-  def patch(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def patch(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.patch(pathSuffix, body))
 
-  def post(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def post(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.post(pathSuffix, body))
 
-  def put(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client, Throwable, Response] =
+  def put(pathSuffix: String, body: Body)(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] =
     ZIO.serviceWithZIO[Client](_.put(pathSuffix, body))
 
   def request(
     request: Request,
-  )(implicit trace: Trace): ZIO[Client, Throwable, Response] = ZIO.serviceWithZIO[Client](_.request(request))
+  )(implicit trace: Trace): ZIO[Client & Scope, Throwable, Response] = ZIO.serviceWithZIO[Client](_.request(request))
 
   def socket[R](
     version: Version = Version.Http_1_1,

--- a/zio-http/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/src/main/scala/zio/http/ZClientAspect.scala
@@ -140,7 +140,7 @@ object ZClientAspect {
             headers: Headers,
             body: In,
             sslConfig: Option[ClientSSLConfig],
-          )(implicit trace: Trace): ZIO[Env, Err, Out] =
+          )(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
             client
               .request(version, method, url, headers, body, sslConfig)
               .sandbox
@@ -216,7 +216,7 @@ object ZClientAspect {
             headers: Headers,
             body: In,
             sslConfig: Option[ClientSSLConfig],
-          )(implicit trace: Trace): ZIO[Env, Err, Out] =
+          )(implicit trace: Trace): ZIO[Env & Scope, Err, Out] =
             client
               .request(version, method, url, headers, body, sslConfig)
               .sandbox

--- a/zio-http/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
@@ -57,7 +57,7 @@ final case class EndpointExecutor[+MI](
     alt: Alternator[E, invocation.middleware.Err],
     ev: MI <:< invocation.middleware.In,
     trace: Trace,
-  ): ZIO[Any, alt.Out, B] = {
+  ): ZIO[Scope, alt.Out, B] = {
     middlewareInput.flatMap { mi =>
       getClient(invocation.endpoint).orDie.flatMap { endpointClient =>
         endpointClient.execute(client, invocation)(ev(mi))

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -28,7 +28,7 @@ private[endpoint] final case class EndpointClient[I, E, O, M <: EndpointMiddlewa
 ) {
   def execute(client: Client, invocation: Invocation[I, E, O, M])(
     mi: invocation.middleware.In,
-  )(implicit alt: Alternator[E, invocation.middleware.Err], trace: Trace): ZIO[Any, alt.Out, O] = {
+  )(implicit alt: Alternator[E, invocation.middleware.Err], trace: Trace): ZIO[Scope, alt.Out, O] = {
     val request0 = endpoint.input.encodeRequest(invocation.input)
     val request  = request0.copy(url = endpointRoot ++ request0.url)
 

--- a/zio-http/src/test/scala/zio/http/ClientHttpsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientHttpsSpec.scala
@@ -19,7 +19,7 @@ package zio.http
 import zio.test.Assertion.{anything, equalTo, fails, isSubtype}
 import zio.test.TestAspect.{ignore, timeout}
 import zio.test.{ZIOSpecDefault, assertZIO}
-import zio.{ZLayer, durationInt}
+import zio.{Scope, ZLayer, durationInt}
 
 import zio.http.Status
 import zio.http.netty.NettyConfig
@@ -65,6 +65,7 @@ object ClientHttpsSpec extends ZIOSpecDefault {
     NettyClientDriver.live,
     DnsResolver.default,
     ZLayer.succeed(NettyConfig.default),
+    Scope.default,
   ) @@ timeout(
     30 seconds,
   ) @@ ignore

--- a/zio-http/src/test/scala/zio/http/ClientProxySpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientProxySpec.scala
@@ -47,6 +47,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               NettyClientDriver.live,
               DnsResolver.default,
               ZLayer.succeed(NettyConfig.default),
+              Scope.default,
             )
         } yield out
       assertZIO(res.either)(isLeft(isSubtype[ConnectException](anything)))
@@ -68,6 +69,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               NettyClientDriver.live,
               DnsResolver.default,
               ZLayer.succeed(NettyConfig.default),
+              Scope.default,
             )
         } yield out
       assertZIO(res.either)(isRight)
@@ -101,6 +103,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               NettyClientDriver.live,
               DnsResolver.default,
               ZLayer.succeed(NettyConfig.default),
+              Scope.default,
             )
         } yield out
       assertZIO(res.either)(isRight)

--- a/zio-http/src/test/scala/zio/http/ClientStreamingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientStreamingSpec.scala
@@ -60,7 +60,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
 
   // TODO: test failure cases
 
-  private def tests(streamingServer: Boolean): Seq[Spec[Client, Throwable]] =
+  private def tests(streamingServer: Boolean): Seq[Spec[Client with Scope, Throwable]] =
     Seq(
       test("simple get") {
         for {
@@ -317,6 +317,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
       ZLayer.succeed(NettyConfig.default),
       ZLayer.succeed(Client.Config.default.connectionTimeout(100.seconds).idleTimeout(100.seconds)),
       Client.live,
+      Scope.default,
     ) @@ withLiveClock @@ sequential
 
   private def server(streaming: Boolean): ZIO[Any, Throwable, Int] =

--- a/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
+++ b/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
@@ -38,7 +38,7 @@ object DynamicAppTest extends ZIOSpecDefault {
     .withDefaultErrorResponse
 
   val layer =
-    ZLayer.make[Client & Server](
+    ZLayer.make[Client & Server & Scope](
       ZLayer.succeed(ZClient.Config.default),
       NettyClientDriver.live,
       Client.customized,
@@ -46,6 +46,7 @@ object DynamicAppTest extends ZIOSpecDefault {
       Server.live,
       DnsResolver.default,
       ZLayer.succeed(NettyConfig.default),
+      Scope.default,
     )
 
   def spec = suite("Server")(

--- a/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
@@ -49,5 +49,6 @@ object NettyMaxHeaderLengthSpec extends ZIOSpecDefault {
       Client.default,
       Server.live,
       ZLayer.succeed(serverConfig),
+      Scope.default,
     ) @@ withLiveClock
 }

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 
 import zio.test.TestAspect.withLiveClock
 import zio.test.{ZIOSpecDefault, assertTrue}
-import zio.{Chunk, ZIO, ZInputStream, ZLayer}
+import zio.{Chunk, Scope, ZIO, ZInputStream, ZLayer}
 
 import zio.stream.ZStream
 
@@ -94,6 +94,7 @@ object ResponseCompressionSpec extends ZIOSpecDefault {
       ZLayer.succeed(serverConfig),
       Server.live,
       Client.default,
+      Scope.default
     ) @@ withLiveClock
 
   private def decompressed(bytes: Chunk[Byte]): ZIO[Any, Throwable, String] =

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -94,7 +94,7 @@ object ResponseCompressionSpec extends ZIOSpecDefault {
       ZLayer.succeed(serverConfig),
       Server.live,
       Client.default,
-      Scope.default
+      Scope.default,
     ) @@ withLiveClock
 
   private def decompressed(bytes: Chunk[Byte]): ZIO[Any, Throwable, String] =

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -19,7 +19,7 @@ package zio.http
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{ignore, timeout}
 import zio.test.{Gen, ZIOSpecDefault, assertZIO, check}
-import zio.{ZIO, ZLayer, durationInt}
+import zio.{Scope, ZIO, ZLayer, durationInt}
 
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
@@ -61,6 +61,7 @@ object SSLSpec extends ZIOSpecDefault {
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.default),
+            Scope.default,
           ),
           test("fail with DecoderException when client doesn't have the server certificate") {
             val actual = Client
@@ -75,6 +76,7 @@ object SSLSpec extends ZIOSpecDefault {
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.default),
+            Scope.default,
           ),
           test("succeed when client has default SSL") {
             val actual = Client
@@ -87,6 +89,7 @@ object SSLSpec extends ZIOSpecDefault {
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.default),
+            Scope.default,
           ),
           test("Https Redirect when client makes http request") {
             val actual = Client
@@ -99,6 +102,7 @@ object SSLSpec extends ZIOSpecDefault {
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.default),
+            Scope.default,
           ),
           test("Https request with a large payload should respond with 413") {
             check(payload) { payload =>
@@ -117,6 +121,7 @@ object SSLSpec extends ZIOSpecDefault {
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.default),
+            Scope.default,
           ),
         ),
       ),

--- a/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -81,5 +81,6 @@ object ZClientAspectSpec extends ZIOSpecDefault {
       ZLayer.succeed(Server.Config.default.onAnyOpenPort),
       Server.live,
       Client.default,
+      Scope.default,
     ) @@ withLiveClock
 }

--- a/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
@@ -93,8 +93,8 @@ abstract class HttpRunnableSpec extends ZIOSpecDefault { self =>
       }
 
     def deployAndRequest(
-      call: Client => ZIO[Any, Throwable, Response],
-    ): Handler[Client with DynamicServer with R, Throwable, Any, Response] = {
+      call: Client => ZIO[Scope, Throwable, Response],
+    ): Handler[Client with DynamicServer with R with Scope, Throwable, Any, Response] = {
       for {
         port     <- Handler.fromZIO(DynamicServer.port)
         id       <- Handler.fromZIO(DynamicServer.deploy[R](app))
@@ -109,7 +109,7 @@ abstract class HttpRunnableSpec extends ZIOSpecDefault { self =>
       } yield response
     }
 
-    def deployChunked: Http[R with Client with DynamicServer, Throwable, Request, Response] =
+    def deployChunked: Http[R with Client with DynamicServer with Scope, Throwable, Request, Response] =
       Http.fromHandler {
         for {
           port     <- Handler.fromZIO(DynamicServer.port)

--- a/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -115,5 +115,6 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
       },
     ).provide(
       singleConnectionClient,
+      Scope.default,
     ) @@ withLiveClock
 }


### PR DESCRIPTION
Resolves #2246. /claim #2246

Making a request acquires a resource in that it opens a connection that must be closed even if the stream body is not consumed.