### PR TITLE
Fix: Middleware.StaticServe crashes on empty path

### DIFF
--- a/zio-http/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/src/main/scala/zio/http/Middleware.scala
@@ -284,7 +284,8 @@ object Middleware extends HandlerAspects {
       }
 
       override def apply[Env1 <: Any, Err](routes: Routes[Env1, Err]): Routes[Env1, Err] = {
-        val mountpoint = Method.GET / path.segments.map(PathCodec.literal).reduceLeft(_ / _)
+        val mountpoint =
+          Method.GET / path.segments.map(PathCodec.literal).reduceLeftOption(_ / _).getOrElse(PathCodec.empty)
         val pattern    = mountpoint / trailing
         val other      = Routes(
           pattern -> Handler


### PR DESCRIPTION
Fixes potential 

```scala
Caused by: java.lang.UnsupportedOperationException: empty.reduceLeft
        at scala.collection.IterableOnceOps.reduceLeft(IterableOnce.scala:757)
        at scala.collection.IterableOnceOps.reduceLeft$(IterableOnce.scala:755)
        at zio.Chunk.reduceLeft(Chunk.scala:42)
        at zio.http.Middleware$$anon$6.apply(Middleware.scala:287)
```

when a StaticServe Middleware is installed on an empty path.