### PR TITLE
Send HTTP requests like GET /?p=1 instead of GET ?p=1

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/client/NettyRequestEncoder.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/NettyRequestEncoder.scala
@@ -34,9 +34,11 @@ private[zio] object NettyRequestEncoder {
     val method   = Conversions.methodToNetty(req.method)
     val jVersion = Conversions.versionToNetty(req.version)
 
+    def replaceEmptyPathWithSlash(url: zio.http.URL) = if (url.path.isEmpty) url.addLeadingSlash else url
+
     // As per the spec, the path should contain only the relative path.
     // Host and port information should be in the headers.
-    val path = req.url.relative.encode
+    val path = replaceEmptyPathWithSlash(req.url).relative.encode
 
     val encodedReqHeaders = Conversions.headersToNetty(req.allHeaders)
 


### PR DESCRIPTION
closes #2238

<br>

An HTTP request for a URL like `http://example.com?p=1` should be
```
GET /?p=1 ...
```

not

```
GET ?p=1 ...
```
<br>

The path should start with a slash.

<br>
<br>

/claim #2238