### PR TITLE
Implement handleErrorCauseZIO for executing ZIO effects on error

### DIFF
--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -368,14 +368,15 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     self.foldHandler(err => Handler.fromZIO(f(err)), Handler.succeed(_))
 
   /**
-   * Transforms all failures except effectfull interruption.
+   * Transforms all failures of the handler effectfully except pure
+   * interruption.
    */
   final def mapErrorCauseZIO[R1 <: R, Err1, Out1 >: Out](
     f: Cause[Err] => ZIO[R1, Err1, Out1],
   )(implicit trace: Trace): Handler[R1, Err1, In, Out1] =
     self.foldCauseHandler(
       err =>
-        if (err.isInterruptedOnly) Handler.fromZIO(f(err.asInstanceOf[Cause[Nothing]])) else Handler.fromZIO(f(err)),
+        if (err.isInterruptedOnly) Handler.failCause(err.asInstanceOf[Cause[Nothing]]) else Handler.fromZIO(f(err)),
       Handler.succeed(_),
     )
 

--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -368,6 +368,18 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     self.foldHandler(err => Handler.fromZIO(f(err)), Handler.succeed(_))
 
   /**
+   * Transforms all failures except effectfull interruption.
+   */
+  final def mapErrorCauseZIO[R1 <: R, Err1, Out1 >: Out](
+    f: Cause[Err] => ZIO[R1, Err1, Out1],
+  )(implicit trace: Trace): Handler[R1, Err1, In, Out1] =
+    self.foldCauseHandler(
+      err =>
+        if (err.isInterruptedOnly) Handler.fromZIO(f(err.asInstanceOf[Cause[Nothing]])) else Handler.fromZIO(f(err)),
+      Handler.succeed(_),
+    )
+
+  /**
    * Returns a new handler where the error channel has been merged into the
    * success channel to their common combined type.
    */

--- a/zio-http/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/src/main/scala/zio/http/Routes.scala
@@ -76,6 +76,9 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
   def handleErrorCause(f: Cause[Err] => Response)(implicit trace: Trace): Routes[Env, Nothing] =
     new Routes(routes.map(_.handleErrorCause(f)))
 
+  def handleErrorCauseZIO(f: Cause[Err] => ZIO[Any, Nothing, Response])(implicit trace: Trace): Routes[Env, Nothing] =
+    new Routes(routes.map(_.handleErrorCauseZIO(f)))
+
   /**
    * Returns new routes that have each been provided the specified environment,
    * thus eliminating their requirement for any specific environment.

--- a/zio-http/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RouteSpec.scala
@@ -75,10 +75,7 @@ object RouteSpec extends ZIOHttpSpec {
           response <- errorHandled.toHttpApp.runZIO(request)
           result   <- p.await.catchAllCause(c => ZIO.succeed(c.prettyPrint))
 
-        } yield assertTrue(
-          response.status == Status.InternalServerError,
-          result.contains("hmm..."),
-        )
+        } yield assertTrue(extractStatus(response) == Status.InternalServerError, result.contains("hmm..."))
       },
     ),
   )


### PR DESCRIPTION
- **Error Handling in Routes**: Implemented the `handleErrorCauseZIO` function that is triggered upon encountering an error, ensuring that side effects are performed.


- **Testing**: Added tests to check that `handleErrorCauseZIO` correctly executes ZIO effects using TestConsole, when handling errors.


cc: @guersam 