### PR TITLE
use richtext codec for content type

### DIFF
--- a/zio-http/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/src/main/scala/zio/http/MediaType.scala
@@ -33,6 +33,7 @@ final case class MediaType(
 object MediaType extends MediaTypes {
   private val extensionMap: Map[String, MediaType]   = allMediaTypes.flatMap(m => m.fileExtensions.map(_ -> m)).toMap
   private val contentTypeMap: Map[String, MediaType] = allMediaTypes.map(m => m.fullType -> m).toMap
+  val mainTypeMap                                    = allMediaTypes.map(m => m.mainType -> m).toMap
 
   def forContentType(contentType: String): Option[MediaType] = {
     val index = contentType.indexOf(";")

--- a/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
@@ -33,6 +33,9 @@ import zio.{Chunk, NonEmptyChunk}
  */
 sealed trait RichTextCodec[A] { self =>
 
+  final def string(implicit ev: A =:= Chunk[Char]): RichTextCodec[String] =
+    self.asType[Chunk[Char]].transform(_.mkString, a => Chunk(a.toList: _*))
+
   /**
    * Returns a new codec that is the sequential composition of this codec and
    * the specified codec, but which only produces the value of this codec.
@@ -154,6 +157,7 @@ sealed trait RichTextCodec[A] { self =>
     collectOrFail(failure) {
       case x if p(x) => x
     }
+
 }
 object RichTextCodec {
   private[codec] case object Empty                                        extends RichTextCodec[Unit]
@@ -214,6 +218,8 @@ object RichTextCodec {
    * A codec that describes a letter character.
    */
   val letter: RichTextCodec[Char] = filter(_.isLetter) ?! "letter"
+
+  val string: RichTextCodec[String] = letter.repeat.string
 
   /**
    * A codec that describes a literal character sequence.
@@ -501,7 +507,7 @@ object RichTextCodec {
   private def encode[A](value: A, self: RichTextCodec[A]): Either[String, String] = {
     self match {
       case RichTextCodec.Empty                           => Right("")
-      case RichTextCodec.CharIn(_)                       => { Right(value.asInstanceOf[Char].toString) }
+      case RichTextCodec.CharIn(_)                       => Right(value.asInstanceOf[Char].toString)
       case RichTextCodec.TransformOrFail(codec, _, from) =>
         from(value) match {
           case Left(err)     => Left(err)
@@ -514,13 +520,12 @@ object RichTextCodec {
           case Right(b) => right.encode(b)
         }
       case RichTextCodec.Lazy(codec0)                    => codec0().encode(value)
-      case RichTextCodec.Zip(left, right, combiner)      => {
+      case RichTextCodec.Zip(left, right, combiner)      =>
         val (a, b) = combiner.separate(value)
         for {
           l <- left.encode(a)
           r <- right.encode(b)
         } yield l + r
-      }
       case RichTextCodec.Tagged(_, codec, _)             => codec.encode(value)
     }
   }
@@ -559,6 +564,7 @@ object RichTextCodec {
         } yield (r._1, combiner.combine(l._2, r._2))
 
       case RichTextCodec.Tagged(_, codec, _) => parse(value, codec)
+
     }
 
 }

--- a/zio-http/src/test/scala/zio/http/headers/ContentTypeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/ContentTypeSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.headers
+
+import zio.test._
+
+import zio.http.Header.ContentType
+import zio.http.{MediaType, ZIOHttpSpec}
+
+object ContentTypeSpec extends ZIOHttpSpec {
+
+  override def spec = suite("ContentType header suite")(
+    test("parsing of invalid ContentType values") {
+      assertTrue(
+        ContentType.parse("").isLeft,
+        ContentType.parse("something").isLeft,
+      )
+    },
+    test("parsing of valid ContentType values") {
+      val charsetUtf8 = java.nio.charset.Charset.forName("utf-8")
+      val boundary    = zio.http.Boundary("---------------------------974767299852498929531610575")
+      def checkBoth(in: String, result: ContentType) =
+        assertTrue(
+          ContentType.parse(in).toOption.get == result,
+        ) && assertTrue(
+          ContentType.render(result) == in,
+        )
+      checkBoth("x-word/listing-text", ContentType(MediaType.parseCustomMediaType(s"x-word/listing-text").get)) &&
+      checkBoth(MediaType.image.`png`.fullType, ContentType(MediaType.image.`png`)) &&
+      checkBoth(
+        s"${MediaType.text.`html`.fullType}; charset=${charsetUtf8.toString.toLowerCase}",
+        ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      ) &&
+      checkBoth(
+        s"${MediaType.text.`html`.fullType}; charset=${charsetUtf8.toString.toLowerCase}; boundary=${boundary.id}",
+        ContentType(MediaType.text.`html`, Some(boundary), Some(charsetUtf8)),
+      ) &&
+      assertTrue(
+        ContentType
+          .parse(s"${MediaType.text.`html`.fullType};charset=${charsetUtf8.toString}")
+          .toOption
+          .get == ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      ) && assertTrue(
+        ContentType
+          .parse(s"""${MediaType.text.`html`.fullType};charset="${charsetUtf8.toString}"""")
+          .toOption
+          .get == ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      ) && assertTrue(
+        ContentType
+          .parse(s"""${MediaType.text.`html`.fullType};charset="${charsetUtf8.toString}"; version=1.0.0""")
+          .toOption
+          .get == ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      ) && assertTrue(
+        ContentType
+          .parse(s"""${MediaType.text.`html`.fullType};charset="${charsetUtf8.toString}"; version="1.0.0"""")
+          .toOption
+          .get == ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      ) && assertTrue(
+        ContentType
+          .parse(s"""${MediaType.text.`html`.fullType};    charset="${charsetUtf8.toString}"""")
+          .toOption
+          .get == ContentType(MediaType.text.`html`, None, Some(charsetUtf8)),
+      )
+    },
+    test("parsing and encoding is symmetrical") {
+      val results =
+        MediaType.allMediaTypes.map(mediaType => ContentType.render(ContentType.parse(mediaType.fullType).toOption.get))
+      assertTrue(MediaType.allMediaTypes.map(_.fullType) == results)
+    },
+  )
+
+}


### PR DESCRIPTION
Commit due to https://github.com/zio/zio-http/issues/2416

- use RichTextCodec for ContentType header
- accept multiple parameters in ContentType (but only keep `boundary` and `charset` around after parsing)
- accept quoted version for parameter values