### PR TITLE
Negative values support for TextCodec and SegmentCodec

### DIFF
--- a/zio-http/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -148,6 +148,7 @@ object SegmentCodec          {
         val SegmentCodec = segments(index)
         var i            = 0
         var defined      = true
+        if (SegmentCodec.length > 1 && SegmentCodec.charAt(0) == '-') i += 1
         while (i < SegmentCodec.length) {
           if (!SegmentCodec.charAt(i).isDigit) {
             defined = false
@@ -170,6 +171,7 @@ object SegmentCodec          {
         val SegmentCodec = segments(index)
         var i            = 0
         var defined      = true
+        if (SegmentCodec.length > 1 && SegmentCodec.charAt(0) == '-') i += 1
         while (i < SegmentCodec.length) {
           if (!SegmentCodec.charAt(i).isDigit) {
             defined = false

--- a/zio-http/src/main/scala/zio/http/codec/TextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/TextCodec.scala
@@ -94,6 +94,7 @@ object TextCodec {
     def isDefinedAt(value: String): Boolean = {
       var i       = 0
       var defined = true
+      if (value.length > 1 && value.charAt(0) == '-') i += 1
       while (i < value.length) {
         if (!value.charAt(i).isDigit) {
           defined = false
@@ -117,6 +118,7 @@ object TextCodec {
     def isDefinedAt(value: String): Boolean = {
       var i       = 0
       var defined = true
+      if (value.length > 1 && value.charAt(0) == '-') i += 1
       while (i < value.length) {
         if (!value.charAt(i).isDigit) {
           defined = false


### PR DESCRIPTION
Add support for negative numbers in `TextCodec` and `SegmentCodec`. Both negative `Int` and `Long` will be correctly parsed in URL segments, headers and query parameters.

Closes #2378
/claim #2378