### PR TITLE
Add `hasFormMultipartContentType` for checking `Content-Type: multipart/form-data`

### DIFF
--- a/zio-http/src/main/scala/zio/http/internal/HeaderChecks.scala
+++ b/zio-http/src/main/scala/zio/http/internal/HeaderChecks.scala
@@ -32,6 +32,9 @@ trait HeaderChecks[+A] { self: HeaderOps[A] with A =>
   final def hasFormUrlencodedContentType: Boolean =
     hasContentType(MediaType.application.`x-www-form-urlencoded`.fullType)
 
+  final def hasFormMultipartContentType: Boolean =
+    hasContentType(MediaType.multipart.`form-data`.fullType)
+
   final def hasHeader(name: CharSequence): Boolean =
     rawHeader(name).nonEmpty
 

--- a/zio-http/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HeaderSpec.scala
@@ -166,6 +166,20 @@ object HeaderSpec extends ZIOSpecDefault {
         assert(actual)(isFalse)
       },
     ),
+    suite("isFormMultipartContentType")(
+      test("should return true if content-type is multipart/form-data") {
+        val actual = contentTypeFormMultipart.hasFormMultipartContentType
+        assert(actual)(isTrue)
+      },
+      test("should return false if content-type is not multipart/form-data") {
+        val actual = contentTypeTextPlain.hasFormMultipartContentType
+        assert(actual)(isFalse)
+      },
+      test("should return false if content-type doesn't exist") {
+        val actual = acceptJson.hasFormMultipartContentType
+        assert(actual)(isFalse)
+      },
+    ),
   )
 
   private val acceptJson                = Headers(Header.Accept(MediaType.application.json))
@@ -174,6 +188,7 @@ object HeaderSpec extends ZIOSpecDefault {
   private val contentTypeXml            = Headers(Header.ContentType(MediaType.application.xml))
   private val contentTypeJson           = Headers(Header.ContentType(MediaType.application.json))
   private val contentTypeFormUrlEncoded = Headers(Header.ContentType(MediaType.application.`x-www-form-urlencoded`))
+  private val contentTypeFormMultipart  = Headers(Header.ContentType(MediaType.multipart.`form-data`))
   private def customAcceptJsonHeader    = Header.Accept(MediaType.application.json)
   private def customContentJsonHeader   = Header.ContentType(MediaType.application.json)
   private def customHeaders: Headers    = Headers(customContentJsonHeader, customAcceptJsonHeader)


### PR DESCRIPTION
closes #2215.

Add `hasFormMultipartContentType` predicate for checking `Content-Type: multipart/form-data`.

There is already `hasFormUrlencodedContentType`, and `hasJsonContentType` predicates for checking `Content-Type: application/x-www-form-urlencoded`, and `Content-Type: application/json` respectively. 

/claim #2215