### PR TITLE
Increase Endpoint test coverage

### DIFF
--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -1052,11 +1052,11 @@ object EndpointSpec extends ZIOHttpSpec {
     suite("examples")(
       test("add examples to endpoint") {
         check(Gen.alphaNumericString, Gen.alphaNumericString) { (repo1, repo2) =>
-          val endpoint  = Endpoint(GET / "repos" / string("org"))
+          val endpoint             = Endpoint(GET / "repos" / string("org"))
             .out[String]
             .examplesIn("org" -> "zio")
             .examplesOut("repos" -> s"all, zio, repos, $repo1, $repo2")
-          val endpoint2 =
+          val endpoint2            =
             Endpoint(GET / "repos" / string("org") / string("repo"))
               .out[String]
               .examplesIn(
@@ -1066,16 +1066,25 @@ object EndpointSpec extends ZIOHttpSpec {
                 "org/repo4" -> ("zio", repo2),
               )
               .examplesOut("repos" -> s"zio, http, $repo1, $repo2")
+          val inExamples1          = endpoint.examplesIn
+          val expectedInExamples1  = Map("org" -> "zio")
+          val outExamples1         = endpoint.examplesOut
+          val expectedOutExamples1 = Map("repos" -> s"all, zio, repos, $repo1, $repo2")
+          val inExamples2          = endpoint2.examplesIn
+          val expectedInExamples2  = Map(
+            "org/repo1" -> ("zio", "http"),
+            "org/repo2" -> ("zio", "zio"),
+            "org/repo3" -> ("zio", repo1),
+            "org/repo4" -> ("zio", repo2),
+          )
+          val outExamples2         = endpoint2.examplesOut
+          val expectedOutExamples2 = Map("repos" -> s"zio, http, $repo1, $repo2")
+
           assertTrue(
-            endpoint.examplesIn == Map("org" -> "zio"),
-            endpoint.examplesOut == Map("repos" -> s"all, zio, repos, $repo1, $repo2"),
-            endpoint2.examplesIn == Map(
-              "org/repo1" -> ("zio", "http"),
-              "org/repo2" -> ("zio", "zio"),
-              "org/repo3" -> ("zio", repo1),
-              "org/repo4" -> ("zio", repo2),
-            ),
-            endpoint2.examplesOut == Map("repos" -> s"zio, http, $repo1, $repo2"),
+            inExamples1 == expectedInExamples1,
+            outExamples1 == expectedOutExamples1,
+            inExamples2 == expectedInExamples2,
+            outExamples2 == expectedOutExamples2,
           )
         }
       },

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -258,7 +258,7 @@ object EndpointSpec extends ZIOHttpSpec {
         check(Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue)) {
           (userId, postId, commentId, replyId) =>
             val broadUsers                       =
-              Endpoint(GET / "users").out[String].implement {
+              Endpoint(GET / "users").out[String](Doc.p("Created user id")).implement {
                 Handler.succeed("path(users)")
               }
             val broadUsersId                     =
@@ -499,8 +499,8 @@ object EndpointSpec extends ZIOHttpSpec {
 
             val endpoint =
               Endpoint(POST / "posts")
-                .in[NewPost]
-                .out[Int]
+                .in[NewPost](Doc.p("New post"))
+                .out[PostCreated](MediaType.application.`json`)
             val routes   =
               endpoint.implement(Handler.succeed(postId))
             val request  =
@@ -654,7 +654,7 @@ object EndpointSpec extends ZIOHttpSpec {
 
             val routes =
               Endpoint(POST / "users")
-                .in[User]
+                .in[User](Doc.p("User schema with id"))
                 .out[String]
                 .implement {
                   Handler.fromFunctionZIO { _ =>
@@ -686,7 +686,7 @@ object EndpointSpec extends ZIOHttpSpec {
         test("responding with a byte stream") {
           check(Gen.chunkOfBounded(1, 1024)(Gen.byte)) { bytes =>
             val route = Endpoint(GET / "test-byte-stream")
-              .outStream[Byte]
+              .outStream[Byte](Doc.p("Test data"))
               .implement(Handler.succeed(ZStream.fromChunk(bytes).rechunk(16)))
 
             for {
@@ -876,9 +876,9 @@ object EndpointSpec extends ZIOHttpSpec {
               bytes <- Random.nextBytes(1024)
               route =
                 Endpoint(POST / "test-form")
-                  .inStream[Byte]("uploaded-image")
+                  .inStream[Byte]("uploaded-image", Doc.p("Image data"))
                   .in[String]("title")
-                  .in[ImageMetadata]("metadata")
+                  .in[ImageMetadata]("metadata", Doc.p("Image metadata with description and creation date and time"))
                   .out[(Long, String, ImageMetadata)]
                   .implement {
                     Handler.fromFunctionZIO { case (stream, title, metadata) =>

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -47,345 +47,364 @@ object EndpointSpec extends ZIOHttpSpec {
   def spec = suite("EndpointSpec")(
     suite("handler")(
       test("simple request") {
-        val testRoutes = testEndpoint(
-          Routes(
-            Endpoint(GET / "users" / int("userId"))
-              .out[String]
-              .implement {
-                Handler.fromFunction { userId =>
-                  s"path(users, $userId)"
-                }
-              },
-            Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-              .query(query("name"))
-              .out[String]
-              .implement {
-                Handler.fromFunction { case (userId, postId, name) =>
-                  s"path(users, $userId, posts, $postId) query(name=$name)"
-                }
-              },
-          ),
-        ) _
-        testRoutes("/users/123", "path(users, 123)") &&
-        testRoutes("/users/123/posts/555?name=adam", "path(users, 123, posts, 555) query(name=adam)")
+        check(Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.alphaNumericString) {
+          (userId, postId, username) =>
+            val testRoutes = testEndpoint(
+              Routes(
+                Endpoint(GET / "users" / int("userId"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { userId =>
+                      s"path(users, $userId)"
+                    }
+                  },
+                Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
+                  .query(query("name"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { case (userId, postId, name) =>
+                      s"path(users, $userId, posts, $postId) query(name=$name)"
+                    }
+                  },
+              ),
+            ) _
+            testRoutes(s"/users/$userId", s"path(users, $userId)") &&
+            testRoutes(
+              s"/users/$userId/posts/$postId?name=$username",
+              s"path(users, $userId, posts, $postId) query(name=$username)",
+            )
+        }
       },
       test("optional query parameter") {
-        val testRoutes = testEndpoint(
-          Routes(
-            Endpoint(GET / "users" / int("userId"))
-              .query(query("details").optional)
-              .out[String]
-              .implement {
-                Handler.fromFunction { case (userId, details) =>
-                  s"path(users, $userId, $details)"
-                }
-              },
-          ),
-        ) _
-        testRoutes("/users/123", "path(users, 123, None)") &&
-        testRoutes("/users/123?details=", "path(users, 123, Some())") &&
-        testRoutes("/users/123?details=456", "path(users, 123, Some(456))")
+        check(Gen.int(1, Int.MaxValue), Gen.alphaNumericString) { (userId, details) =>
+          val testRoutes = testEndpoint(
+            Routes(
+              Endpoint(GET / "users" / int("userId"))
+                .query(query("details").optional)
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, details) =>
+                    s"path(users, $userId, $details)"
+                  }
+                },
+            ),
+          ) _
+          testRoutes(s"/users/$userId", s"path(users, $userId, None)") &&
+          testRoutes(s"/users/$userId?details=", s"path(users, $userId, Some())") &&
+          testRoutes(s"/users/$userId?details=$details", s"path(users, $userId, Some($details))")
+        }
       },
       test("multiple optional query parameters") {
-        val testRoutes = testEndpoint(
-          Routes(
-            Endpoint(GET / "users" / int("userId"))
-              .query(query("key").optional)
-              .query(query("value").optional)
-              .out[String]
-              .implement {
-                Handler.fromFunction { case (userId, key, value) =>
-                  s"path(users, $userId, $key, $value)"
-                }
-              },
-          ),
-        ) _
-        testRoutes("/users/123", "path(users, 123, None, None)") &&
-        testRoutes("/users/123?key=&value=", "path(users, 123, Some(), Some())") &&
-        testRoutes("/users/123?key=&value=X", "path(users, 123, Some(), Some(X))") &&
-        testRoutes("/users/123?key=X&value=Y", "path(users, 123, Some(X), Some(Y))")
+        check(Gen.int(1, Int.MaxValue), Gen.alphaNumericString, Gen.alphaNumericString) { (userId, key, value) =>
+          val testRoutes = testEndpoint(
+            Routes(
+              Endpoint(GET / "users" / int("userId"))
+                .query(query("key").optional)
+                .query(query("value").optional)
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, key, value) =>
+                    s"path(users, $userId, $key, $value)"
+                  }
+                },
+            ),
+          ) _
+          testRoutes(s"/users/$userId", s"path(users, $userId, None, None)") &&
+          testRoutes(s"/users/$userId?key=&value=", s"path(users, $userId, Some(), Some())") &&
+          testRoutes(s"/users/$userId?key=&value=$value", s"path(users, $userId, Some(), Some($value))") &&
+          testRoutes(s"/users/$userId?key=$key&value=$value", s"path(users, $userId, Some($key), Some($value))")
+        }
       },
       test("bad request for failed codec") {
-        val endpoint =
-          Endpoint(GET / "posts")
-            .query(queryInt("id"))
-            .out[Int]
+        check(Gen.int(1, Int.MaxValue), Gen.boolean) { (id, notAnId) =>
+          val endpoint =
+            Endpoint(GET / "posts")
+              .query(queryInt("id"))
+              .out[Int]
 
-        val routes =
-          endpoint.implement { Handler.succeed(42) }
+          val routes =
+            endpoint.implement {
+              Handler.succeed(id)
+            }
 
-        for {
-          response <- routes.toHttpApp.runZIO(
-            Request.get(URL.decode("/posts?id=notanid").toOption.get),
-          )
-        } yield assertTrue(extractStatus(response).code == 400)
+          for {
+            response <- routes.toHttpApp.runZIO(
+              Request.get(URL.decode(s"/posts?id=$notAnId").toOption.get),
+            )
+          } yield assertTrue(extractStatus(response).code == 400)
+        }
       },
       test("out of order api") {
-        val testRoutes = testEndpoint(
-          Routes(
-            Endpoint(GET / "users" / int("userId"))
-              .out[String]
-              .implement {
+        check(Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.alphaNumericString, Gen.int(1, Int.MaxValue)) {
+          (userId, postId, name, age) =>
+            val testRoutes = testEndpoint(
+              Routes(
+                Endpoint(GET / "users" / int("userId"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { userId =>
+                      s"path(users, $userId)"
+                    }
+                  },
+                Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
+                  .query(query("name"))
+                  .query(query("age"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { case (userId, postId, name, age) =>
+                      s"path(users, $userId, posts, $postId) query(name=$name, age=$age)"
+                    }
+                  },
+              ),
+            ) _
+            testRoutes(s"/users/$userId", s"path(users, $userId)") &&
+            testRoutes(
+              s"/users/$userId/posts/$postId?name=$name&age=$age",
+              s"path(users, $userId, posts, $postId) query(name=$name, age=$age)",
+            )
+        }
+      },
+      test("fallback") {
+        check(Gen.int(1, Int.MaxValue), Gen.alphaNumericString) { (userId, username) =>
+          val testRoutes = testEndpoint(
+            Routes(
+              Endpoint(GET / "users")
+                .query(queryInt("userId") | query("userId"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { userId =>
+                    val value = userId.fold(_.toString, identity)
+                    s"path(users) query(userId=$value)"
+                  }
+                },
+            ),
+          ) _
+          testRoutes(s"/users?userId=$userId", s"path(users) query(userId=$userId)") &&
+          testRoutes(s"/users?userId=$username", s"path(users) query(userId=$username)")
+        }
+      },
+      test("broad api") {
+        check(Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue)) {
+          (userId, postId, commentId, replyId) =>
+            val broadUsers              =
+              Endpoint(GET / "users").out[String].implement {
+                Handler.succeed("path(users)")
+              }
+            val broadUsersId            =
+              Endpoint(GET / "users" / int("userId")).out[String].implement {
                 Handler.fromFunction { userId =>
                   s"path(users, $userId)"
                 }
-              },
-            Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-              .query(query("name"))
-              .query(query("age"))
-              .out[String]
-              .implement {
-                Handler.fromFunction { case (userId, postId, name, age) =>
-                  s"path(users, $userId, posts, $postId) query(name=$name, age=$age)"
+              }
+            val boardUsersPosts         =
+              Endpoint(GET / "users" / int("userId") / "posts")
+                .out[String]
+                .implement {
+                  Handler.fromFunction { userId =>
+                    s"path(users, $userId, posts)"
+                  }
                 }
-              },
-          ),
-        ) _
-        testRoutes("/users/123", "path(users, 123)") &&
-        testRoutes(
-          "/users/123/posts/555?name=adam&age=9000",
-          "path(users, 123, posts, 555) query(name=adam, age=9000)",
-        )
-      },
-      test("fallback") {
-        val testRoutes = testEndpoint(
-          Routes(
-            Endpoint(GET / "users")
-              .query(queryInt("userId") | query("userId"))
-              .out[String]
-              .implement {
-                Handler.fromFunction { userId =>
-                  val value = userId.fold(_.toString, identity)
-                  s"path(users) query(userId=$value)"
+            val boardUsersPostsId       =
+              Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, postId) =>
+                    s"path(users, $userId, posts, $postId)"
+                  }
                 }
-              },
-          ),
-        ) _
-        testRoutes("/users?userId=123", "path(users) query(userId=123)") &&
-        testRoutes("/users?userId=adam", "path(users) query(userId=adam)")
-      },
-      test("broad api") {
-        val broadUsers              =
-          Endpoint(GET / "users").out[String].implement { Handler.succeed("path(users)") }
-        val broadUsersId            =
-          Endpoint(GET / "users" / int("userId")).out[String].implement {
-            Handler.fromFunction { userId =>
-              s"path(users, $userId)"
-            }
-          }
-        val boardUsersPosts         =
-          Endpoint(GET / "users" / int("userId") / "posts")
-            .out[String]
-            .implement {
-              Handler.fromFunction { userId =>
-                s"path(users, $userId, posts)"
-              }
-            }
-        val boardUsersPostsId       =
-          Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, postId) =>
-                s"path(users, $userId, posts, $postId)"
-              }
-            }
-        val boardUsersPostsComments =
-          Endpoint(
-            GET /
-              "users" / int("userId") / "posts" / int("postId") / "comments",
-          )
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, postId) =>
-                s"path(users, $userId, posts, $postId, comments)"
-              }
-            }
+            val boardUsersPostsComments =
+              Endpoint(
+                GET /
+                  "users" / int("userId") / "posts" / int("postId") / "comments",
+              )
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, postId) =>
+                    s"path(users, $userId, posts, $postId, comments)"
+                  }
+                }
 
-        val boardUsersPostsCommentsId        =
-          Endpoint(
-            GET /
-              "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId"),
-          )
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, postId, commentId) =>
-                s"path(users, $userId, posts, $postId, comments, $commentId)"
+            val boardUsersPostsCommentsId        =
+              Endpoint(
+                GET /
+                  "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId"),
+              )
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, postId, commentId) =>
+                    s"path(users, $userId, posts, $postId, comments, $commentId)"
+                  }
+                }
+            val broadPosts                       =
+              Endpoint(GET / "posts").out[String].implement(Handler.succeed("path(posts)"))
+            val broadPostsId                     =
+              Endpoint(GET / "posts" / int("postId")).out[String].implement {
+                Handler.fromFunction { postId =>
+                  s"path(posts, $postId)"
+                }
               }
-            }
-        val broadPosts                       =
-          Endpoint(GET / "posts").out[String].implement(Handler.succeed("path(posts)"))
-        val broadPostsId                     =
-          Endpoint(GET / "posts" / int("postId")).out[String].implement {
-            Handler.fromFunction { postId =>
-              s"path(posts, $postId)"
-            }
-          }
-        val boardPostsComments               =
-          Endpoint(GET / "posts" / int("postId") / "comments")
-            .out[String]
-            .implement {
-              Handler.fromFunction { postId =>
-                s"path(posts, $postId, comments)"
+            val boardPostsComments               =
+              Endpoint(GET / "posts" / int("postId") / "comments")
+                .out[String]
+                .implement {
+                  Handler.fromFunction { postId =>
+                    s"path(posts, $postId, comments)"
+                  }
+                }
+            val boardPostsCommentsId             =
+              Endpoint(GET / "posts" / int("postId") / "comments" / int("commentId"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (postId, commentId) =>
+                    s"path(posts, $postId, comments, $commentId)"
+                  }
+                }
+            val broadComments                    =
+              Endpoint(GET / "comments").out[String].implement(Handler.succeed("path(comments)"))
+            val broadCommentsId                  =
+              Endpoint(GET / "comments" / int("commentId")).out[String].implement {
+                Handler.fromFunction { commentId =>
+                  s"path(comments, $commentId)"
+                }
               }
-            }
-        val boardPostsCommentsId             =
-          Endpoint(GET / "posts" / int("postId") / "comments" / int("commentId"))
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (postId, commentId) =>
-                s"path(posts, $postId, comments, $commentId)"
-              }
-            }
-        val broadComments                    =
-          Endpoint(GET / "comments").out[String].implement(Handler.succeed("path(comments)"))
-        val broadCommentsId                  =
-          Endpoint(GET / "comments" / int("commentId")).out[String].implement {
-            Handler.fromFunction { commentId =>
-              s"path(comments, $commentId)"
-            }
-          }
-        val broadUsersComments               =
-          Endpoint(GET / "users" / int("userId") / "comments")
-            .out[String]
-            .implement {
-              Handler.fromFunction { userId =>
-                s"path(users, $userId, comments)"
-              }
-            }
-        val broadUsersCommentsId             =
-          Endpoint(GET / "users" / int("userId") / "comments" / int("commentId"))
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, commentId) =>
-                s"path(users, $userId, comments, $commentId)"
-              }
-            }
-        val boardUsersPostsCommentsReplies   =
-          Endpoint(
-            GET /
-              "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId") / "replies",
-          )
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, postId, commentId) =>
-                s"path(users, $userId, posts, $postId, comments, $commentId, replies)"
-              }
-            }
-        val boardUsersPostsCommentsRepliesId =
-          Endpoint(
-            GET /
-              "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId") /
-              "replies" / int("replyId"),
-          )
-            .out[String]
-            .implement {
-              Handler.fromFunction { case (userId, postId, commentId, replyId) =>
-                s"path(users, $userId, posts, $postId, comments, $commentId, replies, $replyId)"
-              }
-            }
+            val broadUsersComments               =
+              Endpoint(GET / "users" / int("userId") / "comments")
+                .out[String]
+                .implement {
+                  Handler.fromFunction { userId =>
+                    s"path(users, $userId, comments)"
+                  }
+                }
+            val broadUsersCommentsId             =
+              Endpoint(GET / "users" / int("userId") / "comments" / int("commentId"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, commentId) =>
+                    s"path(users, $userId, comments, $commentId)"
+                  }
+                }
+            val boardUsersPostsCommentsReplies   =
+              Endpoint(
+                GET /
+                  "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId") / "replies",
+              )
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, postId, commentId) =>
+                    s"path(users, $userId, posts, $postId, comments, $commentId, replies)"
+                  }
+                }
+            val boardUsersPostsCommentsRepliesId =
+              Endpoint(
+                GET /
+                  "users" / int("userId") / "posts" / int("postId") / "comments" / int("commentId") /
+                  "replies" / int("replyId"),
+              )
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, postId, commentId, replyId) =>
+                    s"path(users, $userId, posts, $postId, comments, $commentId, replies, $replyId)"
+                  }
+                }
 
-        val testRoutes = testEndpoint(
-          Routes(
-            broadUsers,
-            broadUsersId,
-            boardUsersPosts,
-            boardUsersPostsId,
-            boardUsersPostsComments,
-            boardUsersPostsCommentsId,
-            broadPosts,
-            broadPostsId,
-            boardPostsComments,
-            boardPostsCommentsId,
-            broadComments,
-            broadCommentsId,
-            broadUsersComments,
-            broadUsersCommentsId,
-            boardUsersPostsCommentsReplies,
-            boardUsersPostsCommentsRepliesId,
-          ),
-        ) _
+            val testRoutes = testEndpoint(
+              Routes(
+                broadUsers,
+                broadUsersId,
+                boardUsersPosts,
+                boardUsersPostsId,
+                boardUsersPostsComments,
+                boardUsersPostsCommentsId,
+                broadPosts,
+                broadPostsId,
+                boardPostsComments,
+                boardPostsCommentsId,
+                broadComments,
+                broadCommentsId,
+                broadUsersComments,
+                broadUsersCommentsId,
+                boardUsersPostsCommentsReplies,
+                boardUsersPostsCommentsRepliesId,
+              ),
+            ) _
 
-        testRoutes("/users", "path(users)") &&
-        testRoutes("/users/123", "path(users, 123)") &&
-        testRoutes("/users/123/posts", "path(users, 123, posts)") &&
-        testRoutes("/users/123/posts/555", "path(users, 123, posts, 555)") &&
-        testRoutes("/users/123/posts/555/comments", "path(users, 123, posts, 555, comments)") &&
-        testRoutes("/users/123/posts/555/comments/777", "path(users, 123, posts, 555, comments, 777)") &&
-        testRoutes("/posts", "path(posts)") &&
-        testRoutes("/posts/555", "path(posts, 555)") &&
-        testRoutes("/posts/555/comments", "path(posts, 555, comments)") &&
-        testRoutes("/posts/555/comments/777", "path(posts, 555, comments, 777)") &&
-        testRoutes("/comments", "path(comments)") &&
-        testRoutes("/comments/777", "path(comments, 777)") &&
-        testRoutes("/users/123/comments", "path(users, 123, comments)") &&
-        testRoutes("/users/123/comments/777", "path(users, 123, comments, 777)") &&
-        testRoutes(
-          "/users/123/posts/555/comments/777/replies",
-          "path(users, 123, posts, 555, comments, 777, replies)",
-        ) &&
-        testRoutes(
-          "/users/123/posts/555/comments/777/replies/999",
-          "path(users, 123, posts, 555, comments, 777, replies, 999)",
-        )
-
+            testRoutes("/users", "path(users)") &&
+            testRoutes(s"/users/$userId", s"path(users, $userId)") &&
+            testRoutes(s"/users/$userId/posts", s"path(users, $userId, posts)") &&
+            testRoutes(s"/users/$userId/posts/$postId", s"path(users, $userId, posts, $postId)") &&
+            testRoutes(s"/users/$userId/posts/$postId/comments", s"path(users, $userId, posts, $postId, comments)") &&
+            testRoutes(
+              s"/users/$userId/posts/$postId/comments/$commentId",
+              s"path(users, $userId, posts, $postId, comments, $commentId)",
+            ) &&
+            testRoutes(s"/posts", "path(posts)") &&
+            testRoutes(s"/posts/$postId", s"path(posts, $postId)") &&
+            testRoutes(s"/posts/$postId/comments", s"path(posts, $postId, comments)") &&
+            testRoutes(s"/posts/$postId/comments/$commentId", s"path(posts, $postId, comments, $commentId)") &&
+            testRoutes("/comments", "path(comments)") &&
+            testRoutes(s"/comments/$commentId", s"path(comments, $commentId)") &&
+            testRoutes(s"/users/$userId/comments", s"path(users, $userId, comments)") &&
+            testRoutes(s"/users/$userId/comments/$commentId", s"path(users, $userId, comments, $commentId)") &&
+            testRoutes(
+              s"/users/$userId/posts/$postId/comments/$commentId/replies",
+              s"path(users, $userId, posts, $postId, comments, $commentId, replies)",
+            ) &&
+            testRoutes(
+              s"/users/$userId/posts/$postId/comments/$commentId/replies/$replyId",
+              s"path(users, $userId, posts, $postId, comments, $commentId, replies, $replyId)",
+            )
+        }
       },
       test("composite in codecs") {
-        val headerOrQuery = HeaderCodec.name[String]("X-Header") | QueryCodec.query("header")
-
-        val endpoint = Endpoint(GET / "test").out[String].inCodec(headerOrQuery)
-
-        val routes = endpoint.implement(Handler.identity)
-
-        val request = Request.get(
-          URL
-            .decode("/test?header=query-value")
-            .toOption
-            .get,
-        )
-
-        val requestWithHeaderAndQuery = request.addHeader("X-Header", "header-value")
-
-        val requestWithHeader = Request
-          .get(
+        check(Gen.alphaNumericString, Gen.alphaNumericString) { (queryValue, headerValue) =>
+          val headerOrQuery             = HeaderCodec.name[String]("X-Header") | QueryCodec.query("header")
+          val endpoint                  = Endpoint(GET / "test").out[String].inCodec(headerOrQuery)
+          val routes                    = endpoint.implement(Handler.identity)
+          val request                   = Request.get(
             URL
-              .decode("/test")
+              .decode(s"/test?header=$queryValue")
               .toOption
               .get,
           )
-          .addHeader("X-Header", "header-value")
+          val requestWithHeaderAndQuery = request.addHeader("X-Header", headerValue)
+          val requestWithHeader         = Request
+            .get(
+              URL
+                .decode("/test")
+                .toOption
+                .get,
+            )
+            .addHeader("X-Header", headerValue)
 
-        for {
-          response       <- routes.toHttpApp.runZIO(request)
-          onlyQuery      <- response.body.asString.orDie
-          response       <- routes.toHttpApp.runZIO(requestWithHeader)
-          onlyHeader     <- response.body.asString.orDie
-          response       <- routes.toHttpApp.runZIO(requestWithHeaderAndQuery)
-          headerAndQuery <- response.body.asString.orDie
-        } yield assertTrue(
-          onlyQuery == """"query-value"""",
-          onlyHeader == """"header-value"""",
-          headerAndQuery == """"header-value"""",
-        )
+          for {
+            response       <- routes.toHttpApp.runZIO(request)
+            onlyQuery      <- response.body.asString.orDie
+            response       <- routes.toHttpApp.runZIO(requestWithHeader)
+            onlyHeader     <- response.body.asString.orDie
+            response       <- routes.toHttpApp.runZIO(requestWithHeaderAndQuery)
+            headerAndQuery <- response.body.asString.orDie
+          } yield assertTrue(
+            onlyQuery == s""""$queryValue"""",
+            onlyHeader == s""""$headerValue"""",
+            headerAndQuery == s""""$headerValue"""",
+          )
+        }
       },
       test("composite out codecs") {
-        val headerOrQuery = HeaderCodec.name[String]("X-Header") | StatusCodec.status(Status.Created)
-
-        val endpoint = Endpoint(GET / "test").query(QueryCodec.queryBool("Created")).outCodec(headerOrQuery)
-
-        val routes =
+        val headerOrQuery     = HeaderCodec.name[String]("X-Header") | StatusCodec.status(Status.Created)
+        val endpoint          = Endpoint(GET / "test").query(QueryCodec.queryBool("Created")).outCodec(headerOrQuery)
+        val routes            =
           endpoint.implement {
             Handler.fromFunction { created =>
               if (created) Right(()) else Left("not created")
             }
           }
-
-        val requestCreated = Request.get(
+        val requestCreated    = Request.get(
           URL
             .decode("/test?Created=true")
             .toOption
             .get,
         )
-
         val requestNotCreated = Request.get(
           URL
             .decode("/test?Created=false")
@@ -405,393 +424,427 @@ object EndpointSpec extends ZIOHttpSpec {
       },
       suite("request bodies")(
         test("simple input") {
+          check(Gen.string, Gen.int(1, Int.MaxValue)) { (postValue, postId) =>
+            implicit val newPostSchema: Schema[NewPost] = DeriveSchema.gen[NewPost]
 
-          implicit val newPostSchema: Schema[NewPost] = DeriveSchema.gen[NewPost]
-
-          val endpoint =
-            Endpoint(POST / "posts")
-              .in[NewPost]
-              .out[Int]
-
-          val routes =
-            endpoint.implement(Handler.succeed(42))
-
-          val request =
-            Request
-              .post(
-                URL.decode("/posts").toOption.get,
-                Body.fromString("""{"value": "My new post!"}"""),
-              )
-
-          for {
-            response <- routes.toHttpApp.runZIO(request)
-            body     <- response.body.asString.orDie
-          } yield assertTrue(extractStatus(response).isSuccess) && assertTrue(body == "42")
-        },
-        test("bad request for failed codec") {
-          implicit val newPostSchema: Schema[NewPost] = DeriveSchema.gen[NewPost]
-
-          val endpoint =
-            Endpoint(POST / "posts")
-              .in[NewPost]
-              .out[Int]
-
-          val routes =
-            endpoint.implement(Handler.succeed(42))
-
-          for {
-            response <- routes.toHttpApp.runZIO(
+            val endpoint =
+              Endpoint(POST / "posts")
+                .in[NewPost]
+                .out[Int]
+            val routes   =
+              endpoint.implement(Handler.succeed(postId))
+            val request  =
               Request
                 .post(
                   URL.decode("/posts").toOption.get,
-                  Body.fromString("""{"vale": "My new post!"}"""),
-                ),
-            )
-          } yield assertTrue(extractStatus(response).code == 400)
+                  Body.fromString(s"""{"value": "$postValue"}"""),
+                )
+
+            for {
+              response <- routes.toHttpApp.runZIO(request)
+              body     <- response.body.asString.orDie
+            } yield assertTrue(extractStatus(response).isSuccess) && assertTrue(body == postId.toString)
+          }
+        },
+        test("bad request for failed codec") {
+          check(Gen.string, Gen.int(1, Int.MaxValue)) { (postValue, postId) =>
+            implicit val newPostSchema: Schema[NewPost] = DeriveSchema.gen[NewPost]
+
+            val endpoint =
+              Endpoint(POST / "posts")
+                .in[NewPost]
+                .out[Int]
+            val routes   =
+              endpoint.implement(Handler.succeed(postId))
+
+            for {
+              response <- routes.toHttpApp.runZIO(
+                Request
+                  .post(
+                    URL.decode("/posts").toOption.get,
+                    Body.fromString(s"""{"vale": "$postValue"}"""),
+                  ),
+              )
+            } yield assertTrue(extractStatus(response).code == 400)
+          }
         },
       ),
       suite("404")(
         test("on wrong path") {
-          val testRoutes = test404(
-            Routes(
-              Endpoint(GET / "users" / int("userId"))
-                .out[String]
-                .implement {
-                  Handler.fromFunction { userId =>
-                    s"path(users, $userId)"
-                  }
-                },
-              Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-                .query(query("name"))
-                .out[String]
-                .implement {
-                  Handler.fromFunction { case (userId, postId, name) =>
-                    s"path(users, $userId, posts, $postId) query(name=$name)"
-                  }
-                },
-            ),
-          ) _
-          testRoutes("/user/123", Method.GET) &&
-          testRoutes("/users/123/wrong", Method.GET)
+          check(Gen.int(1, Int.MaxValue)) { userId =>
+            val testRoutes = test404(
+              Routes(
+                Endpoint(GET / "users" / int("userId"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { userId =>
+                      s"path(users, $userId)"
+                    }
+                  },
+                Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
+                  .query(query("name"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { case (userId, postId, name) =>
+                      s"path(users, $userId, posts, $postId) query(name=$name)"
+                    }
+                  },
+              ),
+            ) _
+            testRoutes(s"/user/$userId", Method.GET) &&
+            testRoutes(s"/users/$userId/wrong", Method.GET)
+          }
         },
         test("on wrong method") {
-          val testRoutes = test404(
-            Routes(
-              Endpoint(GET / "users" / int("userId"))
-                .out[String]
-                .implement {
-                  Handler.fromFunction { userId =>
-                    s"path(users, $userId)"
-                  }
-                },
-              Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-                .query(query("name"))
-                .out[String]
-                .implement {
-                  Handler.fromFunction { case (userId, postId, name) =>
-                    s"path(users, $userId, posts, $postId) query(name=$name)"
-                  }
-                },
-            ),
-          ) _
-          testRoutes("/users/123", Method.POST) &&
-          testRoutes("/users/123/posts/555?name=adam", Method.PUT)
+          check(Gen.int(1, Int.MaxValue), Gen.int(1, Int.MaxValue), Gen.alphaNumericString) { (userId, postId, name) =>
+            val testRoutes = test404(
+              Routes(
+                Endpoint(GET / "users" / int("userId"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { userId =>
+                      s"path(users, $userId)"
+                    }
+                  },
+                Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
+                  .query(query("name"))
+                  .out[String]
+                  .implement {
+                    Handler.fromFunction { case (userId, postId, name) =>
+                      s"path(users, $userId, posts, $postId) query(name=$name)"
+                    }
+                  },
+              ),
+            ) _
+            testRoutes(s"/users/$userId", Method.POST) &&
+            testRoutes(s"/users/$userId/posts/$postId?name=$name", Method.PUT)
+          }
         },
       ),
       suite("custom error")(
         test("simple custom error response") {
-          val routes =
-            Endpoint(GET / "users" / int("userId"))
-              .out[String]
-              .outError[String](Status.Custom(999))
-              .implement {
-                Handler.fromFunctionZIO { userId =>
-                  ZIO.fail(s"path(users, $userId)")
+          check(Gen.int(1, Int.MaxValue), Gen.int) { (userId, customCode) =>
+            val routes  =
+              Endpoint(GET / "users" / int("userId"))
+                .out[String]
+                .outError[String](Status.Custom(customCode))
+                .implement {
+                  Handler.fromFunctionZIO { userId =>
+                    ZIO.fail(s"path(users, $userId)")
+                  }
                 }
-              }
+            val request =
+              Request
+                .get(
+                  URL.decode(s"/users/$userId").toOption.get,
+                )
 
-          val request =
-            Request
-              .get(
-                URL.decode("/users/123").toOption.get,
-              )
-
-          for {
-            response <- routes.toHttpApp.runZIO(request)
-            body     <- response.body.asString.orDie
-          } yield assertTrue(extractStatus(response).code == 999, body == "\"path(users, 123)\"")
+            for {
+              response <- routes.toHttpApp.runZIO(request)
+              body     <- response.body.asString.orDie
+            } yield assertTrue(extractStatus(response).code == customCode, body == s""""path(users, $userId)"""")
+          }
         },
         test("status depending on the error subtype") {
-          val routes =
-            Endpoint(GET / "users" / int("userId"))
-              .out[String]
-              .outErrors[TestError](
-                HttpCodec.error[TestError.UnexpectedError](Status.InternalServerError),
-                HttpCodec.error[TestError.InvalidUser](Status.NotFound),
-              )
-              .implement {
-                Handler.fromFunctionZIO { userId =>
-                  if (userId == 123) ZIO.fail(TestError.InvalidUser(userId))
-                  else ZIO.fail(TestError.UnexpectedError("something went wrong"))
+          check(Gen.int(1, 1000), Gen.int(1001, Int.MaxValue)) { (myUserId, invalidUserId) =>
+            val routes =
+              Endpoint(GET / "users" / int("userId"))
+                .out[String]
+                .outErrors[TestError](
+                  HttpCodec.error[TestError.UnexpectedError](Status.InternalServerError),
+                  HttpCodec.error[TestError.InvalidUser](Status.NotFound),
+                )
+                .implement {
+                  Handler.fromFunctionZIO { userId =>
+                    if (userId == myUserId) ZIO.fail(TestError.InvalidUser(userId))
+                    else ZIO.fail(TestError.UnexpectedError("something went wrong"))
+                  }
                 }
-              }
 
-          val request1 = Request.get(URL.decode("/users/123").toOption.get)
-          val request2 = Request.get(URL.decode("/users/321").toOption.get)
+            val request1 = Request.get(URL.decode(s"/users/$myUserId").toOption.get)
+            val request2 = Request.get(URL.decode(s"/users/$invalidUserId").toOption.get)
 
-          for {
-            response1 <- routes.toHttpApp.runZIO(request1)
-            body1     <- response1.body.asString.orDie
+            for {
+              response1 <- routes.toHttpApp.runZIO(request1)
+              body1     <- response1.body.asString.orDie
 
-            response2 <- routes.toHttpApp.runZIO(request2)
-            body2     <- response2.body.asString.orDie
-          } yield assertTrue(
-            extractStatus(response1) == Status.NotFound,
-            body1 == "{\"userId\":123}",
-            extractStatus(response2) == Status.InternalServerError,
-            body2 == "{\"message\":\"something went wrong\"}",
-          )
+              response2 <- routes.toHttpApp.runZIO(request2)
+              body2     <- response2.body.asString.orDie
+            } yield assertTrue(
+              extractStatus(response1) == Status.NotFound,
+              body1 == s"""{"userId":$myUserId}""",
+              extractStatus(response2) == Status.InternalServerError,
+              body2 == """{"message":"something went wrong"}""",
+            )
+          }
         },
         test("validation occurs automatically on schema") {
+          check(Gen.int(1, Int.MaxValue)) { userId =>
+            implicit val schema: Schema[User] = DeriveSchema.gen[User]
 
-          implicit val schema: Schema[User] = DeriveSchema.gen[User]
-
-          val routes =
-            Endpoint(POST / "users")
-              .in[User]
-              .out[String]
-              .implement {
-                Handler.fromFunctionZIO { _ =>
-                  ZIO.succeed("User ID is greater than 0")
+            val routes =
+              Endpoint(POST / "users")
+                .in[User]
+                .out[String]
+                .implement {
+                  Handler.fromFunctionZIO { _ =>
+                    ZIO.succeed("User ID is greater than 0")
+                  }
                 }
-              }
-              .handleErrorCause { case cause =>
-                Response.text("Caught: " + cause.defects.headOption.fold("no known cause")(d => d.getMessage))
-              }
+                .handleErrorCause { cause =>
+                  Response.text("Caught: " + cause.defects.headOption.fold("no known cause")(d => d.getMessage))
+                }
 
-          val request1 = Request.post(URL.decode("/users").toOption.get, Body.fromString("""{"id":0}"""))
-          val request2 = Request.post(URL.decode("/users").toOption.get, Body.fromString("""{"id":1}"""))
+            val request1 = Request.post(URL.decode("/users").toOption.get, Body.fromString("""{"id":0}"""))
+            val request2 = Request.post(URL.decode("/users").toOption.get, Body.fromString(s"""{"id":$userId}"""))
 
-          for {
-            response1 <- routes.toHttpApp.runZIO(request1)
-            body1     <- response1.body.asString.orDie
-
-            response2 <- routes.toHttpApp.runZIO(request2)
-            body2     <- response2.body.asString.orDie
-          } yield assertTrue(
-            extractStatus(response1) == Status.BadRequest,
-            body1 == "",
-            extractStatus(response2) == Status.Ok,
-            body2 == "\"User ID is greater than 0\"",
-          )
+            for {
+              response1 <- routes.toHttpApp.runZIO(request1)
+              body1     <- response1.body.asString.orDie
+              response2 <- routes.toHttpApp.runZIO(request2)
+              body2     <- response2.body.asString.orDie
+            } yield assertTrue(
+              extractStatus(response1) == Status.BadRequest,
+              body1 == "",
+              extractStatus(response2) == Status.Ok,
+              body2 == "\"User ID is greater than 0\"",
+            )
+          }
         },
       ),
       suite("byte stream input/output")(
         test("responding with a byte stream") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(GET / "test-byte-stream")
-                .outStream[Byte]
-                .implement(Handler.succeed(ZStream.fromChunk(bytes).rechunk(16)))
+          check(Gen.chunkOfBounded(1, 1024)(Gen.byte)) { bytes =>
+            val route = Endpoint(GET / "test-byte-stream")
+              .outStream[Byte]
+              .implement(Handler.succeed(ZStream.fromChunk(bytes).rechunk(16)))
 
-            result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-byte-stream").toOption.get)).exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            body     <- response.body.asChunk.orDie
-          } yield assertTrue(
-            response.header(ContentType) == Some(ContentType(MediaType.application.`octet-stream`)),
-            body == bytes,
-          )
+            for {
+              result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-byte-stream").toOption.get)).exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
+                  }
+              }
+              body     <- response.body.asChunk.orDie
+            } yield assertTrue(
+              response.header(ContentType) == Some(ContentType(MediaType.application.`octet-stream`)),
+              body == bytes,
+            )
+          }
         },
         test("responding with a byte stream, custom media type") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(GET / "test-byte-stream")
-                .outStream[Byte](Status.Ok, MediaType.image.png)
-                .implement(Handler.succeed(ZStream.fromChunk(bytes).rechunk(16)))
+          check(Gen.chunkOfBounded(1, 1024)(Gen.byte)) { bytes =>
+            val route = Endpoint(GET / "test-byte-stream")
+              .outStream[Byte](Status.Ok, MediaType.image.png)
+              .implement(Handler.succeed(ZStream.fromChunk(bytes).rechunk(16)))
 
-            result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-byte-stream").toOption.get)).exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            body     <- response.body.asChunk.orDie
-          } yield assertTrue(
-            response.header(ContentType) == Some(ContentType(MediaType.image.png)),
-            body == bytes,
-          )
+            for {
+              result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-byte-stream").toOption.get)).exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
+                  }
+              }
+              body     <- response.body.asChunk.orDie
+            } yield assertTrue(
+              response.header(ContentType) == Some(ContentType(MediaType.image.png)),
+              body == bytes,
+            )
+          }
         },
         test("request body as a byte stream") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(POST / "test-byte-stream")
-                .inStream[Byte]
-                .out[Long]
-                .implement {
-                  Handler.fromFunctionZIO { byteStream =>
-                    byteStream.runCount
+          check(Gen.chunkOfBounded(1, 1024)(Gen.byte)) { bytes =>
+            val route = Endpoint(POST / "test-byte-stream")
+              .inStream[Byte]
+              .out[Long]
+              .implement {
+                Handler.fromFunctionZIO { byteStream =>
+                  byteStream.runCount
+                }
+              }
+
+            for {
+              result   <- route.toHttpApp
+                .runZIO(Request.post(URL.decode("/test-byte-stream").toOption.get, Body.fromChunk(bytes)))
+                .exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
                   }
-                }
-            result   <- route.toHttpApp
-              .runZIO(Request.post(URL.decode("/test-byte-stream").toOption.get, Body.fromChunk(bytes)))
-              .exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            body     <- response.body.asString.orDie
-          } yield assertTrue(
-            body == "1024",
-          )
+              }
+              body     <- response.body.asString.orDie
+            } yield assertTrue(body == bytes.size.toString)
+          }
         },
       ),
       suite("multipart/form-data")(
         test("multiple outputs produce multipart response") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(GET / "test-form")
-                .outCodec(
-                  HttpCodec.contentStream[Byte]("image", MediaType.image.png) ++
-                    HttpCodec.content[String]("title") ++
-                    HttpCodec.content[Int]("width") ++
-                    HttpCodec.content[Int]("height") ++
-                    HttpCodec.content[ImageMetadata]("metadata"),
-                )
-                .implement {
-                  Handler.succeed(
-                    (
-                      ZStream.fromChunk(bytes),
-                      "example",
-                      320,
-                      200,
-                      ImageMetadata("some description", Instant.parse("2020-01-01T00:00:00Z")),
-                    ),
+          check(
+            Gen.alphaNumericString,
+            Gen.int(1, Int.MaxValue),
+            Gen.int(1, Int.MaxValue),
+            Gen.alphaNumericString,
+            Gen.instant,
+          ) { (title, width, height, description, createdAt) =>
+            for {
+              bytes <- Random.nextBytes(1024)
+              route =
+                Endpoint(GET / "test-form")
+                  .outCodec(
+                    HttpCodec.contentStream[Byte]("image", MediaType.image.png) ++
+                      HttpCodec.content[String]("title") ++
+                      HttpCodec.content[Int]("width") ++
+                      HttpCodec.content[Int]("height") ++
+                      HttpCodec.content[ImageMetadata]("metadata"),
                   )
-                }
-            result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-form").toOption.get)).exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            form     <- response.body.asMultipartForm.orDie
-            mediaType = response.header(Header.ContentType).map(_.mediaType)
-          } yield assertTrue(
-            mediaType == Some(MediaType.multipart.`form-data`),
-            form.formData.size == 5,
-            form.formData.map(_.name).toSet == Set("image", "title", "width", "height", "metadata"),
-            form.get("image").map(_.contentType) == Some(MediaType.image.png),
-            form.get("image").map(_.asInstanceOf[FormField.Binary].data) == Some(bytes),
-            form.get("title").map(_.asInstanceOf[FormField.Text].value) == Some("example"),
-            form.get("width").map(_.asInstanceOf[FormField.Text].value) == Some("320"),
-            form.get("height").map(_.asInstanceOf[FormField.Text].value) == Some("200"),
-            form.get("metadata").map(_.asInstanceOf[FormField.Binary].data) == Some(
-              Chunk.fromArray("""{"description":"some description","createdAt":"2020-01-01T00:00:00Z"}""".getBytes),
-            ),
-          )
+                  .implement {
+                    Handler.succeed(
+                      (
+                        ZStream.fromChunk(bytes),
+                        title,
+                        width,
+                        height,
+                        ImageMetadata(description, createdAt),
+                      ),
+                    )
+                  }
+              result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-form").toOption.get)).exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
+                  }
+              }
+              form     <- response.body.asMultipartForm.orDie
+              mediaType = response.header(Header.ContentType).map(_.mediaType)
+            } yield assertTrue(
+              mediaType == Some(MediaType.multipart.`form-data`),
+              form.formData.size == 5,
+              form.formData.map(_.name).toSet == Set("image", "title", "width", "height", "metadata"),
+              form.get("image").map(_.contentType) == Some(MediaType.image.png),
+              form.get("image").map(_.asInstanceOf[FormField.Binary].data) == Some(bytes),
+              form.get("title").map(_.asInstanceOf[FormField.Text].value) == Some(title),
+              form.get("width").map(_.asInstanceOf[FormField.Text].value) == Some(width.toString),
+              form.get("height").map(_.asInstanceOf[FormField.Text].value) == Some(height.toString),
+              form.get("metadata").map(_.asInstanceOf[FormField.Binary].data) == Some(
+                Chunk.fromArray(s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes),
+              ),
+            )
+          }
         },
         test("outputs without name get automatically generated names") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(GET / "test-form")
-                .outCodec(
-                  HttpCodec.contentStream[Byte](MediaType.image.png) ++
-                    HttpCodec.content[String] ++
-                    HttpCodec.content[Int] ++
-                    HttpCodec.content[Int] ++
-                    HttpCodec.content[ImageMetadata],
-                )
-                .implement {
-                  Handler.succeed(
-                    (
-                      ZStream.fromChunk(bytes),
-                      "example",
-                      320,
-                      200,
-                      ImageMetadata("some description", Instant.parse("2020-01-01T00:00:00Z")),
-                    ),
+          check(
+            Gen.alphaNumericString,
+            Gen.int(1, Int.MaxValue),
+            Gen.int(1, Int.MaxValue),
+            Gen.alphaNumericString,
+            Gen.instant,
+          ) { (title, width, height, description, createdAt) =>
+            for {
+              bytes <- Random.nextBytes(1024)
+              route =
+                Endpoint(GET / "test-form")
+                  .outCodec(
+                    HttpCodec.contentStream[Byte](MediaType.image.png) ++
+                      HttpCodec.content[String] ++
+                      HttpCodec.content[Int] ++
+                      HttpCodec.content[Int] ++
+                      HttpCodec.content[ImageMetadata],
                   )
-                }
-            result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-form").toOption.get)).exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            form     <- response.body.asMultipartForm.orDie
-            mediaType = response.header(Header.ContentType).map(_.mediaType)
-          } yield assertTrue(
-            mediaType == Some(MediaType.multipart.`form-data`),
-            form.formData.size == 5,
-            form.formData.map(_.name).toSet == Set("field0", "field1", "field2", "field3", "field4"),
-          )
+                  .implement {
+                    Handler.succeed(
+                      (
+                        ZStream.fromChunk(bytes),
+                        title,
+                        width,
+                        height,
+                        ImageMetadata(description, createdAt),
+                      ),
+                    )
+                  }
+              result   <- route.toHttpApp.runZIO(Request.get(URL.decode("/test-form").toOption.get)).exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
+                  }
+              }
+              form     <- response.body.asMultipartForm.orDie
+              mediaType = response.header(Header.ContentType).map(_.mediaType)
+            } yield assertTrue(
+              mediaType == Some(MediaType.multipart.`form-data`),
+              form.formData.size == 5,
+              form.formData.map(_.name).toSet == Set("field0", "field1", "field2", "field3", "field4"),
+              form.get("field0").map(_.contentType) == Some(MediaType.image.png),
+              form.get("field0").map(_.asInstanceOf[FormField.Binary].data) == Some(bytes),
+              form.get("field1").map(_.asInstanceOf[FormField.Text].value) == Some(title),
+              form.get("field2").map(_.asInstanceOf[FormField.Text].value) == Some(width.toString),
+              form.get("field3").map(_.asInstanceOf[FormField.Text].value) == Some(height.toString),
+              form.get("field4").map(_.asInstanceOf[FormField.Binary].data) == Some(
+                Chunk.fromArray(s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes),
+              ),
+            )
+          }
         },
         test("multiple inputs got decoded from multipart/form-data body") {
-          for {
-            bytes <- Random.nextBytes(1024)
-            route =
-              Endpoint(POST / "test-form")
-                .inStream[Byte]("uploaded-image")
-                .in[String]("title")
-                .in[ImageMetadata]("metadata")
-                .out[(Long, String, ImageMetadata)]
-                .implement {
-                  Handler.fromFunctionZIO { case (stream, title, metadata) =>
-                    stream.runCount.map(count => (count, title, metadata))
+          check(Gen.alphaNumericString, Gen.alphaNumericString, Gen.instant) { (title, description, createdAt) =>
+            for {
+              bytes <- Random.nextBytes(1024)
+              route =
+                Endpoint(POST / "test-form")
+                  .inStream[Byte]("uploaded-image")
+                  .in[String]("title")
+                  .in[ImageMetadata]("metadata")
+                  .out[(Long, String, ImageMetadata)]
+                  .implement {
+                    Handler.fromFunctionZIO { case (stream, title, metadata) =>
+                      stream.runCount.map(count => (count, title, metadata))
+                    }
                   }
-                }
-            form  = Form(
-              FormField.simpleField("title", "Hello world"),
-              FormField.binaryField(
-                "metadata",
-                Chunk.fromArray("""{"description":"some description","createdAt":"2020-01-01T00:00:00Z"}""".getBytes),
-                MediaType.application.json,
-              ),
-              FormField.binaryField("uploaded-image", bytes, MediaType.image.png),
-            )
-            boundary <- Boundary.randomUUID
-            result   <- route.toHttpApp
-              .runZIO(
-                Request.post(URL.decode("/test-form").toOption.get, Body.fromMultipartForm(form, boundary)),
+              form  = Form(
+                FormField.simpleField("title", title),
+                FormField.binaryField(
+                  "metadata",
+                  Chunk.fromArray(
+                    s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes,
+                  ),
+                  MediaType.application.json,
+                ),
+                FormField.binaryField("uploaded-image", bytes, MediaType.image.png),
               )
-              .exit
-            response <- result match {
-              case Exit.Success(value) => ZIO.succeed(value)
-              case Exit.Failure(cause) =>
-                cause.failureOrCause match {
-                  case Left(response) => ZIO.succeed(response)
-                  case Right(cause)   => ZIO.failCause(cause)
-                }
-            }
-            result   <- response.body.asString.orDie
-          } yield assertTrue(
-            result == """[[1024,"Hello world"],{"description":"some description","createdAt":"2020-01-01T00:00:00Z"}]""",
-          )
+              boundary <- Boundary.randomUUID
+              result   <- route.toHttpApp
+                .runZIO(
+                  Request.post(URL.decode("/test-form").toOption.get, Body.fromMultipartForm(form, boundary)),
+                )
+                .exit
+              response <- result match {
+                case Exit.Success(value) => ZIO.succeed(value)
+                case Exit.Failure(cause) =>
+                  cause.failureOrCause match {
+                    case Left(response) => ZIO.succeed(response)
+                    case Right(cause)   => ZIO.failCause(cause)
+                  }
+              }
+              result   <- response.body.asString.orDie
+            } yield assertTrue(
+              result == s"""[[1024,"$title"],{"description":"$description","createdAt":"$createdAt"}]""",
+            )
+          }
         },
         test("multipart input/output roundtrip check") {
           check(Gen.chunkOfBounded(2, 8)(formField)) { fields =>

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -502,7 +502,7 @@ object EndpointSpec extends ZIOHttpSpec {
             val endpoint =
               Endpoint(POST / "posts")
                 .in[NewPost](Doc.p("New post"))
-                .out[PostCreated](Status.Created)
+                .out[PostCreated](Status.Created, MediaType.application.`json`)
             val routes   =
               endpoint.implement(Handler.succeed(PostCreated(postId)))
             val request  =
@@ -514,10 +514,12 @@ object EndpointSpec extends ZIOHttpSpec {
 
             for {
               response <- routes.toHttpApp.runZIO(request)
-              responseCode = extractStatus(response)
+              code        = extractStatus(response)
+              contentType = response.header(Header.ContentType)
               body <- response.body.asString.orDie
             } yield assertTrue(extractStatus(response).isSuccess) &&
-              assertTrue(responseCode == Status.Created) &&
+              assertTrue(code == Status.Created) &&
+              assertTrue(contentType == Some(ContentType(MediaType.application.`json`))) &&
               assertTrue(body == s"""{"id":$postId}""")
           }
         },

--- a/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -24,9 +24,8 @@ import zio.test._
 import zio.stream.ZStream
 
 import zio.schema.annotation.validate
-import zio.schema.codec.{DecodeError, JsonCodec}
 import zio.schema.validation.Validation
-import zio.schema.{DeriveSchema, Schema, StandardType}
+import zio.schema.{DeriveSchema, Schema}
 
 import zio.http.Header.ContentType
 import zio.http.Method._


### PR DESCRIPTION
Current **test coverage** on main branch for `Endpoint` is: **41.25%** ([Codecov](https://app.codecov.io/github/zio/zio-http/blob/main/zio-http%2Fsrc%2Fmain%2Fscala%2Fzio%2Fhttp%2Fendpoint%2FEndpoint.scala)).

The test coverage of this branch improves for `Endpoint`: around **+20%**.

A summary of the changes introduces in this PR are:
- Add tests for `.header`
- Add tests for `Doc` method variants of `.out`, `.outStream`, `.in`, `.inStream`
- Add tests for `.out` variants (custom status code, custom media type, ...)
- Introduce generators

There are for sure still margin of improvements, so any feedback is more than welcome.

Closes: https://github.com/zio/zio-http/issues/2204
/claim https://github.com/zio/zio-http/issues/2204