### PR TITLE
Update Contributor Guidelines link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Learn more on the [ZIO Http homepage](https://github.com/zio/zio-http)!
 
 ## Contributing
 
-For the general guidelines, see ZIO [contributor's guide](https://zio.dev/about/contributing).
+For the general guidelines, see ZIO [contributor's guide](https://zio.dev/contributor-guidelines).
 
 ## Code of Conduct
 


### PR DESCRIPTION
**Changes Overview:**
Updated the link on the readme of contributing page to direct to the correct resource.

**Context:**
The existing link in the readme page had become outdated, causing confusion for contributors seeking essential information. This pull request resolves the issue by replacing the link with the most recent and pertinent resource.

**Reasons for the Change:**
The previous link became invalid, necessitating an update to ensure contributors can effortlessly access the required information. This adjustment is in line with the repository's objective of providing precise and current resources for contributors.

**Previous Link:**
https://zio.dev/about/contributing

**Updated Link:**
https://zio.dev/contributor-guidelines/
