### PR TITLE
Throw exception when reading from AsyncBody after the channel closed (#2399)

### DIFF
--- a/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
@@ -55,9 +55,9 @@ abstract class HttpRunnableSpec extends ZIOHttpSpec { self =>
         }
       } yield response
 
-    def deployAndRequest(
-      call: Client => ZIO[Scope, Throwable, Response],
-    ): Handler[Client with DynamicServer with R with Scope, Throwable, Any, Response] =
+    def deployAndRequest[Output](
+      call: Client => ZIO[Scope, Throwable, Output],
+    ): Handler[Client with DynamicServer with R with Scope, Throwable, Any, Output] =
       for {
         port     <- Handler.fromZIO(DynamicServer.port)
         id       <- Handler.fromZIO(DynamicServer.deploy[R](app))


### PR DESCRIPTION
Currently, when we call `Response.body.asStream`, we don't check to see if the corresponding response channel is open or not. If the channel has been closed and the user attempts to read the response body, it's possible for the body stream to hang (i.e never finish or throw an error), leading to the code hanging as illustrated in #2399. This behavior is undesirable since the user isn't aware of the channel closing (because we take care of that behind the scene), leading to the issue being hard to debug.

This commit adds a check to `AsyncBodyReader.connect` so that we will throw an exception when the user attempts to read an unfinished response body from a closed channel.

PR note: I'm new to the code base, so let me know if throwing an exception is bad style (I'm doing it because there's already an exception in that same function :)

/claim #2399 