### PR TITLE
Content-Length, chunked transfer encoding and Host header improvements

### DIFF
--- a/docs/dsl/body.md
+++ b/docs/dsl/body.md
@@ -59,13 +59,13 @@ To create an `Body` that encodes a Stream you can use `Body.fromStream`.
 - Using a Stream of Bytes
 
 ```scala mdoc:silent
-  val streamHttpData1: Body = Body.fromStream(ZStream.fromChunk(Chunk.fromArray("Some String".getBytes(Charsets.Http))))
+  val streamHttpData1: Body = Body.fromStreamChunked(ZStream.fromChunk(Chunk.fromArray("Some String".getBytes(Charsets.Http))))
 ```
 
 - Using a Stream of String
 
 ```scala mdoc:silent
-  val streamHttpData2: Body = Body.fromCharSequenceStream(ZStream("a", "b", "c"), Charsets.Http)
+  val streamHttpData2: Body = Body.fromCharSequenceStreamChunked(ZStream("a", "b", "c"), Charsets.Http)
 ```
 
 ### Creating a Body from a `File`
@@ -73,5 +73,5 @@ To create an `Body` that encodes a Stream you can use `Body.fromStream`.
 To create an `Body` that encodes a File you can use `Body.fromFile`:
 
 ```scala mdoc:silent:crash
-  val fileHttpData: Body = Body.fromFile(new java.io.File(getClass.getResource("/fileName.txt").getPath))
+  val fileHttpData: ZIO[Any, Nothing, Body] = Body.fromFile(new java.io.File(getClass.getResource("/fileName.txt").getPath))
 ```

--- a/docs/dsl/headers.md
+++ b/docs/dsl/headers.md
@@ -88,9 +88,7 @@ object SimpleResponseDispatcher extends ZIOAppDefault {
           if (acceptsStreaming)
             Response(
               status = Status.Ok,
-              // Setting response header 
-              headers = Headers(Header.ContentLength(message.length.toLong)), // adding CONTENT-LENGTH header
-              body = Body.fromStream(ZStream.fromChunk(message)), // Encoding content using a ZStream
+              body = Body.fromStream(ZStream.fromChunk(message), message.length.toLong), // Encoding content using a ZStream
             )
           else {
             // Adding a custom header to Response

--- a/docs/examples/advanced/streaming-file.md
+++ b/docs/examples/advanced/streaming-file.md
@@ -22,7 +22,7 @@ object FileStreaming extends ZIOAppDefault {
 
     // Read the file as ZStream
     // Uses the blocking version of ZStream.fromFile
-    Method.GET / "blocking" -> Handler.fromStream(ZStream.fromPath(Paths.get("README.md"))),
+    Method.GET / "blocking" -> Handler.fromStreamChunked(ZStream.fromPath(Paths.get("README.md"))),
 
     // Uses netty's capability to write file content to the Channel
     // Content-type response headers are automatically identified and added

--- a/docs/examples/advanced/streaming-response.md
+++ b/docs/examples/advanced/streaming-response.md
@@ -30,8 +30,7 @@ object StreamingResponse extends ZIOAppDefault {
       handler(
         http.Response(
           status = Status.Ok,
-          headers = Headers(Header.ContentLength(message.length.toLong)),
-          body = Body.fromStream(ZStream.fromChunk(message)), // Encoding content using a ZStream
+          body = Body.fromStream(ZStream.fromChunk(message), message.length.toLong), // Encoding content using a ZStream
         ),
       ),
   ).toHttpApp

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/Retriever.scala
@@ -50,7 +50,7 @@ private[cli] object Retriever {
 
     override def retrieve(): Task[FormField] =
       for {
-        chunk <- Body.fromFile(new java.io.File(path.toUri())).asChunk
+        chunk <- Body.fromFile(new java.io.File(path.toUri())).flatMap(_.asChunk)
       } yield FormField.binaryField(name, chunk, media)
 
   }

--- a/zio-http-example/src/main/scala/example/FileStreaming.scala
+++ b/zio-http-example/src/main/scala/example/FileStreaming.scala
@@ -17,7 +17,7 @@ object FileStreaming extends ZIOAppDefault {
 
     // Read the file as ZStream
     // Uses the blocking version of ZStream.fromFile
-    Method.GET / "blocking" -> Handler.fromStream(ZStream.fromPath(Paths.get("README.md"))),
+    Method.GET / "blocking" -> Handler.fromStreamChunked(ZStream.fromPath(Paths.get("README.md"))),
 
     // Uses netty's capability to write file content to the Channel
     // Content-type response headers are automatically identified and added

--- a/zio-http-example/src/main/scala/example/RequestStreaming.scala
+++ b/zio-http-example/src/main/scala/example/RequestStreaming.scala
@@ -14,7 +14,7 @@ object RequestStreaming extends ZIOAppDefault {
 
     // Creating HttpData from the stream
     // This works for file of any size
-    val data = Body.fromStream(stream)
+    val data = Body.fromStreamChunked(stream)
 
     Response(body = data)
   }).toHttpApp

--- a/zio-http-example/src/main/scala/example/StreamingResponse.scala
+++ b/zio-http-example/src/main/scala/example/StreamingResponse.scala
@@ -25,8 +25,7 @@ object StreamingResponse extends ZIOAppDefault {
       handler(
         http.Response(
           status = Status.Ok,
-          headers = Headers(Header.ContentLength(message.length.toLong)),
-          body = Body.fromStream(ZStream.fromChunk(message)), // Encoding content using a ZStream
+          body = Body.fromStream(ZStream.fromChunk(message), message.length.toLong), // Encoding content using a ZStream
         ),
       ),
   ).toHttpApp

--- a/zio-http/src/main/scala/zio/http/Body.scala
+++ b/zio-http/src/main/scala/zio/http/Body.scala
@@ -16,7 +16,7 @@
 
 package zio.http
 
-import java.io.FileInputStream
+import java.io.{FileInputStream, IOException}
 import java.nio.charset._
 import java.nio.file._
 
@@ -121,6 +121,11 @@ trait Body { self =>
   def isComplete: Boolean
 
   /**
+   * Returns whether or not the content length is known
+   */
+  def knownContentLength: Option[Long]
+
+  /**
    * Returns whether or not the body is known to be empty. Note that some bodies
    * may not be known to be empty until an attempt is made to consume them.
    */
@@ -167,8 +172,10 @@ object Body {
   /**
    * Constructs a [[zio.http.Body]] from the contents of a file.
    */
-  def fromFile(file: java.io.File, chunkSize: Int = 1024 * 4): Body =
-    FileBody(file, chunkSize)
+  def fromFile(file: java.io.File, chunkSize: Int = 1024 * 4)(implicit trace: Trace): ZIO[Any, Nothing, Body] =
+    ZIO.succeed(file.length()).map { fileSize =>
+      FileBody(file, chunkSize, fileSize)
+    }
 
   /**
    * Constructs a [[zio.http.Body]] from from form data, using multipart
@@ -180,7 +187,7 @@ object Body {
   )(implicit trace: Trace): Body = {
     val bytes = form.multipartBytes(specificBoundary)
 
-    StreamBody(bytes, Some(MediaType.multipart.`form-data`), Some(specificBoundary))
+    StreamBody(bytes, knownContentLength = None, Some(MediaType.multipart.`form-data`), Some(specificBoundary))
   }
 
   /**
@@ -192,26 +199,48 @@ object Body {
     form: Form,
   )(implicit trace: Trace): UIO[Body] =
     form.multipartBytesUUID.map { case (boundary, bytes) =>
-      StreamBody(bytes, Some(MediaType.multipart.`form-data`), Some(boundary))
+      StreamBody(bytes, knownContentLength = None, Some(MediaType.multipart.`form-data`), Some(boundary))
     }
 
   /**
-   * Constructs a [[zio.http.Body]] from a stream of bytes.
+   * Constructs a [[zio.http.Body]] from a stream of bytes with a known length.
    */
-  def fromStream(stream: ZStream[Any, Throwable, Byte]): Body =
-    StreamBody(stream)
+  def fromStream(stream: ZStream[Any, Throwable, Byte], contentLength: Long): Body =
+    StreamBody(stream, knownContentLength = Some(contentLength))
 
   /**
-   * Constructs a [[zio.http.Body]] from a stream of text, using the specified
-   * character set, which defaults to the HTTP character set.
+   * Constructs a [[zio.http.Body]] from a stream of bytes of unknown length,
+   * using chunked transfer encoding.
+   */
+  def fromStreamChunked(stream: ZStream[Any, Throwable, Byte]): Body =
+    StreamBody(stream, knownContentLength = None)
+
+  /**
+   * Constructs a [[zio.http.Body]] from a stream of text with known length,
+   * using the specified character set, which defaults to the HTTP character
+   * set.
    */
   def fromCharSequenceStream(
+    stream: ZStream[Any, Throwable, CharSequence],
+    contentLength: Long,
+    charset: Charset = Charsets.Http,
+  )(implicit
+    trace: Trace,
+  ): Body =
+    fromStream(stream.map(seq => Chunk.fromArray(seq.toString.getBytes(charset))).flattenChunks, contentLength)
+
+  /**
+   * Constructs a [[zio.http.Body]] from a stream of text with unknown length
+   * using chunked transfer encoding, using the specified character set, which
+   * defaults to the HTTP character set.
+   */
+  def fromCharSequenceStreamChunked(
     stream: ZStream[Any, Throwable, CharSequence],
     charset: Charset = Charsets.Http,
   )(implicit
     trace: Trace,
   ): Body =
-    fromStream(stream.map(seq => Chunk.fromArray(seq.toString.getBytes(charset))).flattenChunks)
+    fromStreamChunked(stream.map(seq => Chunk.fromArray(seq.toString.getBytes(charset))).flattenChunks)
 
   /**
    * Helper to create Body from String
@@ -262,6 +291,8 @@ object Body {
     override def contentType(newMediaType: MediaType): Body = EmptyBody
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body = EmptyBody
+
+    override def knownContentLength: Option[Long] = Some(0L)
   }
 
   private[zio] final case class ChunkBody(
@@ -291,11 +322,14 @@ object Body {
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
       copy(mediaType = Some(newMediaType), boundary = boundary.orElse(Some(newBoundary)))
+
+    override def knownContentLength: Option[Long] = Some(data.length.toLong)
   }
 
   private[zio] final case class FileBody(
-    val file: java.io.File,
+    file: java.io.File,
     chunkSize: Int = 1024 * 4,
+    fileSize: Long,
     override val mediaType: Option[MediaType] = None,
     override val boundary: Option[Boundary] = None,
   ) extends Body
@@ -339,10 +373,13 @@ object Body {
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
       copy(mediaType = Some(newMediaType), boundary = boundary.orElse(Some(newBoundary)))
+
+    override def knownContentLength: Option[Long] = Some(fileSize)
   }
 
   private[zio] final case class StreamBody(
     stream: ZStream[Any, Throwable, Byte],
+    knownContentLength: Option[Long],
     override val mediaType: Option[MediaType] = None,
     override val boundary: Option[Boundary] = None,
   ) extends Body {
@@ -384,6 +421,8 @@ object Body {
     def contentType(newMediaType: zio.http.MediaType): zio.http.Body = this
 
     def contentType(newMediaType: zio.http.MediaType, newBoundary: zio.http.Boundary): zio.http.Body = this
+
+    override def knownContentLength: Option[Long] = Some(0L)
 
   }
 

--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -832,17 +832,18 @@ object Handler {
             ZIO.fail(new AccessDeniedException(file.getAbsolutePath))
           } else {
             if (file.isFile) {
-              val length   = Headers(Header.ContentLength(file.length()))
-              val response = http.Response(headers = length, body = Body.fromFile(file))
-              val pathName = file.toPath.toString
+              Body.fromFile(file).flatMap { body =>
+                val response = http.Response(body = body)
+                val pathName = file.toPath.toString
 
-              // Set MIME type in the response headers. This is only relevant in
-              // case of RandomAccessFile transfers as browsers use the MIME type,
-              // not the file extension, to determine how to process a URL.
-              // {{{<a href="MSDN Doc">https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type</a>}}}
-              determineMediaType(pathName) match {
-                case Some(mediaType) => ZIO.succeed(response.addHeader(Header.ContentType(mediaType)))
-                case None            => ZIO.succeed(response)
+                // Set MIME type in the response headers. This is only relevant in
+                // case of RandomAccessFile transfers as browsers use the MIME type,
+                // not the file extension, to determine how to process a URL.
+                // {{{<a href="MSDN Doc">https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type</a>}}}
+                determineMediaType(pathName) match {
+                  case Some(mediaType) => ZIO.succeed(response.addHeader(Header.ContentType(mediaType)))
+                  case None            => ZIO.succeed(response)
+                }
               }
             } else {
               ZIO.fail(new NotDirectoryException(s"Found directory instead of a file."))
@@ -897,11 +898,10 @@ object Handler {
                   .acquireReleaseWith(openZip)(closeZip)
                   .mapZIO(jar => ZIO.attemptBlocking(jar.getEntry(resourcePath) -> jar))
                   .flatMap { case (entry, jar) => ZStream.fromInputStream(jar.getInputStream(entry)) }
-                response      = Response(body = Body.fromStream(inZStream))
+                response      = Response(body = Body.fromStream(inZStream, contentLength))
               } yield mediaType.fold(response) { t =>
                 response
                   .addHeader(Header.ContentType(t))
-                  .addHeader(Header.ContentLength(contentLength))
               }
             }
         }
@@ -913,27 +913,53 @@ object Handler {
 
   /**
    * Creates a Handler that always succeeds with a 200 status code and the
-   * provided ZStream as the body
+   * provided ZStream with a known content length as the body
    */
-  def fromStream[R](stream: ZStream[R, Throwable, String], charset: Charset = Charsets.Http)(implicit
-    trace: Trace,
+  def fromStream[R](stream: ZStream[R, Throwable, String], contentLength: Long, charset: Charset = Charsets.Http)(
+    implicit trace: Trace,
   ): Handler[R, Throwable, Any, Response] =
     Handler.fromZIO {
       ZIO.environment[R].map { env =>
-        fromBody(Body.fromCharSequenceStream(stream.provideEnvironment(env), charset))
+        fromBody(Body.fromCharSequenceStream(stream.provideEnvironment(env), contentLength, charset))
       }
     }.flatten
 
   /**
    * Creates a Handler that always succeeds with a 200 status code and the
-   * provided ZStream as the body
+   * provided ZStream with a known content length as the body
    */
-  def fromStream[R](stream: ZStream[R, Throwable, Byte])(implicit
+  def fromStream[R](stream: ZStream[R, Throwable, Byte], contentLength: Long)(implicit
     trace: Trace,
   ): Handler[R, Throwable, Any, Response] =
     Handler.fromZIO {
       ZIO.environment[R].map { env =>
-        fromBody(Body.fromStream(stream.provideEnvironment(env)))
+        fromBody(Body.fromStream(stream.provideEnvironment(env), contentLength))
+      }
+    }.flatten
+
+  /**
+   * Creates a Handler that always succeeds with a 200 status code and the
+   * provided ZStream as the body using chunked transfer encoding
+   */
+  def fromStreamChunked[R](stream: ZStream[R, Throwable, String], charset: Charset = Charsets.Http)(implicit
+    trace: Trace,
+  ): Handler[R, Throwable, Any, Response] =
+    Handler.fromZIO {
+      ZIO.environment[R].map { env =>
+        fromBody(Body.fromCharSequenceStreamChunked(stream.provideEnvironment(env), charset))
+      }
+    }.flatten
+
+  /**
+   * Creates a Handler that always succeeds with a 200 status code and the
+   * provided ZStream as the body using chunked transfer encoding
+   */
+  def fromStreamChunked[R](stream: ZStream[R, Throwable, Byte])(implicit
+    trace: Trace,
+  ): Handler[R, Throwable, Any, Response] =
+    Handler.fromZIO {
+      ZIO.environment[R].map { env =>
+        fromBody(Body.fromStreamChunked(stream.provideEnvironment(env)))
       }
     }.flatten
 

--- a/zio-http/src/main/scala/zio/http/Response.scala
+++ b/zio-http/src/main/scala/zio/http/Response.scala
@@ -181,7 +181,7 @@ object Response {
    *   \- stream of data to be sent as Server Sent Events
    */
   def fromServerSentEvents(data: ZStream[Any, Nothing, ServerSentEvent])(implicit trace: Trace): Response =
-    Response(Status.Ok, contentTypeEventStream, Body.fromCharSequenceStream(data.map(_.encode)))
+    Response(Status.Ok, contentTypeEventStream, Body.fromCharSequenceStreamChunked(data.map(_.encode)))
 
   /**
    * Creates a new response for the provided socket app

--- a/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -143,10 +143,10 @@ private[http] object BodyCodec {
       ZIO.succeed((body.asStream >>> ZPipeline.decodeCharsWith(Charset.defaultCharset()) >>> codec.streamDecoder).orDie)
 
     def encodeToBody(value: ZStream[Any, Nothing, E], codec: BinaryCodec[E])(implicit trace: Trace): Body =
-      Body.fromStream(value >>> codec.streamEncoder)
+      Body.fromStreamChunked(value >>> codec.streamEncoder)
 
     def encodeToBody(value: ZStream[Any, Nothing, E], codec: Codec[String, Char, E])(implicit trace: Trace): Body =
-      Body.fromStream(value >>> codec.streamEncoder.map(_.toByte))
+      Body.fromStreamChunked(value >>> codec.streamEncoder.map(_.toByte))
 
     type Element = E
   }

--- a/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -530,13 +530,15 @@ private[codec] object EncoderDecoder {
       } else None
     private def encodeBody(inputs: Array[Any], contentType: => Header.ContentType): Body = {
       if (isByteStream) {
-        Body.fromStream(inputs(0).asInstanceOf[ZStream[Any, Nothing, Byte]])
+        Body.fromStreamChunked(inputs(0).asInstanceOf[ZStream[Any, Nothing, Byte]])
       } else {
         if (inputs.length > 1) {
           Body.fromMultipartForm(encodeMultipartFormData(inputs), formBoundary)
         } else {
           if (isEventStream) {
-            Body.fromCharSequenceStream(inputs(0).asInstanceOf[ZStream[Any, Nothing, ServerSentEvent]].map(_.encode))
+            Body.fromCharSequenceStreamChunked(
+              inputs(0).asInstanceOf[ZStream[Any, Nothing, ServerSentEvent]].map(_.encode),
+            )
           } else if (inputs.length < 1) {
             Body.empty
           } else {

--- a/zio-http/src/main/scala/zio/http/netty/NettyBody.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBody.scala
@@ -39,8 +39,14 @@ object NettyBody extends BodyEncoding {
 
   private[zio] def fromAsync(
     unsafeAsync: UnsafeAsync => Unit,
+    knownContentLength: Option[Long],
     contentTypeHeader: Option[Header.ContentType] = None,
-  ): Body = AsyncBody(unsafeAsync, contentTypeHeader.map(_.mediaType), contentTypeHeader.flatMap(_.boundary))
+  ): Body = AsyncBody(
+    unsafeAsync,
+    knownContentLength,
+    contentTypeHeader.map(_.mediaType),
+    contentTypeHeader.flatMap(_.boundary),
+  )
 
   /**
    * Helper to create Body from ByteBuf
@@ -79,6 +85,8 @@ object NettyBody extends BodyEncoding {
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
       copy(mediaType = Some(newMediaType), boundary = boundary.orElse(Some(newBoundary)))
+
+    override def knownContentLength: Option[Long] = Some(asciiString.length().toLong)
   }
 
   private[zio] final case class ByteBufBody(
@@ -109,10 +117,13 @@ object NettyBody extends BodyEncoding {
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
       copy(mediaType = Some(newMediaType), boundary = boundary.orElse(Some(newBoundary)))
+
+    override def knownContentLength: Option[Long] = Some(byteBuf.readableBytes().toLong)
   }
 
   private[zio] final case class AsyncBody(
     unsafeAsync: UnsafeAsync => Unit,
+    knownContentLength: Option[Long],
     override val mediaType: Option[MediaType] = None,
     override val boundary: Option[Boundary] = None,
   ) extends Body

--- a/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -224,13 +224,9 @@ private[zio] final case class ServerInboundHandler(
           remoteAddress = remoteAddress,
         )
       case nettyReq: HttpRequest     =>
-        val handler = addAsyncBodyHandler(ctx)
-        val body    = NettyBody.fromAsync(
-          { async =>
-            handler.connect(async)
-          },
-          contentType,
-        )
+        val knownContentLength = headers.get(Header.ContentLength).map(_.length)
+        val handler            = addAsyncBodyHandler(ctx)
+        val body               = NettyBody.fromAsync(async => handler.connect(async), knownContentLength, contentType)
 
         Request(
           body = body,

--- a/zio-http/src/test/scala/zio/http/BodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/BodySpec.scala
@@ -37,7 +37,7 @@ object BodySpec extends ZIOHttpSpec {
               check(Gen.string) { payload =>
                 val stringBuffer    = payload.getBytes(Charsets.Http)
                 val responseContent = ZStream.fromIterable(stringBuffer, chunkSize = 2)
-                val res             = Body.fromStream(responseContent).asString(Charsets.Http)
+                val res             = Body.fromStreamChunked(responseContent).asString(Charsets.Http)
                 assertZIO(res)(equalTo(payload))
               }
             },
@@ -45,12 +45,12 @@ object BodySpec extends ZIOHttpSpec {
           suite("fromFile")(
             test("success") {
               lazy val file = testFile
-              val res       = Body.fromFile(file).asString(Charsets.Http)
+              val res       = Body.fromFile(file).flatMap(_.asString(Charsets.Http))
               assertZIO(res)(equalTo("foo\nbar"))
             },
             test("success small chunk") {
               lazy val file = testFile
-              val res       = Body.fromFile(file, 3).asString(Charsets.Http)
+              val res       = Body.fromFile(file, 3).flatMap(_.asString(Charsets.Http))
               assertZIO(res)(equalTo("foo\nbar"))
             },
           ),

--- a/zio-http/src/test/scala/zio/http/ClientSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientSpec.scala
@@ -64,7 +64,7 @@ object ClientSpec extends HttpRunnableSpec {
       val app    = Handler.fromFunctionZIO[Request] { req => req.body.asString.map(Response.text(_)) }.sandbox.toHttpApp
       val stream = ZStream.fromIterable(List("a", "b", "c"), chunkSize = 1)
       val res    = app
-        .deploy(Request(method = Method.POST, body = Body.fromCharSequenceStream(stream)))
+        .deploy(Request(method = Method.POST, body = Body.fromCharSequenceStreamChunked(stream)))
         .flatMap(_.body.asString)
       assertZIO(res)(equalTo("abc"))
     },
@@ -87,7 +87,7 @@ object ClientSpec extends HttpRunnableSpec {
       } yield assertTrue(loggedUrl == s"$baseURL/")
     },
     test("reading of unfinished body must fail") {
-      val app         = Handler.fromStream(ZStream.never).sandbox.toHttpApp
+      val app         = Handler.fromStreamChunked(ZStream.never).sandbox.toHttpApp
       val requestCode = (client: Client) =>
         (for {
           response <- ZIO.scoped(client(Request()))

--- a/zio-http/src/test/scala/zio/http/HandlerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/HandlerSpec.scala
@@ -387,11 +387,12 @@ object HandlerSpec extends ZIOHttpSpec with ExitAssertion {
           val tempFile = tempPath.toFile
           val http     = Handler.fromFileZIO(ZIO.succeed(tempFile))
           for {
-            r <- http.apply {}
+            r        <- http.apply {}
+            tempFile <- Body.fromFile(tempFile)
           } yield {
             assert(r.status)(equalTo(Status.Ok)) &&
             assert(r.headers)(contains(Header.ContentType(MediaType.image.`jpeg`))) &&
-            assert(r.body)(equalTo(Body.fromFile(tempFile)))
+            assert(r.body)(equalTo(tempFile))
           }
         }
       },

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -41,7 +41,7 @@ object ResponseCompressionSpec extends ZIOHttpSpec {
             Headers(
               Header.ContentType(MediaType.text.plain),
             ),
-            Body.fromCharSequenceStream(
+            Body.fromCharSequenceStreamChunked(
               ZStream
                 .unfold[Long, String](0L) { s =>
                   if (s < 1000) Some((s"$s\n", s + 1)) else None

--- a/zio-http/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ServerSpec.scala
@@ -129,7 +129,7 @@ object ServerSpec extends HttpRunnableSpec {
             val app        =
               Routes(RoutePattern.any -> handler((_: Path, req: Request) => Response(body = req.body))).toHttpApp
             val res        =
-              app.deploy.body.mapZIO(_.asChunk.map(_.length)).run(body = Body.fromCharSequenceStream(dataStream))
+              app.deploy.body.mapZIO(_.asChunk.map(_.length)).run(body = Body.fromCharSequenceStreamChunked(dataStream))
             assertZIO(res)(equalTo(MaxSize))
           }
       } +
@@ -337,13 +337,13 @@ object ServerSpec extends HttpRunnableSpec {
       }
     },
     test("text streaming") {
-      val res = Handler.fromStream(ZStream("a", "b", "c")).sandbox.toHttpApp.deploy.body.mapZIO(_.asString).run()
+      val res = Handler.fromStreamChunked(ZStream("a", "b", "c")).sandbox.toHttpApp.deploy.body.mapZIO(_.asString).run()
       assertZIO(res)(equalTo("abc"))
     },
     test("echo streaming") {
       val res = Routes
         .singleton(handler { (_: Path, req: Request) =>
-          Handler.fromStream(ZStream.fromZIO(req.body.asChunk).flattenChunks): Handler[
+          Handler.fromStreamChunked(ZStream.fromZIO(req.body.asChunk).flattenChunks): Handler[
             Any,
             Throwable,
             (Path, Request),
@@ -361,7 +361,14 @@ object ServerSpec extends HttpRunnableSpec {
     test("file-streaming") {
       val path = getClass.getResource("/TestFile.txt").getPath
       val res  =
-        Handler.fromStream(ZStream.fromPath(Paths.get(path))).sandbox.toHttpApp.deploy.body.mapZIO(_.asString).run()
+        Handler
+          .fromStreamChunked(ZStream.fromPath(Paths.get(path)))
+          .sandbox
+          .toHttpApp
+          .deploy
+          .body
+          .mapZIO(_.asString)
+          .run()
       assertZIO(res)(equalTo("foo\nbar"))
     } @@ TestAspect.os(os => !os.isWindows),
     suite("html")(
@@ -426,7 +433,7 @@ object ServerSpec extends HttpRunnableSpec {
     test("POST Request stream") {
       val app: HttpApp[Any] = Routes.singleton {
         handler { (_: Path, req: Request) =>
-          Response(body = Body.fromStream(req.body.asStream))
+          Response(body = Body.fromStreamChunked(req.body.asStream))
         }
       }.toHttpApp
 

--- a/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
@@ -63,7 +63,8 @@ object HttpGen {
       url     <- HttpGen.url
       headers <- Gen.listOf(HttpGen.header).map(Headers(_))
       version <- httpVersion
-    } yield Request(version, method, url, headers, Body.fromFile(file), None)
+      body    <- Gen.fromZIO(Body.fromFile(file))
+    } yield Request(version, method, url, headers, body, None)
   }
 
   def genAbsoluteLocation: Gen[Any, Location.Absolute] = for {
@@ -97,7 +98,7 @@ object HttpGen {
       cnt  <- Gen
         .fromIterable(
           List(
-            Body.fromStream(
+            Body.fromStreamChunked(
               ZStream.fromIterable(list, chunkSize = 2).map(b => Chunk.fromArray(b.getBytes())).flattenChunks,
             ),
             Body.fromString(list.mkString("")),
@@ -134,7 +135,7 @@ object HttpGen {
       cnt  <- Gen
         .fromIterable(
           List(
-            Body.fromStream(
+            Body.fromStreamChunked(
               ZStream.fromIterable(list, chunkSize = 2).map(b => Chunk.fromArray(b.getBytes())).flattenChunks,
             ),
             Body.fromString(list.mkString("")),

--- a/zio-http/src/test/scala/zio/http/netty/NettyBodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyBodySpec.scala
@@ -31,12 +31,12 @@ object NettyBodySpec extends ZIOHttpSpec {
       suite("fromAsync")(
         test("success") {
           val message = Chunk.fromArray("Hello World".getBytes(Charsets.Http))
-          val chunk   = NettyBody.fromAsync(async => async(message, isLast = true)).asChunk
+          val chunk   = NettyBody.fromAsync(async => async(message, isLast = true), knownContentLength = None).asChunk
           assertZIO(chunk)(equalTo(message))
         },
         test("fail") {
           val exception = new RuntimeException("Some Error")
-          val error     = NettyBody.fromAsync(_ => throw exception).asChunk.flip
+          val error     = NettyBody.fromAsync(_ => throw exception, knownContentLength = None).asChunk.flip
           assertZIO(error)(equalTo(exception))
         },
       ),

--- a/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -19,10 +19,7 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
         handler(
           http.Response(
             status = Status.Ok,
-            // content length header is important,
-            // in this case the server will not use chunked transfer encoding even if response is a stream
-            headers = Headers(Header.ContentLength(len)),
-            body = Body.fromStream(streams.next()),
+            body = Body.fromStream(streams.next(), len),
           ),
         ),
     ).sandbox.toHttpApp

--- a/zio-http/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
@@ -31,7 +31,7 @@ import zio.http.netty.NettyConfig
 object NettyConnectionPoolSpec extends HttpRunnableSpec {
 
   private val app = Routes(
-    Method.POST / "streaming" -> handler((req: Request) => Response(body = Body.fromStream(req.body.asStream))),
+    Method.POST / "streaming" -> handler((req: Request) => Response(body = Body.fromStreamChunked(req.body.asStream))),
     Method.GET / "slow"       -> handler(ZIO.sleep(1.hour).as(Response.text("done"))),
     Method.ANY / trailing     -> handler((_: Path, req: Request) => req.body.asString.map(Response.text(_))),
   ).sandbox.toHttpApp
@@ -76,7 +76,7 @@ object NettyConnectionPoolSpec extends HttpRunnableSpec {
                   .deploy(
                     Request(
                       method = Method.POST,
-                      body = Body.fromCharSequenceStream(stream),
+                      body = Body.fromCharSequenceStreamChunked(stream),
                       headers = extraHeaders,
                     ),
                   )
@@ -113,7 +113,7 @@ object NettyConnectionPoolSpec extends HttpRunnableSpec {
                   Request(
                     method = Method.POST,
                     url = URL.root / "streaming",
-                    body = Body.fromCharSequenceStream(stream),
+                    body = Body.fromCharSequenceStreamChunked(stream),
                     headers = extraHeaders,
                   ),
                 )


### PR DESCRIPTION
Some fixes and improvements based on recent Discord discussions:

- If there is already a `Host` header set, it is not going to be overwritten based on the request url
- Content length information is now attached to the various `Body` types. If the content length is set, we will not use chunked transfer encoding, regardless of the body is streaming or not. 
- Some `Body` and `Handler` constructors are duplicated now having a variant that gets a known content length, and one that does not (using the post-fix `Chunked` for them)