### PR TITLE
Add `md` interpolator to create Markdown based docs

### DIFF
--- a/zio-http/src/main/scala-2/zio/http/MdInterpolator.scala
+++ b/zio-http/src/main/scala-2/zio/http/MdInterpolator.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio.http.codec.Doc
+
+trait MdInterpolator {
+
+  implicit class MdInterpolatorHelper(val sc: StringContext) {
+    def md(args: Any*): Doc = Doc.fromCommonMark(sc.s(args: _*).stripMargin)
+  }
+}

--- a/zio-http/src/main/scala-3/zio/http/MdInterpolator.scala
+++ b/zio-http/src/main/scala-3/zio/http/MdInterpolator.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import zio.http.codec.Doc
+
+trait MdInterpolator {
+
+  extension(inline sc: StringContext) {
+    inline def md(inline args: Any*): Doc = Doc.fromCommonMark(sc.s(args*).stripMargin)
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/package.scala
+++ b/zio-http/src/main/scala/zio/http/package.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import zio.http.codec.PathCodec
 
-package object http extends UrlInterpolator {
+package object http extends UrlInterpolator with MdInterpolator {
 
   /**
    * A smart constructor that attempts to construct a handler from the specified

--- a/zio-http/src/test/scala/zio/http/codec/DocSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/DocSpec.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package zio.http.endpoint
+package zio.http.codec
 
 import zio.test._
 
-import zio.http.ZIOHttpSpec
-import zio.http.codec.Doc
+import zio.http._
 import zio.http.codec.Doc._
 
 object DocSpec extends ZIOHttpSpec {
@@ -65,7 +64,7 @@ object DocSpec extends ZIOHttpSpec {
                        |
                        |<span style="color:red">This is an error</span>
                        |
-                       |```ZIO.succeed(1)```
+                       |`ZIO.succeed(1)`
                        |
                        |**This is strong**
                        |
@@ -207,6 +206,18 @@ object DocSpec extends ZIOHttpSpec {
                        |    - This is another nested enumeration item
                        |""".stripMargin
       assertTrue(complexDoc == expected)
+    },
+    test("md interpolator") {
+
+      val name     = "John"
+      val age      = 42
+      val doc      = md"""# Hello $name!
+                        |
+                        |You are $age years old."""
+      val expected = """# Hello John!
+                       |
+                       |You are 42 years old.""".stripMargin
+      assertTrue(doc.toCommonMark == expected)
     },
   )
 }

--- a/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
@@ -27,8 +27,8 @@ object RichTextCodecSpec extends ZIOHttpSpec {
 
   def textOf(doc: Doc): Option[String] =
     doc match {
-      case Doc.Paragraph(Doc.Span.Code(text)) => Some(text)
-      case _                                  => None
+      case Doc.Paragraph(Doc.Span.Code(text, _)) => Some(text)
+      case _                                     => None
     }
 
   override def spec = suite("Rich Text Codec Spec")(


### PR DESCRIPTION
Also distinguish between inline code and code block docs

The interpolator is currently not parsing, but is just dump and saves the input as "raw".
Trying to print it as plain text or html would currently fail.
Writing a markdown to Doc parser seemed to be too complex for now.
Maybe we could use `RichTextCodec` to impl. this later for all 3 formats (plain, commonmark, html)?

I worked together with someone from the intellij scala plugin at the ScalaDays.
He added default support for syntax highlighting of string interpolators named `md`.
So with the next release of the Scala plugin, md strings will have highlighting. But it can be activated manually already in the scala plugin settings.

![Screenshot 2023-09-20 at 06 06 58](https://github.com/zio/zio-http/assets/7283535/0c9271d5-b00e-4585-a72e-58b21b6bb0bd)
![Screenshot 2023-09-20 at 06 07 37](https://github.com/zio/zio-http/assets/7283535/bee68a12-2a21-4f55-803f-2ab3a927fd06)


fixes #2202 
/claim #2202
