### PR TITLE
Implement Routes#apply

### DIFF
--- a/zio-http/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/src/main/scala/zio/http/Routes.scala
@@ -57,6 +57,9 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
   def @@[Env1 <: Env](aspect: Middleware[Env1]): Routes[Env1, Err] =
     aspect(self)
 
+  def apply(request: Request)(implicit ev: Err <:< Response, trace: Trace): ZIO[Env, Response, Response] =
+    self.toHttpApp.apply(request)
+
   def asEnvType[Env2](implicit ev: Env2 <:< Env): Routes[Env2, Err] =
     self.asInstanceOf[Routes[Env2, Err]]
 


### PR DESCRIPTION
Resolves #2548. /claim #2548

`Route#apply` is already implemented and returns a `ZIO[Env, Response, Response]` so I think it makes sense for `Routes#apply` to do so as well. Also, I don't think the more polymorphic variant is well defined since a `Route` may already have a middleware applied to it that is a function from handler to handler where the error type is already specialized to `Response` and converting a `Cause` to a `Response` is not information preserving.