### PR TITLE
fix: Avoid IPv6 in system DNS queries by default (#2280)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.Keys.scalaVersion
 
 object Dependencies {
   val JwtCoreVersion                = "9.1.1"
-  val NettyVersion                  = "4.1.98.Final"
+  val NettyVersion                  = "4.1.99.Final"
   val NettyIncubatorVersion         = "0.0.20.Final"
   val ScalaCompactCollectionVersion = "2.11.0"
   val ZioVersion                    = "2.0.18"


### PR DESCRIPTION
Currently, there are cases where users cannot use IPv6 due to their network
infrastructure not supporting it. Therefore, we should not resolve hostnames to
IPv6 addresses unless told otherwise.

This commit defaults DNS queries to IPv4-only. It also allows users to resolve
IPv6 addresses by setting the system property `java.net.preferIPv6Addresses`.

/claim https://github.com/zio/zio-http/issues/2280

Reference: https://docs.oracle.com/javase/8/docs/technotes/guides/net/ipv6_guide/