### PR TITLE
Add a test of a middleware providing a context to a `Routes`

### DIFF
--- a/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -80,13 +80,13 @@ object AuthSpec extends ZIOHttpSpec with HttpAppTestExtensions {
         val app = {
           Routes(
             Method.GET / "context" -> basicAuthContextM ->
-              Handler.fromFunction[(AuthContext, Request)] { case (c: AuthContext, _) => Response.text(c.value) }
+              Handler.fromFunction[(AuthContext, Request)] { case (c: AuthContext, _) => Response.text(c.value) },
           )
         }.toHttpApp
         assertZIO(
           app
             .runZIO(Request.get(URL.root / "context").copy(headers = successBasicHeader))
-            .flatMap(_.body.asString)
+            .flatMap(_.body.asString),
         )(equalTo("user"))
       },
     ),

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -79,11 +79,15 @@ object AuthSpec extends ZIOHttpSpec with HttpAppTestExtensions {
       test("Extract username via context with Routes") {
         val app = {
           Routes(
-            Method.GET / "context" ->
-              Handler.fromFunction[(AuthContext, Request)] { case (c, _) => Response.text(c.value) },
-          ) @@ basicAuthContextM
+            Method.GET / "context" -> basicAuthContextM ->
+              Handler.fromFunction[(AuthContext, Request)] { case (c: AuthContext, _) => Response.text(c.value) }
+          )
         }.toHttpApp
-        assertZIO(app.runZIO(Request.get(URL.root / "context").copy(headers = successBasicHeader)))(equalTo("user"))
+        assertZIO(
+          app
+            .runZIO(Request.get(URL.root / "context").copy(headers = successBasicHeader))
+            .flatMap(_.body.asString)
+        )(equalTo("user"))
       },
     ),
     suite("basicAuthZIO")(

--- a/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -16,11 +16,12 @@
 
 package zio.http.internal.middlewares
 
-import zio.http._
-import zio.http.internal.HttpAppTestExtensions
 import zio.test.Assertion._
 import zio.test._
 import zio.{Ref, ZIO}
+
+import zio.http._
+import zio.http.internal.HttpAppTestExtensions
 
 object AuthSpec extends ZIOHttpSpec with HttpAppTestExtensions {
   def extractStatus(response: Response): Status = response.status


### PR DESCRIPTION
It gives an example on how to use a "providing middleware" when using `Routes`
I struggled to find how