### PR TITLE
fix: case-insensitive FormField headers

### DIFF
--- a/zio-http/src/main/scala/zio/http/FormField.scala
+++ b/zio-http/src/main/scala/zio/http/FormField.scala
@@ -25,9 +25,6 @@ import zio.stream.{Take, ZPipeline, ZStream}
 import zio.http.FormDecodingError._
 import zio.http.Header.ContentTransferEncoding
 import zio.http.internal.FormAST
-import zio.stream.{Take, ZPipeline, ZStream}
-
-import java.nio.charset._
 
 /**
  * Represents a field in a form. Every field contains name, content type

--- a/zio-http/src/main/scala/zio/http/FormField.scala
+++ b/zio-http/src/main/scala/zio/http/FormField.scala
@@ -155,15 +155,15 @@ object FormField {
           Chunk.empty[FormAST.Content],
         ),
       ) {
-        case (accum, header: FormAST.Header) if header.name == "Content-Disposition"       =>
+        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-disposition"       =>
           (Some(header), accum._2, accum._3, accum._4)
-        case (accum, content: FormAST.Content)                                             =>
+        case (accum, content: FormAST.Content)                                                         =>
           (accum._1, accum._2, accum._3, accum._4 :+ content)
-        case (accum, header: FormAST.Header) if header.name == "Content-Type"              =>
+        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-type"              =>
           (accum._1, Some(header), accum._3, accum._4)
-        case (accum, header: FormAST.Header) if header.name == "Content-Transfer-Encoding" =>
+        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-transfer-encoding" =>
           (accum._1, accum._2, Some(header), accum._4)
-        case (accum, _)                                                                    => accum
+        case (accum, _)                                                                                => accum
       }
 
     for {

--- a/zio-http/src/main/scala/zio/http/FormField.scala
+++ b/zio-http/src/main/scala/zio/http/FormField.scala
@@ -15,7 +15,13 @@
  */
 
 package zio.http
+import java.nio.charset._
+
 import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import zio.stream.{Take, ZPipeline, ZStream}
+
 import zio.http.FormDecodingError._
 import zio.http.Header.ContentTransferEncoding
 import zio.http.internal.FormAST

--- a/zio-http/src/main/scala/zio/http/FormField.scala
+++ b/zio-http/src/main/scala/zio/http/FormField.scala
@@ -15,16 +15,13 @@
  */
 
 package zio.http
-import java.nio.charset._
-
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
-
-import zio.stream.{Take, ZPipeline, ZStream}
-
 import zio.http.FormDecodingError._
 import zio.http.Header.ContentTransferEncoding
 import zio.http.internal.FormAST
+import zio.stream.{Take, ZPipeline, ZStream}
+
+import java.nio.charset._
 
 /**
  * Represents a field in a form. Every field contains name, content type
@@ -155,15 +152,15 @@ object FormField {
           Chunk.empty[FormAST.Content],
         ),
       ) {
-        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-disposition"       =>
+        case (accum, header: FormAST.Header) if header.name.equalsIgnoreCase("Content-Disposition")       =>
           (Some(header), accum._2, accum._3, accum._4)
-        case (accum, content: FormAST.Content)                                                         =>
+        case (accum, content: FormAST.Content)                                                            =>
           (accum._1, accum._2, accum._3, accum._4 :+ content)
-        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-type"              =>
+        case (accum, header: FormAST.Header) if header.name.equalsIgnoreCase("Content-Type")              =>
           (accum._1, Some(header), accum._3, accum._4)
-        case (accum, header: FormAST.Header) if header.name.toLowerCase == "content-transfer-encoding" =>
+        case (accum, header: FormAST.Header) if header.name.equalsIgnoreCase("Content-Transfer-Encoding") =>
           (accum._1, accum._2, Some(header), accum._4)
-        case (accum, _)                                                                                => accum
+        case (accum, _)                                                                                   => accum
       }
 
     for {


### PR DESCRIPTION
Some clients send FormField headers in lower case. However we seem to require them to be capitalized. I can't find a clear spec for headers in this context, but from headers in general we can probably expect it to vary. One example where we're incompatible is [react-native](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Network/FormData.js#L77).