### PR TITLE
feat: Allow dynamic schema in openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ZIO HTTP is a scala library for building http apps. It is powered by ZIO and [Ne
 Setup via `build.sbt`:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC3"
+libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC4"
 ```
 
 **NOTES ON VERSIONING:**

--- a/zio-http/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -415,7 +415,7 @@ object JsonSchema {
       case Schema.Lazy(schema0)                                                              =>
         fromZSchemaMulti(schema0(), refType)
       case Schema.Dynamic(_)                                                                 =>
-        throw new IllegalArgumentException("Dynamic schema is not supported.")
+        JsonSchemas(AnyJson, None, Map.empty)
     }
   }
 
@@ -435,7 +435,7 @@ object JsonSchema {
       JsonSchemas(
         JsonSchema.ArrayType(Some(nested.root)),
         ref,
-        nested.children + (nested.rootRef.get -> nested.root),
+        nested.children ++ (nested.rootRef.map(_ -> nested.root)),
       )
     }
   }
@@ -559,7 +559,8 @@ object JsonSchema {
       case Schema.Tuple2(left, right, _) => AllOfSchema(Chunk(fromZSchema(left, refType), fromZSchema(right, refType)))
       case Schema.Either(left, right, _) => OneOfSchema(Chunk(fromZSchema(left, refType), fromZSchema(right, refType)))
       case Schema.Lazy(schema0)          => fromZSchema(schema0(), refType)
-      case Schema.Dynamic(_)             => throw new IllegalArgumentException("Dynamic schema is not supported.")
+      case Schema.Dynamic(_)             => AnyJson
+
     }
 
   sealed trait SchemaStyle extends Product with Serializable
@@ -905,6 +906,11 @@ object JsonSchema {
       SerializableJsonSchema(
         schemaType = Some(TypeOrTypes.Type("null")),
       )
+  }
+
+  case object AnyJson extends JsonSchema {
+    override protected[openapi] def toSerializableSchema: SerializableJsonSchema =
+      SerializableJsonSchema()
   }
 
 }


### PR DESCRIPTION
Openapi just constrains the possible values, but they are always JSON. In case of dynamic schema we do not know anything about the possible values, so we simply remove all constraints.