### PR TITLE
Provide context to multiple routes (#2488)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -74,7 +74,9 @@ object RouteSpec extends ZIOHttpSpec {
     ),
     suite("error handle")(
       test("handleErrorCauseZIO should execute a ZIO effect") {
-        val route = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
+        val route: Route[Any, Exception] = Method.GET / "endpoint" -> handler { (_: Request) =>
+          ZIO.fail(new Exception("hmm..."))
+        }
         for {
           p <- zio.Promise.make[Exception, String]
 
@@ -88,7 +90,9 @@ object RouteSpec extends ZIOHttpSpec {
         } yield assertTrue(extractStatus(response) == Status.InternalServerError, result.contains("hmm..."))
       },
       test("handleErrorCauseRequestZIO should produce an error based on the request") {
-        val route = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
+        val route: Route[Any, Exception] = Method.GET / "endpoint" -> handler { (_: Request) =>
+          ZIO.fail(new Exception("hmm..."))
+        }
         for {
           p <- zio.Promise.make[Exception, String]
 
@@ -109,12 +113,14 @@ object RouteSpec extends ZIOHttpSpec {
         )
       },
       test("handleErrorCauseRequest should produce an error based on the request") {
-        val route        = Method.GET / "endpoint" -> handler { (_: Request) => ZIO.fail(new Exception("hmm...")) }
-        val errorHandled =
+        val route: Route[Any, Exception] = Method.GET / "endpoint" -> handler { (_: Request) =>
+          ZIO.fail(new Exception("hmm..."))
+        }
+        val errorHandled                 =
           route.handleErrorRequest((e, req) =>
             Response.internalServerError(s"error accessing ${req.path.encode}: ${e.getMessage}"),
           )
-        val request      = Request.get(URL.decode("/endpoint").toOption.get)
+        val request                      = Request.get(URL.decode("/endpoint").toOption.get)
         for {
           response      <- errorHandled.toHttpApp.runZIO(request)
           resultWarning <- ZIO.fromOption(response.headers.get(Header.Warning).map(_.text))

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
@@ -104,10 +104,12 @@ object ServerSpec extends HttpRunnableSpec {
           }
       } +
       suite("echo content") {
-        val app = (RoutePattern.any ->
-          handler { (_: Path, req: Request) =>
-            req.body.asString.map(text => Response.text(text))
-          }).sandbox.toHttpApp
+        val app = Routes(
+          RoutePattern.any ->
+            handler { (_: Path, req: Request) =>
+              req.body.asString.map(text => Response.text(text))
+            },
+        ).sandbox.toHttpApp
 
         test("status is 200") {
           val res = app.deploy.status.run()

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -134,7 +134,7 @@ object Middleware extends HandlerAspects {
         response.addHeaders(headers)
       })
 
-    val optionsRoute = {
+    val optionsRoute: Route[Any, Nothing] = {
       implicit val trace: Trace = Trace.empty
 
       Method.OPTIONS / trailing -> handler { (_: Path, request: Request) =>

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -429,6 +429,14 @@ object Route                   {
     override def toString() = s"Route.Augmented(${route}, ${aspect})"
   }
 
+  final case class PartialRoute[PathInput, Ctx, In, Input, -Env, +Err](
+    routePattern: RoutePattern[PathInput],
+    handler: Handler[Env, Err, Input, Response],
+    zippable1: Zippable.Out[PathInput, Ctx, In],
+    zippable: Zippable.Out[In, Request, Input],
+    trace: Trace,
+  )
+
   private final case class Handled[-Env](
     routePattern: RoutePattern[_],
     handler: Handler[Env, Response, Request, Response],
@@ -439,7 +447,7 @@ object Route                   {
 
     override def toString() = s"Route.Handled(${routePattern}, ${location})"
   }
-  private final case class Unhandled[Params, Input, -Env, +Err](
+  private[http] final case class Unhandled[Params, Input, -Env, +Err](
     rpm: Route.Builder[Env, Params],
     handler: Handler[Env, Err, Input, Response],
     zippable: Zippable.Out[Params, Request, Input],

--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -64,6 +64,13 @@ final case class RoutePattern[A](method: Method, pathCodec: PathCodec[A]) { self
   ): Route[Env, Err] =
     Route.route(Route.Builder(self, HandlerAspect.identity))(handler)(zippable.zippable, trace)
 
+  def -->[Env, Err, I, Ctx, In](handler: Handler[Env, Err, I, Response])(implicit
+    zippable: RequestHandlerInput[In, I],
+    trace: zio.Trace,
+    context: Zippable.Out[A, Ctx, In],
+  ): Route.PartialRoute[A, Ctx, In, I, Env, Err] =
+    Route.PartialRoute(self, handler, context, zippable.zippable, trace)
+
   /**
    * Creates a route from this pattern and the specified handler, which ignores
    * any parameters produced by this route pattern. This method exists for

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -213,30 +213,22 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
 }
 object Routes {
 
+  case class Builder[Env, Ctx, Err](routes: Seq[Route.Builder[Env, _, Ctx, _, Err]]) {
+    def @@(aspect: HandlerAspect[Env, Ctx]): Routes[Env, Err] =
+      new Routes(Chunk.fromIterable(routes.map(_ @@ aspect)))
+  }
+
   /**
    * Constructs new routes from a varargs of individual routes.
    */
   def apply[Env, Err](route: zio.http.Route[Env, Err], routes: zio.http.Route[Env, Err]*): Routes[Env, Err] =
     new Routes(Chunk(route) ++ Chunk.fromIterable(routes))
 
-  def apply[Env, Err, Ctx](aspect: HandlerAspect[Env, Ctx])(
-    route: Route.PartialRoute[_, Ctx, _, _, Env, Err],
-    routes: Route.PartialRoute[_, Ctx, _, _, Env, Err]*,
-  ): Routes[Env, Err] =
-    new Routes(
-      Chunk.fromIterable(
-        (route +: routes).map(route => {
-          val zippable = route.zippable1.asInstanceOf[Zippable[Any, Ctx]]
-          route.routePattern
-            .asInstanceOf[RoutePattern[Any]]
-            .->(aspect)(zippable)
-            .->(route.handler.asInstanceOf[Handler[Env, Err, Any, Response]])(
-              RequestHandlerInput(route.zippable.asInstanceOf[Zippable.Out[zippable.Out, Request, Any]]),
-              route.trace,
-            )
-        }),
-      ),
-    )
+  def build[Env, Err, Ctx](
+    route: Route.Builder[Env, _, Ctx, _, Err],
+    routes: Route.Builder[Env, _, Ctx, _, Err]*,
+  ): Routes.Builder[Env, Ctx, Err] =
+    Routes.Builder[Env, Ctx, Err](route +: routes)
 
   /**
    * A empty routes value that contains no routes inside it.


### PR DESCRIPTION
This PR is not good to go, but shows that I found a way how to provide a context to multiple routes without any more explicit typing or extremely strange syntax.

RFC and I happily accept suggestions on the syntax.

/claim #2488