### PR TITLE
add new flash type and changed flash api

### DIFF
--- a/zio-http/src/main/scala/zio/http/Flash.scala
+++ b/zio-http/src/main/scala/zio/http/Flash.scala
@@ -1,9 +1,9 @@
 package zio.http
 
+import java.net.{URLDecoder, URLEncoder}
+
 import zio.schema.Schema
 import zio.schema.codec.JsonCodec
-
-import java.net.{URLDecoder, URLEncoder}
 
 /**
  * `Flash` represents a flash value that one can retrieve from the
@@ -37,15 +37,15 @@ object Flash {
   sealed trait Setter[A] { self =>
 
     /**
-     * Combines setting this flash value with another setter for `that`.
+     * Combines setting this flash value with another setter `that`.
      */
-    def ++[B](that: => Setter[B]): Setter[(A, B)] = Setter.Concat(self, that)
+    def ++[B](that: => Setter[B]): Setter[Unit] = Setter.Concat(self, that)
   }
 
   private[http] object Setter {
-    case class Set[A](schema: Schema[A], key: String, a: A) extends Flash.Setter[A]
+    case class Set[A](schema: Schema[A], key: String, a: A) extends Flash.Setter[Unit]
 
-    case class Concat[A, B](left: Setter[A], right: Setter[B]) extends Flash.Setter[(A, B)]
+    case class Concat[A, B](left: Setter[A], right: Setter[B]) extends Flash.Setter[Unit]
 
     def run[A](self: Setter[A]): Cookie.Response = {
       def loop[B](self: Setter[B], map: Map[String, String]): Map[String, String] =
@@ -70,7 +70,7 @@ object Flash {
   /**
    * Sets any flash value of type `A` with the given key `key`.
    */
-  def set[A: Schema](key: String, a: A): Setter[A] = Setter.Set(Schema[A], key, a)
+  def set[A: Schema](key: String, a: A): Setter[Unit] = Setter.Set(Schema[A], key, a)
 
   private[http] val COOKIE_NAME = "zio-http-flash"
 

--- a/zio-http/src/main/scala/zio/http/Flash.scala
+++ b/zio-http/src/main/scala/zio/http/Flash.scala
@@ -1,0 +1,129 @@
+package zio.http
+
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec
+
+import java.net.{URLDecoder, URLEncoder}
+
+sealed trait Flash[+A] { self =>
+
+  def flatMap[B](f: A => Flash[B]): Flash[B] = Flash.FlatMap(self, f)
+
+  def map[B](f: A => B): Flash[B] = self.flatMap(a => Flash.succeed(f(a)))
+
+  def orElse[B >: A](that: => Flash[B]): Flash[B] = Flash.OrElse(self, that)
+
+  def <>[B >: A](that: => Flash[B]): Flash[B] = self.orElse(that)
+
+  def zip[B](that: => Flash[B]): Flash[(A, B)] = self.zipWith(that)((a, b) => a -> b)
+
+  def <*>[B](that: => Flash[B]): Flash[(A, B)] = self.zip(that)
+
+  def zipWith[B, C](that: => Flash[B])(f: (A, B) => C): Flash[C] =
+    self.flatMap(a => that.map(b => f(a, b)))
+
+  def optional: Flash[Option[A]] = self.map(Option(_)) <> Flash.succeed(None)
+}
+
+object Flash {
+
+  sealed trait Setter[A] { self =>
+    def ++[B](that: => Setter[B]): Setter[(A, B)] = Setter.Concat(self, that)
+  }
+
+  private[http] object Setter {
+    case class Set[A](schema: Schema[A], key: String, a: A) extends Flash.Setter[A]
+
+    case class Concat[A, B](left: Setter[A], right: Setter[B]) extends Flash.Setter[(A, B)]
+
+    def run[A](self: Setter[A]): Cookie.Response = {
+      def loop[B](self: Setter[B], map: Map[String, String]): Map[String, String] =
+        self match {
+          case Set(schema, key, a) =>
+            map.updated(key, JsonCodec.jsonEncoder(schema).encodeJson(a).toString)
+          case Concat(left, right) =>
+            loop(right, loop(left, map))
+        }
+      val map                                                                     = loop(self, Map.empty)
+      Cookie.Response(
+        Flash.COOKIE_NAME,
+        URLEncoder.encode(
+          JsonCodec.jsonEncoder(Schema[Map[String, String]]).encodeJson(map).toString,
+          java.nio.charset.Charset.defaultCharset,
+        ),
+      )
+
+    }
+  }
+
+  def set[A: Schema](key: String, a: A): Setter[A] = Setter.Set(Schema[A], key, a)
+
+  private[http] val COOKIE_NAME = "zio-http-flash"
+
+  private case class Get[A](schema: Schema[A], key: String) extends Flash[A]
+
+  private case class FlatMap[A, B](self: Flash[A], f: A => Flash[B]) extends Flash[B]
+
+  private case class OrElse[A, B >: A](self: Flash[A], that: Flash[B]) extends Flash[B]
+
+  private case class WithInput[A](f: Map[String, String] => Flash[A]) extends Flash[A]
+
+  private case class Succeed[A](a: A) extends Flash[A]
+
+  private def succeed[A](a: A): Flash[A] = Succeed(a)
+
+  private def withInput[A](f: Map[String, String] => Flash[A]): Flash[A] = WithInput(f)
+
+  def get[A: Schema](key: String): Flash[A] = Flash.Get(Schema[A], key)
+
+  def getString(key: String): Flash[String] = get[String](key)
+
+  def getFloat(key: String): Flash[Float] = get[Float](key)
+
+  def getDouble(key: String): Flash[Double] = get[Double](key)
+
+  def getInt(key: String): Flash[Int] = get[Int](key)
+
+  def getLong(key: String): Flash[Long] = get[Long](key)
+
+  def getBoolean(key: String): Flash[Boolean] = get[Boolean](key)
+
+  def get[A: Schema]: Flash[A] = withInput { map =>
+    map.keys.map(a => Flash.get(a)(Schema[A])).reduce(_ <> _)
+  }
+
+  private def loop[A](flash: Flash[A], map: Map[String, String]): Either[Throwable, A] =
+    flash match {
+      case Get(schema, key)   =>
+        map.get(key).toRight(new Throwable(s"no key: $key")).flatMap { value =>
+          JsonCodec.jsonDecoder(schema).decodeJson(value).left.map(e => new Throwable(e))
+        }
+      case WithInput(f)       =>
+        loop(f(map), map)
+      case OrElse(self, that) =>
+        loop(self, map).orElse(loop(that, map)).asInstanceOf[Either[Throwable, A]]
+      case FlatMap(self, f)   =>
+        loop(self, map) match {
+          case Right(value) => loop(f(value), map)
+          case Left(e)      => Left(e)
+        }
+      case Succeed(a)         => Right(a)
+    }
+
+  private[http] def run[A](flash: Flash[A], request: Request): Either[Throwable, A] = {
+    request
+      .cookie(COOKIE_NAME)
+      .toRight(new Throwable("flash cookie doesn't exist"))
+      .flatMap { cookie =>
+        try Right(URLDecoder.decode(cookie.content, java.nio.charset.Charset.defaultCharset))
+        catch {
+          case e: Exception => Left(e)
+        }
+      }
+      .flatMap { cookieContent =>
+        JsonCodec.jsonDecoder(Schema.map[String, String]).decodeJson(cookieContent).left.map(e => new Throwable(e))
+      }
+      .flatMap(loop(flash, _))
+  }
+
+}

--- a/zio-http/src/main/scala/zio/http/Request.scala
+++ b/zio-http/src/main/scala/zio/http/Request.scala
@@ -16,15 +16,16 @@
 
 package zio.http
 
-import zio.http.codec.TextCodec
-
 import java.net.{InetAddress, URLDecoder, URLEncoder}
+
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{Chunk, Trace, ZIO}
 
-import zio.http.internal.HeaderOps
 import zio.schema.Schema
 import zio.schema.codec.JsonCodec
+
+import zio.http.codec.TextCodec
+import zio.http.internal.HeaderOps
 
 final case class Request(
   version: Version = Version.Default,
@@ -152,7 +153,7 @@ final case class Request(
     header(Header.Cookie).fold(Chunk.empty[Cookie])(_.value.toChunk)
 
   /**
-   * Uses the `A` from the given `flash` if it exists and runs `f` with the `A`
+   * Uses `A` from the given `flash` if it exists and runs `f` with `A`
    * afterwards.
    */
   def flashWithZIO[A1, R, A](flash: Flash[A1])(f: A1 => ZIO[R, Throwable, A])(implicit
@@ -161,7 +162,7 @@ final case class Request(
     flashWithOrFailImpl(flash)(identity)(f)
 
   /**
-   * Uses the `A` from the given `flash` if it exists and runs `f` with the `A`
+   * Uses `A` from the given `flash` if it exists and runs `f` with `A`
    * afterwards.
    *
    * Also, you can set a custom failure value from a flash retrieval error with
@@ -173,7 +174,7 @@ final case class Request(
     flashWithOrFailImpl(flash)(_ => flashRetrievalError)(f)
 
   /**
-   * Returns an `A` from the flash scope if it exists.
+   * Returns an `A` from the flash if it exists.
    */
   def flash[A](flash: Flash[A]): Option[A] = Flash.run(flash, self).toOption
 

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -51,6 +51,12 @@ final case class Response(
     addCookie(Flash.Setter.run(flash))
 
   /**
+   * Adds optional flash values to the (cookie-based) flash scope.
+   */
+  def addFlash[A](flashOption: Option[Flash.Setter[A]]): Response =
+    flashOption.fold(self)(addFlash(_))
+
+  /**
    * Collects the potentially streaming body of the response into a single
    * chunk.
    */

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -16,6 +16,7 @@
 
 package zio.http
 
+import java.net.URLEncoder
 import java.nio.file.{AccessDeniedException, NotDirectoryException}
 
 import scala.annotation.tailrec
@@ -25,12 +26,11 @@ import zio.{Cause, Task, Trace, ZIO}
 
 import zio.stream.ZStream
 
-import zio.http.internal.HeaderOps
-import zio.http.template.Html
 import zio.schema.Schema
 import zio.schema.codec.JsonCodec
 
-import java.net.URLEncoder
+import zio.http.internal.HeaderOps
+import zio.http.template.Html
 
 final case class Response(
   status: Status = Status.Ok,
@@ -47,7 +47,7 @@ final case class Response(
   /**
    * Add flash values to the (cookie-based) flash scope.
    */
-  def addFlash[A: Schema](flash: Flash.Setter[A]): Response =
+  def addFlash[A](flash: Flash.Setter[A]): Response =
     addCookie(Flash.Setter.run(flash))
 
   /**

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -27,6 +27,10 @@ import zio.stream.ZStream
 
 import zio.http.internal.HeaderOps
 import zio.http.template.Html
+import zio.schema.Schema
+import zio.schema.codec.JsonCodec
+
+import java.net.URLEncoder
 
 final case class Response(
   status: Status = Status.Ok,
@@ -40,8 +44,11 @@ final case class Response(
   def addCookie(cookie: Cookie.Response): Response =
     self.copy(headers = self.headers ++ Headers(Header.SetCookie(cookie)))
 
-  def addFlashMessage(message: String): Response =
-    addCookie(Cookie.Response("zio-http-flash", message))
+  /**
+   * Add flash values to the (cookie-based) flash scope.
+   */
+  def addFlash[A: Schema](flash: Flash.Setter[A]): Response =
+    addCookie(Flash.Setter.run(flash))
 
   /**
    * Collects the potentially streaming body of the response into a single

--- a/zio-http/src/test/scala/zio/http/FlashSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FlashSpec.scala
@@ -1,6 +1,6 @@
 package zio.http
 
-import zio.{NonEmptyChunk}
+import zio.{NonEmptyChunk, ZIO}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test._
 
@@ -29,6 +29,8 @@ object FlashSpec extends ZIOHttpSpec {
 
         val cookie2 = Cookie.Request(Flash.COOKIE_NAME, cookie1.content)
         val request = Request(headers = Headers(Header.Cookie(NonEmptyChunk(cookie2))))
+
+        val aaa = request.flashWithZIO(Flash.get[Articles])(a => ZIO.succeed(a))
 
         assertTrue(request.flash(Flash.get[Articles]("does-not-exist") <> Flash.get[Articles]("articles")).isDefined) &&
         assertTrue(request.flash(Flash.get[Map[String, String]]).isDefined) &&

--- a/zio-http/src/test/scala/zio/http/FlashSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FlashSpec.scala
@@ -1,8 +1,9 @@
 package zio.http
 
-import zio.{NonEmptyChunk, ZIO}
-import zio.schema.{DeriveSchema, Schema}
 import zio.test._
+import zio.{NonEmptyChunk, ZIO}
+
+import zio.schema.{DeriveSchema, Schema}
 
 object FlashSpec extends ZIOHttpSpec {
 

--- a/zio-http/src/test/scala/zio/http/FlashSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FlashSpec.scala
@@ -1,0 +1,46 @@
+package zio.http
+
+import zio.{NonEmptyChunk}
+import zio.schema.{DeriveSchema, Schema}
+import zio.test._
+
+object FlashSpec extends ZIOHttpSpec {
+
+  case class Article(name: String, price: Double)
+  object Article {
+    implicit val schema: Schema[Article] = DeriveSchema.gen
+  }
+
+  case class Articles(list: List[Article])
+
+  object Articles {
+    implicit val schema: Schema[Articles] = DeriveSchema.gen
+  }
+
+
+  override def spec =
+
+    suite("flash")(
+      test("set and get") {
+
+        val flash1 = Flash.set("articles", Articles(List(Article("m\"i`l'k", 2.99), Article("choco", 4.99))))
+        val flash2 = Flash.set("dataMap", Map("a" -> "A", "b" -> "B", "c" -> "CCC\"CCC\"CCCCC"))
+        val flash3 = Flash.set("dataList", List("a", "b", "c"))
+        val flash4 = Flash.set("articlesTuple", Article("a", 1.00) -> Article("b", 2.00))
+        val cookie1 = Flash.Setter.run(flash1 ++ flash2 ++ flash3 ++ flash4)
+
+        val cookie2 = Cookie.Request(Flash.COOKIE_NAME, cookie1.content)
+        val request = Request(headers = Headers(Header.Cookie(NonEmptyChunk(cookie2))))
+
+        assertTrue(request.flash(Flash.get[Articles]("does-not-exist") <> Flash.get[Articles]("articles")).isDefined) &&
+        assertTrue(request.flash(Flash.get[Map[String, String]]).isDefined) &&
+        assertTrue(request.flash(Flash.get[Articles]("articles").zip(Flash.get[Map[String, String]]).map { case (a, b) => s" ---> $a @@@ $b <---- " }).isDefined) &&
+        assertTrue(request.flash(Flash.getString("articles").optional.zip(Flash.getDouble("bbb").optional)).isDefined) &&
+        assertTrue(request.flash(Flash.get[List[String]]("dataList")).isDefined) &&
+        assertTrue(request.flash(Flash.get[List[String]]).isDefined) &&
+        assertTrue(request.flash(Flash.get[List[Int]]).isEmpty) &&
+        assertTrue(request.flash(Flash.get[(Article, Article)]("articlesTuple")).isDefined)
+      }
+    )
+
+}

--- a/zio-http/src/test/scala/zio/http/FlashSpec.scala
+++ b/zio-http/src/test/scala/zio/http/FlashSpec.scala
@@ -17,16 +17,14 @@ object FlashSpec extends ZIOHttpSpec {
     implicit val schema: Schema[Articles] = DeriveSchema.gen
   }
 
-
   override def spec =
-
     suite("flash")(
       test("set and get") {
 
-        val flash1 = Flash.set("articles", Articles(List(Article("m\"i`l'k", 2.99), Article("choco", 4.99))))
-        val flash2 = Flash.set("dataMap", Map("a" -> "A", "b" -> "B", "c" -> "CCC\"CCC\"CCCCC"))
-        val flash3 = Flash.set("dataList", List("a", "b", "c"))
-        val flash4 = Flash.set("articlesTuple", Article("a", 1.00) -> Article("b", 2.00))
+        val flash1  = Flash.set("articles", Articles(List(Article("m\"i`l'k", 2.99), Article("choco", 4.99))))
+        val flash2  = Flash.set("dataMap", Map("a" -> "A", "b" -> "B", "c" -> "CCC\"CCC\"CCCCC"))
+        val flash3  = Flash.set("dataList", List("a", "b", "c"))
+        val flash4  = Flash.set("articlesTuple", Article("a", 1.00) -> Article("b", 2.00))
         val cookie1 = Flash.Setter.run(flash1 ++ flash2 ++ flash3 ++ flash4)
 
         val cookie2 = Cookie.Request(Flash.COOKIE_NAME, cookie1.content)
@@ -34,13 +32,21 @@ object FlashSpec extends ZIOHttpSpec {
 
         assertTrue(request.flash(Flash.get[Articles]("does-not-exist") <> Flash.get[Articles]("articles")).isDefined) &&
         assertTrue(request.flash(Flash.get[Map[String, String]]).isDefined) &&
-        assertTrue(request.flash(Flash.get[Articles]("articles").zip(Flash.get[Map[String, String]]).map { case (a, b) => s" ---> $a @@@ $b <---- " }).isDefined) &&
-        assertTrue(request.flash(Flash.getString("articles").optional.zip(Flash.getDouble("bbb").optional)).isDefined) &&
+        assertTrue(
+          request
+            .flash(Flash.get[Articles]("articles").zip(Flash.get[Map[String, String]]).map { case (a, b) =>
+              s" ---> $a @@@ $b <---- "
+            })
+            .isDefined,
+        ) &&
+        assertTrue(
+          request.flash(Flash.getString("articles").optional.zip(Flash.getDouble("bbb").optional)).isDefined,
+        ) &&
         assertTrue(request.flash(Flash.get[List[String]]("dataList")).isDefined) &&
         assertTrue(request.flash(Flash.get[List[String]]).isDefined) &&
         assertTrue(request.flash(Flash.get[List[Int]]).isEmpty) &&
         assertTrue(request.flash(Flash.get[(Article, Article)]("articlesTuple")).isDefined)
-      }
+      },
     )
 
 }


### PR DESCRIPTION
The `flash scope` now is based on a serialized, url-encoded json object (with `zio-schema`) that is transported in a cookie named `zio-http-flash`. I removed the super simple `flashMessage` operator in favor of a new compositional domain type `zio.http.Flash` that has proper operators for `setting` and `getting` typed values from the flash scope. 

**Setting a value with a Response**: `Response.ok.addFlash(Flash.set("name", "mr. miller") ++ Flash.set("email", Email("hello@domain.com")))`

**Getting a value from a Request**: `req.flash(Flash.get[Email])` or `req.flash(Flash.getString("namePrimary") <> Flash.getString("nameSecondary") <*> Flash.getFloat("priceSum"))`

I think that we could mirror that same API in a type for (cookie-based) session handling.