### PR TITLE
Add scalafmt core as dependency to zio-http-gen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import BuildHelper._
-import Dependencies.{scalafmt, _}
+import Dependencies._
 import sbt.librarymanagement.ScalaArtifacts.isScala3
 import scala.concurrent.duration._
 
@@ -246,7 +246,8 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio`,
       `zio-test`,
       `zio-test-sbt`,
-      scalafmt.cross(CrossVersion.for3Use2_13),
+      `scalafmt-dynamic`.cross(CrossVersion.for3Use2_13),
+      `scalafmt-core`.cross(CrossVersion.for3Use2_13),
     ),
   )
   .dependsOn(zioHttp)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,8 @@ object Dependencies {
   val `jwt-core`                 = "com.github.jwt-scala"   %% "jwt-core"                % JwtCoreVersion
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
-  val scalafmt = "org.scalameta" %% "scalafmt-dynamic" % "3.7.17"
+  val `scalafmt-dynamic` = "org.scalameta" %% "scalafmt-dynamic" % "3.7.17"
+  val `scalafmt-core`    = "org.scalameta" %% "scalafmt-core" % "3.7.17"
 
   val netty =
     Seq(

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -1,6 +1,5 @@
 package zio.http.gen.scala
 
-import java.io.File
 import java.nio.file._
 
 import scala.jdk.CollectionConverters._
@@ -200,5 +199,5 @@ object CodeGenSpec extends ZIOSpecDefault {
           "/GeneratedPaymentNoDiscriminator.scala",
         )
       },
-    ) @@ java11OrNewer @@ flaky // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer
 }


### PR DESCRIPTION
This shifts it being downloaded during test execution to download during
sbt init/compile. This should result in more stable tests.
Before downloading scalafmt in ci was flaky
