### PR TITLE
accept header endpoint new

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,7 @@ lazy val zioHttp = (project in file("zio-http"))
       `zio-streams`,
       `zio-schema`,
       `zio-schema-json`,
+      `zio-schema-protobuf`,
       `zio-test`,
       `zio-test-sbt`,
       `netty-incubator`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,4 +1,4 @@
-import sbt.*
+import sbt._
 import sbt.Keys.scalaVersion
 
 object Dependencies {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
+import sbt.*
 import sbt.Keys.scalaVersion
-import sbt._
 
 object Dependencies {
   val JwtCoreVersion                = "9.1.1"
@@ -29,12 +29,13 @@ object Dependencies {
   val `netty-incubator` =
     "io.netty.incubator" % "netty-incubator-transport-native-io_uring" % NettyIncubatorVersion classifier "linux-x86_64"
 
-  val zio               = "dev.zio" %% "zio"             % ZioVersion
-  val `zio-cli`         = "dev.zio" %% "zio-cli"         % ZioCliVersion
-  val `zio-streams`     = "dev.zio" %% "zio-streams"     % ZioVersion
-  val `zio-schema`      = "dev.zio" %% "zio-schema"      % ZioSchemaVersion
-  val `zio-schema-json` = "dev.zio" %% "zio-schema-json" % ZioSchemaVersion
-  val `zio-test`        = "dev.zio" %% "zio-test"        % ZioVersion % "test"
-  val `zio-test-sbt`    = "dev.zio" %% "zio-test-sbt"    % ZioVersion % "test"
+  val zio                   = "dev.zio" %% "zio"                 % ZioVersion
+  val `zio-cli`             = "dev.zio" %% "zio-cli"             % ZioCliVersion
+  val `zio-streams`         = "dev.zio" %% "zio-streams"         % ZioVersion
+  val `zio-schema`          = "dev.zio" %% "zio-schema"          % ZioSchemaVersion
+  val `zio-schema-json`     = "dev.zio" %% "zio-schema-json"     % ZioSchemaVersion
+  val `zio-schema-protobuf` = "dev.zio" %% "zio-schema-protobuf" % ZioSchemaVersion
+  val `zio-test`            = "dev.zio" %% "zio-test"            % ZioVersion % "test"
+  val `zio-test-sbt`        = "dev.zio" %% "zio-test-sbt"        % ZioVersion % "test"
 
 }

--- a/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
+++ b/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
@@ -1,7 +1,6 @@
 package example
 
 import zio.http.codec.HttpCodec._
-import zio.http.codec.HttpCodecType.PathQuery
 import zio.http.codec._
 
 object CombinerTypesExample extends App {

--- a/zio-http/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/MediaType.scala
@@ -27,7 +27,7 @@ final case class MediaType(
   extensions: Map[String, String] = Map.empty,
   parameters: Map[String, String] = Map.empty,
 ) {
-  def fullType: String = s"$mainType/$subType"
+  lazy val fullType: String = s"$mainType/$subType"
 }
 
 object MediaType extends MediaTypes {

--- a/zio-http/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/MediaType.scala
@@ -37,11 +37,12 @@ object MediaType extends MediaTypes {
   def forContentType(contentType: String): Option[MediaType] = {
     val index = contentType.indexOf(";")
     if (index == -1)
-      contentTypeMap.get(contentType)
+      contentTypeMap.get(contentType).orElse(parseCustomMediaType(contentType))
     else {
       val (contentType1, parameter) = contentType.splitAt(index)
       contentTypeMap
         .get(contentType1)
+        .orElse(parseCustomMediaType(contentType1))
         .map(_.copy(parameters = parseOptionalParameters(parameter.split(";"))))
     }
   }

--- a/zio-http/src/main/scala/zio/http/Request.scala
+++ b/zio-http/src/main/scala/zio/http/Request.scala
@@ -141,4 +141,8 @@ object Request {
   def put(path: String, body: Body): Request = Request(method = Method.PUT, url = URL(Path(path)), body = body)
 
   def put(url: URL, body: Body): Request = Request(method = Method.PUT, url = url, body = body)
+
+  object Patch {
+    val empty: Patch = Patch(Headers.empty, QueryParams.empty)
+  }
 }

--- a/zio-http/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/src/main/scala/zio/http/ZClientAspect.scala
@@ -109,6 +109,14 @@ object ZClientAspect {
    * Client aspect that logs a debug message to the console after each request
    */
   final def debug(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
+    debug(PartialFunction.empty)
+
+  /**
+   * Client aspect that logs a debug message to the console after each request
+   */
+  final def debug(
+    extraMessage: PartialFunction[Response, String],
+  )(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
     new ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] {
 
       /**
@@ -140,11 +148,10 @@ object ZClientAspect {
               .timed
               .tap {
                 case (duration, Exit.Success(response)) =>
-                  Console
-                    .printLine(
-                      s"${response.status.code} $method ${url.encode} ${duration.toMillis}ms",
-                    )
-                    .orDie
+                  {
+                    Console.printLine(s"${response.status.code} $method ${url.encode} ${duration.toMillis}ms") *>
+                      Console.printLine(extraMessage(response)).when(extraMessage.isDefinedAt(response))
+                  }.orDie
                 case (duration, Exit.Failure(cause))    =>
                   Console
                     .printLine(

--- a/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HeaderCodecs.scala
@@ -22,6 +22,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.http.Header
 import zio.http.Header.HeaderType
+import zio.http.{Header, MediaType}
 
 private[codec] trait HeaderCodecs {
   private[http] def headerCodec[A](name: String, value: TextCodec[A]): HeaderCodec[A] =

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -150,7 +150,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Uses this codec to encode the Scala value into a request.
    */
   final def encodeRequest(value: Value): Request =
-    encodeWith(value)((url, _, method, headers, body) =>
+    encodeWith(value, Chunk.empty)((url, _, method, headers, body) =>
       Request(
         url = url,
         method = method.getOrElse(Method.GET),
@@ -165,7 +165,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
    * Uses this codec to encode the Scala value as a patch to a request.
    */
   final def encodeRequestPatch(value: Value): Request.Patch =
-    encodeWith(value)((url, _, _, headers, _) =>
+    encodeWith(value, Chunk.empty)((url, _, _, headers, _) =>
       Request.Patch(
         addQueryParams = url.queryParams,
         addHeaders = headers,
@@ -175,23 +175,23 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Uses this codec to encode the Scala value as a response.
    */
-  final def encodeResponse[Z](value: Value): Response =
-    encodeWith(value)((_, status, _, headers, body) =>
+  final def encodeResponse[Z](value: Value, outputTypes: Chunk[MediaType]): Response =
+    encodeWith(value, outputTypes)((_, status, _, headers, body) =>
       Response(headers = headers, body = body, status = status.getOrElse(Status.Ok)),
     )
 
   /**
    * Uses this codec to encode the Scala value as a response patch.
    */
-  final def encodeResponsePatch[Z](value: Value): Response.Patch =
-    encodeWith(value)((_, status, _, headers, _) =>
+  final def encodeResponsePatch[Z](value: Value, outputTypes: Chunk[MediaType]): Response.Patch =
+    encodeWith(value, outputTypes)((_, status, _, headers, _) =>
       Response.Patch.addHeaders(headers) ++ status.map(Response.Patch.status(_)).getOrElse(Response.Patch.empty),
     )
 
-  private final def encodeWith[Z](value: Value)(
+  private final def encodeWith[Z](value: Value, outputTypes: Chunk[MediaType])(
     f: (URL, Option[Status], Option[Method], Headers, Body) => Z,
   ): Z =
-    encoderDecoder.encodeWith(value)(f)
+    encoderDecoder.withOutputTypes(outputTypes).encodeWith(value)(f)
 
   def examples(examples: Iterable[Value]): HttpCodec[AtomTypes, Value] =
     HttpCodec.WithExamples(self, Chunk.fromIterable(examples))

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -16,6 +16,8 @@
 
 package zio.http.codec
 
+import java.util.concurrent.ConcurrentHashMap
+
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
@@ -26,7 +28,9 @@ import zio.stream.ZStream
 
 import zio.schema.Schema
 
+import zio.http.Header.Accept.MediaTypeWithQFactor
 import zio.http._
+import zio.http.codec.internal.EncoderDecoder
 
 /**
  * A [[zio.http.codec.HttpCodec]] represents a codec for a part of an HTTP
@@ -42,7 +46,37 @@ import zio.http._
  */
 sealed trait HttpCodec[-AtomTypes, Value] {
   self =>
-  private lazy val encoderDecoder = zio.http.codec.internal.EncoderDecoder(self)
+
+  private lazy val encoderDecoders: ConcurrentHashMap[String, EncoderDecoder[_, _]] =
+    new ConcurrentHashMap[String, EncoderDecoder[_, _]]()
+
+  private lazy val defaultEncoderDecoder: EncoderDecoder[AtomTypes, Value]                              =
+    EncoderDecoder(self, None)
+  private def encoderDecoder(mediaTypes: Chunk[MediaTypeWithQFactor]): EncoderDecoder[AtomTypes, Value] =
+    if (mediaTypes.isEmpty) defaultEncoderDecoder
+    else {
+      var mediaType: Option[MediaTypeWithQFactor] = None
+      var i                                       = 0
+      while (i < mediaTypes.length) {
+        if (mediaTypes(i).qFactor.getOrElse(1.0) > mediaType.map(_.qFactor.getOrElse(1.0)).getOrElse(0.0)) {
+          mediaType = Some(mediaTypes(i))
+        }
+        i += 1
+      }
+      mediaType match {
+        case Some(mediaType) =>
+          encoderDecoders
+            .computeIfAbsent(
+              mediaType.mediaType.fullType,
+              mediaType => {
+                EncoderDecoder(self, Some(mediaType))
+              },
+            )
+            .asInstanceOf[EncoderDecoder[AtomTypes, Value]]
+        case None            =>
+          throw new IllegalArgumentException("No supported media type provided") // TODO: Better error handling
+      }
+    }
 
   /**
    * Returns a new codec that is the same as this one, but has attached docs,
@@ -144,7 +178,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   private final def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
     trace: Trace,
   ): Task[Value] =
-    encoderDecoder.decode(url, status, method, headers, body)
+    encoderDecoder(Chunk.empty).decode(url, status, method, headers, body)
 
   /**
    * Uses this codec to encode the Scala value into a request.
@@ -175,7 +209,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Uses this codec to encode the Scala value as a response.
    */
-  final def encodeResponse[Z](value: Value, outputTypes: Chunk[MediaType]): Response =
+  final def encodeResponse[Z](value: Value, outputTypes: Chunk[MediaTypeWithQFactor]): Response =
     encodeWith(value, outputTypes)((_, status, _, headers, body) =>
       Response(headers = headers, body = body, status = status.getOrElse(Status.Ok)),
     )
@@ -183,15 +217,15 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Uses this codec to encode the Scala value as a response patch.
    */
-  final def encodeResponsePatch[Z](value: Value, outputTypes: Chunk[MediaType]): Response.Patch =
+  final def encodeResponsePatch[Z](value: Value, outputTypes: Chunk[MediaTypeWithQFactor]): Response.Patch =
     encodeWith(value, outputTypes)((_, status, _, headers, _) =>
       Response.Patch.addHeaders(headers) ++ status.map(Response.Patch.status(_)).getOrElse(Response.Patch.empty),
     )
 
-  private final def encodeWith[Z](value: Value, outputTypes: Chunk[MediaType])(
+  private final def encodeWith[Z](value: Value, outputTypes: Chunk[MediaTypeWithQFactor])(
     f: (URL, Option[Status], Option[Method], Headers, Body) => Z,
   ): Z =
-    encoderDecoder.withOutputTypes(outputTypes).encodeWith(value)(f)
+    encoderDecoder(outputTypes).encodeWith(value)(f)
 
   def examples(examples: Iterable[Value]): HttpCodec[AtomTypes, Value] =
     HttpCodec.WithExamples(self, Chunk.fromIterable(examples))

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -26,6 +26,7 @@ import zio.http.{Path, Status}
 sealed trait HttpCodecError extends Exception with NoStackTrace {
   override def getMessage(): String = message
   def message: String
+  override def getMessage: String = message
 }
 object HttpCodecError {
   final case class MissingHeader(headerName: String)                                    extends HttpCodecError {
@@ -56,6 +57,10 @@ object HttpCodecError {
     def message = s"Malformed request body failed to decode: $details"
   }
   final case class CustomError(message: String)                                         extends HttpCodecError
+
+  final case class UnsupportedContentType(contentType: String) extends HttpCodecError {
+    def message = s"Unsupported content type $contentType"
+  }
 
   def isHttpCodecError(cause: Cause[Any]): Boolean = {
     !cause.isFailure && cause.defects.forall(e => e.isInstanceOf[HttpCodecError])

--- a/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -26,7 +26,6 @@ import zio.http.{Path, Status}
 sealed trait HttpCodecError extends Exception with NoStackTrace {
   override def getMessage(): String = message
   def message: String
-  override def getMessage: String = message
 }
 object HttpCodecError {
   final case class MissingHeader(headerName: String)                                    extends HttpCodecError {

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -22,12 +22,16 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
 
 import zio.http.{Body, MediaType}
+import java.nio.charset.Charset
+
+import zio._
+
+import zio.stream.{ZPipeline, ZStream}
+
 import zio.schema._
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.{ZPipeline, ZStream}
-import zio.{ZIO, _}
 
-import java.nio.charset.Charset
+import zio.http.{Body, MediaType}
 
 /**
  * A BodyCodec encapsulates the logic necessary to both encode and decode bodies

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -21,10 +21,13 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.stream.ZStream
 
+import zio.http.{Body, MediaType}
 import zio.schema._
-import zio.schema.codec.BinaryCodec
+import zio.schema.codec.{BinaryCodec, Codec}
+import zio.stream.{ZPipeline, ZStream}
+import zio.{ZIO, _}
 
-import zio.http.{Body, FormField, MediaType}
+import java.nio.charset.Charset
 
 /**
  * A BodyCodec encapsulates the logic necessary to both encode and decode bodies
@@ -45,9 +48,19 @@ private[internal] sealed trait BodyCodec[A] { self =>
   def decodeFromBody(body: Body, codec: BinaryCodec[Element])(implicit trace: Trace): IO[Throwable, A]
 
   /**
+   * Attempts to decode the `A` from a body using the given codec.
+   */
+  def decodeFromBody(body: Body, codec: Codec[String, Char, Element]): IO[Throwable, A]
+
+  /**
    * Encodes the `A` to a body in the given codec.
    */
   def encodeToBody(value: A, codec: BinaryCodec[Element])(implicit trace: Trace): Body
+
+  /**
+   * Encodes the `A` to a body in the given codec.
+   */
+  def encodeToBody(value: A, codec: Codec[String, Char, Element]): Body
 
   /**
    * Erases the type for easier use in the internal implementation.
@@ -68,6 +81,11 @@ private[internal] sealed trait BodyCodec[A] { self =>
   def mediaType: Option[MediaType]
 
   /**
+   * Returns the media type or application/json if not specified
+   */
+  def mediaTypeOrJson: MediaType = mediaType.getOrElse(MediaType.application.`json`)
+
+  /**
    * Name of the body part
    *
    * In case of multipart/form-data encoding one request or response can consist
@@ -81,7 +99,11 @@ private[internal] object BodyCodec {
 
     def decodeFromBody(body: Body, codec: BinaryCodec[Unit])(implicit trace: Trace): IO[Nothing, Unit] = ZIO.unit
 
+    def decodeFromBody(body: Body, codec: Codec[String, Char, Unit]): IO[Nothing, Unit] = ZIO.unit
+
     def encodeToBody(value: Unit, codec: BinaryCodec[Unit])(implicit trace: Trace): Body = Body.empty
+
+    def encodeToBody(value: Unit, codec: Codec[String, Char, Unit]): Body = Body.empty
 
     def schema: Schema[Unit] = Schema[Unit]
 
@@ -94,14 +116,18 @@ private[internal] object BodyCodec {
       extends BodyCodec[A] {
     def decodeFromBody(body: Body, codec: BinaryCodec[A])(implicit trace: Trace): IO[Throwable, A] = {
       if (schema == Schema[Unit]) ZIO.unit.asInstanceOf[IO[Throwable, A]]
-      else
-        body.asChunk.flatMap { chunk =>
-          ZIO.fromEither(codec.decode(chunk))
-        }
+      else body.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
     }
+
+    def decodeFromBody(body: Body, codec: Codec[String, Char, A]): IO[Throwable, A] =
+      if (schema == Schema[Unit]) ZIO.unit.asInstanceOf[IO[Throwable, A]]
+      else body.asString.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
 
     def encodeToBody(value: A, codec: BinaryCodec[A])(implicit trace: Trace): Body =
       Body.fromChunk(codec.encode(value))
+
+    def encodeToBody(value: A, codec: Codec[String, Char, A]): Body =
+      Body.fromString(codec.encode(value))
 
     type Element = A
   }
@@ -113,8 +139,14 @@ private[internal] object BodyCodec {
     ): IO[Throwable, ZStream[Any, Nothing, E]] =
       ZIO.succeed((body.asStream >>> codec.streamDecoder).orDie)
 
+    def decodeFromBody(body: Body, codec: Codec[String, Char, E]): IO[Throwable, ZStream[Any, Nothing, E]] =
+      ZIO.succeed((body.asStream >>> ZPipeline.decodeCharsWith(Charset.defaultCharset()) >>> codec.streamDecoder).orDie)
+
     def encodeToBody(value: ZStream[Any, Nothing, E], codec: BinaryCodec[E])(implicit trace: Trace): Body =
       Body.fromStream(value >>> codec.streamEncoder)
+
+    def encodeToBody(value: ZStream[Any, Nothing, E], codec: Codec[String, Char, E]): Body =
+      Body.fromStream(value >>> codec.streamEncoder.map(_.toByte))
 
     type Element = E
   }

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -85,11 +85,6 @@ private[internal] sealed trait BodyCodec[A] { self =>
   def mediaType: Option[MediaType]
 
   /**
-   * Returns the media type or application/json if not specified
-   */
-  def mediaTypeOrJson: MediaType = mediaType.getOrElse(MediaType.application.`json`)
-
-  /**
    * Name of the body part
    *
    * In case of multipart/form-data encoding one request or response can consist

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -26,11 +26,12 @@ import zio.schema.codec._
 import zio.schema.{Schema, StandardType}
 
 import zio.stream.ZStream
-import zio.http._
-import zio.http.codec._
+import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.ZStream
+
+import zio.http._
+import zio.http.codec._
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -17,20 +17,10 @@
 package zio.http.codec.internal
 
 import zio._
-
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.stream.ZStream
 
-import zio.schema.codec._
-import zio.schema.{Schema, StandardType}
-
-import zio.stream.ZStream
-import zio.stream.ZStream
-import zio.schema.Schema
-import zio.schema.codec.{BinaryCodec, Codec}
-
-import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -181,7 +181,7 @@ private[codec] object EncoderDecoder                   {
                 codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
                 mediaType,
               )
-            case None                                  =>
+            case _                                     =>
               throw HttpCodecError.UnsupportedContentType(mediaType.fullType)
           }
         }
@@ -204,7 +204,7 @@ private[codec] object EncoderDecoder                   {
               field.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
             case Some(codec: Codec[String, Char, Any]) =>
               field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
-            case None                                  =>
+            case _                                     =>
               ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
           }
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -16,9 +16,6 @@
 
 package zio.http.codec.internal
 
-import java.time._
-import java.util.UUID
-
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -29,6 +26,9 @@ import zio.schema.{Schema, StandardType}
 
 import zio.http._
 import zio.http.codec._
+import zio.schema.Schema
+import zio.schema.codec.{BinaryCodec, Codec}
+import zio.stream.ZStream
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
@@ -149,10 +149,11 @@ private[codec] object EncoderDecoder                   {
 
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
-    private val codecs: Map[String, MediaTypeCodec] = {
+    private val codecs: Map[String, MediaTypeCodec[_]] = {
       val defaultCodecs = List(
         MediaTypeCodec.json(flattened.content),
         MediaTypeCodec.protobuf(flattened.content),
+        MediaTypeCodec.text(flattened.content),
       ).flatMap(c => c.acceptedTypes.map(at => at.fullType -> c)).toMap
       if (outputTypes.isEmpty) defaultCodecs
       else {
@@ -171,74 +172,53 @@ private[codec] object EncoderDecoder                   {
     private val formFieldEncoders: Chunk[(String, Any) => FormField] =
       flattened.content.map { bodyCodec => (name: String, value: Any) =>
         {
-          val erased = bodyCodec.erase
-          erased.schema match {
-            case Schema.Primitive(_, _) =>
-              FormField.simpleField(name, value.toString)
-            case _                      =>
-              val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
+          val erased    = bodyCodec.erase
+          val mediaType = bodyCodec.mediaTypeOrJson
+          val codec     =
+            codecs
+              .get(mediaType.fullType)
+              .map(_.codecs(erased))
+
+          codec match {
+            case Some(codec: BinaryCodec[Any])         =>
+              FormField.binaryField(
+                name,
+                codec.encode(value.asInstanceOf[erased.Element]),
+                mediaType,
+              )
+            case Some(codec: Codec[String, Char, Any]) =>
               FormField.textField(
                 name,
-                new String(jsonCodec.encode(value.asInstanceOf[erased.Element]).toArray, Charsets.Utf8),
-                MediaType.application.json,
+                codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
+                mediaType,
               )
+            case None                                  =>
+              throw HttpCodecError.UnsupportedContentType(mediaType.fullType)
           }
         }
       }
 
     implicit val trace: Trace = Trace.empty
 
-    private val jsonDecoders: Chunk[Body => IO[Throwable, _]]             =
-      flattened.content.map { bodyCodec =>
-        val jsonCodec = JsonCodec.schemaBasedBinaryCodec(bodyCodec.schema)
-        bodyCodec.decodeFromBody(_, jsonCodec)
-      }
     private val formFieldDecoders: Chunk[FormField => IO[Throwable, Any]] =
       flattened.content.map { bodyCodec => (field: FormField) =>
         {
-          val erased = bodyCodec.erase
-          erased.schema match {
-            case Schema.Primitive(standardType, _) =>
-              field.asText.flatMap { text =>
-                standardType.asInstanceOf[StandardType[_]] match {
-                  case StandardType.UnitType           => ZIO.succeed(())
-                  case StandardType.StringType         => ZIO.succeed(text)
-                  case StandardType.BoolType           => ZIO.attempt(text.toBoolean)
-                  case StandardType.ByteType           => ZIO.attempt(text.toByte)
-                  case StandardType.ShortType          => ZIO.attempt(text.toShort)
-                  case StandardType.IntType            => ZIO.attempt(text.toInt)
-                  case StandardType.LongType           => ZIO.attempt(text.toLong)
-                  case StandardType.FloatType          => ZIO.attempt(text.toFloat)
-                  case StandardType.DoubleType         => ZIO.attempt(text.toDouble)
-                  case StandardType.BinaryType         => ZIO.die(new IllegalStateException("Binary is not supported"))
-                  case StandardType.CharType           => ZIO.attempt(text.charAt(0))
-                  case StandardType.UUIDType           => ZIO.attempt(UUID.fromString(text))
-                  case StandardType.BigDecimalType     => ZIO.attempt(BigDecimal(text))
-                  case StandardType.BigIntegerType     => ZIO.attempt(BigInt(text))
-                  case StandardType.DayOfWeekType      => ZIO.attempt(DayOfWeek.valueOf(text))
-                  case StandardType.MonthType          => ZIO.attempt(Month.valueOf(text))
-                  case StandardType.MonthDayType       => ZIO.attempt(MonthDay.parse(text))
-                  case StandardType.PeriodType         => ZIO.attempt(Period.parse(text))
-                  case StandardType.YearType           => ZIO.attempt(Year.parse(text))
-                  case StandardType.YearMonthType      => ZIO.attempt(YearMonth.parse(text))
-                  case StandardType.ZoneIdType         => ZIO.attempt(ZoneId.of(text))
-                  case StandardType.ZoneOffsetType     => ZIO.attempt(ZoneOffset.of(text))
-                  case StandardType.DurationType       => ZIO.attempt(java.time.Duration.parse(text))
-                  case StandardType.InstantType        => ZIO.attempt(Instant.parse(text))
-                  case StandardType.LocalDateType      => ZIO.attempt(LocalDate.parse(text))
-                  case StandardType.LocalTimeType      => ZIO.attempt(LocalTime.parse(text))
-                  case StandardType.LocalDateTimeType  => ZIO.attempt(LocalDateTime.parse(text))
-                  case StandardType.OffsetTimeType     => ZIO.attempt(OffsetTime.parse(text))
-                  case StandardType.OffsetDateTimeType => ZIO.attempt(OffsetDateTime.parse(text))
-                  case StandardType.ZonedDateTimeType  => ZIO.attempt(ZonedDateTime.parse(text))
-                }
-              }
-            case _                                 =>
-              val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
-              field.asChunk.flatMap { chunk =>
-                ZIO.fromEither(jsonCodec.decode(chunk))
-              }
+          val erased    = bodyCodec.erase
+          val mediaType = bodyCodec.mediaTypeOrJson
+          val codec     =
+            codecs
+              .get(mediaType.fullType)
+              .map(_.codecs(erased))
+
+          codec match {
+            case Some(codec: BinaryCodec[Any])         =>
+              field.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
+            case Some(codec: Codec[String, Char, Any]) =>
+              field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
+            case None                                  =>
+              ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
           }
+
         }
       }
     private val formBoundary                = Boundary("----zio-http-boundary-D4792A5C-93E0-43B5-9A1F-48E38FDE5714")

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -36,6 +36,16 @@ private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   ): Task[Value]
 
   def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z
+
+  def withOutputTypes(outputTypes: Chunk[MediaType]): EncoderDecoder[AtomTypes, Value] = {
+    if (outputTypes.isEmpty) this
+    else {
+      this match {
+        case EncoderDecoder.Multiple(httpCodecs) => EncoderDecoder.Multiple(httpCodecs)
+        case EncoderDecoder.Single(httpCodec, _) => EncoderDecoder.Single(httpCodec, outputTypes)
+      }
+    }
+  }
 }
 private[codec] object EncoderDecoder                   {
   def apply[AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value]): EncoderDecoder[AtomTypes, Value] = {
@@ -51,8 +61,6 @@ private[codec] object EncoderDecoder                   {
   private final case class Multiple[-AtomTypes, Value](httpCodecs: Chunk[HttpCodec[AtomTypes, Value]])
       extends EncoderDecoder[AtomTypes, Value] {
     val singles = httpCodecs.map(Single(_))
-    val head    = singles.head
-    val tail    = singles.tail
 
     def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
       trace: Trace,
@@ -132,19 +140,33 @@ private[codec] object EncoderDecoder                   {
     }
   }
 
-  private final case class Single[-AtomTypes, Value](httpCodec: HttpCodec[AtomTypes, Value])
-      extends EncoderDecoder[AtomTypes, Value] {
+  private final case class Single[-AtomTypes, Value](
+    httpCodec: HttpCodec[AtomTypes, Value],
+    outputTypes: Chunk[MediaType] = Chunk.empty,
+  ) extends EncoderDecoder[AtomTypes, Value] {
     private val constructor   = Mechanic.makeConstructor(httpCodec)
     private val deconstructor = Mechanic.makeDeconstructor(httpCodec)
 
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
-    private val jsonEncoders: Chunk[Any => Body] =
-      flattened.content.map { bodyCodec =>
-        val erased    = bodyCodec.erase
-        val jsonCodec = JsonCodec.schemaBasedBinaryCodec(erased.schema)
-        erased.encodeToBody(_, jsonCodec)
+    private val codecs: Map[String, MediaTypeCodec] = {
+      val defaultCodecs = List(
+        MediaTypeCodec.json(flattened.content),
+        MediaTypeCodec.protobuf(flattened.content),
+      ).flatMap(c => c.acceptedTypes.map(at => at.fullType -> c)).toMap
+      if (outputTypes.isEmpty) defaultCodecs
+      else {
+        outputTypes.collectFirst {
+          case mt if defaultCodecs.isDefinedAt(mt.fullType) => Map(mt.fullType -> defaultCodecs(mt.fullType))
+        }.getOrElse(
+          throw HttpCodecError.UnsupportedContentType(
+            s"""Non of the Accept header mime types is currently supported.
+               |Accepted are: ${outputTypes.map(_.fullType).mkString(",")}.
+               |Supported mime types are: ${defaultCodecs.keys.mkString(", ")}""".stripMargin,
+          ),
+        )
       }
+    }
 
     private val formFieldEncoders: Chunk[(String, Any) => FormField] =
       flattened.content.map { bodyCodec => (name: String, value: Any) =>
@@ -252,10 +274,12 @@ private[codec] object EncoderDecoder                   {
       decodeStatus(status, inputsBuilder.status)
       decodeMethod(method, inputsBuilder.method)
       decodeHeaders(headers, inputsBuilder.header)
-      decodeBody(body, inputsBuilder.content).as(constructor(inputsBuilder))
+      decodeBody(body, inputsBuilder.content, contentMediaType(headers)).as(constructor(inputsBuilder))
     }
 
-    final def encodeWith[Z](value: Value)(f: (URL, Option[Status], Option[Method], Headers, Body) => Z): Z = {
+    final def encodeWith[Z](value: Value)(
+      f: (URL, Option[Status], Option[Method], Headers, Body) => Z,
+    ): Z = {
       val inputs = deconstructor(value)
 
       val path               = encodePath(inputs.path)
@@ -263,8 +287,8 @@ private[codec] object EncoderDecoder                   {
       val status             = encodeStatus(inputs.status)
       val method             = encodeMethod(inputs.method)
       val headers            = encodeHeaders(inputs.header)
-      val body               = encodeBody(inputs.content)
       val contentTypeHeaders = encodeContentType(inputs.content)
+      val body               = encodeBody(inputs.content, contentTypeHeaders.get(Header.ContentType).get)
 
       f(URL(path, queryParams = query), status, method, headers ++ contentTypeHeaders, body)
     }
@@ -360,15 +384,18 @@ private[codec] object EncoderDecoder                   {
       }
     }
 
-    private def decodeBody(body: Body, inputs: Array[Any])(implicit trace: Trace): Task[Unit] = {
+    private def decodeBody(body: Body, inputs: Array[Any], contentType: MediaType)(implicit
+      trace: Trace,
+    ): Task[Unit] = {
       if (isByteStream) {
         ZIO.attempt(inputs(0) = body.asStream.orDie)
-      } else if (jsonDecoders.length == 0) {
+      } else if (flattened.content.isEmpty) {
         ZIO.unit
-      } else if (jsonDecoders.length == 1) {
-        jsonDecoders(0)(body).map { result => inputs(0) = result }.mapError { err =>
-          HttpCodecError.MalformedBody(err.getMessage(), Some(err))
-        }
+      } else if (flattened.content.size == 1) {
+        codecs(contentType.fullType)
+          .decodeSingle(body)
+          .map { result => inputs(0) = result }
+          .mapError { err => HttpCodecError.MalformedBody(err.getMessage(), Some(err)) }
       } else {
         body.asMultipartFormStream.flatMap { form =>
           if (onlyTheLastFieldIsStreaming)
@@ -524,15 +551,14 @@ private[codec] object EncoderDecoder                   {
       headers
     }
 
-    private def encodeMethod(inputs: Array[Any]): Option[zio.http.Method] =
+    private def encodeMethod(inputs: Array[Any]): Option[zio.http.Method]                =
       if (flattened.method.nonEmpty) {
         flattened.method.head match {
           case _: SimpleCodec.Unspecified[_] => Some(inputs(0).asInstanceOf[Method])
           case SimpleCodec.Specified(method) => Some(method)
         }
       } else None
-
-    private def encodeBody(inputs: Array[Any]): Body = {
+    private def encodeBody(inputs: Array[Any], contentType: => Header.ContentType): Body = {
       if (isByteStream) {
         Body.fromStream(inputs(0).asInstanceOf[ZStream[Any, Nothing, Byte]])
       } else {
@@ -541,10 +567,16 @@ private[codec] object EncoderDecoder                   {
         } else {
           if (isEventStream) {
             Body.fromStream(inputs(0).asInstanceOf[ZStream[Any, Nothing, ServerSentEvent]].map(_.encode))
-          } else if (jsonEncoders.length < 1) Body.empty
-          else {
-            val encoder = jsonEncoders(0)
-            encoder(inputs(0))
+          } else if (inputs.length < 1) {
+            Body.empty
+          } else {
+            val codec = {
+              codecs.getOrElse(
+                contentType.mediaType.fullType,
+                throw HttpCodecError.UnsupportedContentType(contentType.renderedValue),
+              )
+            }
+            codec.encodeSingle(inputs(0))
           }
         }
       }
@@ -578,9 +610,12 @@ private[codec] object EncoderDecoder                   {
           Headers(Header.ContentType(MediaType.multipart.`form-data`))
         } else {
           if (isEventStream) Headers(Header.ContentType(MediaType.text.`event-stream`))
-          else if (jsonEncoders.length < 1) Headers.empty
+          else if (flattened.content.length < 1) Headers.empty
           else {
-            val mediaType = flattened.content(0).mediaType.getOrElse(MediaType.application.json)
+            val mediaType = flattened.content(0).mediaType.getOrElse {
+              if (codecs.size == 1) MediaType.parseCustomMediaType(codecs.keys.head).get
+              else MediaType.application.json
+            }
             Headers(Header.ContentType(mediaType))
           }
         }
@@ -599,4 +634,7 @@ private[codec] object EncoderDecoder                   {
         case _                                                                     => false
       }
   }
+
+  private def contentMediaType(headers: Headers) =
+    headers.get(Header.ContentType).map(_.mediaType).getOrElse(MediaType.application.`json`)
 }

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -30,11 +30,12 @@ import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
 
-import zio.http._
-import zio.http.codec._
+import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.ZStream
+
+import zio.http._
+import zio.http.codec._
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -32,6 +32,9 @@ import zio.schema.codec.{BinaryCodec, Codec}
 
 import zio.http._
 import zio.http.codec._
+import zio.schema.Schema
+import zio.schema.codec.{BinaryCodec, Codec}
+import zio.stream.ZStream
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit
@@ -169,19 +172,19 @@ private[codec] object EncoderDecoder                   {
               .map(_.codecs(erased))
 
           codec match {
-            case Some(codec: BinaryCodec[Any])         =>
+            case Some(codec: BinaryCodec[Any] @unchecked) if codec.isInstanceOf[BinaryCodec[Any]]                 =>
               FormField.binaryField(
                 name,
                 codec.encode(value.asInstanceOf[erased.Element]),
                 mediaType,
               )
-            case Some(codec: Codec[String, Char, Any]) =>
+            case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               FormField.textField(
                 name,
                 codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
                 mediaType,
               )
-            case _                                     =>
+            case _                                                                                                =>
               throw HttpCodecError.UnsupportedContentType(mediaType.fullType)
           }
         }
@@ -200,11 +203,11 @@ private[codec] object EncoderDecoder                   {
               .map(_.codecs(erased))
 
           codec match {
-            case Some(codec: BinaryCodec[Any])         =>
+            case Some(codec: BinaryCodec[Any] @unchecked) if codec.isInstanceOf[BinaryCodec[Any]]                 =>
               field.asChunk.flatMap(chunk => ZIO.fromEither(codec.decode(chunk)))
-            case Some(codec: Codec[String, Char, Any]) =>
+            case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
-            case _                                     =>
+            case _                                                                                                =>
               ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
           }
 

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -17,6 +17,7 @@
 package zio.http.codec.internal
 
 import zio._
+
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.stream.ZStream
@@ -24,11 +25,12 @@ import zio.stream.ZStream
 import zio.schema.codec._
 import zio.schema.{Schema, StandardType}
 
-import zio.http._
-import zio.http.codec._
+import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.{BinaryCodec, Codec}
-import zio.stream.ZStream
+
+import zio.http._
+import zio.http.codec._
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] {
   def decode(url: URL, status: Status, method: Method, headers: Headers, body: Body)(implicit

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -151,20 +151,25 @@ private[codec] object EncoderDecoder {
     private val flattened: AtomizedCodecs = AtomizedCodecs.flatten(httpCodec)
 
     private val codecs: Map[String, MediaTypeCodec[_]] =
-      MediaTypeCodec.codecsFor(outputType, flattened.content)
+      MediaTypeCodec.codecsFor(if (flattened.content.size == 1) outputType else None, flattened.content)
 
     private def mediaTypeOrJson(bodyCodec: BodyCodec[_]): MediaType =
       bodyCodec.mediaType.getOrElse(MediaType.application.`json`)
+    private def mediaTypeOrText(bodyCodec: BodyCodec[_]): MediaType =
+      bodyCodec.mediaType.getOrElse(MediaType.text.`plain`)
 
     private val formFieldEncoders: Chunk[(String, Any) => FormField] =
       flattened.content.map { bodyCodec => (name: String, value: Any) =>
         {
           val erased    = bodyCodec.erase
-          val mediaType = mediaTypeOrJson(bodyCodec)
-          val codec     =
-            codecs
-              .get(mediaType.fullType)
-              .map(_.codecs(erased))
+          val mediaType = bodyCodec.schema match {
+            case _: Schema.Primitive[_] => mediaTypeOrText(bodyCodec)
+            case _                      => mediaTypeOrJson(bodyCodec)
+          }
+
+          val codec = codecs
+            .get(mediaType.fullType)
+            .map(_.codecs(erased))
 
           codec match {
             case Some(codec: BinaryCodec[Any] @unchecked) if codec.isInstanceOf[BinaryCodec[Any]]                 =>
@@ -176,7 +181,7 @@ private[codec] object EncoderDecoder {
             case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               FormField.textField(
                 name,
-                codec.encode(value.asInstanceOf[erased.Element], Charsets.Utf8),
+                codec.encode(value.asInstanceOf[erased.Element]),
                 mediaType,
               )
             case _                                                                                                =>
@@ -190,11 +195,10 @@ private[codec] object EncoderDecoder {
     private val formFieldDecoders: Chunk[FormField => IO[Throwable, Any]] =
       flattened.content.map { bodyCodec => (field: FormField) =>
         {
-          val erased    = bodyCodec.erase
-          val mediaType = mediaTypeOrJson(bodyCodec)
-          val codec     =
+          val erased = bodyCodec.erase
+          val codec  =
             codecs
-              .get(mediaType.fullType)
+              .get(field.contentType.fullType)
               .map(_.codecs(erased))
 
           codec match {
@@ -203,7 +207,7 @@ private[codec] object EncoderDecoder {
             case Some(codec: Codec[String, Char, Any] @unchecked) if codec.isInstanceOf[Codec[String, Char, Any]] =>
               field.asText.flatMap(text => ZIO.fromEither(codec.decode(text)))
             case _                                                                                                =>
-              ZIO.fail(HttpCodecError.UnsupportedContentType(mediaType.fullType))
+              ZIO.fail(HttpCodecError.UnsupportedContentType(field.contentType.fullType))
           }
 
         }

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,47 +1,110 @@
 package zio.http.codec.internal
 
 import zio._
-
-import zio.schema.Schema
-import zio.schema.codec._
-
 import zio.http._
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+import zio.stream.ZPipeline
 
-sealed trait MediaTypeCodec {
+import java.time.{
+  DayOfWeek,
+  Instant,
+  LocalDate,
+  LocalDateTime,
+  LocalTime,
+  Month,
+  MonthDay,
+  OffsetTime,
+  Period,
+  Year,
+  YearMonth,
+  ZoneId,
+  ZoneOffset,
+}
+import java.util.UUID
+import scala.util.Try
+
+sealed trait MediaTypeCodec[Codec] {
 
   def acceptedTypes: Chunk[MediaType]
   def decoders: Chunk[Body => IO[Throwable, _]]
   def decodeSingle(body: Body): IO[Throwable, Any] = decoders(0)(body)
   def encoders: Chunk[Any => Body]
   def encodeSingle(a: Any): Body                   = encoders(0)(a)
+  def codecs: Map[BodyCodec[Any], Codec]
 
 }
 
+sealed trait BinaryMediaTypeCodec extends MediaTypeCodec[BinaryCodec[Any]]
+
+sealed trait TextMediaTypeCodec extends MediaTypeCodec[Codec[String, Char, Any]]
+
 object MediaTypeCodec {
-  def apply(
+  private def binary(
     content: Chunk[BodyCodec[_]],
     binaryCodec: Schema[Any] => BinaryCodec[Any],
     acceptTypes: Chunk[MediaType],
-  ): MediaTypeCodec = new MediaTypeCodec {
+  ): BinaryMediaTypeCodec = new BinaryMediaTypeCodec {
+
     override def encoders: Chunk[Any => Body] =
       content.map { bodyCodec =>
-        val erased    = bodyCodec.erase
-        val jsonCodec = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
-        erased.encodeToBody(_, jsonCodec)
+        val erased = bodyCodec.erase
+        val codec  = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
+        erased.encodeToBody(_, codec)
       }
 
     override def decoders: Chunk[Body => IO[Throwable, _]] =
       content.map { bodyCodec =>
-        val jsonCodec =
+        val codec =
           binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
             .asInstanceOf[BinaryCodec[bodyCodec.Element]]
-        bodyCodec.decodeFromBody(_, jsonCodec)
+        bodyCodec.decodeFromBody(_, codec)
       }
+
+    override def codecs: Map[BodyCodec[Any], BinaryCodec[Any]] =
+      content.map { bodyCodec =>
+        val codec =
+          binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[BinaryCodec[bodyCodec.Element]]
+        bodyCodec.erase -> codec.asInstanceOf[BinaryCodec[Any]]
+      }.toMap
 
     override val acceptedTypes: Chunk[MediaType] = acceptTypes
   }
-  def json(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
-    apply(
+
+  private def text(
+    content: Chunk[BodyCodec[_]],
+    textCodec: Schema[Any] => Codec[String, Char, Any],
+    acceptTypes: Chunk[MediaType],
+  ): TextMediaTypeCodec = new TextMediaTypeCodec {
+
+    override def encoders: Chunk[Any => Body] =
+      content.map { bodyCodec =>
+        val erased = bodyCodec.erase
+        val codec = textCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[Codec[String, Char, erased.Element]]
+        ((a: erased.Element) => erased.encodeToBody(a, codec)).asInstanceOf[Any => Body]
+      }
+
+    override def decoders: Chunk[Body => IO[Throwable, _]] =
+      content.map { bodyCodec =>
+        val codec =
+          textCodec(bodyCodec.schema.asInstanceOf[Schema[Any]]).asInstanceOf[Codec[String, Char, bodyCodec.Element]]
+        bodyCodec.decodeFromBody(_, codec)
+      }
+
+    override def codecs: Map[BodyCodec[Any], Codec[String, Char, Any]] =
+      content.map { bodyCodec =>
+        val codec =
+          textCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[Codec[String, Char, bodyCodec.Element]]
+        bodyCodec.erase -> codec.asInstanceOf[Codec[String, Char, Any]]
+      }.toMap
+
+    override val acceptedTypes: Chunk[MediaType] = acceptTypes
+  }
+
+  def json(content: Chunk[BodyCodec[_]]): BinaryMediaTypeCodec =
+    binary(
       content,
       JsonCodec.schemaBasedBinaryCodec[Any](_),
       Chunk(
@@ -49,12 +112,86 @@ object MediaTypeCodec {
       ),
     )
 
-  def protobuf(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
-    apply(
+  def protobuf(content: Chunk[BodyCodec[_]]): BinaryMediaTypeCodec =
+    binary(
       content,
       ProtobufCodec.protobufCodec[Any](_),
       Chunk(
         MediaType.parseCustomMediaType("application/protobuf").get,
       ),
     )
+
+  def text(content: Chunk[BodyCodec[_]]): TextMediaTypeCodec =
+    text(
+      content,
+      TextCodec.fromSchema[Any],
+      Chunk.fromIterable(MediaType.text.all),
+    )
+
+}
+
+private[internal] object TextCodec {
+  def fromSchema[A](schema: Schema[A]): Codec[String, Char, A] = {
+    if (!schema.isInstanceOf[Schema.Primitive[_]]) {
+      throw new IllegalArgumentException(
+        s"Schema $schema is not a primitive. Only primitive schemas are supported by TextCodec.",
+      )
+    }
+
+    new Codec[String, Char, A] {
+      override def encode(a: A): String                      =
+        schema match {
+          case Schema.Primitive(_, _) => a.toString
+          case _                      =>
+            throw new IllegalArgumentException(
+              s"Cannot encode $a of type ${a.getClass} with schema $schema",
+            )
+        }
+      override def decode(s: String): Either[DecodeError, A] =
+        schema match {
+          case Schema.Primitive(standardType, _) =>
+            (standardType match {
+              case StandardType.StringType => Right(s)
+              case StandardType.BoolType   => Try(s.toBoolean).toEither
+              case StandardType.ByteType   => Try(s.toByte).toEither
+              case StandardType.ShortType  => Try(s.toShort).toEither
+              case StandardType.IntType    => Try(s.toInt).toEither
+              case StandardType.LongType   => Try(s.toLong).toEither
+              case StandardType.FloatType  => Try(s.toFloat).toEither
+              case StandardType.DoubleType => Try(s.toDouble).toEither
+              case StandardType.BinaryType => Left(DecodeError.ValidationError(null, null, "Binary is not supported"))
+              case StandardType.CharType   => Right(s.charAt(0))
+              case StandardType.UUIDType   => Try(UUID.fromString(s)).toEither
+              case StandardType.BigDecimalType    => Try(BigDecimal(s)).toEither
+              case StandardType.BigIntegerType    => Try(BigInt(s)).toEither
+              case StandardType.DayOfWeekType     => Try(DayOfWeek.valueOf(s)).toEither
+              case StandardType.MonthType         => Try(Month.valueOf(s)).toEither
+              case StandardType.MonthDayType      => Try(MonthDay.parse(s)).toEither
+              case StandardType.PeriodType        => Try(Period.parse(s)).toEither
+              case StandardType.YearType          => Try(Year.parse(s)).toEither
+              case StandardType.YearMonthType     => Try(YearMonth.parse(s)).toEither
+              case StandardType.ZoneIdType        => Try(ZoneId.of(s)).toEither
+              case StandardType.ZoneOffsetType    => Try(ZoneOffset.of(s)).toEither
+              case StandardType.DurationType      => Try(java.time.Duration.parse(s)).toEither
+              case StandardType.InstantType       => Try(Instant.parse(s)).toEither
+              case StandardType.LocalDateType     => Try(LocalDate.parse(s)).toEither
+              case StandardType.LocalTimeType     => Try(LocalTime.parse(s)).toEither
+              case StandardType.LocalDateTimeType => Try(LocalDateTime.parse(s)).toEither
+              case StandardType.OffsetTimeType    => Try(OffsetTime.parse(s)).toEither
+            }).map(_.asInstanceOf[A]).left.map(e => DecodeError.ReadError(Cause.fail(e), e.getMessage))
+          case _                                 =>
+            Left(
+              DecodeError.ReadError(Cause.empty, "Only primitive types are supported. But found: " + schema.toString),
+            )
+        }
+
+      override def streamEncoder: ZPipeline[Any, Nothing, A, Char] =
+        ZPipeline.map((a: A) => Chunk.fromArray(a.toString.toArray)).flattenChunks
+
+      override def streamDecoder: ZPipeline[Any, DecodeError, Char, A] =
+        (ZPipeline[Char].map(_.toByte) >>> ZPipeline.utf8Decode)
+          .map(decode(_).fold(throw _, identity))
+          .mapErrorCause(e => Cause.fail(DecodeError.ReadError(e, e.squash.getMessage)))
+    }
+  }
 }

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,18 +1,22 @@
 package zio.http.codec.internal
 
-import zio._
-import zio.http._
-import zio.http.codec.HttpCodecError
-import zio.schema.codec._
-import zio.schema.{Schema, StandardType}
-import zio.stream.ZPipeline
-
 import java.time._
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.ConcurrentMapHasAsScala
 import scala.util.Try
+
+import zio._
+
+import zio.stream.ZPipeline
+
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+
+import zio.http._
+import zio.http.codec.HttpCodecError
 
 final case class MediaTypeCodecDefinition[T <: MediaTypeCodec[_]](
   acceptedTypes: Chunk[MediaType],

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,0 +1,60 @@
+package zio.http.codec.internal
+
+import zio._
+
+import zio.schema.Schema
+import zio.schema.codec._
+
+import zio.http._
+
+sealed trait MediaTypeCodec {
+
+  def acceptedTypes: Chunk[MediaType]
+  def decoders: Chunk[Body => IO[Throwable, _]]
+  def decodeSingle(body: Body): IO[Throwable, Any] = decoders(0)(body)
+  def encoders: Chunk[Any => Body]
+  def encodeSingle(a: Any): Body                   = encoders(0)(a)
+
+}
+
+object MediaTypeCodec {
+  def apply(
+    content: Chunk[BodyCodec[_]],
+    binaryCodec: Schema[Any] => BinaryCodec[Any],
+    acceptTypes: Chunk[MediaType],
+  ): MediaTypeCodec = new MediaTypeCodec {
+    override def encoders: Chunk[Any => Body] =
+      content.map { bodyCodec =>
+        val erased    = bodyCodec.erase
+        val jsonCodec = binaryCodec(erased.schema.asInstanceOf[Schema[Any]]).asInstanceOf[BinaryCodec[erased.Element]]
+        erased.encodeToBody(_, jsonCodec)
+      }
+
+    override def decoders: Chunk[Body => IO[Throwable, _]] =
+      content.map { bodyCodec =>
+        val jsonCodec =
+          binaryCodec(bodyCodec.schema.asInstanceOf[Schema[Any]])
+            .asInstanceOf[BinaryCodec[bodyCodec.Element]]
+        bodyCodec.decodeFromBody(_, jsonCodec)
+      }
+
+    override val acceptedTypes: Chunk[MediaType] = acceptTypes
+  }
+  def json(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
+    apply(
+      content,
+      JsonCodec.schemaBasedBinaryCodec[Any](_),
+      Chunk(
+        MediaType.application.`json`,
+      ),
+    )
+
+  def protobuf(content: Chunk[BodyCodec[_]]): MediaTypeCodec =
+    apply(
+      content,
+      ProtobufCodec.protobufCodec[Any](_),
+      Chunk(
+        MediaType.parseCustomMediaType("application/protobuf").get,
+      ),
+    )
+}

--- a/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/MediaTypeCodec.scala
@@ -1,28 +1,18 @@
 package zio.http.codec.internal
 
+import java.time._
+import java.util.UUID
+
+import scala.util.Try
+
 import zio._
-import zio.http._
-import zio.schema.codec._
-import zio.schema.{Schema, StandardType}
+
 import zio.stream.ZPipeline
 
-import java.time.{
-  DayOfWeek,
-  Instant,
-  LocalDate,
-  LocalDateTime,
-  LocalTime,
-  Month,
-  MonthDay,
-  OffsetTime,
-  Period,
-  Year,
-  YearMonth,
-  ZoneId,
-  ZoneOffset,
-}
-import java.util.UUID
-import scala.util.Try
+import zio.schema.codec._
+import zio.schema.{Schema, StandardType}
+
+import zio.http._
 
 sealed trait MediaTypeCodec[Codec] {
 

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -39,7 +39,7 @@ private[endpoint] final case class EndpointClient[P, I, E, O, M <: EndpointMiddl
         patchedRequest
       else
         patchedRequest.addHeader(
-          Header.Accept(MediaType.parseCustomMediaType("application/protobuf").get, MediaType.application.json),
+          Header.Accept(MediaType.application.json, MediaType.parseCustomMediaType("application/protobuf").get),
         )
 
     client.request(withDefaultAcceptHeader).orDie.flatMap { response =>

--- a/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -32,9 +32,17 @@ private[endpoint] final case class EndpointClient[P, I, E, O, M <: EndpointMiddl
     val request0 = endpoint.input.encodeRequest(invocation.input)
     val request  = request0.copy(url = endpointRoot ++ request0.url)
 
-    val requestPatch = invocation.middleware.input.encodeRequestPatch(mi)
+    val requestPatch            = invocation.middleware.input.encodeRequestPatch(mi)
+    val patchedRequest          = request.patch(requestPatch)
+    val withDefaultAcceptHeader =
+      if (patchedRequest.headers.exists(_.headerName == Header.Accept.name))
+        patchedRequest
+      else
+        patchedRequest.addHeader(
+          Header.Accept(MediaType.parseCustomMediaType("application/protobuf").get, MediaType.application.json),
+        )
 
-    client(request.patch(requestPatch)).orDie.flatMap { response =>
+    client.request(withDefaultAcceptHeader).orDie.flatMap { response =>
       if (response.status.isSuccess) {
         endpoint.output.decodeResponse(response).orDie
       } else {

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
@@ -463,13 +463,16 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug{ case r: Response =>
-          r.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
-        })),
+      Client.customized.map(env =>
+        ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging) )),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),
       DnsResolver.default,
       Scope.default,
     ) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
+
+  def extraLogging: PartialFunction[Response, String] = {
+    _.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
+  }
 }

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
@@ -19,7 +19,7 @@ package zio.http.endpoint
 import zio._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.{Spec, TestResult, ZIOSpecDefault, assert}
+import zio.test._
 
 import zio.stream.ZStream
 
@@ -29,7 +29,7 @@ import zio.http.Header.Authorization
 import zio.http.Method._
 import zio.http._
 import zio.http.codec.HttpCodec.{authorization, query}
-import zio.http.codec.{Doc, HttpCodec, QueryCodec}
+import zio.http.codec.{Doc, HeaderCodec, HttpCodec, QueryCodec}
 import zio.http.netty.server.NettyDriver
 
 object EndpointRoundtripSpec extends ZIOSpecDefault {
@@ -141,6 +141,25 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
           (10, 20),
           Post(20, "title", "body", 10),
         )
+      },
+      test("simple get with protobuf encoding") {
+        val usersPostAPI =
+          Endpoint
+            .get(literal("users") / int("userId") / literal("posts") / int("postId"))
+            .out[Post]
+            .header(HeaderCodec.accept)
+
+        val usersPostHandler =
+          usersPostAPI.implement { case (userId, postId, _) =>
+            ZIO.succeed(Post(postId, "title", "body", userId))
+          }
+
+        testEndpoint(
+          usersPostAPI,
+          usersPostHandler,
+          (10, 20, Header.Accept(MediaType.parseCustomMediaType("application/protobuf").get)),
+          Post(20, "title", "body", 10),
+        ) && assertZIO(TestConsole.output)(contains("ContentType: application/protobuf\n"))
       },
       test("simple get with optional query params") {
         val api =
@@ -441,5 +460,16 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
           )
         }
       } @@ timeout(10.seconds) @@ ifEnvNotSet("CI"), // NOTE: random hangs on CI
-    ).provideLayer(testLayer) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
+    ).provide(
+      Server.live,
+      ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
+      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug{ case r: Response =>
+          r.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
+        })),
+      ClientDriver.shared,
+      NettyDriver.live,
+      ZLayer.succeed(ZClient.Config.default),
+      DnsResolver.default,
+      Scope.default,
+    ) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
 }

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
@@ -463,7 +463,7 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging))),
+      Client.customized.map(env => ZEnvironment(env.get @@ clientDebugAspect)),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),
@@ -471,7 +471,9 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
       Scope.default,
     ) @@ withLiveClock @@ sequential @@ timeout(300.seconds)
 
-  def extraLogging: PartialFunction[Response, String] = {
-    _.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
+  private def extraLogging: PartialFunction[Response, String] = { case r =>
+    r.headers.get(Header.ContentType).map(_.renderedValue).mkString("ContentType: ", "", "")
   }
+  private def clientDebugAspect                               =
+    ZClientAspect.debug(extraLogging)
 }

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
@@ -463,8 +463,7 @@ object EndpointRoundtripSpec extends ZIOSpecDefault {
     ).provide(
       Server.live,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env =>
-        ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging) )),
+      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug(extraLogging))),
       ClientDriver.shared,
       NettyDriver.live,
       ZLayer.succeed(ZClient.Config.default),

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -23,8 +23,6 @@ import zio.http.Header.AccessControlAllowMethods
 import zio.http.Middleware.{CorsConfig, cors}
 import zio.http._
 import zio.http.internal.HttpAppTestExtensions
-import zio.http.internal.middlewares.CorsSpec.app
-import zio.http.internal.middlewares.Cors.CorsConfig
 
 object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -24,6 +24,7 @@ import zio.http.Middleware.{CorsConfig, cors}
 import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 import zio.http.internal.middlewares.CorsSpec.app
+import zio.http.internal.middlewares.Cors.CorsConfig
 
 object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status


### PR DESCRIPTION
- `Endpoint` api en-/decodes based on accept header
- Fix scala 2.12 compilation
- Fix wildcard import
- Extract aspect creation to fix Scala 2.12 test
- Use accept/content-type header also for multipart encoding/decoding
- Formatting
- Make codec creation lazy and cache it
- Merge fix and formatting
- Fix Scala 2.12 build: concurrent map converter
- Use plain java map as cache; add missing schema types to TextCodec
- Fix type check
- Formatting
- Redesign EncoderDecoder creation for specific media type for efficiency
- Fix multipart encoding for endpoint API
- migrate into main
