### PR TITLE
feat: Allow Unknown AcceptEncoding

### DIFF
--- a/zio-http/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HeaderSpec.scala
@@ -16,11 +16,11 @@
 
 package zio.http
 
+import zio.NonEmptyChunk
 import zio.test.Assertion._
 import zio.test.{ZIOSpecDefault, assert}
 
 import io.netty.handler.codec.http.{HttpHeaderNames, HttpHeaderValues}
-import zio.NonEmptyChunk
 
 object HeaderSpec extends ZIOSpecDefault {
 

--- a/zio-http/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HeaderSpec.scala
@@ -205,7 +205,7 @@ object HeaderSpec extends ZIOSpecDefault {
       test("should parse an unknown header with weight") {
         val header = Header.AcceptEncoding.parse("zio-http;q=0.6")
         assert(header)(isRight(equalTo(Header.AcceptEncoding.Unknown("zio-http", Some(0.6d)))))
-      }
+      },
     ),
     suite("isFormMultipartContentType")(
       test("should return true if content-type is multipart/form-data") {


### PR DESCRIPTION
As discussed with @vigoo  on Discord, there is an issue with the current implementation of the AcceptEncoding header.
If the header contains an invalid value or an unsupported encoding, the whole header is disregarded and None is return.

curl's --compressed returns `Accept-Encoding: gzip, br, deflate, zstd`  on my machine and `zstd` is not supported by zio-http (I was not even aware that it existed).

This is a proposal to add support for unknown accept encoding header instead of disregarding the whole header. Another implementation would have been to simply skip them, but it also meant that users of zio-http would have no way to support custom/unsupported encoding.