### PR TITLE
add xss protection as default

### DIFF
--- a/zio-http/src/main/scala/zio/http/internal/OutputEncoder.scala
+++ b/zio-http/src/main/scala/zio/http/internal/OutputEncoder.scala
@@ -24,7 +24,6 @@ private[http] object OutputEncoder {
   private val `>` = "&gt;"
   private val `"` = "&quot;"
   private val `'` = "&#x27;"
-  private val `/` = "&#x2F;"
 
   /**
    * Encode HTML characters that can cause XSS, according to OWASP
@@ -32,7 +31,7 @@ private[http] object OutputEncoder {
    * https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#output-encoding-rules-summary
    *
    * Specification: Convert & to &amp;, Convert < to &lt;, Convert > to &gt;,
-   * Convert " to &quot;, Convert ' to &#x27;, Convert / to &#x2F;
+   * Convert " to &quot;, Convert ' to &#x27;
    *
    * Only use this function to encode characters inside HTML context:
    * <html>output</html
@@ -61,7 +60,6 @@ private[http] object OutputEncoder {
     case '>'     => `>`
     case '"'     => `"`
     case '\''    => `'`
-    case '/'     => `/`
     case _ @char => char.toString
   }
 

--- a/zio-http/src/test/scala/zio/http/template/DomSpec.scala
+++ b/zio-http/src/test/scala/zio/http/template/DomSpec.scala
@@ -86,6 +86,30 @@ object DomSpec extends ZIOHttpSpec {
 
       assertTrue(dom.encode == """<a href="https://www.zio-http.com">zio-http</a>""")
     },
+    test("xss protection for text nodes") {
+      val dom = Dom.element(
+        "a", 
+        Dom.attr("href", "http://www.zio-http.com"), 
+        Dom.text("""<script type="text/javascript">alert("xss")</script>""")
+      )
+      assertTrue(dom.encode == """<a href="http://www.zio-http.com">&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;</a>""")
+    },
+    test("xss protection for attributes") {
+      val dom = Dom.element(
+        "a", 
+        Dom.attr("href", """<script type="text/javascript">alert("xss")</script>"""), 
+        Dom.text("my link")
+      )
+      assertTrue(dom.encode == """<a href="&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;">my link</a>""")
+    },
+    test("raw output") {
+      val dom = Dom.element(
+        "a", 
+        Dom.attr("href", "http://www.zio-http.com"), 
+        Dom.raw("""<script type="text/javascript">alert("xss")</script>""")
+      )
+      assertTrue(dom.encode == """<a href="http://www.zio-http.com"><script type="text/javascript">alert("xss")</script></a>""")
+    },    
     suite("Self Closing")(
       test("void") {
         checkAll(voidTagGen) { name =>

--- a/zio-http/src/test/scala/zio/http/template/DomSpec.scala
+++ b/zio-http/src/test/scala/zio/http/template/DomSpec.scala
@@ -88,28 +88,34 @@ object DomSpec extends ZIOHttpSpec {
     },
     test("xss protection for text nodes") {
       val dom = Dom.element(
-        "a", 
-        Dom.attr("href", "http://www.zio-http.com"), 
-        Dom.text("""<script type="text/javascript">alert("xss")</script>""")
+        "a",
+        Dom.attr("href", "http://www.zio-http.com"),
+        Dom.text("""<script type="text/javascript">alert("xss")</script>"""),
       )
-      assertTrue(dom.encode == """<a href="http://www.zio-http.com">&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;</a>""")
+      assertTrue(
+        dom.encode == """<a href="http://www.zio-http.com">&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;</a>""",
+      )
     },
     test("xss protection for attributes") {
       val dom = Dom.element(
-        "a", 
-        Dom.attr("href", """<script type="text/javascript">alert("xss")</script>"""), 
-        Dom.text("my link")
+        "a",
+        Dom.attr("href", """<script type="text/javascript">alert("xss")</script>"""),
+        Dom.text("my link"),
       )
-      assertTrue(dom.encode == """<a href="&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;">my link</a>""")
+      assertTrue(
+        dom.encode == """<a href="&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;xss&quot;)&lt;/script&gt;">my link</a>""",
+      )
     },
     test("raw output") {
       val dom = Dom.element(
-        "a", 
-        Dom.attr("href", "http://www.zio-http.com"), 
-        Dom.raw("""<script type="text/javascript">alert("xss")</script>""")
+        "a",
+        Dom.attr("href", "http://www.zio-http.com"),
+        Dom.raw("""<script type="text/javascript">alert("xss")</script>"""),
       )
-      assertTrue(dom.encode == """<a href="http://www.zio-http.com"><script type="text/javascript">alert("xss")</script></a>""")
-    },    
+      assertTrue(
+        dom.encode == """<a href="http://www.zio-http.com"><script type="text/javascript">alert("xss")</script></a>""",
+      )
+    },
     suite("Self Closing")(
       test("void") {
         checkAll(voidTagGen) { name =>


### PR DESCRIPTION
Escape output by default for xss protection when using the builtin template module - one can bypass escaping output by using `Dom.raw(s:String)`. At the moment we do not prevent any xss attacks e.g.: 

![image](https://github.com/zio/zio-http/assets/202410/ba55408e-9e88-448a-b024-6a4c6b2950bf)

When using this routing code: 

```
    Method.GET / "bluuu" -> handler { req:Request => 
      val param = req.url.queryParams.getOrElse("id", "")
      Response.html(
        div(
          param
        )
      )  
    },
```
Instead with this commit we escape the xss attack without changing any client code: 

![image](https://github.com/zio/zio-http/assets/202410/87e33f30-54d2-4f4f-b3fd-52be0551ee01)

Also I removed '/' from the list of escaped characters as that seems very strict (am I wrong?) and we would need to get along with escaped slash characters in resulting html code e.g. instead of `<a href="http://www.zio.dev">zio</a>` we would get `<a href="http:&#x2F;&#x2F;www.zio.dev">zio</a>` or instead of `<img src="/path/to/image.jpg" />` we would get `<img src="&#x2F;path&#x2F;to&#x2F;image.jpg" />`. It would work in the browser but the resulting html would be really ugly. 

From my experience it's a reasonable tradeoff to escape the following characters as per default: `&`, `<`, `>`, `"`, `'`. 