### PR TITLE
Error handling methods on `Route`/`Routes` that can access `Request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ZIO HTTP is a scala library for building http apps. It is powered by ZIO and [Ne
 Setup via `build.sbt`:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC3"
+libraryDependencies += "dev.zio" %% "zio-http" % "3.0.0-RC4"
 ```
 
 **NOTES ON VERSIONING:**

--- a/zio-http/src/main/scala/zio/http/Header.scala
+++ b/zio-http/src/main/scala/zio/http/Header.scala
@@ -4173,8 +4173,9 @@ object Header {
           2xx warn-codes describe some aspect of the representation that is not rectified by a validation and
              will not be deleted by a cache after validation unless a full response is sent.
        */
-      val warnCode: Int = Try {
-        Integer.parseInt(warningString.split(" ")(0))
+      val warnCodeString = warningString.split(" ")(0)
+      val warnCode: Int  = Try {
+        Integer.parseInt(warnCodeString)
       }.getOrElse(-1)
 
       /*
@@ -4187,11 +4188,11 @@ object Header {
          <warn-text>
          An advisory text describing the error.
        */
-      val descriptionStartIndex = warningString.indexOf('\"')
-      val descriptionEndIndex   = warningString.indexOf("\"", warningString.indexOf("\"") + 1)
+      val descriptionStartIndex = warningString.indexOf('\"', warnCodeString.length + warnAgent.length) + 1
+      val descriptionEndIndex   = warningString.indexOf("\"", descriptionStartIndex)
       val description           =
         Try {
-          warningString.substring(descriptionStartIndex, descriptionEndIndex + 1)
+          warningString.substring(descriptionStartIndex, descriptionEndIndex)
         }.getOrElse("")
 
       /*
@@ -4249,17 +4250,16 @@ object Header {
 
     def render(warning: Warning): String =
       warning match {
-        case Warning(code, agent, text, date) => {
+        case Warning(code, agent, text, date) =>
           val formattedDate = date match {
             case Some(value) => DateEncoding.default.encodeDate(value)
             case None        => ""
           }
           if (formattedDate.isEmpty) {
-            code.toString + " " + agent + " " + text
+            code.toString + " " + agent + " " + '"' + text + '"'
           } else {
-            code.toString + " " + agent + " " + text + " " + '"' + formattedDate + '"'
+            code.toString + " " + agent + " " + '"' + text + '"' + " " + '"' + formattedDate + '"'
           }
-        }
       }
   }
 

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -136,7 +136,7 @@ object Response {
 
     val message2 = OutputEncoder.encodeHtml(if (message == null) status.text else message)
 
-    Response(status = status, headers = Headers(Header.Warning(status.code, "ZIO HTTP", message2)))
+    Response(status = status, headers = Headers(Header.Warning(199, "ZIO HTTP", message2)))
   }
 
   def error(status: Status.Error): Response =

--- a/zio-http/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/src/main/scala/zio/http/Routes.scala
@@ -16,7 +16,6 @@
 package zio.http
 
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * Represents a collection of routes, each of which is defined by a pattern and
@@ -65,19 +64,58 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
 
   /**
    * Handles all typed errors in the routes by converting them into responses.
+   * This method can be used to convert routes that do not handle their errors
+   * into ones that do handle their errors.
    */
   def handleError(f: Err => Response)(implicit trace: Trace): Routes[Env, Nothing] =
     new Routes(routes.map(_.handleError(f)))
 
   /**
    * Handles all typed errors, as well as all non-recoverable errors, by
-   * converting them into responses.
+   * converting them into responses. This method can be used to convert routes
+   * that do not handle their errors into ones that do handle their errors.
    */
   def handleErrorCause(f: Cause[Err] => Response)(implicit trace: Trace): Routes[Env, Nothing] =
     new Routes(routes.map(_.handleErrorCause(f)))
 
+  /**
+   * Handles all typed errors, as well as all non-recoverable errors, by
+   * converting them into a ZIO effect that produces the response. This method
+   * can be used to convert routes that do not handle their errors into ones
+   * that do handle their errors.
+   */
   def handleErrorCauseZIO(f: Cause[Err] => ZIO[Any, Nothing, Response])(implicit trace: Trace): Routes[Env, Nothing] =
     new Routes(routes.map(_.handleErrorCauseZIO(f)))
+
+  /**
+   * Handles all typed errors in the routes by converting them into responses,
+   * taking into account the request that caused the error. This method can be
+   * used to convert routes that do not handle their errors into ones that do
+   * handle their errors.
+   */
+  def handleErrorRequest(f: (Err, Request) => Response)(implicit trace: Trace): Routes[Env, Nothing] =
+    new Routes(routes.map(_.handleErrorRequest(f)))
+
+  /**
+   * Handles all typed errors in the routes by converting them into responses,
+   * taking into account the request that caused the error. This method can be
+   * used to convert routes that do not handle their errors into ones that do
+   * handle their errors.
+   */
+  def handleErrorRequestCause(f: (Request, Cause[Err]) => Response)(implicit trace: Trace): Routes[Env, Nothing] =
+    new Routes(routes.map(_.handleErrorRequestCause(f)))
+
+  /**
+   * Handles all typed errors, as well as all non-recoverable errors, by
+   * converting them into a ZIO effect that produces the response, taking into
+   * account the request that caused the error. This method can be used to
+   * convert routes that do not handle their errors into ones that do handle
+   * their errors.
+   */
+  def handleErrorRequestCauseZIO(f: (Request, Cause[Err]) => ZIO[Any, Nothing, Response])(implicit
+    trace: Trace,
+  ): Routes[Env, Nothing] =
+    new Routes(routes.map(_.handleErrorRequestCauseZIO(f)))
 
   /**
    * Returns new routes that have each been provided the specified environment,

--- a/zio-http/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RouteSpec.scala
@@ -64,7 +64,7 @@ object RouteSpec extends ZIOHttpSpec {
     ),
     suite("error handle")(
       test("handleErrorCauseZIO should execute a ZIO effect") {
-        val route = Method.GET / "endpoint" -> handler { (req: Request) => ZIO.fail(new Exception("hmm...")) }
+        val route = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
         for {
           p <- zio.Promise.make[Exception, String]
 
@@ -76,6 +76,43 @@ object RouteSpec extends ZIOHttpSpec {
           result   <- p.await.catchAllCause(c => ZIO.succeed(c.prettyPrint))
 
         } yield assertTrue(extractStatus(response) == Status.InternalServerError, result.contains("hmm..."))
+      },
+      test("handleErrorCauseRequestZIO should produce an error based on the request") {
+        val route = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
+        for {
+          p <- zio.Promise.make[Exception, String]
+
+          errorHandled = route
+            .handleErrorRequestCauseZIO((req, c) =>
+              p.failCause(c).as(Response.internalServerError(s"error accessing ${req.path.encode}")),
+            )
+
+          request = Request.get(URL.decode("/endpoint").toOption.get)
+          response      <- errorHandled.toHttpApp.runZIO(request)
+          result        <- p.await.catchAllCause(c => ZIO.succeed(c.prettyPrint))
+          resultWarning <- ZIO.fromOption(response.headers.get(Header.Warning).map(_.text))
+
+        } yield assertTrue(
+          extractStatus(response) == Status.InternalServerError,
+          resultWarning == "error accessing /endpoint",
+          result.contains("hmm..."),
+        )
+      },
+      test("handleErrorCauseRequest should produce an error based on the request") {
+        val route        = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
+        val errorHandled =
+          route.handleErrorRequest((e, req) =>
+            Response.internalServerError(s"error accessing ${req.path.encode}: ${e.getMessage}"),
+          )
+        val request      = Request.get(URL.decode("/endpoint").toOption.get)
+        for {
+          response      <- errorHandled.toHttpApp.runZIO(request)
+          resultWarning <- ZIO.fromOption(response.headers.get(Header.Warning).map(_.text))
+
+        } yield assertTrue(
+          extractStatus(response) == Status.InternalServerError,
+          resultWarning == "error accessing /endpoint: hmm...",
+        )
       },
     ),
   )

--- a/zio-http/src/test/scala/zio/http/headers/WarningSpec.scala
+++ b/zio-http/src/test/scala/zio/http/headers/WarningSpec.scala
@@ -58,11 +58,11 @@ object WarningSpec extends ZIOHttpSpec {
       },
       test("Accepts Valid Warning with Date") {
         assertTrue(
-          Warning.parse(validWarningWithDate) == Right(Warning(112, "-", "\"cache down\"", Some(stubDate))),
+          Warning.parse(validWarningWithDate) == Right(Warning(112, "-", "cache down", Some(stubDate))),
         )
       },
       test("Accepts Valid Warning without Date") {
-        assertTrue(Warning.parse(validWarning) == Right(Warning(110, "anderson/1.3.37", "\"Response is stale\"")))
+        assertTrue(Warning.parse(validWarning) == Right(Warning(110, "anderson/1.3.37", "Response is stale")))
       },
       test("parsing and encoding is symmetrical for warning with Date") {
         val encodedWarningwithDate = Warning.render(Warning.parse(validWarningWithDate).toOption.get)


### PR DESCRIPTION
Bug fix on Warning header