### PR TITLE
Allow creating a body from `Array[Byte]`

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -13,10 +13,39 @@ import sttp.client3.{HttpURLConnectionBackend, UriContext, basicRequest}
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
 class ServerInboundHandlerBenchmark {
+  private val random      = scala.util.Random
+  random.setSeed(42)
+  private val largeString = random.alphanumeric.take(100_000).mkString
+
+  private val baseUrl = "http://localhost:8080"
+  private val headers = Headers(Header.ContentType(MediaType.text.`plain`).untyped)
+
+  private val arrayEndpoint = "array"
+  private val arrayResponse = ZIO.succeed(
+    Response(
+      status = Status.Ok,
+      headers = headers,
+      body = Body.fromArray(largeString.getBytes),
+    ),
+  )
+  private val arrayRoute    = Route.route(Method.GET / arrayEndpoint)(handler(arrayResponse))
+  private val arrayRequest  = basicRequest.get(uri"$baseUrl/$arrayEndpoint")
+
+  private val chunkEndpoint = "chunk"
+  private val chunkResponse = ZIO.succeed(
+    Response(
+      status = Status.Ok,
+      headers = headers,
+      body = Body.fromChunk(Chunk.fromArray(largeString.getBytes)),
+    ),
+  )
+  private val chunkRoute    = Route.route(Method.GET / chunkEndpoint)(handler(chunkResponse))
+  private val chunkRequest  = basicRequest.get(uri"$baseUrl/$chunkEndpoint")
+
   private val testResponse = ZIO.succeed(Response.text("Hello World!"))
   private val testEndPoint = "test"
   private val testRoute    = Route.route(Method.GET / testEndPoint)(handler(testResponse))
-  private val testUrl      = s"http://localhost:8080/$testEndPoint"
+  private val testUrl      = s"$baseUrl/$testEndPoint"
   private val testRequest  = basicRequest.get(uri"$testUrl")
 
   private val shutdownResponse = Response.text("shutting down")
@@ -27,7 +56,8 @@ class ServerInboundHandlerBenchmark {
 
   private def shutdownRoute(shutdownSignal: Promise[Nothing, Unit]) =
     Route.route(Method.GET / shutdownEndpoint)(handler(shutdownSignal.succeed(()).as(shutdownResponse)))
-  private def http(shutdownSignal: Promise[Nothing, Unit]) = Routes(testRoute, shutdownRoute(shutdownSignal)).toHttpApp
+  private def http(shutdownSignal: Promise[Nothing, Unit])          =
+    Routes(testRoute, arrayRoute, chunkRoute, shutdownRoute(shutdownSignal)).toHttpApp
 
   @Setup(Level.Trial)
   def setup(): Unit = {
@@ -58,7 +88,21 @@ class ServerInboundHandlerBenchmark {
   }
 
   @Benchmark
-  def benchmarkApp(): Unit = {
+  def benchmarkLargeArray(): Unit = {
+    val statusCode = arrayRequest.send(backend).code
+    if (!statusCode.isSuccess)
+      throw new RuntimeException(s"Received unexpected status code ${statusCode.code}")
+  }
+
+  @Benchmark
+  def benchmarkLargeChunk(): Unit = {
+    val statusCode = chunkRequest.send(backend).code
+    if (!statusCode.isSuccess)
+      throw new RuntimeException(s"Received unexpected status code ${statusCode.code}")
+  }
+
+  @Benchmark
+  def benchmarkSimple(): Unit = {
     val statusCode = testRequest.send(backend).code
     if (!statusCode.isSuccess)
       throw new RuntimeException(s"Received unexpected status code ${statusCode.code}")

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -15,7 +15,7 @@ import sttp.client3.{HttpURLConnectionBackend, UriContext, basicRequest}
 class ServerInboundHandlerBenchmark {
   private val random      = scala.util.Random
   random.setSeed(42)
-  private val largeString = random.alphanumeric.take(100_000).mkString
+  private val largeString = random.alphanumeric.take(100000).mkString
 
   private val baseUrl = "http://localhost:8080"
   private val headers = Headers(Header.ContentType(MediaType.text.`plain`).untyped)

--- a/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -108,6 +108,9 @@ object NettyBodyWriter {
               }
           },
         )
+      case ArrayBody(data, _, _)              =>
+        ctx.writeAndFlush(Unpooled.wrappedBuffer(data))
+        None
       case ChunkBody(data, _, _)              =>
         ctx.write(Unpooled.wrappedBuffer(data.toArray))
         ctx.flush()

--- a/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
+++ b/zio-http/src/test/scala/zio/http/internal/HttpGen.scala
@@ -102,6 +102,7 @@ object HttpGen {
             ),
             Body.fromString(list.mkString("")),
             Body.fromChunk(Chunk.fromArray(list.mkString("").getBytes())),
+            Body.fromArray(list.mkString("").getBytes()),
             Body.empty,
           ),
         )
@@ -139,6 +140,7 @@ object HttpGen {
             ),
             Body.fromString(list.mkString("")),
             Body.fromChunk(Chunk.fromArray(list.mkString("").getBytes())),
+            Body.fromArray(list.mkString("").getBytes()),
           ),
         )
     } yield cnt


### PR DESCRIPTION
I was doing some profiling on a simple "Hello world" app for large byte payloads (~65kb), and one of the things that stood out was that there was a very big memory allocation due to the copying of the `Chunk[Byte]` into an `Array[Byte]` (see screenshot at the bottom).

I think that this allocation can be avoided in 1 of 2 ways:

1. Extract the underlying `Array[Byte]` from `Chunk.Arr[Byte]` in the `UnsafeBytes#unsafeAsArray` method
2. Expose a new method allowing users to create a body directly via an array

In this PR, I went with (2) mostly because it eliminates the possibility of the array wrapped in a Chunk to be mutated. Having said that, (1) would not require changes in user's code to see the performance improvement so I'm happy to change this PR and go with option 1 instead.

I also added some extra benchmarks to showcase that besides the memory allocations, this change also improves the throughput of responses with large payloads. In the case of a 100kb payload, that's ~5% improvement in throughput. Note that the copying of the array happens _prior_ to any compression taking place, so it's likely that many users will see some benefit from this change

```
[info] Benchmark                                           Mode  Cnt      Score    Error  Units
[info] ServerInboundHandlerBenchmark.benchmarkLargeArray  thrpt    5  12104.157 ± 78.598  ops/s
[info] ServerInboundHandlerBenchmark.benchmarkLargeChunk  thrpt    5  11519.093 ± 99.231  ops/s
```

Flamegraph:

<img width="954" alt="image" src="https://github.com/zio/zio-http/assets/67301607/1e9f4500-f830-4e3f-bc13-4bc36ce9db61">
