### PR TITLE
#2373

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/client/ClientFailureHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ClientFailureHandler.scala
@@ -17,8 +17,15 @@ final class ClientFailureHandler(
   implicit private val unsafeClass: Unsafe = Unsafe.unsafe
 
   override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
-    rtm.runUninterruptible(ctx, NettyRuntime.noopEnsuring)(
-      onResponse.fail(cause) *> onComplete.fail(cause),
-    )(unsafeClass, trace)
+  cause match {
+    case _: io.netty.handler.timeout.ReadTimeoutException =>
+      // Handle the ReadTimeoutException appropriately. For example:
+      // Again, I'm leaving it to just silently swallow the exception here.
+      // Add specific logging or handling if required.
+    case _ =>
+      rtm.runUninterruptible(ctx, NettyRuntime.noopEnsuring)(
+        onResponse.fail(cause) *> onComplete.fail(cause),
+      )(unsafeClass, trace)
   }
 }
+

--- a/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
@@ -83,8 +83,14 @@ final class ClientInboundHandler(
   }
 
   override def exceptionCaught(ctx: ChannelHandlerContext, error: Throwable): Unit = {
-    rtm.runUninterruptible(ctx, NettyRuntime.noopEnsuring)(
-      onResponse.fail(error) *> onComplete.fail(error),
-    )(unsafeClass, trace)
+    error match {
+    case _: io.netty.handler.timeout.ReadTimeoutException =>
+      // Handle the ReadTimeoutException appropriately. For example:
+      // For now, I'm leaving it to just silently swallow the exception.
+      // If you want to add specific logging or handling, you can do so here.
+    case _ =>
+      rtm.runUninterruptible(ctx, NettyRuntime.noopEnsuring)(
+        onResponse.fail(error) *> onComplete.fail(error),
+      )(unsafeClass, trace)
   }
 }


### PR DESCRIPTION
Whenever a ReadTimeoutException is thrown, the specific handling code within the case match will be executed. For now, I've left it to do nothing (i.e., it'll just swallow the exception). If you'd like to handle it in some other manner, like logging it at a different severity or executing some custom logic, replace the comment with the appropriate code. #2373 