### PR TITLE
`Endpoint` api en-/decodes based on accept header

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val zioHttp = (project in file("zio-http"))
       `zio-streams`,
       `zio-schema`,
       `zio-schema-json`,
+      `zio-schema-protobuf`,
       `zio-test`,
       `zio-test-sbt`,
       `netty-incubator`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt.*
+import sbt._
 import sbt.Keys.scalaVersion
 
 object Dependencies {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
+import sbt.*
 import sbt.Keys.scalaVersion
-import sbt._
 
 object Dependencies {
   val JwtCoreVersion                = "9.1.1"
@@ -29,13 +29,14 @@ object Dependencies {
   val `netty-incubator` =
     "io.netty.incubator" % "netty-incubator-transport-native-io_uring" % NettyIncubatorVersion classifier "linux-x86_64"
 
-  val zio               = "dev.zio" %% "zio"             % ZioVersion
-  val `zio-cli`         = "dev.zio" %% "zio-cli"         % ZioCliVersion
-  val `zio-streams`     = "dev.zio" %% "zio-streams"     % ZioVersion
-  val `zio-schema`      = "dev.zio" %% "zio-schema"      % ZioSchemaVersion
-  val `zio-schema-json` = "dev.zio" %% "zio-schema-json" % ZioSchemaVersion
-  val `zio-test`        = "dev.zio" %% "zio-test"        % ZioVersion % "test"
-  val `zio-test-sbt`    = "dev.zio" %% "zio-test-sbt"    % ZioVersion % "test"
+  val zio                   = "dev.zio" %% "zio"                 % ZioVersion
+  val `zio-cli`             = "dev.zio" %% "zio-cli"             % ZioCliVersion
+  val `zio-streams`         = "dev.zio" %% "zio-streams"         % ZioVersion
+  val `zio-schema`          = "dev.zio" %% "zio-schema"          % ZioSchemaVersion
+  val `zio-schema-json`     = "dev.zio" %% "zio-schema-json"     % ZioSchemaVersion
+  val `zio-schema-protobuf` = "dev.zio" %% "zio-schema-protobuf" % ZioSchemaVersion
+  val `zio-test`            = "dev.zio" %% "zio-test"            % ZioVersion % "test"
+  val `zio-test-sbt`        = "dev.zio" %% "zio-test-sbt"        % ZioVersion % "test"
 
   val reflect = Def.map(scalaVersion)("org.scala-lang" % "scala-reflect" % _)
 

--- a/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
+++ b/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
@@ -1,7 +1,6 @@
 package example
 
 import zio.http.codec.HttpCodec._
-import zio.http.codec.HttpCodecType.PathQuery
 import zio.http.codec._
 
 object CombinerTypesExample extends App {

--- a/zio-http-example/src/main/scala/example/HttpCodecExample.scala
+++ b/zio-http-example/src/main/scala/example/HttpCodecExample.scala
@@ -2,7 +2,7 @@ package example
 
 import zio.http.codec.HttpCodec._
 import zio.http.codec.HttpCodecType.PathQuery
-import zio.http.codec.{HttpCodec, HttpCodecType, PathCodec, QueryCodec}
+import zio.http.codec.{HttpCodec, HttpCodecType, PathCodec}
 import zio.http.endpoint.Endpoint
 
 object HttpCodecExample {

--- a/zio-http/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/MediaType.scala
@@ -37,11 +37,12 @@ object MediaType extends MediaTypes {
   def forContentType(contentType: String): Option[MediaType] = {
     val index = contentType.indexOf(";")
     if (index == -1)
-      contentTypeMap.get(contentType)
+      contentTypeMap.get(contentType).orElse(parseCustomMediaType(contentType))
     else {
       val (contentType1, parameter) = contentType.splitAt(index)
       contentTypeMap
         .get(contentType1)
+        .orElse(parseCustomMediaType(contentType1))
         .map(_.copy(parameters = parseOptionalParameters(parameter.tail.split(";"))))
     }
   }

--- a/zio-http/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/MediaType.scala
@@ -27,7 +27,7 @@ final case class MediaType(
   extensions: Map[String, String] = Map.empty,
   parameters: Map[String, String] = Map.empty,
 ) {
-  def fullType: String = s"$mainType/$subType"
+  lazy val fullType: String = s"$mainType/$subType"
 }
 
 object MediaType extends MediaTypes {

--- a/zio-http/src/main/scala/zio/http/Request.scala
+++ b/zio-http/src/main/scala/zio/http/Request.scala
@@ -131,4 +131,8 @@ object Request {
   def put(path: String, body: Body): Request = Request(method = Method.PUT, url = URL(Path(path)), body = body)
 
   def put(url: URL, body: Body): Request = Request(method = Method.PUT, url = url, body = body)
+
+  object Patch {
+    val empty: Patch = Patch(Headers.empty, QueryParams.empty)
+  }
 }

--- a/zio-http/src/main/scala/zio/http/URL.scala
+++ b/zio-http/src/main/scala/zio/http/URL.scala
@@ -24,7 +24,6 @@ import zio.Chunk
 
 import zio.http.URL.{Fragment, Location, portFromScheme}
 import zio.http.internal.QueryParamEncoding
-import zio.http.{Charsets, Scheme}
 
 final case class URL(
   path: Path,

--- a/zio-http/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/src/main/scala/zio/http/ZClientAspect.scala
@@ -109,6 +109,14 @@ object ZClientAspect {
    * Client aspect that logs a debug message to the console after each request
    */
   final def debug(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
+    debug(PartialFunction.empty)
+
+  /**
+   * Client aspect that logs a debug message to the console after each request
+   */
+  final def debug(
+    extraMessage: PartialFunction[Response, String],
+  )(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
     new ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] {
 
       /**
@@ -140,11 +148,10 @@ object ZClientAspect {
               .timed
               .tap {
                 case (duration, Exit.Success(response)) =>
-                  Console
-                    .printLine(
-                      s"${response.status.code} $method ${url.encode} ${duration.toMillis}ms",
-                    )
-                    .orDie
+                  {
+                    Console.printLine(s"${response.status.code} $method ${url.encode} ${duration.toMillis}ms") *>
+                      Console.printLine(extraMessage(response)).when(extraMessage.isDefinedAt(response))
+                  }.orDie
                 case (duration, Exit.Failure(cause))    =>
                   Console
                     .printLine(

--- a/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
@@ -18,8 +18,8 @@ package zio.http.codec
 
 import scala.util.Try
 
-import zio.http.Header
 import zio.http.Header.HeaderType
+import zio.http.{Header, MediaType}
 
 private[codec] trait HeaderCodecs {
   private[http] def headerCodec[A](name: String, value: TextCodec[A]): HeaderCodec[A] =

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -167,7 +167,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Uses this codec to encode the Scala value into a request.
    */
   final def encodeRequest(value: Value): Request =
-    encodeWith(value)((url, _, method, headers, body) =>
+    encodeWith(value, Chunk.empty)((url, _, method, headers, body) =>
       Request(
         url = url,
         method = method.getOrElse(Method.GET),
@@ -182,7 +182,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Uses this codec to encode the Scala value as a patch to a request.
    */
   final def encodeRequestPatch(value: Value): Request.Patch =
-    encodeWith(value)((url, _, _, headers, _) =>
+    encodeWith(value, Chunk.empty)((url, _, _, headers, _) =>
       Request.Patch(
         addQueryParams = url.queryParams,
         addHeaders = headers,
@@ -192,23 +192,23 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Uses this codec to encode the Scala value as a response.
    */
-  final def encodeResponse[Z](value: Value): Response =
-    encodeWith(value)((_, status, _, headers, body) =>
+  final def encodeResponse[Z](value: Value, outputTypes: Chunk[MediaType]): Response =
+    encodeWith(value, outputTypes)((_, status, _, headers, body) =>
       Response(headers = headers, body = body, status = status.getOrElse(Status.Ok)),
     )
 
   /**
    * Uses this codec to encode the Scala value as a response patch.
    */
-  final def encodeResponsePatch[Z](value: Value): Response.Patch =
-    encodeWith(value)((_, status, _, headers, _) =>
+  final def encodeResponsePatch[Z](value: Value, outputTypes: Chunk[MediaType]): Response.Patch =
+    encodeWith(value, outputTypes)((_, status, _, headers, _) =>
       Response.Patch.addHeaders(headers) ++ status.map(Response.Patch.status(_)).getOrElse(Response.Patch.empty),
     )
 
-  private final def encodeWith[Z](value: Value)(
+  private final def encodeWith[Z](value: Value, outputTypes: Chunk[MediaType])(
     f: (URL, Option[Status], Option[Method], Headers, Body) => Z,
   ): Z =
-    encoderDecoder.encodeWith(value)(f)
+    encoderDecoder.withOutputTypes(outputTypes).encodeWith(value)(f)
 
   def examples(examples: Iterable[Value]): HttpCodec[AtomTypes, Value] =
     HttpCodec.WithExamples(self, Chunk.fromIterable(examples))

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -25,7 +25,6 @@ import zio.http.{Path, Status}
 sealed trait HttpCodecError extends Exception with NoStackTrace {
   override def getMessage(): String = message
   def message: String
-  override def getMessage: String = message
 }
 object HttpCodecError {
   final case class MissingHeader(headerName: String)                                    extends HttpCodecError {

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -25,6 +25,7 @@ import zio.http.{Path, Status}
 sealed trait HttpCodecError extends Exception with NoStackTrace {
   override def getMessage(): String = message
   def message: String
+  override def getMessage: String = message
 }
 object HttpCodecError {
   final case class MissingHeader(headerName: String)                                    extends HttpCodecError {
@@ -55,6 +56,10 @@ object HttpCodecError {
     def message = s"Malformed request body failed to decode: $details"
   }
   final case class CustomError(message: String)                                         extends HttpCodecError
+
+  final case class UnsupportedContentType(contentType: String) extends HttpCodecError {
+    def message = s"Unsupported content type $contentType"
+  }
 
   def isHttpCodecError(cause: Cause[Any]): Boolean = {
     !cause.isFailure && cause.defects.forall(e => e.isInstanceOf[HttpCodecError])

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -79,11 +79,6 @@ private[internal] sealed trait BodyCodec[A] { self =>
   def mediaType: Option[MediaType]
 
   /**
-   * Returns the media type or application/json if not specified
-   */
-  def mediaTypeOrJson: MediaType = mediaType.getOrElse(MediaType.application.`json`)
-
-  /**
    * Name of the body part
    *
    * In case of multipart/form-data encoding one request or response can consist

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -16,13 +16,16 @@
 
 package zio.http.codec.internal
 
-import zio.http.{Body, MediaType}
+import java.nio.charset.Charset
+
+import zio._
+
+import zio.stream.{ZPipeline, ZStream}
+
 import zio.schema._
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.{ZPipeline, ZStream}
-import zio.{ZIO, _}
 
-import java.nio.charset.Charset
+import zio.http.{Body, MediaType}
 
 /**
  * A BodyCodec encapsulates the logic necessary to both encode and decode bodies

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -33,23 +33,17 @@ private[codec] trait EncoderDecoder[-AtomTypes, Value] {
 
   def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z
 
-  def withOutputTypes(outputTypes: Chunk[MediaType]): EncoderDecoder[AtomTypes, Value] = {
-    if (outputTypes.isEmpty) this
-    else {
-      this match {
-        case EncoderDecoder.Multiple(httpCodecs) => EncoderDecoder.Multiple(httpCodecs)
-        case EncoderDecoder.Single(httpCodec, _) => EncoderDecoder.Single(httpCodec, outputTypes)
-      }
-    }
-  }
 }
-private[codec] object EncoderDecoder                   {
-  def apply[AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value]): EncoderDecoder[AtomTypes, Value] = {
+private[codec] object EncoderDecoder {
+  def apply[AtomTypes, Value](
+    httpCodec: HttpCodec[AtomTypes, Value],
+    mediaType: Option[String],
+  ): EncoderDecoder[AtomTypes, Value] = {
     val flattened = httpCodec.alternatives
 
     flattened.length match {
       case 0 => Undefined()
-      case 1 => Single(flattened.head)
+      case 1 => Single(flattened.head, mediaType)
       case _ => Multiple(flattened)
     }
   }
@@ -138,7 +132,7 @@ private[codec] object EncoderDecoder                   {
 
   private final case class Single[-AtomTypes, Value](
     httpCodec: HttpCodec[AtomTypes, Value],
-    outputTypes: Chunk[MediaType] = Chunk.empty,
+    outputType: Option[String] = None,
   ) extends EncoderDecoder[AtomTypes, Value] {
     private val constructor   = Mechanic.makeConstructor(httpCodec)
     private val deconstructor = Mechanic.makeDeconstructor(httpCodec)
@@ -146,7 +140,7 @@ private[codec] object EncoderDecoder                   {
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
     private val codecs: Map[String, MediaTypeCodec[_]] =
-      MediaTypeCodec.codecsFor(outputTypes, flattened.content)
+      MediaTypeCodec.codecsFor(outputType, flattened.content)
 
     private def mediaTypeOrJson(bodyCodec: BodyCodec[_]): MediaType =
       bodyCodec.mediaType.getOrElse(MediaType.application.`json`)

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -17,11 +17,14 @@
 package zio.http.codec.internal
 
 import zio._
-import zio.http._
-import zio.http.codec._
+
+import zio.stream.ZStream
+
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.ZStream
+
+import zio.http._
+import zio.http.codec._
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -17,14 +17,11 @@
 package zio.http.codec.internal
 
 import zio._
-
-import zio.stream.ZStream
-
-import zio.schema.Schema
-import zio.schema.codec.{BinaryCodec, Codec}
-
 import zio.http._
 import zio.http.codec._
+import zio.schema.Schema
+import zio.schema.codec.{BinaryCodec, Codec}
+import zio.stream.ZStream
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
@@ -162,19 +159,19 @@ private[codec] object EncoderDecoder                   {
               .map(_.codecs(erased))
 
           codec match {
-            case Some(codec: BinaryCodec[Any])         =>
+            case Some(codec: BinaryCodec[Any] @unchecked) if codec.isInstanceOf[BinaryCodec[Any]]                 =>
               FormField.binaryField(
                 name,
                 codec.encode(value.asInstanceOf[erased.Element]),
                 mediaType,
               )
-            case Some(codec: Codec[String, Char, Any]) =>
+            case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               FormField.textField(
                 name,
                 codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
                 mediaType,
               )
-            case _                                     =>
+            case _                                                                                                =>
               throw HttpCodecError.UnsupportedContentType(mediaType.fullType)
           }
         }
@@ -191,11 +188,11 @@ private[codec] object EncoderDecoder                   {
               .map(_.codecs(erased))
 
           codec match {
-            case Some(codec: BinaryCodec[Any])         =>
+            case Some(codec: BinaryCodec[Any] @unchecked) if codec.isInstanceOf[BinaryCodec[Any]]                 =>
               field.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
-            case Some(codec: Codec[String, Char, Any]) =>
+            case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
-            case _                                     =>
+            case _                                                                                                =>
               ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
           }
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -174,7 +174,7 @@ private[codec] object EncoderDecoder                   {
                 codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
                 mediaType,
               )
-            case None                                  =>
+            case _                                     =>
               throw HttpCodecError.UnsupportedContentType(mediaType.fullType)
           }
         }
@@ -195,7 +195,7 @@ private[codec] object EncoderDecoder                   {
               field.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
             case Some(codec: Codec[String, Char, Any]) =>
               field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
-            case None                                  =>
+            case _                                     =>
               ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
           }
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -17,14 +17,11 @@
 package zio.http.codec.internal
 
 import zio._
-
-import zio.stream.ZStream
-
-import zio.schema.Schema
-import zio.schema.codec.{BinaryCodec, Codec}
-
 import zio.http._
 import zio.http.codec._
+import zio.schema.Schema
+import zio.schema.codec.{BinaryCodec, Codec}
+import zio.stream.ZStream
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
@@ -145,31 +142,17 @@ private[codec] object EncoderDecoder                   {
 
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
-    private val codecs: Map[String, MediaTypeCodec[_]] = {
-      val defaultCodecs = List(
-        MediaTypeCodec.json(flattened.content),
-        MediaTypeCodec.protobuf(flattened.content),
-        MediaTypeCodec.text(flattened.content),
-      ).flatMap(c => c.acceptedTypes.map(at => at.fullType -> c)).toMap
-      if (outputTypes.isEmpty) defaultCodecs
-      else {
-        outputTypes.collectFirst {
-          case mt if defaultCodecs.isDefinedAt(mt.fullType) => Map(mt.fullType -> defaultCodecs(mt.fullType))
-        }.getOrElse(
-          throw HttpCodecError.UnsupportedContentType(
-            s"""Non of the Accept header mime types is currently supported.
-               |Accepted are: ${outputTypes.map(_.fullType).mkString(",")}.
-               |Supported mime types are: ${defaultCodecs.keys.mkString(", ")}""".stripMargin,
-          ),
-        )
-      }
-    }
+    private val codecs: Map[String, MediaTypeCodec[_]] =
+      MediaTypeCodec.codecsFor(outputTypes, flattened.content)
+
+    private def mediaTypeOrJson(bodyCodec: BodyCodec[_]): MediaType =
+      bodyCodec.mediaType.getOrElse(MediaType.application.`json`)
 
     private val formFieldEncoders: Chunk[(String, Any) => FormField] =
       flattened.content.map { bodyCodec => (name: String, value: Any) =>
         {
           val erased    = bodyCodec.erase
-          val mediaType = bodyCodec.mediaTypeOrJson
+          val mediaType = mediaTypeOrJson(bodyCodec)
           val codec     =
             codecs
               .get(mediaType.fullType)
@@ -198,7 +181,7 @@ private[codec] object EncoderDecoder                   {
       flattened.content.map { bodyCodec => (field: FormField) =>
         {
           val erased    = bodyCodec.erase
-          val mediaType = bodyCodec.mediaTypeOrJson
+          val mediaType = mediaTypeOrJson(bodyCodec)
           val codec     =
             codecs
               .get(mediaType.fullType)

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,47 +1,110 @@
 package zio.http.codec.internal
 
 import zio._
-
-import zio.schema.Schema
-import zio.schema.codec._
-
 import zio.http._
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+import zio.stream.ZPipeline
 
-sealed trait MediaTypeCodec {
+import java.time.{
+  DayOfWeek,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  Month,
+  MonthDay,
+  OffsetTime,
+  Period,
+  Year,
+  YearMonth,
+  ZoneId,
+  ZoneOffset,
+}
+import java.util.UUID
+import scala.util.Try
+
+sealed trait MediaTypeCodec[Codec] {
 
   def acceptedTypes: Chunk[MediaType]
   def decoders: Chunk[Body => IO[Throwable, _]]
   def decodeSingle(body: Body): IO[Throwable, Any] = decoders(0)(body)
   def encoders: Chunk[Any => Body]
   def encodeSingle(a: Any): Body                   = encoders(0)(a)
+  def codecs: Map[BodyCodec[Any], Codec]
 
 }
 
+sealed trait BinaryMediaTypeCodec extends MediaTypeCodec[BinaryCodec[Any]]
+
+sealed trait TextMediaTypeCodec extends MediaTypeCodec[Codec[String, Char, Any]]
+
 object MediaTypeCodec {
-  def apply(
+  private def binary(
     content: Chunk[BodyCodec[_]],
     binaryCodec: Schema[Any] => BinaryCodec[Any],
     acceptTypes: Chunk[MediaType],
-  ): MediaTypeCodec = new MediaTypeCodec {
+  ): BinaryMediaTypeCodec = new BinaryMediaTypeCodec {
+
     override def encoders: Chunk[Any => Body] =
       content.map { bodyCodec =>
-        val erased    = bodyCodec.erase
-        val jsonCodec = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
-        erased.encodeToBody(_, jsonCodec)
+        val erased = bodyCodec.erase
+        val codec  = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
+        erased.encodeToBody(_, codec)
       }
 
     override def decoders: Chunk[Body => IO[Throwable, _]] =
       content.map { bodyCodec =>
-        val jsonCodec =
+        val codec =
           binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
             .asInstanceOf[BinaryCodec[bodyCodec.Element]]
-        bodyCodec.decodeFromBody(_, jsonCodec)
+        bodyCodec.decodeFromBody(_, codec)
       }
+
+    override def codecs: Map[BodyCodec[Any], BinaryCodec[Any]] =
+      content.map { bodyCodec =>
+        val codec =
+          binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[BinaryCodec[bodyCodec.Element]]
+        bodyCodec.erase -> codec.asInstanceOf[BinaryCodec[Any]]
+      }.toMap
 
     override val acceptedTypes: Chunk[MediaType] = acceptTypes
   }
-  def json(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
-    apply(
+
+  private def text(
+    content: Chunk[BodyCodec[_]],
+    textCodec: Schema[Any] => Codec[String, Char, Any],
+    acceptTypes: Chunk[MediaType],
+  ): TextMediaTypeCodec = new TextMediaTypeCodec {
+
+    override def encoders: Chunk[Any => Body] =
+      content.map { bodyCodec =>
+        val erased = bodyCodec.erase
+        val codec = textCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[Codec[String, Char, erased.Element]]
+        ((a: erased.Element) => erased.encodeToBody(a, codec)).asInstanceOf[Any => Body]
+      }
+
+    override def decoders: Chunk[Body => IO[Throwable, _]] =
+      content.map { bodyCodec =>
+        val codec =
+          textCodec(bodyCodec.schema.asInstanceOf[Schema[Any]]).asInstanceOf[Codec[String, Char, bodyCodec.Element]]
+        bodyCodec.decodeFromBody(_, codec)
+      }
+
+    override def codecs: Map[BodyCodec[Any], Codec[String, Char, Any]] =
+      content.map { bodyCodec =>
+        val codec =
+          textCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[Codec[String, Char, bodyCodec.Element]]
+        bodyCodec.erase -> codec.asInstanceOf[Codec[String, Char, Any]]
+      }.toMap
+
+    override val acceptedTypes: Chunk[MediaType] = acceptTypes
+  }
+
+  def json(content: Chunk[BodyCodec[_]]): BinaryMediaTypeCodec =
+    binary(
       content,
       JsonCodec.schemaBasedBinaryCodec[Any](_),
       Chunk(
@@ -49,12 +112,86 @@ object MediaTypeCodec {
       ),
     )
 
-  def protobuf(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
-    apply(
+  def protobuf(content: Chunk[BodyCodec[_]]): BinaryMediaTypeCodec =
+    binary(
       content,
       ProtobufCodec.protobufCodec[Any](_),
       Chunk(
         MediaType.parseCustomMediaType("application/protobuf").get,
       ),
     )
+
+  def text(content: Chunk[BodyCodec[_]]): TextMediaTypeCodec =
+    text(
+      content,
+      TextCodec.fromSchema[Any],
+      Chunk.fromIterable(MediaType.text.all),
+    )
+
+}
+
+private[internal] object TextCodec {
+  def fromSchema[A](schema: Schema[A]): Codec[String, Char, A] = {
+    if (!schema.isInstanceOf[Schema.Primitive[_]]) {
+      throw new IllegalArgumentException(
+        s"Schema $schema is not a primitive. Only primitive schemas are supported by TextCodec.",
+      )
+    }
+
+    new Codec[String, Char, A] {
+      override def encode(a: A): String                      =
+        schema match {
+          case Schema.Primitive(_, _) => a.toString
+          case _                      =>
+            throw new IllegalArgumentException(
+              s"Cannot encode $a of type ${a.getClass} with schema $schema",
+            )
+        }
+      override def decode(s: String): Either[DecodeError, A] =
+        schema match {
+          case Schema.Primitive(standardType, _) =>
+            (standardType match {
+              case StandardType.StringType => Right(s)
+              case StandardType.BoolType   => Try(s.toBoolean).toEither
+              case StandardType.ByteType   => Try(s.toByte).toEither
+              case StandardType.ShortType  => Try(s.toShort).toEither
+              case StandardType.IntType    => Try(s.toInt).toEither
+              case StandardType.LongType   => Try(s.toLong).toEither
+              case StandardType.FloatType  => Try(s.toFloat).toEither
+              case StandardType.DoubleType => Try(s.toDouble).toEither
+              case StandardType.BinaryType => Left(DecodeError.ValidationError(null, null, "Binary is not supported"))
+              case StandardType.CharType   => Right(s.charAt(0))
+              case StandardType.UUIDType   => Try(UUID.fromString(s)).toEither
+              case StandardType.BigDecimalType    => Try(BigDecimal(s)).toEither
+              case StandardType.BigIntegerType    => Try(BigInt(s)).toEither
+              case StandardType.DayOfWeekType     => Try(DayOfWeek.valueOf(s)).toEither
+              case StandardType.MonthType         => Try(Month.valueOf(s)).toEither
+              case StandardType.MonthDayType      => Try(MonthDay.parse(s)).toEither
+              case StandardType.PeriodType        => Try(Period.parse(s)).toEither
+              case StandardType.YearType          => Try(Year.parse(s)).toEither
+              case StandardType.YearMonthType     => Try(YearMonth.parse(s)).toEither
+              case StandardType.ZoneIdType        => Try(ZoneId.of(s)).toEither
+              case StandardType.ZoneOffsetType    => Try(ZoneOffset.of(s)).toEither
+              case StandardType.DurationType      => Try(java.time.Duration.parse(s)).toEither
+              case StandardType.InstantType       => Try(Instant.parse(s)).toEither
+              case StandardType.LocalDateType     => Try(LocalDate.parse(s)).toEither
+              case StandardType.LocalTimeType     => Try(LocalTime.parse(s)).toEither
+              case StandardType.LocalDateTimeType => Try(LocalDateTime.parse(s)).toEither
+              case StandardType.OffsetTimeType    => Try(OffsetTime.parse(s)).toEither
+            }).map(_.asInstanceOf[A]).left.map(e => DecodeError.ReadError(Cause.fail(e), e.getMessage))
+          case _                                 =>
+            Left(
+              DecodeError.ReadError(Cause.empty, "Only primitive types are supported. But found: " + schema.toString),
+            )
+        }
+
+      override def streamEncoder: ZPipeline[Any, Nothing, A, Char] =
+        ZPipeline.map((a: A) => Chunk.fromArray(a.toString.toArray)).flattenChunks
+
+      override def streamDecoder: ZPipeline[Any, DecodeError, Char, A] =
+        (ZPipeline[Char].map(_.toByte) >>> ZPipeline.utf8Decode)
+          .map(decode(_).fold(throw _, identity))
+          .mapErrorCause(e => Cause.fail(DecodeError.ReadError(e, e.squash.getMessage)))
+    }
+  }
 }

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,18 +1,22 @@
 package zio.http.codec.internal
 
-import zio._
-import zio.http._
-import zio.http.codec.HttpCodecError
-import zio.schema.codec._
-import zio.schema.{Schema, StandardType}
-import zio.stream.ZPipeline
-
 import java.time._
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 import scala.util.Try
+
+import zio._
+
+import zio.stream.ZPipeline
+
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+
+import zio.http._
+import zio.http.codec.HttpCodecError
 
 final case class MediaTypeCodecDefinition[T <: MediaTypeCodec[_]](
   acceptedTypes: Chunk[MediaType],

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,0 +1,60 @@
+package zio.http.codec.internal
+
+import zio._
+
+import zio.schema.Schema
+import zio.schema.codec._
+
+import zio.http._
+
+sealed trait MediaTypeCodec {
+
+  def acceptedTypes: Chunk[MediaType]
+  def decoders: Chunk[Body => IO[Throwable, _]]
+  def decodeSingle(body: Body): IO[Throwable, Any] = decoders(0)(body)
+  def encoders: Chunk[Any => Body]
+  def encodeSingle(a: Any): Body                   = encoders(0)(a)
+
+}
+
+object MediaTypeCodec {
+  def apply(
+    content: Chunk[BodyCodec[_]],
+    binaryCodec: Schema[Any] => BinaryCodec[Any],
+    acceptTypes: Chunk[MediaType],
+  ): MediaTypeCodec = new MediaTypeCodec {
+    override def encoders: Chunk[Any => Body] =
+      content.map { bodyCodec =>
+        val erased    = bodyCodec.erase
+        val jsonCodec = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
+        erased.encodeToBody(_, jsonCodec)
+      }
+
+    override def decoders: Chunk[Body => IO[Throwable, _]] =
+      content.map { bodyCodec =>
+        val jsonCodec =
+          binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[BinaryCodec[bodyCodec.Element]]
+        bodyCodec.decodeFromBody(_, jsonCodec)
+      }
+
+    override val acceptedTypes: Chunk[MediaType] = acceptTypes
+  }
+  def json(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
+    apply(
+      content,
+      JsonCodec.schemaBasedBinaryCodec[Any](_),
+      Chunk(
+        MediaType.application.`json`,
+      ),
+    )
+
+  def protobuf(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
+    apply(
+      content,
+      ProtobufCodec.protobufCodec[Any](_),
+      Chunk(
+        MediaType.parseCustomMediaType("application/protobuf").get,
+      ),
+    )
+}

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,28 +1,18 @@
 package zio.http.codec.internal
 
+import java.time._
+import java.util.UUID
+
+import scala.util.Try
+
 import zio._
-import zio.http._
-import zio.schema.codec._
-import zio.schema.{Schema, StandardType}
+
 import zio.stream.ZPipeline
 
-import java.time.{
-  DayOfWeek,
-  Instant,
-  LocalDate,
-  LocalDateTime,
-  LocalTime,
-  Month,
-  MonthDay,
-  OffsetTime,
-  Period,
-  Year,
-  YearMonth,
-  ZoneId,
-  ZoneOffset,
-}
-import java.util.UUID
-import scala.util.Try
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+
+import zio.http._
 
 sealed trait MediaTypeCodec[Codec] {
 

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -39,7 +39,7 @@ private[endpoint] final case class EndpointClient[I, E, O, M <: EndpointMiddlewa
         patchedRequest
       else
         patchedRequest.addHeader(
-          Header.Accept(MediaType.parseCustomMediaType("application/protobuf").get, MediaType.application.json),
+          Header.Accept(MediaType.application.json, MediaType.parseCustomMediaType("application/protobuf").get),
         )
 
     client.request(withDefaultAcceptHeader).orDie.flatMap { response =>

--- a/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
@@ -458,8 +458,7 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env =>
-        ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging) )),
+      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging))),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),

--- a/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
@@ -458,13 +458,16 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug{ case r: Response =>
-          r.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
-        })),
+      Client.customized.map(env =>
+        ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging) )),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),
       DnsResolver.default,
       Scope.default,
     ) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
+
+  def extraLogging: PartialFunction[Response, String] = {
+    _.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
+  }
 }

--- a/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/ServerClientIntegrationSpec.scala
@@ -458,7 +458,7 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging))),
+      Client.customized.map(env => ZEnvironment(env.get @@ clientDebugAspect)),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),
@@ -466,7 +466,9 @@ object ServerClientIntegrationSpec extends ZIOSpecDefault {
       Scope.default,
     ) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
 
-  def extraLogging: PartialFunction[Response, String] = {
-    _.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
+  private def extraLogging: PartialFunction[Response, String] = { case r =>
+    r.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
   }
+  private def clientDebugAspect                               =
+    ZClientAspect.debug(extraLogging)
 }

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -24,7 +24,6 @@ import zio.http.HttpAppMiddleware.cors
 import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 import zio.http.internal.middlewares.Cors.CorsConfig
-import zio.http.internal.middlewares.CorsSpec.app
 
 object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status


### PR DESCRIPTION
The default codec is still json. Only added support for protobuf and plain text.

fixes #1506 
/claim  #1506 