### PR TITLE
Fix stream body delay

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -29,7 +29,9 @@ import io.netty.channel._
 import io.netty.handler.codec.http.{DefaultHttpContent, LastHttpContent}
 object NettyBodyWriter {
 
-  def writeAndFlush(body: Body, ctx: ChannelHandlerContext)(implicit trace: Trace): Option[Task[Unit]] =
+  def writeAndFlush(body: Body, contentLength: Option[Long], ctx: ChannelHandlerContext)(implicit
+    trace: Trace,
+  ): Option[Task[Unit]] =
     body match {
       case body: ByteBufBody                  =>
         ctx.write(body.byteBuf)
@@ -66,27 +68,44 @@ object NettyBodyWriter {
         None
       case StreamBody(stream, _, _)           =>
         Some(
-          stream.chunks
-            .runFoldZIO(Option.empty[Chunk[Byte]]) {
-              case (Some(previous), current) =>
+          contentLength match {
+            case Some(length) =>
+              stream.chunks
+                .runFoldZIO(length) { (remaining, bytes) =>
+                  remaining - bytes.size match {
+                    case 0L =>
+                      NettyFutureExecutor.executed {
+                        ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes.toArray)))
+                        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+                      }.as(0)
+
+                    case n =>
+                      NettyFutureExecutor.executed {
+                        ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes.toArray)))
+                      }.as(n)
+                  }
+                }
+                .flatMap {
+                  case 0L        => ZIO.unit
+                  case remaining =>
+                    val actualLength = length - remaining
+                    ZIO.logWarning(s"Expected Content-Length of $length, but sent $actualLength bytes") *>
+                      NettyFutureExecutor.executed {
+                        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+                      }
+                }
+
+            case None =>
+              stream.chunks.mapZIO { bytes =>
                 NettyFutureExecutor.executed {
-                  ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(previous.toArray)))
-                } *>
-                  ZIO.succeed(Some(current))
-              case (_, current)              =>
-                ZIO.succeed(Some(current))
-            }
-            .flatMap { maybeLastChunk =>
-              // last chunk is handled separately to avoid fiber interrupt before EMPTY_LAST_CONTENT is sent
-              ZIO.attempt(
-                maybeLastChunk.foreach { lastChunk =>
-                  ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(lastChunk.toArray)))
-                },
-              ) *>
+                  ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes.toArray)))
+                }
+              }.runDrain.zipRight {
                 NettyFutureExecutor.executed {
                   ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
                 }
-            },
+              }
+          },
         )
       case ChunkBody(data, _, _)              =>
         ctx.write(Unpooled.wrappedBuffer(data.toArray))

--- a/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -75,9 +75,10 @@ object NettyBodyWriter {
                   remaining - bytes.size match {
                     case 0L =>
                       NettyFutureExecutor.executed {
+                        // Flushes the last body content and LastHttpContent together to avoid race conditions.
                         ctx.write(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes.toArray)))
                         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-                      }.as(0)
+                      }.as(0L)
 
                     case n =>
                       NettyFutureExecutor.executed {

--- a/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
@@ -55,7 +55,7 @@ final class ClientInboundHandler(
         ctx.writeAndFlush(fullRequest)
       case _: HttpRequest               =>
         ctx.write(jReq)
-        NettyBodyWriter.writeAndFlush(req.body, ctx).foreach { effect =>
+        NettyBodyWriter.writeAndFlush(req.body, None, ctx).foreach { effect =>
           rtm.run(ctx, NettyRuntime.noopEnsuring)(effect)(Unsafe.unsafe, trace)
         }
     }

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -175,7 +175,7 @@ private[zio] final case class ServerInboundHandler(
         if (!jResponse.isInstanceOf[FullHttpResponse]) {
           val contentLength = jResponse.headers.get(HttpHeaderNames.CONTENT_LENGTH) match {
             case null  => None
-            case value => value.toLongOption
+            case value => Some(value.toLong)
           }
           NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx)
         } else


### PR DESCRIPTION
/claim #2284

This PR reverts #2156 to fix #2284.

#2156, which is an attempt to solve #2155, does not seem to be a proper solution for the problem. Especially the Scenario 2 described in #2155 requires the full HTTP 1.1 Pipelining implementation, but pipelining has several drawbacks so that it is now superseded by [HTTP 2 Multiplexing](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-http2-17#section-5).

https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x#http_pipelining
> **Note:** HTTP pipelining is not activated by default in modern browsers:
>
> - Buggy [proxies](https://en.wikipedia.org/wiki/Proxy_server) are still common and these lead to strange and erratic behaviors that Web developers cannot foresee and diagnose easily.
> - Pipelining is complex to implement correctly: the size of the resource being transferred, the effective [RTT](https://en.wikipedia.org/wiki/Round-trip_delay_time) that will be used, as well as the effective bandwidth, have a direct incidence on the improvement provided by the pipeline. Without knowing these, important messages may be delayed behind unimportant ones. The notion of important even evolves during page layout! HTTP pipelining therefore brings a marginal improvement in most cases only.
> - Pipelining is subject to the [HOL](https://en.wikipedia.org/wiki/Head-of-line_blocking) problem.
> 
> For these reasons, pipelining has been superseded by a better algorithm, _multiplexing_, that is used by HTTP/2.
