### PR TITLE
add note regarding classical "redirect after post" situations

### DIFF
--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -263,8 +263,11 @@ object Response {
   def ok: Response = status(Status.Ok)
 
   /**
-   * Creates an empty response with status 301 or 302 depending on if it's
+   * Creates an empty response with status 307 or 308 depending on if it's
    * permanent or not.
+   *
+   * Note: if you intend to always redirect a browser with a HTTP GET to the
+   * given location you very likely should use `Response#seeOther` instead.
    */
   def redirect(location: URL, isPermanent: Boolean = false): Response = {
     val status = if (isPermanent) Status.PermanentRedirect else Status.TemporaryRedirect
@@ -272,7 +275,7 @@ object Response {
   }
 
   /**
-   * Creates an empty response with status 303
+   * Creates an empty response with status 303.
    */
   def seeOther(location: URL): Response =
     Response(status = Status.SeeOther, headers = Headers(Header.Location(location)))


### PR DESCRIPTION
307 and 308 are not sufficient to perform classical "redirect after post" e.g. after submitting valid login credentials one wants to be redirected with a http get to an application start page. 

If one sends back a 307 or 308 with a new location in the header the browser still **keeps the http post** method (as that was used for performing the login before) for performing the redirect - that very likely results in a 404. 

When one sends back a 303 (SeeOther) instead one gets the behaviour for a classical "redirect after post" as that always **changes the http method to http get** for the redirect. 

I think it is worth emphasizing that situation in a helpful comment as a "redirect after post" doesn't work with our method `Response#redirect` (as the method name suggests) - one needs to use `Response#seeOther` to **always** redirect with a http get. 

The same with other words: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303