### PR TITLE
Optimize RichTextCodec

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ProbeContentTypeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ProbeContentTypeBenchmark.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.util.Random
 
+import zio.http.Header.ContentType
 import zio.http.MediaType
 
 import org.openjdk.jmh.annotations._
@@ -14,11 +15,24 @@ import org.openjdk.jmh.annotations._
 class ProbeContentTypeBenchmark {
 
   private val extensions = List("mp4", "def", "mp3", "js", "html", "css", "gif", "jpeg")
+  private val header     = ContentType(MediaType.application.`json`)
 
   @Benchmark
   def benchmarkApp(): Unit = {
     val rand = Random.nextInt(8)
     MediaType.forFileExtension(extensions(rand))
+    ()
+  }
+
+  @Benchmark
+  def benchmarkParseContentType(): Unit = {
+    ContentType.parse("application/json; charset=utf-8")
+    ()
+  }
+
+  @Benchmark
+  def benchmarkRenderContentType(): Unit = {
+    ContentType.render(header)
     ()
   }
 }

--- a/zio-http/src/main/scala/zio/http/Header.scala
+++ b/zio-http/src/main/scala/zio/http/Header.scala
@@ -2501,7 +2501,8 @@ object Header {
       val valueQuoted  = quote ~ tokenStringQuoted ~ quote
       val value        = valueQuoted | tokenString
 
-      val whitespaces = RichTextCodec.whitespaceChar.repeat.const(Chunk.single(' '))
+      val unitChunk   = Chunk.single(())
+      val whitespaces = RichTextCodec.whitespaceChar.repeat.transform[Char](_ => ' ')(_ => unitChunk).const(' ')
       val param       = ((
         RichTextCodec.char(';').const(';') ~>
           whitespaces ~>

--- a/zio-http/src/main/scala/zio/http/Header.scala
+++ b/zio-http/src/main/scala/zio/http/Header.scala
@@ -30,7 +30,6 @@ import scala.util.{Either, Failure, Success, Try}
 import zio._
 
 import zio.http.codec.RichTextCodec
-import zio.http.endpoint.openapi.OpenAPI.SecurityScheme.Http
 import zio.http.internal.DateEncoding
 
 sealed trait Header {
@@ -2466,6 +2465,8 @@ object Header {
     override def self: Self = this
 
     override def headerType: HeaderType.Typed[ContentType] = ContentType
+
+    override lazy val renderedValue: String = ContentType.render(this)
   }
 
   object ContentType extends HeaderType {
@@ -2481,47 +2482,54 @@ object Header {
     private val codec: RichTextCodec[ContentType] = {
 
       // char `.` according to BNF not allowed as `token`, but here tolerated
-      val token = RichTextCodec.charsNot(' ', '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=')
+      val token       = RichTextCodec.charsNot(' ', '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=')
+      val tokenString = token.repeat.string
 
-      val tokenQuoted = RichTextCodec.charsNot(' ', '"')
+      val tokenStringQuoted = RichTextCodec.charsNot(' ', '"').repeat.string
 
-      val type1         = RichTextCodec.string.collectOrFail("unsupported main type") {
+      val type1        = RichTextCodec.string.collectOrFail("unsupported main type") {
         case value if MediaType.mainTypeMap.contains(value) => value
       }
-      val type1x        = (RichTextCodec.literalCI("x-") ~ token.repeat.string).transform[String](in => s"${in._1}${in._2}")(in => ("x-", s"${in.substring(2)}"))
-      val codecType1    = (type1 | type1x).transform[String](_.merge) {
+      val type1x       = (RichTextCodec.literalCI("x-") ~ tokenString).transform[String](in => s"${in._1}${in._2}")(in => ("x-", s"${in.substring(2)}"))
+      val codecType1   = (type1 | type1x).transform[String](_.merge) {
         case x if x.startsWith("x-") => Right(x)
         case x                       => Left(x)
       }
-      val codecType2    = token.repeat.string
-      val codecType     = (codecType1 <~ RichTextCodec.char('/').const('/')) ~ codecType2
-      val attribute     = token.repeat.string
-      val valueUnquoted = token.repeat.string
-      val valueQuoted   = RichTextCodec.char('"') ~ tokenQuoted.repeat.string ~ RichTextCodec.char('"')
-      val value         = valueQuoted | valueUnquoted
+      val forwardSlash = RichTextCodec.char('/').const('/')
+      val codecType    = (codecType1 <~ forwardSlash) ~ tokenString
+      val quote        = RichTextCodec.char('"')
+      val valueQuoted  = quote ~ tokenStringQuoted ~ quote
+      val value        = valueQuoted | tokenString
 
-      val param  = ((
+      val whitespaces = RichTextCodec.whitespaces.transform[Char](_ => ' ')(_ => ()).const(' ')
+      val param       = ((
         RichTextCodec.char(';').const(';') ~>
-          (RichTextCodec.whitespaceChar.repeat | RichTextCodec.empty).transform[Char](_ => ' ')(_ => Left(Chunk(()))).const(' ') ~>
-          attribute <~
+          whitespaces ~>
+          tokenString <~
           RichTextCodec.char('=').const('=')
       ) ~ value)
         .transformOrFailLeft[ContentType.Parameter](in => ContentType.Parameter.fromCodec(in))(in => in.toCodec)
-      val params = param.repeat
+      val params      = param.repeat
+
       (codecType ~ params).transform[ContentType] { case (mainType, subType, params) =>
         ContentType(
           MediaType.forContentType(s"$mainType/$subType").get,
-          params.collect { case p if p.key == ContentType.Parameter.Boundary.name => zio.http.Boundary(p.value) }.headOption,
-          params.collect { case p if p.key == ContentType.Parameter.Charset.name => java.nio.charset.Charset.forName(p.value) }.headOption,
+          params.collectFirst { case p if p.key == ContentType.Parameter.Boundary.name => zio.http.Boundary(p.value) },
+          params.collectFirst { case p if p.key == ContentType.Parameter.Charset.name => java.nio.charset.Charset.forName(p.value) },
         )
       }(in =>
         (
           in.mediaType.mainType,
-          in.mediaType.subType,
-          Chunk(
-            in.charset.map(in => Parameter.Charset(Parameter.Payload(Parameter.Charset.name, in, false))),
-            in.boundary.map(in => Parameter.Boundary(Parameter.Payload(Parameter.Boundary.name, in, false))),
-          ).flatten,
+          in.mediaType.subType, {
+            val charset  = in.charset.map(in => Parameter.Charset(Parameter.Payload(Parameter.Charset.name, in, false)))
+            val boundary = in.boundary.map(in => Parameter.Boundary(Parameter.Payload(Parameter.Boundary.name, in, false)))
+            (charset, boundary) match {
+              case (Some(c), Some(b)) => Chunk(c, b)
+              case (Some(c), _)       => Chunk.single(c)
+              case (_, Some(b))       => Chunk.single(b)
+              case _                  => Chunk.empty
+            }
+          },
         ),
       )
     }

--- a/zio-http/src/main/scala/zio/http/Header.scala
+++ b/zio-http/src/main/scala/zio/http/Header.scala
@@ -2501,7 +2501,7 @@ object Header {
       val valueQuoted  = quote ~ tokenStringQuoted ~ quote
       val value        = valueQuoted | tokenString
 
-      val whitespaces = RichTextCodec.whitespaces.transform[Char](_ => ' ')(_ => ()).const(' ')
+      val whitespaces = RichTextCodec.whitespaceChar.repeat.const(Chunk.single(' '))
       val param       = ((
         RichTextCodec.char(';').const(';') ~>
           whitespaces ~>

--- a/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.codec
 
-import zio.{Chunk, NonEmptyChunk}
-
 import java.lang.Integer.parseInt
+
 import scala.annotation.tailrec
 import scala.collection.immutable.BitSet
 import scala.util.control.ControlThrowable
+
+import zio.{Chunk, NonEmptyChunk}
 
 /**
  * A `RichTextCodec` is a more compositional version of `TextCodec`, which has
@@ -636,7 +637,7 @@ object RichTextCodec {
   private class ParserIndex {
     private var i = 0
 
-    def get(): Int         = i
+    def get(): Int          = i
     def set(idx: Int): Unit = i = idx
 
     def getAndIncr(): Int = {
@@ -645,7 +646,7 @@ object RichTextCodec {
       res
     }
 
-    def decr(): Unit        = i -= 1
+    def decr(): Unit = i -= 1
   }
 
 }

--- a/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
+++ b/zio-http/src/main/scala/zio/http/codec/RichTextCodec.scala
@@ -16,12 +16,13 @@
 
 package zio.http.codec
 
-import zio.{Chunk, NonEmptyChunk}
-
 import java.lang.Integer.parseInt
+
 import scala.annotation.tailrec
 import scala.collection.immutable.BitSet
 import scala.util.control.ControlThrowable
+
+import zio.{Chunk, NonEmptyChunk}
 
 /**
  * A `RichTextCodec` is a more compositional version of `TextCodec`, which has

--- a/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
+++ b/zio-http/src/test/scala/zio/http/codec/RichTextCodecSpec.scala
@@ -118,13 +118,11 @@ object RichTextCodecSpec extends ZIOHttpSpec {
       },
       test("describe simple recursion") {
         val codec = RichTextCodec.char('x').repeat
-        // This would be perhaps nicer as «1» ⩴ “x”* or even without the label.
-        assertTrue(textOf(codec.describe).get == "«1» ⩴ (“x” «1»)?")
+        assertTrue(textOf(codec.describe).get == "“x”*")
       },
       test("describe tagged simple recursion") {
         val codec = RichTextCodec.char('x').repeat ?? "xs"
-        // This would be perhaps nicer as «xs» ⩴ “x”*
-        assertTrue(textOf(codec.describe).get == "«xs» ⩴ (“x” «xs»)?")
+        assertTrue(textOf(codec.describe).get == "«xs» ⩴ “x”*")
       },
       test("describe tagged with recursion") {
         lazy val integer: RichTextCodec[_] = (RichTextCodec.digit ~ (RichTextCodec.empty | integer)) ?? "integer"


### PR DESCRIPTION
/claim #2573

I know the issue was only for fixing the encoding performance, but as a welcoming side-effect these changes also improve the overall performance of the RichTextCodec. Also, the rendering of the content-type header is now cached (in a lazy val), so users that reuse the same instance of a `ContentType` will not incur any runtime overhead for encoding it on repeated requests.

Breaking(?) changes:
- RichTextCodec is now a `sealed abstract class` instead of a `sealed trait`. This improved performance marginally although I'm happy to revert it if you prefer to have it as a sealed trait instead.
- The description of repeated codecs was changed (see changed unit test). The main reasoning for this is that it was very hard to replicate the same error message now that the implementation of repeated codecs is different. I saw that in the unit test there was a recommendation for changing the description (which personally I think is clearer) and since that was easy to do with the new Repeated implementation I went with that

## Benchmark results

#### Summary

Parsing:
- ~5x increased throughput
- ~10x reduced memory allocations

Encoding:
- ~15x increased throughput
- ~20x reduced memory allocations

<details>
  <summary><h4>JMH results (click to expand)</h4></summary>

main branch:
```
[info] Benchmark                                                                 Mode  Cnt       Score      Error   Units
[info] ProbeContentTypeBenchmark.benchmarkParseContentType                      thrpt    5  110070.585 ±  371.643   ops/s
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.alloc.rate        thrpt    5    3551.249 ±   12.025  MB/sec
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.alloc.rate.norm   thrpt    5   33832.021 ±    0.001    B/op
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.count             thrpt    5     168.000             counts
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.time              thrpt    5      81.000                 ms
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType                     thrpt    5  294430.289 ± 1231.373   ops/s
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.alloc.rate       thrpt    5    3272.757 ±   13.771  MB/sec
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.alloc.rate.norm  thrpt    5   11656.008 ±    0.001    B/op
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.count            thrpt    5     198.000             counts
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.time             thrpt    5      91.000                 ms
```

PR:
```
[info] ProbeContentTypeBenchmark.benchmarkParseContentType                      thrpt    5   567862.566 ± 45382.116   ops/s
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.alloc.rate        thrpt    5     1732.915 ±   138.500  MB/sec
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.alloc.rate.norm   thrpt    5     3200.004 ±     0.001    B/op
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.count             thrpt    5      155.000              counts
[info] ProbeContentTypeBenchmark.benchmarkParseContentType:gc.time              thrpt    5       59.000                  ms
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType                     thrpt    5  4756430.171 ± 53198.579   ops/s
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.alloc.rate       thrpt    5     2104.663 ±    23.531  MB/sec
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.alloc.rate.norm  thrpt    5      464.000 ±     0.001    B/op
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.count            thrpt    5      193.000              counts
[info] ProbeContentTypeBenchmark.benchmarkRenderContentType:gc.time             thrpt    5       71.000                  ms
```
</details>