### PR TITLE
Make type Scheme follow the specs

### DIFF
--- a/zio-http/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -70,7 +70,7 @@ object NettyConnectionPool {
           case None        =>
         }
 
-        if (location.scheme.isSecure) {
+        if (location.scheme.isSecure.getOrElse(false)) {
           pipeline.addLast(
             Names.SSLHandler,
             ClientSSLConverter

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -66,7 +66,7 @@ object ResponseCompressionSpec extends ZIOHttpSpec {
           response     <- client.request(
             Request(
               method = Method.GET,
-              url = URL(Root / "text", kind = URL.Location.Absolute(Scheme.HTTP, "localhost", server.port)),
+              url = URL(Root / "text", kind = URL.Location.Absolute(Scheme.HTTP, "localhost", Some(server.port))),
             )
               .addHeader(Header.AcceptEncoding(Header.AcceptEncoding.GZip(), Header.AcceptEncoding.Deflate())),
           )
@@ -82,7 +82,7 @@ object ResponseCompressionSpec extends ZIOHttpSpec {
           response     <- client.request(
             Request(
               method = Method.GET,
-              url = URL(Root / "stream", kind = URL.Location.Absolute(Scheme.HTTP, "localhost", server.port)),
+              url = URL(Root / "stream", kind = URL.Location.Absolute(Scheme.HTTP, "localhost", Some(server.port))),
             )
               .addHeader(Header.AcceptEncoding(Header.AcceptEncoding.GZip(), Header.AcceptEncoding.Deflate())),
           )

--- a/zio-http/src/test/scala/zio/http/SchemeSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SchemeSpec.scala
@@ -31,5 +31,8 @@ object SchemeSpec extends ZIOHttpSpec {
     test("null string decode") {
       assert(Scheme.decode(null))(isNone)
     },
+    test("decode chrome-extension") {
+      assertTrue(Scheme.decode("chrome-extension").isDefined)
+    },
   )
 }

--- a/zio-http/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/URLSpec.scala
@@ -49,14 +49,14 @@ object URLSpec extends ZIOHttpSpec {
       ),
       suite("normalize")(
         test("adds leading slash") {
-          val url = URL(Path("a/b/c"), URL.Location.Absolute(Scheme.HTTP, "abc.com", 80), QueryParams.empty, None)
+          val url = URL(Path("a/b/c"), URL.Location.Absolute(Scheme.HTTP, "abc.com", Some(80)), QueryParams.empty, None)
 
           val url2 = url.normalize
 
           assertTrue(extractPath(url2) == Path("/a/b/c"))
         },
         test("deletes leading slash if there are no path segments") {
-          val url  = URL(Path.root, URL.Location.Absolute(Scheme.HTTP, "abc.com", 80), QueryParams.empty, None)
+          val url  = URL(Path.root, URL.Location.Absolute(Scheme.HTTP, "abc.com", Some(80)), QueryParams.empty, None)
           val url2 = url.normalize
 
           assertTrue(extractPath(url2) == Path.empty)

--- a/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -34,7 +34,7 @@ object ZClientAspectSpec extends ZIOHttpSpec {
           port       <- Server.install(app)
           baseClient <- ZIO.service[Client]
           client = baseClient.url(
-            URL(Path.empty, Location.Absolute(Scheme.HTTP, "localhost", port)),
+            URL(Path.empty, Location.Absolute(Scheme.HTTP, "localhost", Some(port))),
           ) @@ ZClientAspect.debug
           response <- client.request(Request.get(URL.empty / "hello"))
           output   <- TestConsole.output
@@ -51,7 +51,7 @@ object ZClientAspectSpec extends ZIOHttpSpec {
           baseClient <- ZIO.service[Client]
           client = baseClient
             .url(
-              URL(Path.empty, Location.Absolute(Scheme.HTTP, "localhost", port)),
+              URL(Path.empty, Location.Absolute(Scheme.HTTP, "localhost", Some(port))),
             )
             .disableStreaming @@ ZClientAspect.requestLogging(
             loggedRequestHeaders = Set(Header.UserAgent),

--- a/zio-http/src/test/scala/zio/http/headers/OriginSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/OriginSpec.scala
@@ -43,6 +43,7 @@ object OriginSpec extends ZIOHttpSpec {
         assertTrue(
           Origin.parse("http://domain") == Right(Value("http", "domain", None)),
           Origin.parse("https://domain") == Right(Value("https", "domain", None)),
+          Origin.parse("chrome-extension://appid") == Right(Value("chrome-extension", "appid", None)),
         )
       },
       test("parsing of valid Origin values") {

--- a/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
@@ -70,7 +70,7 @@ object HttpGen {
     scheme <- Gen.fromIterable(List(Scheme.HTTP, Scheme.HTTPS))
     host   <- Gen.alphaNumericStringBounded(1, 5)
     port   <- Gen.oneOf(Gen.const(80), Gen.const(443), Gen.int(0, 65536))
-  } yield URL.Location.Absolute(scheme, host, port)
+  } yield URL.Location.Absolute(scheme, host, Some(port))
 
   def genRelativeURL: Gen[Any, URL] = for {
     path        <- HttpGen.anyPath

--- a/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpRunnableSpec.scala
@@ -49,7 +49,7 @@ abstract class HttpRunnableSpec extends ZIOHttpSpec { self =>
           client(
             params
               .addHeader(DynamicServer.APP_ID, id)
-              .copy(url = URL(params.url.path, Location.Absolute(Scheme.HTTP, "localhost", port))),
+              .copy(url = URL(params.url.path, Location.Absolute(Scheme.HTTP, "localhost", Some(port)))),
           )
             .flatMap(_.collect)
         }
@@ -80,7 +80,7 @@ abstract class HttpRunnableSpec extends ZIOHttpSpec { self =>
           client(
             params
               .addHeader(DynamicServer.APP_ID, id)
-              .copy(url = URL(params.url.path, Location.Absolute(Scheme.HTTP, "localhost", port))),
+              .copy(url = URL(params.url.path, Location.Absolute(Scheme.HTTP, "localhost", Some(port)))),
           )
         }
       } yield response


### PR DESCRIPTION
Make type Scheme more flexible
Fix for https://github.com/zio/zio-http/issues/2489 Follow the specs:
- URI RFC - https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
- URL RFC - https://datatracker.ietf.org/doc/html/rfc1738#section-2.1

I'm just concerned about efficiency and keep the source code interface as similar as possible.