### PR TITLE
Tests Cleanup

### DIFF
--- a/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
@@ -7,9 +7,9 @@ import zio.test._
 
 import zio.http.ChannelEvent.{Read, Unregistered, UserEvent, UserEventTriggered}
 import zio.http.netty.server.NettyDriver
-import zio.http.{Headers, Status, Version}
+import zio.http.{Headers, Status, Version, ZIOHttpSpec}
 
-object SocketContractSpec extends ZIOSpecDefault {
+object SocketContractSpec extends ZIOHttpSpec {
 
   def spec: Spec[Any, Any] =
     suite("SocketOps")(

--- a/zio-http-testkit/src/test/scala/zio/http/TestClientSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestClientSpec.scala
@@ -6,7 +6,7 @@ import zio.test._
 import zio.http.ChannelEvent.{Read, UserEvent, UserEventTriggered}
 import zio.http.{Method, Status, WebSocketFrame}
 
-object TestClientSpec extends ZIOSpecDefault {
+object TestClientSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   def spec =

--- a/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
@@ -5,7 +5,7 @@ import zio.test._
 
 import zio.http.netty.server.NettyDriver
 
-object TestServerSpec extends ZIOSpecDefault {
+object TestServerSpec extends ZIOHttpSpec {
   def status(response: Response): Status = response.status
 
   def spec = suite("TestServerSpec")(

--- a/zio-http-testkit/src/test/scala/zio/http/ZIOHttpSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/ZIOHttpSpec.scala
@@ -1,0 +1,9 @@
+package zio.http
+
+import zio._
+import zio.test._
+
+trait ZIOHttpSpec extends ZIOSpecDefault {
+  override def aspects: Chunk[TestAspectPoly] =
+    Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+}

--- a/zio-http/src/test/scala/zio/http/BodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/BodySpec.scala
@@ -25,7 +25,7 @@ import zio.{Scope, durationInt}
 
 import zio.stream.ZStream
 
-object BodySpec extends ZIOSpecDefault {
+object BodySpec extends ZIOHttpSpec {
   private val testFile = new File(getClass.getResource("/TestFile.txt").getPath)
 
   override def spec: Spec[TestEnvironment with Scope, Throwable] =

--- a/zio-http/src/test/scala/zio/http/BoundarySpec.scala
+++ b/zio-http/src/test/scala/zio/http/BoundarySpec.scala
@@ -23,7 +23,7 @@ import zio.test._
 
 import zio.http.forms.Fixtures._
 
-object BoundarySpec extends ZIOSpecDefault {
+object BoundarySpec extends ZIOHttpSpec {
   val CRLF = "\r\n"
 
   val multipartFormBytes3 = Chunk.fromArray(s"""------heythere--${CRLF}""".getBytes(StandardCharsets.UTF_8))

--- a/zio-http/src/test/scala/zio/http/ClientHttpsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientHttpsSpec.scala
@@ -18,13 +18,13 @@ package zio.http
 
 import zio.test.Assertion.{anything, equalTo, fails, hasField}
 import zio.test.TestAspect.{ignore, timeout}
-import zio.test.{ZIOSpecDefault, assertZIO}
+import zio.test.assertZIO
 import zio.{Scope, ZLayer, durationInt}
 
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
 
-object ClientHttpsSpec extends ZIOSpecDefault {
+object ClientHttpsSpec extends ZIOHttpSpec {
 
   val sslConfig = ClientSSLConfig.FromTrustStoreResource(
     trustStorePath = "truststore.jks",

--- a/zio-http/src/test/scala/zio/http/CookieSpec.scala
+++ b/zio-http/src/test/scala/zio/http/CookieSpec.scala
@@ -22,7 +22,7 @@ import zio.test._
 
 import zio.http.Cookie.SameSite
 
-object CookieSpec extends ZIOSpecDefault {
+object CookieSpec extends ZIOHttpSpec {
   override def spec =
     suite("CookieSpec")(
       suite("getter")(

--- a/zio-http/src/test/scala/zio/http/DnsResolverSpec.scala
+++ b/zio-http/src/test/scala/zio/http/DnsResolverSpec.scala
@@ -19,11 +19,11 @@ package zio.http
 import java.net.{InetAddress, UnknownHostException}
 
 import zio._
-import zio.test.{Spec, TestClock, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestClock, TestEnvironment, assertTrue}
 
 import zio.http.DnsResolver.ExpireAction
 
-object DnsResolverSpec extends ZIOSpecDefault {
+object DnsResolverSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("DnsResolver")(
       test("eventually maintains the specified max count") {

--- a/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
+++ b/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
@@ -23,7 +23,7 @@ import zio.test._
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
 
-object DynamicAppTest extends ZIOSpecDefault {
+object DynamicAppTest extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   val httpApp1: HttpApp[Any] =

--- a/zio-http/src/test/scala/zio/http/FormHeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FormHeaderSpec.scala
@@ -20,7 +20,7 @@ import zio.test._
 
 import zio.http.internal.FormAST
 
-object FormHeaderSpec extends ZIOSpecDefault {
+object FormHeaderSpec extends ZIOHttpSpec {
 
   val contentType1 = "Content-Type: text/html; charset=utf-8".getBytes()
   val contextType2 = "Content-Type: multipart/form-data; boundary=something".getBytes

--- a/zio-http/src/test/scala/zio/http/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FormSpec.scala
@@ -22,6 +22,7 @@ import scala.annotation.nowarn
 
 import zio._
 import zio.test.Assertion._
+import zio.test.TestAspect._
 import zio.test._
 
 import zio.stream.{ZStream, ZStreamAspect}
@@ -308,7 +309,7 @@ object FormSpec extends ZIOHttpSpec {
             collected.get("file").get.asInstanceOf[FormField.Binary].data == bytes,
           )
         }
-      },
+      } @@ samples(10),
     )
 
   def spec =

--- a/zio-http/src/test/scala/zio/http/FormSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FormSpec.scala
@@ -29,7 +29,7 @@ import zio.stream.{ZStream, ZStreamAspect}
 import zio.http.Header.ContentTransferEncoding
 import zio.http.forms.Fixtures._
 
-object FormSpec extends ZIOSpecDefault {
+object FormSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   val urlEncodedSuite =

--- a/zio-http/src/test/scala/zio/http/GetBodyAsStringSpec.scala
+++ b/zio-http/src/test/scala/zio/http/GetBodyAsStringSpec.scala
@@ -23,7 +23,7 @@ import zio.Chunk
 import zio.test.Assertion._
 import zio.test._
 
-object GetBodyAsStringSpec extends ZIOSpecDefault {
+object GetBodyAsStringSpec extends ZIOHttpSpec {
 
   def spec = suite("getBodyAsString") {
     val charsetGen: Gen[Any, Charset] =

--- a/zio-http/src/test/scala/zio/http/HandlerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HandlerSpec.scala
@@ -23,7 +23,7 @@ import zio.test.Assertion._
 import zio.test.TestAspect.timeout
 import zio.test._
 
-object HandlerSpec extends ZIOSpecDefault with ExitAssertion {
+object HandlerSpec extends ZIOHttpSpec with ExitAssertion {
 
   def spec = suite("Handler")(
     suite("sandbox")(

--- a/zio-http/src/test/scala/zio/http/HeaderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HeaderSpec.scala
@@ -18,9 +18,9 @@ package zio.http
 
 import zio.NonEmptyChunk
 import zio.test.Assertion._
-import zio.test.{ZIOSpecDefault, assert}
+import zio.test.assert
 
-object HeaderSpec extends ZIOSpecDefault {
+object HeaderSpec extends ZIOHttpSpec {
 
   def spec = suite("Header")(
     suite("getHeader")(

--- a/zio-http/src/test/scala/zio/http/HttpAppMiddlewareSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpAppMiddlewareSpec.scala
@@ -22,7 +22,7 @@ import zio.test._
 
 import zio.http.Method
 
-object HttpAppMiddlewareSpec extends ZIOSpecDefault with ExitAssertion {
+object HttpAppMiddlewareSpec extends ZIOHttpSpec with ExitAssertion {
 
   def spec: Spec[Any, Any] =
     suite("HttpAppMiddleware")(

--- a/zio-http/src/test/scala/zio/http/HttpAppSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HttpAppSpec.scala
@@ -20,7 +20,7 @@ import zio._
 import zio.test.Assertion._
 import zio.test._
 
-object HttpAppSpec extends ZIOSpecDefault {
+object HttpAppSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   def spec = suite("HttpAppSpec")(

--- a/zio-http/src/test/scala/zio/http/MediaTypeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/MediaTypeSpec.scala
@@ -18,7 +18,7 @@ package zio.http
 
 import zio.test._
 
-object MediaTypeSpec extends ZIOSpecDefault {
+object MediaTypeSpec extends ZIOHttpSpec {
   import MediaType._
 
   override def spec = suite("MediaTypeSpec")(

--- a/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
@@ -20,7 +20,7 @@ import zio.test.TestAspect.withLiveClock
 import zio.test._
 import zio.{Scope, ZLayer}
 
-object NettyMaxHeaderLengthSpec extends ZIOSpecDefault {
+object NettyMaxHeaderLengthSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   private val serverConfig: Server.Config = Server.Config.default.onAnyOpenPort.copy(maxHeaderSize = 1)

--- a/zio-http/src/test/scala/zio/http/PathSpec.scala
+++ b/zio-http/src/test/scala/zio/http/PathSpec.scala
@@ -23,7 +23,7 @@ import zio.test._
 
 import zio.http.internal.HttpGen
 
-object PathSpec extends ZIOSpecDefault with ExitAssertion {
+object PathSpec extends ZIOHttpSpec with ExitAssertion {
   import Path.Flag
 
   val a = "a"

--- a/zio-http/src/test/scala/zio/http/QueryParamsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/QueryParamsSpec.scala
@@ -20,7 +20,7 @@ import zio.test.Assertion.equalTo
 import zio.test._
 import zio.{Chunk, ZIO}
 
-object QueryParamsSpec extends ZIOSpecDefault {
+object QueryParamsSpec extends ZIOHttpSpec {
 
   def spec =
     suite("QueryParams")(

--- a/zio-http/src/test/scala/zio/http/RequestSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RequestSpec.scala
@@ -19,7 +19,7 @@ package zio.http
 import zio.Scope
 import zio.test._
 
-object RequestSpec extends ZIOSpecDefault {
+object RequestSpec extends ZIOHttpSpec {
 
   def spec: Spec[TestEnvironment with Scope, Any] = suite("Result")(
     test("`#default`") {

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -20,12 +20,12 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 
 import zio.test.TestAspect.withLiveClock
-import zio.test.{ZIOSpecDefault, assertTrue}
+import zio.test.assertTrue
 import zio.{Chunk, Scope, ZIO, ZInputStream, ZLayer}
 
 import zio.stream.ZStream
 
-object ResponseCompressionSpec extends ZIOSpecDefault {
+object ResponseCompressionSpec extends ZIOHttpSpec {
 
   private val text: HttpApp[Any] =
     Routes(

--- a/zio-http/src/test/scala/zio/http/ResponseSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseSpec.scala
@@ -20,7 +20,7 @@ import zio._
 import zio.test.Assertion._
 import zio.test._
 
-object ResponseSpec extends ZIOSpecDefault {
+object ResponseSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
   private val location: URL                     = URL.decode("www.google.com").toOption.get
 

--- a/zio-http/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -24,7 +24,7 @@ import zio.test._
 import zio.http.internal.HttpGen
 import zio.http.{int => _, uuid => _, _}
 
-object RoutePatternSpec extends ZIOSpecDefault {
+object RoutePatternSpec extends ZIOHttpSpec {
   import zio.http.Method
   import zio.http.RoutePattern._
 

--- a/zio-http/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RouteSpec.scala
@@ -21,7 +21,7 @@ import scala.collection.Seq
 import zio._
 import zio.test._
 
-object RouteSpec extends ZIOSpecDefault {
+object RouteSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   def spec = suite("RouteSpec")(

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -18,13 +18,13 @@ package zio.http
 
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.{ignore, timeout}
-import zio.test.{Gen, ZIOSpecDefault, assertZIO, check}
+import zio.test.{Gen, assertZIO, check}
 import zio.{Scope, ZIO, ZLayer, durationInt}
 
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
 
-object SSLSpec extends ZIOSpecDefault {
+object SSLSpec extends ZIOHttpSpec {
 
   val sslConfig = SSLConfig.fromResource("server.crt", "server.key")
   val config    = Server.Config.default.port(8073).ssl(sslConfig)

--- a/zio-http/src/test/scala/zio/http/SchemeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SchemeSpec.scala
@@ -21,7 +21,7 @@ import zio.test._
 
 import zio.http.internal.HttpGen
 
-object SchemeSpec extends ZIOSpecDefault {
+object SchemeSpec extends ZIOHttpSpec {
   override def spec = suite("SchemeSpec")(
     test("string decode") {
       checkAll(HttpGen.scheme) { scheme =>

--- a/zio-http/src/test/scala/zio/http/StatusSpec.scala
+++ b/zio-http/src/test/scala/zio/http/StatusSpec.scala
@@ -21,7 +21,7 @@ import zio.test._
 
 import zio.http.internal.HttpGen
 
-object StatusSpec extends ZIOSpecDefault {
+object StatusSpec extends ZIOHttpSpec {
   private val statusGen = HttpGen.status
 
   def spec = suite("Status")(

--- a/zio-http/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/URLSpec.scala
@@ -24,7 +24,7 @@ import zio.test._
 
 import zio.http.internal.HttpGen
 
-object URLSpec extends ZIOSpecDefault {
+object URLSpec extends ZIOHttpSpec {
   def extractPath(url: URL): Path = url.path
   def asURL(string: String): URL  = URL.decode(string).toOption.get
 

--- a/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -22,7 +22,7 @@ import zio.{Chunk, Scope, ZIO, ZLayer}
 
 import zio.http.URL.Location
 
-object ZClientAspectSpec extends ZIOSpecDefault {
+object ZClientAspectSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   val app: HttpApp[Any] = Handler.fromFunction[Request] { _ => Response.text("hello") }.toHttpApp

--- a/zio-http/src/test/scala/zio/http/ZIOHttpSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ZIOHttpSpec.scala
@@ -1,0 +1,9 @@
+package zio.http
+
+import zio._
+import zio.test._
+
+trait ZIOHttpSpec extends ZIOSpecDefault {
+  override def aspects: Chunk[TestAspectPoly] =
+    Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+}

--- a/zio-http/src/test/scala/zio/http/codec/HttpCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/HttpCodecSpec.scala
@@ -24,7 +24,7 @@ import zio.test._
 import zio.http._
 import zio.http.codec._
 
-object HttpCodecSpec extends ZIOSpecDefault {
+object HttpCodecSpec extends ZIOHttpSpec {
   val googleUrl     = URL.decode("http://google.com").toOption.get
   val usersUrl      = URL.decode("http://mywebservice.com/users").toOption.get
   val usersIdUrl    = URL.decode("http://mywebservice.com/users/42").toOption.get

--- a/zio-http/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -24,7 +24,7 @@ import zio.test._
 import zio.http._
 import zio.http.codec._
 
-object PathCodecSpec extends ZIOSpecDefault {
+object PathCodecSpec extends ZIOHttpSpec {
   def spec =
     suite("PathCodecSpec")(
       suite("parsing")(

--- a/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
@@ -19,7 +19,9 @@ package zio.http.codec
 import zio.test.Assertion.equalTo
 import zio.test._
 
-object RichTextCodecSpec extends ZIOSpecDefault {
+import zio.http.ZIOHttpSpec
+
+object RichTextCodecSpec extends ZIOHttpSpec {
 
   def success[A](a: A): Either[String, A] = Right(a)
 

--- a/zio-http/src/test/scala/zio/http/endpoint/DocSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/DocSpec.scala
@@ -18,9 +18,11 @@ package zio.http.endpoint
 
 import zio.test._
 
+import zio.http.ZIOHttpSpec
 import zio.http.codec.Doc
 import zio.http.codec.Doc._
-object DocSpec extends ZIOSpecDefault {
+
+object DocSpec extends ZIOHttpSpec {
   override def spec = suite("DocSpec")(
     test("common mark rendering") {
       val complexDoc = (

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointRoundtripSpec.scala
@@ -19,7 +19,7 @@ package zio.http.endpoint
 import zio._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test.{Spec, TestResult, ZIOSpecDefault, assert}
+import zio.test.{Spec, TestResult, assert}
 
 import zio.stream.ZStream
 
@@ -32,7 +32,7 @@ import zio.http.codec.HttpCodec.{authorization, query}
 import zio.http.codec.{Doc, HttpCodec, QueryCodec}
 import zio.http.netty.server.NettyDriver
 
-object EndpointRoundtripSpec extends ZIOSpecDefault {
+object EndpointRoundtripSpec extends ZIOHttpSpec {
   val testLayer: ZLayer[Any, Throwable, Server & Client & Scope] =
     ZLayer.make[Server & Client & Scope](
       Server.live,

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -33,7 +33,7 @@ import zio.http.codec.HttpCodec.{query, queryInt}
 import zio.http.codec._
 import zio.http.forms.Fixtures.formField
 
-object EndpointSpec extends ZIOSpecDefault {
+object EndpointSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   case class NewPost(value: String)

--- a/zio-http/src/test/scala/zio/http/endpoint/internal/UUIDCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/internal/UUIDCodecSpec.scala
@@ -21,9 +21,10 @@ import java.util.UUID
 import zio.Scope
 import zio.test._
 
+import zio.http.ZIOHttpSpec
 import zio.http.codec.TextCodec.UUIDCodec
 
-object UUIDCodecSpec extends ZIOSpecDefault {
+object UUIDCodecSpec extends ZIOHttpSpec {
   val correctUUID                                          = UUID.randomUUID().toString
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("UUIDCodec")(

--- a/zio-http/src/test/scala/zio/http/endpoint/openapi/JsonRendererSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/openapi/JsonRendererSpec.scala
@@ -22,14 +22,14 @@ import scala.util.Try
 
 import zio.test._
 
-import zio.http.Status
 import zio.http.codec.Doc
 import zio.http.endpoint.openapi.OpenAPI.Parameter.{Definition, QueryParameter}
 import zio.http.endpoint.openapi.OpenAPI.Schema.ResponseSchema
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme.ApiKey
 import zio.http.endpoint.openapi.OpenAPI.{Info, Operation, PathItem}
+import zio.http.{Status, ZIOHttpSpec}
 
-object JsonRendererSpec extends ZIOSpecDefault {
+object JsonRendererSpec extends ZIOHttpSpec {
   case object Html
   override def spec =
     suite("JsonRenderer")(

--- a/zio-http/src/test/scala/zio/http/headers/AcceptEncodingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AcceptEncodingSpec.scala
@@ -17,12 +17,13 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue, check}
+import zio.test.{Spec, TestEnvironment, assertTrue, check}
 
 import zio.http.Header.AcceptEncoding
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object AcceptEncodingSpec extends ZIOSpecDefault {
+object AcceptEncodingSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AcceptEncoding suite")(
     suite("Encoding header value transformation should be symmetrical")(
       test("single value") {

--- a/zio-http/src/test/scala/zio/http/headers/AcceptLanguageSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AcceptLanguageSpec.scala
@@ -20,8 +20,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.AcceptLanguage
+import zio.http.ZIOHttpSpec
 
-object AcceptLanguageSpec extends ZIOSpecDefault {
+object AcceptLanguageSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Accept Language header suite")(
       test("accept language header transformation must be symmetrical") {

--- a/zio-http/src/test/scala/zio/http/headers/AcceptPatchSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AcceptPatchSpec.scala
@@ -20,9 +20,9 @@ import zio.test._
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.AcceptPatch
-import zio.http.MediaType
+import zio.http.{MediaType, ZIOHttpSpec}
 
-object AcceptPatchSpec extends ZIOSpecDefault {
+object AcceptPatchSpec extends ZIOHttpSpec {
   import MediaType._
 
   override def spec: Spec[TestEnvironment with Scope, Any] =

--- a/zio-http/src/test/scala/zio/http/headers/AcceptRangesSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AcceptRangesSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.AcceptRanges
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object AcceptRangesSpec extends ZIOSpecDefault {
+object AcceptRangesSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Accept ranges header suite")(
       test("parsing valid values") {

--- a/zio-http/src/test/scala/zio/http/headers/AcceptSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AcceptSpec.scala
@@ -21,9 +21,9 @@ import zio.test._
 
 import zio.http.Header.Accept
 import zio.http.Header.Accept.MediaTypeWithQFactor
-import zio.http.MediaType
+import zio.http.{MediaType, ZIOHttpSpec}
 
-object AcceptSpec extends ZIOSpecDefault {
+object AcceptSpec extends ZIOHttpSpec {
   import MediaType._
 
   override def spec = suite("Accept header suite")(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlAllowCredentialsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlAllowCredentialsSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.AccessControlAllowCredentials
+import zio.http.ZIOHttpSpec
 
-object AccessControlAllowCredentialsSpec extends ZIOSpecDefault {
+object AccessControlAllowCredentialsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlAllowCredentials suite")(
     test("AccessControlAllowCredentials should be parsed correctly for true") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlAllowHeadersSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlAllowHeadersSpec.scala
@@ -17,12 +17,13 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue, check}
+import zio.test.{Spec, TestEnvironment, assertTrue, check}
 
 import zio.http.Header.AccessControlAllowHeaders
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object AccessControlAllowHeadersSpec extends ZIOSpecDefault {
+object AccessControlAllowHeadersSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlAllowHeaders suite")(
     test("AccessControlAllowHeaders should be parsed correctly for *") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlAllowMethodsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlAllowMethodsSpec.scala
@@ -16,13 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.AccessControlAllowMethods
-import zio.http.Method
+import zio.http.{Method, ZIOHttpSpec}
 
-object AccessControlAllowMethodsSpec extends ZIOSpecDefault {
+object AccessControlAllowMethodsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlAllowMethods suite")(
     test("AccessControlAllowMethods should be parsed correctly") {
       val accessControlAllowMethods       = AccessControlAllowMethods.Some(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlExposeHeadersSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlExposeHeadersSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.AccessControlExposeHeaders
+import zio.http.ZIOHttpSpec
 
-object AccessControlExposeHeadersSpec extends ZIOSpecDefault {
+object AccessControlExposeHeadersSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlExposeHeaders suite")(
     test("AccessControlExposeHeaders should be parsed correctly") {
       val accessControlExposeHeaders       = AccessControlExposeHeaders.Some(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlMaxAgeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlMaxAgeSpec.scala
@@ -22,8 +22,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.AccessControlMaxAge
+import zio.http.ZIOHttpSpec
 
-object AccessControlMaxAgeSpec extends ZIOSpecDefault {
+object AccessControlMaxAgeSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Acc header suite")(
     test("parsing of invalid AccessControlMaxAge values returns default") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlRequestHeadersSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlRequestHeadersSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{Chunk, Scope}
 
 import zio.http.Header.AccessControlRequestHeaders
+import zio.http.ZIOHttpSpec
 
-object AccessControlRequestHeadersSpec extends ZIOSpecDefault {
+object AccessControlRequestHeadersSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlRequestHeaders suite")(
     test("AccessControlRequestHeaders") {
       val values                      = Chunk.fromIterable(List("a", "b", "c"))

--- a/zio-http/src/test/scala/zio/http/headers/AccessControlRequestMethodSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AccessControlRequestMethodSpec.scala
@@ -17,12 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.AccessControlRequestMethod
-import zio.http.Method
+import zio.http.{Method, ZIOHttpSpec}
 
-object AccessControlRequestMethodSpec extends ZIOSpecDefault {
+object AccessControlRequestMethodSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("AccessControlRequestMethodSpec")(
     test("AccessControlRequestMethod.toAccessControlRequestMethod") {
       val method = "connect"

--- a/zio-http/src/test/scala/zio/http/headers/AllowSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AllowSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Allow
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object AllowSpec extends ZIOSpecDefault {
+object AllowSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Allow header suite")(
     test("allow header transformation must be symmetrical") {
       check(HttpGen.allowHeader) { allowHeader =>

--- a/zio-http/src/test/scala/zio/http/headers/AuthorizationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/AuthorizationSpec.scala
@@ -23,8 +23,9 @@ import zio.test._
 
 import zio.http.Header.Authorization
 import zio.http.Header.Authorization.Digest
+import zio.http.ZIOHttpSpec
 
-object AuthorizationSpec extends ZIOSpecDefault {
+object AuthorizationSpec extends ZIOHttpSpec {
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Authorization header suite")(

--- a/zio-http/src/test/scala/zio/http/headers/CacheControlSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/CacheControlSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.CacheControl
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object CacheControlSpec extends ZIOSpecDefault {
+object CacheControlSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("CacheControl suite")(
     suite("CacheControl header value transformation should be symmetrical")(
       test("single value") {

--- a/zio-http/src/test/scala/zio/http/headers/ConnectionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ConnectionSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Connection
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object ConnectionSpec extends ZIOSpecDefault {
+object ConnectionSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Connection header suite")(
     test("connection header transformation must be symmetrical") {
       check(HttpGen.connectionHeader) { connectionHeader =>

--- a/zio-http/src/test/scala/zio/http/headers/ContentEncodingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ContentEncodingSpec.scala
@@ -16,14 +16,15 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue, check}
+import zio.test.{Spec, TestEnvironment, assertTrue, check}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.ContentEncoding
 import zio.http.Header.ContentEncoding.Multiple
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object ContentEncodingSpec extends ZIOSpecDefault {
+object ContentEncodingSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ContentEncoding suite")(
     suite("ContentEncoding header value transformation should be symmetrical")(
       test("gen single value") {

--- a/zio-http/src/test/scala/zio/http/headers/CookieSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/CookieSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.Cookie
+import zio.http.ZIOHttpSpec
 
-object CookieSpec extends ZIOSpecDefault {
+object CookieSpec extends ZIOHttpSpec {
 
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Cookie suite")(
     test("Cookie handle valid cookie") {

--- a/zio-http/src/test/scala/zio/http/headers/DNTSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/DNTSpec.scala
@@ -21,8 +21,9 @@ import zio.test._
 
 import zio.http.Header.DNT
 import zio.http.Header.DNT.{NotSpecified, TrackingAllowed, TrackingNotAllowed}
+import zio.http.ZIOHttpSpec
 
-object DNTSpec extends ZIOSpecDefault {
+object DNTSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("DNT header suite")(
     test("parse DNT headers") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/DateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/DateSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.Date
+import zio.http.ZIOHttpSpec
 
-object DateSpec extends ZIOSpecDefault {
+object DateSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Date suite")(
     suite("Date header value transformation should be symmetrical")(
       test("Date rendering should be reversible") {

--- a/zio-http/src/test/scala/zio/http/headers/ETagSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ETagSpec.scala
@@ -21,8 +21,9 @@ import zio.test._
 
 import zio.http.Header.ETag
 import zio.http.Header.ETag.{Strong, Weak}
+import zio.http.ZIOHttpSpec
 
-object ETagSpec extends ZIOSpecDefault {
+object ETagSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("ETag header suite")(
     test("parse ETag header") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/ExpectSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ExpectSpec.scala
@@ -20,8 +20,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Expect
+import zio.http.ZIOHttpSpec
 
-object ExpectSpec extends ZIOSpecDefault {
+object ExpectSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Expect header suite")(
       test("parse valid value") {

--- a/zio-http/src/test/scala/zio/http/headers/ExpiresSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ExpiresSpec.scala
@@ -23,8 +23,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Expires
+import zio.http.ZIOHttpSpec
 
-object ExpiresSpec extends ZIOSpecDefault {
+object ExpiresSpec extends ZIOHttpSpec {
 
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Expires header suite")(
     test("parsing of invalid expires values") {

--- a/zio-http/src/test/scala/zio/http/headers/FromSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/FromSpec.scala
@@ -20,8 +20,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.From
+import zio.http.ZIOHttpSpec
 
-object FromSpec extends ZIOSpecDefault {
+object FromSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("From header suite")(
       test("parse valid value") {

--- a/zio-http/src/test/scala/zio/http/headers/HostSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/HostSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Host
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object HostSpec extends ZIOSpecDefault {
+object HostSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Host header suite")(
       test("Empty Host") {

--- a/zio-http/src/test/scala/zio/http/headers/IfMatchSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/IfMatchSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.IfMatch
+import zio.http.ZIOHttpSpec
 
-object IfMatchSpec extends ZIOSpecDefault {
+object IfMatchSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("IfMatch suite")(
     test("IfMatch '*' should be parsed correctly") {
       val ifMatch = IfMatch.parse("*")

--- a/zio-http/src/test/scala/zio/http/headers/IfModifiedSinceSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/IfModifiedSinceSpec.scala
@@ -19,11 +19,12 @@ package zio.http.headers
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.IfModifiedSince
+import zio.http.ZIOHttpSpec
 
-object IfModifiedSinceSpec extends ZIOSpecDefault {
+object IfModifiedSinceSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("IfModifiedSinceSpec")(
     test("IfModifiedSince should be parsed correctly") {
       val ifModifiedSince = IfModifiedSince.parse("Sun, 06 Nov 1994 08:49:37 GMT")

--- a/zio-http/src/test/scala/zio/http/headers/IfNoneMatchSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/IfNoneMatchSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.IfNoneMatch
+import zio.http.ZIOHttpSpec
 
-object IfNoneMatchSpec extends ZIOSpecDefault {
+object IfNoneMatchSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("IfNoneMatch suite")(
     test("IfMatch '*' should be parsed correctly") {
       val ifMatch = IfNoneMatch.parse("*")

--- a/zio-http/src/test/scala/zio/http/headers/IfRangeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/IfRangeSpec.scala
@@ -19,11 +19,12 @@ package zio.http.headers
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.IfRange
+import zio.http.ZIOHttpSpec
 
-object IfRangeSpec extends ZIOSpecDefault {
+object IfRangeSpec extends ZIOHttpSpec {
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("If-Range header encoder suite")(

--- a/zio-http/src/test/scala/zio/http/headers/IfUnmodifiedSinceSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/IfUnmodifiedSinceSpec.scala
@@ -19,11 +19,12 @@ package zio.http.headers
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.IfUnmodifiedSince
+import zio.http.ZIOHttpSpec
 
-object IfUnmodifiedSinceSpec extends ZIOSpecDefault {
+object IfUnmodifiedSinceSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("IfUnmodifiedSince suite")(
     test("IfUnmodifiedSince should be parsed correctly") {
       val ifModifiedSince = IfUnmodifiedSince.parse("Mon, 07 Nov 1994 08:49:37 GMT")

--- a/zio-http/src/test/scala/zio/http/headers/LastModifiedSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/LastModifiedSpec.scala
@@ -19,11 +19,12 @@ package zio.http.headers
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.LastModified
+import zio.http.ZIOHttpSpec
 
-object LastModifiedSpec extends ZIOSpecDefault {
+object LastModifiedSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("LastModified spec")(
     test("LastModifiedDateTime") {
       val dateTime     = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, ZoneOffset.UTC)

--- a/zio-http/src/test/scala/zio/http/headers/LocationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/LocationSpec.scala
@@ -17,12 +17,13 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{ZIOSpecDefault, _}
+import zio.test._
 
 import zio.http.Header.Location
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object LocationSpec extends ZIOSpecDefault {
+object LocationSpec extends ZIOHttpSpec {
 
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Location header suite")(

--- a/zio-http/src/test/scala/zio/http/headers/OriginSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/OriginSpec.scala
@@ -22,9 +22,9 @@ import zio.test._
 import zio.http.Header.Origin
 import zio.http.Header.Origin.{Null, Value}
 import zio.http.internal.HttpGen
-import zio.http.{Path, QueryParams}
+import zio.http.{Path, QueryParams, ZIOHttpSpec}
 
-object OriginSpec extends ZIOSpecDefault {
+object OriginSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Origin header suite")(
       test("Origin: null") {

--- a/zio-http/src/test/scala/zio/http/headers/ProxyAuthenticateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ProxyAuthenticateSpec.scala
@@ -20,9 +20,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.ProxyAuthenticate
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object ProxyAuthenticateSpec extends ZIOSpecDefault {
+object ProxyAuthenticateSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("ProxyAuthenticateSpec")(
       test("parsing of invalid inputs") {

--- a/zio-http/src/test/scala/zio/http/headers/RangeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/RangeSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.Range
+import zio.http.ZIOHttpSpec
 
-object RangeSpec extends ZIOSpecDefault {
+object RangeSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Range suite")(
     test("parsing of invalid Range values") {
       assertTrue(Range.parse("").isLeft, Range.parse("something").isLeft)

--- a/zio-http/src/test/scala/zio/http/headers/RetryAfterEncodingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/RetryAfterEncodingSpec.scala
@@ -22,9 +22,10 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.RetryAfter
+import zio.http.ZIOHttpSpec
 import zio.http.internal.DateEncoding
 
-object RetryAfterEncodingSpec extends ZIOSpecDefault {
+object RetryAfterEncodingSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Retry-After header encoder suite")(
     test("parsing invalid retry after values") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketAcceptSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketAcceptSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SecWebSocketAccept
+import zio.http.ZIOHttpSpec
 
-object SecWebSocketAcceptSpec extends ZIOSpecDefault {
+object SecWebSocketAcceptSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketAccept suite")(
     test("SecWebSocketAccept should be properly parsed for a valid string") {
       val probe = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketExtensionsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketExtensionsSpec.scala
@@ -16,13 +16,14 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{Chunk, Scope}
 
 import zio.http.Header.SecWebSocketExtensions
 import zio.http.Header.SecWebSocketExtensions.{Extension, Token}
+import zio.http.ZIOHttpSpec
 
-object SecWebSocketExtensionsSpec extends ZIOSpecDefault {
+object SecWebSocketExtensionsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketExtensions suite")(
     test("SecWebSocketExtensions should be properly parsed for a valid string") {
       val probe = "permessage-deflate; client_max_window_bits"

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketKeySpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketKeySpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SecWebSocketKey
+import zio.http.ZIOHttpSpec
 
-object SecWebSocketKeySpec extends ZIOSpecDefault {
+object SecWebSocketKeySpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketKey suite")(
     test("SecWebSocketKey should be properly parsed for a valid string") {
       val probe = "dGhlIHNhbXBsZSBub25jZQ=="

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketLocationSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketLocationSpec.scala
@@ -17,12 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SecWebSocketLocation
-import zio.http.URL
+import zio.http.{URL, ZIOHttpSpec}
 
-object SecWebSocketLocationSpec extends ZIOSpecDefault {
+object SecWebSocketLocationSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketLocation suite")(
     test("SecWebSocketLocation should be properly parsed for a valid string") {
       val probe    = "ws://example.com"

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketOriginSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketOriginSpec.scala
@@ -17,12 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SecWebSocketOrigin
-import zio.http.URL
+import zio.http.{URL, ZIOHttpSpec}
 
-object SecWebSocketOriginSpec extends ZIOSpecDefault {
+object SecWebSocketOriginSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketOrigin suite")(
     test("SecWebSocketOrigin should be properly parsed for a valid string") {
       val probe    = "wss://example.com"

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketProtocolSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketProtocolSpec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.SecWebSocketProtocol
+import zio.http.ZIOHttpSpec
 
-object SecWebSocketProtocolSpec extends ZIOSpecDefault {
+object SecWebSocketProtocolSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketProtocol suite")(
     test("SecWebSocketProtocol should be properly parsed for a valid string") {
       val probe = "chat, superchat"

--- a/zio-http/src/test/scala/zio/http/headers/SecWebSocketVersionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SecWebSocketVersionSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SecWebSocketVersion
+import zio.http.ZIOHttpSpec
 
-object SecWebSocketVersionSpec extends ZIOSpecDefault {
+object SecWebSocketVersionSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SecWebSocketVersion suite")(
     test("SecWebSocketVersion should be properly parsed for a valid string") {
       val probe = "13"

--- a/zio-http/src/test/scala/zio/http/headers/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ServerSpec.scala
@@ -19,8 +19,9 @@ package zio.http.headers
 import zio.test._
 
 import zio.http.Header.Server
+import zio.http.ZIOHttpSpec
 
-object ServerSpec extends ZIOSpecDefault {
+object ServerSpec extends ZIOHttpSpec {
   override def spec = suite("Server header suite")(
     test("empty server value") {
       assertTrue(Server.parse("").isLeft)

--- a/zio-http/src/test/scala/zio/http/headers/SetCookieSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/SetCookieSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.SetCookie
+import zio.http.ZIOHttpSpec
 
-object SetCookieSpec extends ZIOSpecDefault {
+object SetCookieSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("SetCookieSpec suite")(
     test("SetCookie handle valid cookie") {
       val result = SetCookie.parse("foo=bar") match {

--- a/zio-http/src/test/scala/zio/http/headers/TeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/TeSpec.scala
@@ -16,13 +16,14 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.Te
 import zio.http.Header.Te.{Deflate, GZip, Multiple, Trailers}
+import zio.http.ZIOHttpSpec
 
-object TeSpec extends ZIOSpecDefault {
+object TeSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("TE suite")(
     test("parse TE header") {
       val te = "trailers, deflate;q=0.5, gzip;q=0.2"

--- a/zio-http/src/test/scala/zio/http/headers/TrailerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/TrailerSpec.scala
@@ -20,8 +20,9 @@ import zio.Scope
 import zio.test._
 
 import zio.http.Header.Trailer
+import zio.http.ZIOHttpSpec
 
-object TrailerSpec extends ZIOSpecDefault {
+object TrailerSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Trailer header suite")(
       test("parse valid value") {

--- a/zio-http/src/test/scala/zio/http/headers/TransferEncodingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/TransferEncodingSpec.scala
@@ -16,14 +16,15 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue, check}
+import zio.test.{Spec, TestEnvironment, assertTrue, check}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.TransferEncoding
 import zio.http.Header.TransferEncoding.Multiple
+import zio.http.ZIOHttpSpec
 import zio.http.internal.HttpGen
 
-object TransferEncodingSpec extends ZIOSpecDefault {
+object TransferEncodingSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("TransferEncoding suite")(
     suite("TransferEncoding header value transformation should be symmetrical")(
       test("gen single value") {

--- a/zio-http/src/test/scala/zio/http/headers/UpgradeInsecureRequestsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/UpgradeInsecureRequestsSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.UpgradeInsecureRequests
+import zio.http.ZIOHttpSpec
 
-object UpgradeInsecureRequestsSpec extends ZIOSpecDefault {
+object UpgradeInsecureRequestsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("UpgradeInsecureRequests suite")(
     suite("UpgradeInsecureRequests header value transformation should be symmetrical")(
       test("single value") {

--- a/zio-http/src/test/scala/zio/http/headers/UpgradeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/UpgradeSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.Upgrade
+import zio.http.ZIOHttpSpec
 
-object UpgradeSpec extends ZIOSpecDefault {
+object UpgradeSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Upgrade suite")(
     suite("Upgrade header value transformation should be symmetrical")(
       test("single value") {

--- a/zio-http/src/test/scala/zio/http/headers/UserAgentSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/UserAgentSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.UserAgent
+import zio.http.ZIOHttpSpec
 
-object UserAgentSpec extends ZIOSpecDefault {
+object UserAgentSpec extends ZIOHttpSpec {
   def spec: Spec[TestEnvironment with Scope, Any] =
     suite("UserAgent suite")(
       test("UserAgent should be parsed correctly") {

--- a/zio-http/src/test/scala/zio/http/headers/VarySpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/VarySpec.scala
@@ -20,8 +20,9 @@ import zio.test._
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.Vary
+import zio.http.ZIOHttpSpec
 
-object VarySpec extends ZIOSpecDefault {
+object VarySpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Nothing] =
     suite("Vary header suite")(
       test("parse valid values") {

--- a/zio-http/src/test/scala/zio/http/headers/ViaSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ViaSpec.scala
@@ -16,13 +16,14 @@
 
 package zio.http.headers
 
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 import zio.{NonEmptyChunk, Scope}
 
 import zio.http.Header.Via
 import zio.http.Header.Via.ReceivedProtocol
+import zio.http.ZIOHttpSpec
 
-object ViaSpec extends ZIOSpecDefault {
+object ViaSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Via suite")(
       test("parsing of valid values") {

--- a/zio-http/src/test/scala/zio/http/headers/WWWAuthenticateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/WWWAuthenticateSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.WWWAuthenticate
+import zio.http.ZIOHttpSpec
 
-object WWWAuthenticateSpec extends ZIOSpecDefault {
+object WWWAuthenticateSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("WWAuthenticate suite")(
     test("should properly parse WWWAuthenticate Basic header") {
       val header = WWWAuthenticate.Basic(Some("realm"))

--- a/zio-http/src/test/scala/zio/http/headers/WarningSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/WarningSpec.scala
@@ -19,11 +19,12 @@ package zio.http.headers
 import java.time.{ZoneOffset, ZonedDateTime}
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.Warning
+import zio.http.ZIOHttpSpec
 
-object WarningSpec extends ZIOSpecDefault {
+object WarningSpec extends ZIOHttpSpec {
 
   private val validWarning            = "110 anderson/1.3.37 \"Response is stale\""
   private val validWarningWithDate    = "112 - \"cache down\" \"Wed, 21 Oct 2015 07:28:00 GMT\""

--- a/zio-http/src/test/scala/zio/http/headers/XFrameOptionsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/XFrameOptionsSpec.scala
@@ -17,11 +17,12 @@
 package zio.http.headers
 
 import zio.Scope
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+import zio.test.{Spec, TestEnvironment, assertTrue}
 
 import zio.http.Header.XFrameOptions
+import zio.http.ZIOHttpSpec
 
-object XFrameOptionsSpec extends ZIOSpecDefault {
+object XFrameOptionsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("XFrameOptions suite")(
     test("parsing of invalid XFrameOptions values") {
       assertTrue(

--- a/zio-http/src/test/scala/zio/http/html/DomSpec.scala
+++ b/zio-http/src/test/scala/zio/http/html/DomSpec.scala
@@ -16,11 +16,12 @@
 
 package zio.http.html
 
-import zio.test.{ZIOSpecDefault, assertTrue, check, checkAll}
+import zio.test.{assertTrue, check, checkAll}
 
+import zio.http.ZIOHttpSpec
 import zio.http.html.HtmlGen.{tagGen, voidTagGen}
 
-object DomSpec extends ZIOSpecDefault {
+object DomSpec extends ZIOHttpSpec {
   def spec = suite("DomSpec")(
     test("empty") {
       val dom = Dom.empty

--- a/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
+++ b/zio-http/src/test/scala/zio/http/html/HtmlSpec.scala
@@ -19,7 +19,9 @@ package zio.http.html
 import zio.test.Assertion.equalTo
 import zio.test._
 
-case object HtmlSpec extends ZIOSpecDefault {
+import zio.http.ZIOHttpSpec
+
+case object HtmlSpec extends ZIOHttpSpec {
   def spec = {
     suite("HtmlSpec")(
       test("tags") {

--- a/zio-http/src/test/scala/zio/http/internal/CharSequenceExtensionsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/CharSequenceExtensionsSpec.scala
@@ -18,7 +18,9 @@ package zio.http.internal
 
 import zio.test._
 
-object CharSequenceExtensionsSpec extends ZIOSpecDefault {
+import zio.http.ZIOHttpSpec
+
+object CharSequenceExtensionsSpec extends ZIOHttpSpec {
 
   override def spec = suite("CharSequence extensions")(
     test("equals") {

--- a/zio-http/src/test/scala/zio/http/internal/FormStateSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/FormStateSpec.scala
@@ -21,9 +21,9 @@ import java.nio.charset.StandardCharsets
 import zio._
 import zio.test._
 
-import zio.http.Boundary
+import zio.http.{Boundary, ZIOHttpSpec}
 
-object FormStateSpec extends ZIOSpecDefault {
+object FormStateSpec extends ZIOHttpSpec {
 
   val CR = '\r'
 

--- a/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
@@ -16,7 +16,6 @@
 
 package zio.http.internal
 
-import zio.test.ZIOSpecDefault
 import zio.{Scope, ZIO}
 
 import zio.http.URL.Location
@@ -29,7 +28,7 @@ import zio.http._
  * should suffice. HttpRunnableSpec spins of an actual Http server and makes
  * requests.
  */
-abstract class HttpRunnableSpec extends ZIOSpecDefault { self =>
+abstract class HttpRunnableSpec extends ZIOHttpSpec { self =>
   implicit class RunnableHttpClientAppSyntax[R](route: HttpApp[R]) {
 
     def app: HttpApp[R] = route

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -23,7 +23,7 @@ import zio.{Ref, ZIO, ZLayer}
 import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 
-object AuthSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+object AuthSpec extends ZIOHttpSpec with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status
 
   private val successBasicHeader: Headers  = Headers(Header.Authorization.Basic("user", "resu"))

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -25,7 +25,7 @@ import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 import zio.http.internal.middlewares.CorsSpec.app
 
-object CorsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+object CorsSpec extends ZIOHttpSpec with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status
 
   val app = Routes(

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/MetricsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/MetricsSpec.scala
@@ -25,7 +25,7 @@ import zio.http._
 import zio.http.codec.{PathCodec, SegmentCodec}
 import zio.http.internal.HttpAppTestExtensions
 
-object MetricsSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+object MetricsSpec extends ZIOHttpSpec with HttpAppTestExtensions {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("MetricsSpec")(
       test("http_requests_total & http_errors_total") {

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/RequestLoggingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/RequestLoggingSpec.scala
@@ -23,7 +23,7 @@ import zio.http.Middleware.requestLogging
 import zio.http._
 import zio.http.internal.HttpAppTestExtensions
 
-object RequestLoggingSpec extends ZIOSpecDefault with HttpAppTestExtensions {
+object RequestLoggingSpec extends ZIOHttpSpec with HttpAppTestExtensions {
 
   private val app = Routes(
     Method.GET / "ok"     -> Handler.ok,

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
@@ -25,7 +25,7 @@ import zio.http._
 import zio.http.codec.PathCodec
 import zio.http.internal.HttpAppTestExtensions
 
-object WebSpec extends ZIOSpecDefault with HttpAppTestExtensions { self =>
+object WebSpec extends ZIOHttpSpec with HttpAppTestExtensions { self =>
   def extractStatus(response: Response): Status = response.status
 
   private val app =

--- a/zio-http/src/test/scala/zio/http/netty/NettyBodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyBodySpec.scala
@@ -20,12 +20,12 @@ import zio.test.Assertion.equalTo
 import zio.test._
 import zio.{Chunk, Scope}
 
-import zio.http.Charsets
+import zio.http.{Charsets, ZIOHttpSpec}
 
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.util.AsciiString
 
-object NettyBodySpec extends ZIOSpecDefault {
+object NettyBodySpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("NettyBody")(
       suite("fromAsync")(

--- a/zio-http/src/test/scala/zio/http/netty/NettyChannelSpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyChannelSpec.scala
@@ -19,14 +19,14 @@ package zio.http.netty
 import java.util
 
 import zio.test.TestAspect.timeout
-import zio.test.{TestClock, ZIOSpecDefault, assertTrue}
+import zio.test.{TestClock, assertTrue}
 import zio.{UIO, ZIO, durationInt}
 
-import zio.http.Channel
+import zio.http.{Channel, ZIOHttpSpec}
 
 import io.netty.channel.embedded.EmbeddedChannel
 
-object NettyChannelSpec extends ZIOSpecDefault {
+object NettyChannelSpec extends ZIOHttpSpec {
   def spec = suite("Channel")(
     suite("writeAndFlush")(
       test("await = false") {

--- a/zio-http/src/test/scala/zio/http/netty/NettyProxySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyProxySpec.scala
@@ -19,9 +19,9 @@ package zio.http.netty
 import zio.test.Assertion.{equalTo, isNone, isNull, isSome}
 import zio.test._
 
-import zio.http.{Credentials, Proxy, URL}
+import zio.http.{Credentials, Proxy, URL, ZIOHttpSpec}
 
-object NettyProxySpec extends ZIOSpecDefault {
+object NettyProxySpec extends ZIOHttpSpec {
   private val validUrl = URL.decode("http://localhost:8123").toOption.getOrElse(URL.empty)
 
   override def spec = suite("Proxy")(

--- a/zio-http/src/test/scala/zio/http/netty/client/NettyRequestEncoderSpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/client/NettyRequestEncoderSpec.scala
@@ -22,11 +22,11 @@ import zio.test._
 import zio.http.internal.HttpGen
 import zio.http.netty._
 import zio.http.netty.model.Conversions
-import zio.http.{Body, QueryParams, Request, URL}
+import zio.http.{Body, QueryParams, Request, URL, ZIOHttpSpec}
 
 import io.netty.handler.codec.http.HttpHeaderNames
 
-object NettyRequestEncoderSpec extends ZIOSpecDefault {
+object NettyRequestEncoderSpec extends ZIOHttpSpec {
   import NettyRequestEncoder._
 
   val anyClientParam: Gen[Sized, Request] = HttpGen.requestGen(

--- a/zio-http/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -19,12 +19,12 @@ package zio.http.netty.model
 import zio.Scope
 import zio.test._
 
-import zio.http.{Header, Headers, Version}
+import zio.http.{Header, Headers, Version, ZIOHttpSpec}
 
 import io.netty.handler.codec.http.websocketx.WebSocketScheme
 import io.netty.handler.codec.http.{DefaultHttpHeaders, HttpHeaders, HttpScheme, HttpVersion}
 
-object ConversionsSpec extends ZIOSpecDefault {
+object ConversionsSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("Netty conversions")(
       suite("headers")(


### PR DESCRIPTION
Have all tests extend `ZIOHttpSpec` which includes default test aspects that time out tests and measure how long they took.