### PR TITLE
Add benchmark CI (not from fork)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,9 @@ jobs:
   benchmark:
     name: JMH Benchmarks
     permissions:
-      pull-requests: write
       contents: write
+      pull-requests: write
+      issues: write
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Build and run JMH benchmark
         run: |
           sbt ++${{ matrix.scala }} clean compile
-          sbt ++${{ matrix.scala }} 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,10 +218,21 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup Java (temurin@8)
+        if: matrix.java == 'temurin@8'
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
       - name: Build and run JMH benchmark
         run: |
-          sbt clean compile 
-          sbt 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} clean compile
+          sbt ++${{ matrix.scala }} 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,9 @@ jobs:
 
   benchmark:
     name: JMH Benchmarks
+    permissions:
+      pull-requests: write
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,8 @@ jobs:
         id: push_codecov
         run: 'bash <(curl -s https://codecov.io/bash)'
 
-  Jmh_publish:
-    name: Jmh Publish
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+  benchmark:
+    name: JMH Benchmarks
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -219,43 +218,15 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Format Output
-        id: fomat_output
+      - name: Build and run JMH benchmark
         run: |
-          cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
-                    while IFS= read -r line; do
-                    if grep -q "$line" Current.txt
-                    then
-                    grep "$line" Current.txt | sed 's/^.*: //' >> finalCurrent.txt;
-                    else
-                    echo "" >> finalCurrent.txt;
-                    fi
-                      if grep -q "$line" Main.txt
-                    then
-                    grep "$line" Main.txt | sed 's/^.*: //' >> finalMain.txt;
-                    else
-                    echo "" >> finalMain.txt;
-                    fi
-                     done < c.txt
-          paste -d '|' c.txt finalCurrent.txt finalMain.txt > FinalOutput.txt
-           sed -i -e 's/^/|/' FinalOutput.txt
-           sed -i -e 's/$/|/' FinalOutput.txt
-           body=$(cat FinalOutput.txt)
-           body="${body//'%'/'%25'}"
-           body="${body//$'\n'/'%0A'}"
-           body="${body//$'\r'/'%0D'}"
-           echo $body
-           echo ::set-output name=body::$(echo $body)
-
-      
-      - uses: peter-evans/commit-comment@v1
+          sbt clean compile 
+          sbt 'benchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+      - name: JMH Benchmark Action
+        uses: kitlangton/jmh-benchmark-action@main
         with:
-          sha: ${{github.sha}}
-          body: |
+          jmh-output-path: benchmarks/output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-regression: true
 
-            **🚀 Jmh Benchmark:**
 
-            |Name |Current| Main|
-            |-----|----| ----|
-             ${{steps.fomat_output.outputs.body}}
-             

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,8 +231,7 @@ jobs:
           cache: sbt
       - name: Build and run JMH benchmark
         run: |
-          sbt ++${{ matrix.scala }} clean compile
-          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 -rf json -rff output.json .*'
+          sbt ++${{ matrix.scala }} 'zioHttpBenchmarks/jmh:run -i 1 -wi 0 -f1 -t1 -rf json -rff output.json HttpCombineEval.ok'
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       - name: JMH Benchmark Action
         uses: kitlangton/jmh-benchmark-action@main
         with:
-          jmh-output-path: benchmarks/output.json
+          jmh-output-path: zio-http-benchmarks/output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-regression: true
 


### PR DESCRIPTION
So, I already have this PR open here (#2368). But it would appear that PRs opened from forks are given a read-only `GITHUB_TOKEN`—which makes sense when you realize that if it didn't, anyone could simply open a PR and then have full read/write permissions over all pull requests. So, I'm opening this PR from a separate branch _within_ this repo, to make sure I _do_ in fact have the ability to **create a comment on this PR** from within my custom action.

UPDATE: Yup, it was successfully able to add the comment here. (https://github.com/zio/zio-http/pull/2369#issuecomment-1666201297) I'll do some research and see if I can come up with any workarounds or alternatives. It sure would be nice if there was a special "add comments to Pull Requests" permission, as that doesn't seem like such a crazy thing to do.

UPDATE AGAIN: Aha, so it appears the `pull_request_target` event is the solution. [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target)

UPDATE 3: Ha. Turns out that it's _not_ a good idea to use `pull_request_target` when you do any sort of building: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/. The _true_ recommended workaround would be to use two different workflows: one for checking out the PR code, running the benchmarks, and uploading the result as an artifact, and a second for downloading that artifact and commenting on the PR. A simpler option would be to post a markdown job summary, which will work with the normal `pull_request` trigger and will  not require multiple workflows.

UPDATE 4: A job summary would look like this:

![CleanShot 2023-08-05 at 09 23 37@2x](https://github.com/zio/zio-http/assets/7587245/e76549d2-e6ac-40fd-b2a8-385fde442b9a)

Here's an example from the [zio-http workflow](https://github.com/zio/zio-http/actions/runs/5766631894/attempts/2#summary-15644470805) for a PR from a fork (you don't need special permissions to add a job summary, thankfully).