### PR TITLE
docs: Update steps to run examples in sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ object HelloWorld extends ZIOAppDefault {
 
 ## Steps to run an example
 
-1. Edit the [RunSettings](https://github.com/zio/zio-http/blob/main/project/BuildHelper.scala#L107) - modify `className` to the example you'd like to run.
-2. From sbt shell, run `~example/reStart`. You should see `Server started on port: 8080`.
+1. Set the [main application to execute in the example project](https://github.com/zio/zio-http/blob/main/project/Debug.scala).
+2. From sbt shell, run `project zioHttpExample` -> `~reStart`. You should see `Server started on port: 8080`.
 3. Send curl request for defined `http Routes`, for eg : `curl -i "http://localhost:8080/text"` for `example.HelloWorld`.
 
 ## Watch Mode


### PR DESCRIPTION
The documented steps were outdated, this commit corrected them.