### PR TITLE
CLI: Fix `java.lang.UnsupportedOperationException: empty.reduceLeft` error

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -1,13 +1,15 @@
 package zio.http.endpoint.cli
 
+import scala.util.Try
+
 import zio.cli._
+import zio.json.ast._
+
+import zio.schema._
+
 import zio.http._
 import zio.http.codec._
 import zio.http.endpoint._
-import zio.json.ast._
-import zio.schema._
-
-import scala.util.Try
 
 private[cli] final case class CliEndpoint[A](
   embed: (A, CliRequest) => CliRequest,


### PR DESCRIPTION
I have a CLI defined this way:
```scala
import zio.cli.HelpDoc.Span
import zio.cli.{CliApp, HelpDoc, ZIOCliDefault}
import zio.http.codec.HttpCodec.*
import zio.http.endpoint.cli.*
import zio.http.endpoint.{Endpoint, EndpointMiddleware}
import zio.{Chunk, Scope, ZIOAppArgs, ZNothing}

object MyAmazingCLI extends ZIOCliDefault {
  val hello: Endpoint[Unit, ZNothing, ZNothing, EndpointMiddleware.None] =
    Endpoint.get(path = literal("hello") / "world")

  override def cliApp: CliApp[Any & ZIOAppArgs & Scope, Any, Any] =
    HttpCliApp
      .fromEndpoints(
        name = "my-cli",
        version = "0.0.1",
        summary = Span.text("My Amazing CLI"),
        footer = HelpDoc.p("Copyright (c) 2023 CLI.io"),
        host = "localhost",
        port = 8080,       
        endpoints = Chunk(hello),
      )
      .cliApp
}
```

And when I launch it, I have the following error:
```scala
[info] timestamp=2023-07-17T11:46:20.635032Z level=ERROR thread=#zio-fiber-1 message="" cause="Exception in thread "zio-fiber-4" java.lang.UnsupportedOperationException: empty.reduceLeft
[info] 	at scala.collection.IterableOnceOps.reduceLeft(IterableOnce.scala:757)
[info] 	at scala.collection.IterableOnceOps.reduceLeft$(IterableOnce.scala:755)
[info] 	at scala.collection.AbstractIterable.reduceLeft(Iterable.scala:933)
[info] 	at scala.collection.IterableOnceOps.reduce(IterableOnce.scala:728)
[info] 	at scala.collection.IterableOnceOps.reduce$(IterableOnce.scala:728)
[info] 	at scala.collection.AbstractIterable.reduce(Iterable.scala:933)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.loop$1(CliEndpoint.scala:308)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.$anonfun$fromSchema$4(CliEndpoint.scala:312)
[info] 	at zio.Chunk$Arr.foldLeft(Chunk.scala:1650)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.loop$1(CliEndpoint.scala:311)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.$anonfun$fromSchema$1(CliEndpoint.scala:301)
[info] 	at zio.Chunk$Arr.foldLeft(Chunk.scala:1650)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.loop$1(CliEndpoint.scala:300)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.fromSchema(CliEndpoint.scala:646)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.fromInput(CliEndpoint.scala:85)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.fromInput(CliEndpoint.scala:76)
[info] 	at zio.http.endpoint.cli.CliEndpoint$.fromEndpoint(CliEndpoint.scala:70)
[info] 	at zio.http.endpoint.cli.HttpCliApp$.$anonfun$fromEndpoints$1(HttpCliApp.scala:51)
[info] 	at zio.ChunkLike.flatMap(ChunkLike.scala:78)
[info] 	at zio.ChunkLike.flatMap$(ChunkLike.scala:69)
[info] 	at zio.Chunk.flatMap(Chunk.scala:42)
[info] 	at zio.http.endpoint.cli.HttpCliApp$.fromEndpoints(HttpCliApp.scala:51)
[info] 	at io.zeklin.cli.ZeklinCLI$.cliApp(ZeklinCLI.scala:17)
[info] 	at zio.cli.ZIOCli.$anonfun$run$1(ZIOCli.scala:12)
[info] 	at zio.cli.ZIOCli.run(ZIOCli.scala:11)"
[error] Nonzero exit code returned from runner: 1
```

With this fix, I don't have the issue anymore