### PR TITLE
Add benchmark CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,9 @@ jobs:
   benchmark:
     name: JMH Benchmarks
     permissions:
-      pull-requests: write
       contents: write
+      pull-requests: write
+      issues: write
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build and run JMH benchmark
         run: |
           sbt ++${{ matrix.scala }} clean compile
-          sbt ++${{ matrix.scala }} 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,10 +218,21 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
       - name: Build and run JMH benchmark
         run: |
-          sbt clean compile 
-          sbt 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} clean compile
+          sbt ++${{ matrix.scala }} 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
 
   benchmark:
     name: JMH Benchmarks
+    permissions:
+      pull-requests: write
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,8 @@ jobs:
         id: push_codecov
         run: 'bash <(curl -s https://codecov.io/bash)'
 
-  Jmh_publish:
-    name: Jmh Publish
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+  benchmark:
+    name: JMH Benchmarks
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -219,43 +218,15 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Format Output
-        id: fomat_output
+      - name: Build and run JMH benchmark
         run: |
-          cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
-                    while IFS= read -r line; do
-                    if grep -q "$line" Current.txt
-                    then
-                    grep "$line" Current.txt | sed 's/^.*: //' >> finalCurrent.txt;
-                    else
-                    echo "" >> finalCurrent.txt;
-                    fi
-                      if grep -q "$line" Main.txt
-                    then
-                    grep "$line" Main.txt | sed 's/^.*: //' >> finalMain.txt;
-                    else
-                    echo "" >> finalMain.txt;
-                    fi
-                     done < c.txt
-          paste -d '|' c.txt finalCurrent.txt finalMain.txt > FinalOutput.txt
-           sed -i -e 's/^/|/' FinalOutput.txt
-           sed -i -e 's/$/|/' FinalOutput.txt
-           body=$(cat FinalOutput.txt)
-           body="${body//'%'/'%25'}"
-           body="${body//$'\n'/'%0A'}"
-           body="${body//$'\r'/'%0D'}"
-           echo $body
-           echo ::set-output name=body::$(echo $body)
-
-      
-      - uses: peter-evans/commit-comment@v1
+          sbt clean compile 
+          sbt 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+      - name: JMH Benchmark Action
+        uses: kitlangton/jmh-benchmark-action@main
         with:
-          sha: ${{github.sha}}
-          body: |
+          jmh-output-path: benchmarks/output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-regression: true
 
-            **🚀 Jmh Benchmark:**
 
-            |Name |Current| Main|
-            |-----|----| ----|
-             ${{steps.fomat_output.outputs.body}}
-             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,8 +231,7 @@ jobs:
           cache: sbt
       - name: Build and run JMH benchmark
         run: |
-          sbt ++${{ matrix.scala }} clean compile
-          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 1 -wi 0 -f1 -t1 -rf json -rff output.json HttpCombineEval.ok'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:
-          jmh-output-path: benchmarks/output.json
+          jmh-output-path: zio-http-benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-regression: true
 


### PR DESCRIPTION
(Work in progress) /claim #2265

I've created the following [JMH Benchmark Action](https://github.com/kitlangton/jmh-benchmark-action) repository to handle the storing/reporting of benchmark runs.

Example Output:

![CleanShot 2023-08-04 at 12 08 55@2x](https://github.com/zio/zio-http/assets/7587245/fcdc0dba-1f7c-40bc-9937-3cf73e6bb7cc)

I'm going to open the PR to see if it works from the `zio-http` project's more complicated GitHub workflow.