### PR TITLE
ZClient fast shutdown

### DIFF
--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -268,7 +268,7 @@ object ZClient {
 
   val default: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
-    (ZLayer.succeed(Config.default) ++ ZLayer.succeed(NettyConfig.default) ++
+    (ZLayer.succeed(Config.default) ++ ZLayer.succeed(NettyConfig.defaultWithFastShutdown) ++
       DnsResolver.default) >>> live
   }
 
@@ -523,6 +523,7 @@ object ZClient {
     webSocketConfig: WebSocketConfig,
     idleTimeout: Option[Duration],
     connectionTimeout: Option[Duration],
+    shutdownQuietPeriod: Duration,
   ) {
     self =>
 
@@ -610,6 +611,7 @@ object ZClient {
       webSocketConfig = WebSocketConfig.default,
       idleTimeout = Some(50.seconds),
       connectionTimeout = None,
+      shutdownQuietPeriod = 100.milliseconds,
     )
   }
 

--- a/zio-http/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/src/main/scala/zio/http/ZClient.scala
@@ -523,7 +523,6 @@ object ZClient {
     webSocketConfig: WebSocketConfig,
     idleTimeout: Option[Duration],
     connectionTimeout: Option[Duration],
-    shutdownQuietPeriod: Duration,
   ) {
     self =>
 
@@ -611,7 +610,6 @@ object ZClient {
       webSocketConfig = WebSocketConfig.default,
       idleTimeout = Some(50.seconds),
       connectionTimeout = None,
-      shutdownQuietPeriod = 100.milliseconds,
     )
   }
 

--- a/zio-http/src/main/scala/zio/http/netty/NettyConfig.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyConfig.scala
@@ -82,8 +82,8 @@ object NettyConfig {
   )
 
   lazy val defaultWithFastShutdown: NettyConfig = default.copy(
-    shutdownQuietPeriodDuration = Duration.fromMillis(100),
-    shutdownTimeoutDuration = Duration.fromMillis(100),
+    shutdownQuietPeriodDuration = Duration.fromMillis(50),
+    shutdownTimeoutDuration = Duration.fromMillis(250),
   )
 
   sealed trait LeakDetectionLevel {

--- a/zio-http/src/test/scala/zio/http/ClientLayerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientLayerSpec.scala
@@ -1,9 +1,11 @@
 package zio.http
 
 import java.util.concurrent.TimeUnit
+
 import zio.test.Assertion.{isGreaterThan, isLessThan, isWithin}
 import zio.test.{TestAspect, assertZIO}
 import zio.{Clock, ZIO, ZLayer, durationInt}
+
 import zio.http.Client
 import zio.http.netty.NettyConfig
 
@@ -23,7 +25,7 @@ object ClientLayerSpec extends ZIOHttpSpec {
     test("netty client should allow customizing quiet period for client shutdown") {
       val customNettyConfig =
         NettyConfig.default
-                   .copy(shutdownQuietPeriodDuration = 2900.millis, shutdownTimeoutDuration = 3100.millis)
+          .copy(shutdownQuietPeriodDuration = 2900.millis, shutdownTimeoutDuration = 3100.millis)
       val customClientLayer =
         (ZLayer.succeed(Client.Config.default) ++ ZLayer.succeed(customNettyConfig) ++
           DnsResolver.default) >>> Client.live
@@ -32,10 +34,10 @@ object ClientLayerSpec extends ZIOHttpSpec {
         startTime <- ZIO.scoped {
           customClientLayer.build *> Clock.currentTime(TimeUnit.MILLISECONDS)
         }
-        endTime <- Clock.currentTime(TimeUnit.MILLISECONDS)
+        endTime   <- Clock.currentTime(TimeUnit.MILLISECONDS)
       } yield endTime - startTime
       assertZIO[Any, Throwable, Long](timeDifference)(
-        isWithin(2900L, 3100L)
+        isWithin(2900L, 3100L),
       )
     } @@ TestAspect.withLiveClock,
   )

--- a/zio-http/src/test/scala/zio/http/ClientLayerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientLayerSpec.scala
@@ -1,0 +1,28 @@
+package zio.http
+
+import java.util.concurrent.TimeUnit
+
+import zio.test.Assertion.isLessThan
+import zio.test.{TestAspect, assertZIO}
+import zio.{Clock, ZIO, durationInt}
+
+import zio.http.Client
+
+object ClientLayerSpec extends ZIOHttpSpec {
+
+  def clientLayerSpec = suite("ClientLayerSpec")(
+    test("default client should shutdown within 200 ms") {
+      val timeDifference = for {
+        startTime <- ZIO.scoped {
+          Client.default.build *>
+            Clock.currentTime(TimeUnit.MILLISECONDS)
+        }
+        endTime   <- Clock.currentTime(TimeUnit.MILLISECONDS)
+      } yield endTime - startTime
+      assertZIO[Any, Throwable, Long](timeDifference)(isLessThan(200L))
+    } @@ TestAspect.withLiveClock,
+  )
+
+  override def spec = suite("ClientLayer")(clientLayerSpec)
+
+}


### PR DESCRIPTION
Added `shutdownQuietPeriodDuration` and `shutdownTimeOutDuration` to `NettyConfig` allowing users to customize the shutdown behavior of netty's `EventLoopGroup`.

Added `defaultWithFastShutdown` version of `NettyConfig` to be used by `ClientConfig.default`. Quiet period for this default is 50 ms and timeout is at 250 ms.

Added tests confirming that client cleanup takes no more than 250 ms and that a user can increase the quiet period.