### PR TITLE
add flash scope

### DIFF
--- a/zio-http/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/src/main/scala/zio/http/Middleware.scala
@@ -243,4 +243,11 @@ object Middleware extends HandlerAspects {
         )
     }
   }
+
+  /**
+   * Creates a middleware for managing the flash scope.
+   */
+  def flashScopeHandling: HandlerAspect[Any, Unit] = Middleware.intercept { (req, resp) =>
+    req.cookie("zio-http-flash").fold(resp)(flash => resp.addCookie(Cookie.clear(flash.name)))
+  }
 }

--- a/zio-http/src/main/scala/zio/http/Request.scala
+++ b/zio-http/src/main/scala/zio/http/Request.scala
@@ -106,6 +106,13 @@ final case class Request(
    */
   def unnest(prefix: Path): Request =
     copy(url = self.url.copy(path = self.url.path.unnest(prefix)))
+
+  def cookie(name: String): Option[Cookie] =
+    header(Header.Cookie).map(_.value).flatMap(_.filter(_.name == name).headOption)
+
+  def flashMessage: Option[String] =
+    cookie("zio-http-flash").map(_.content)
+
 }
 
 object Request {

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -40,6 +40,9 @@ final case class Response(
   def addCookie(cookie: Cookie.Response): Response =
     self.copy(headers = self.headers ++ Headers(Header.SetCookie(cookie)))
 
+  def addFlashMessage(message: String): Response =
+    addCookie(Cookie.Response("zio-http-flash", message))
+
   /**
    * Collects the potentially streaming body of the response into a single
    * chunk.


### PR DESCRIPTION
This adds functionality for adding a message to the (cookie-based) flash scope and also a middleware for managing that scope automatically. 

The message in the flash scope is kept for a single request only and is cleared afterwards by the provided middleware. At the moment one can only add a single string message to the flash scope. A more featureful implementation should provide support for  a serialized key-value structure. 

The implementation is still a bit rough (duplicate code ...), but it technically works as one would expect. 

I could provide docs and support for key-value structure in a follow-up commit. 

Adding middleware:  
```scala
  override val run =
    Server.serve(appRoutes.toHttpApp @@ Middleware.flashScopeHandling).provide(Server.default)
```

Flash scope usage: 
```scala
Response.seeOther("some url").addFlashMessage("overview not available at the moment")
```
