### PR TITLE
feat: OpenAPI allow non-nominal cases in enum

### DIFF
--- a/zio-http/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -346,12 +346,11 @@ object JsonSchema {
               val key    =
                 nominal(c.schema, refType)
                   .orElse(nominal(c.schema, SchemaStyle.Compact))
-                  .getOrElse(throw new Exception(s"Unsupported enum case schema: ${c.schema}"))
               val nested = fromZSchemaMulti(
                 c.schema,
                 refType,
               )
-              nested.children + (key -> nested.root)
+              nested.children ++ key.map(_ -> nested.root)
             }
             .toMap,
         )


### PR DESCRIPTION
We used to collect the references of the child cases and fail in case we came across a case without a nominal ref. This is not needed to correctly generate the `oneOf` structure in the openapi document, but to include the children to the schemas. After the change, we simply skip cases without a nominal ref when collection children. This allows for schemas like `Enum2(String, Int)` to be turned into `oneOf: [string, number]` correctly. Obviously, there will be no child schemas in this case.