### PR TITLE
add note regarding classical browser redirects

### DIFF
--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -265,6 +265,9 @@ object Response {
   /**
    * Creates an empty response with status 301 or 302 depending on if it's
    * permanent or not.
+   *
+   * Note: if you want to direct a browser to the provided location you should
+   * use `Response#seeOther` instead.
    */
   def redirect(location: URL, isPermanent: Boolean = false): Response = {
     val status = if (isPermanent) Status.PermanentRedirect else Status.TemporaryRedirect


### PR DESCRIPTION
307 and 308 are not sufficient to perform classical "redirect after post" (which the method name suggests) e.g. after submitting valid login credentials one wants to be redirected with a http get to an application start page. 

If one sends back a 307 or 308 with a new location in the header the browser still keeps the http post method (as that was used for performing the login before) for performing the redirect - that very likely results in a 404. 

When one sends back a 303 (SeeOther) instead one gets the behaviour for a classical "browser redirect" as that changes the http method to http get. 

I think it is worth emphasizing that situation in a helpful comment as a "redirect after post" doesn't work with our method `Response#redirect` - one needs to use `Response#seeOther` to **always** redirect with a http get. 

SeeOther: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303