### PR TITLE
Only Handlers with Request input can have HandlerAspects applied (#2527)

### DIFF
--- a/zio-http/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/src/main/scala/zio/http/Handler.scala
@@ -31,8 +31,8 @@ import java.util.zip.ZipFile
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 sealed trait Handler[-R, +Err, -In, +Out] { self =>
 
-  def @@[Env1 <: R, Ctx, In1 <: In](aspect: HandlerAspect[Env1, Unit])(implicit
-    in: In1 <:< Request,
+  def @@[Env1 <: R, In1 <: In](aspect: HandlerAspect[Env1, Unit])(implicit
+    in: Handler.IsRequest[In1],
     out: Out <:< Response,
     err: Err <:< Response,
   ): Handler[Env1, Response, Request, Response] = {
@@ -672,6 +672,12 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
 }
 
 object Handler {
+
+  sealed trait IsRequest[-A]
+
+  object IsRequest {
+    implicit val request: IsRequest[Request] = new IsRequest[Request] {}
+  }
 
   def asChunkBounded(request: Request, limit: Int)(implicit trace: Trace): Handler[Any, Throwable, Any, Chunk[Byte]] =
     Handler.fromZIO(


### PR DESCRIPTION
This fix gives `Handler#@@` the meaning it was supposed to have. It should only work on handlers where `In =:= Request`.
But that was not true. Because of the way the check was implemented, scala could infer `Nothing` for the `In1`and it would compile. Leading then to the runtime error one can see in #2527. 

The more interesting question is: Can we define a generic `HandlerAspect.identity` and a generic version of `Handler#@@` that not only accepts this `identity` but also other similar aspects?
After some playing around, I think the answer is probably no.
The two versions of `@@` that exist, both return a `Handler` that has a `In =:= Request`. But in my opinion, a true `HandlerAspect.identity`, that is not only defined for a `Handler` that has a `In =:= Request`, must preserve the `In` type.

No `applyX` version of `HandlerAspect` can do this currently. The one that would be a candidate to be changed in that way would be `applyHandler`.

So I tried

```scala
  def applyHandler[Env1 <: Env, In](handler: Handler[Env1, Response, In, Response]): Handler[Env1, Response, In, Response] =
    if (self == HandlerAspect.identity) handler
    else {
      for {
        tuple <- protocol.incomingHandler
        (state, (request, ctxOut)) = tuple
        in <- Handler.fromFunction[In]((in: In) => in)
        either   <- Handler.fromZIO(handler(in)).either
        response <- Handler.fromZIO(protocol.outgoingHandler((state, either.merge)))
        response <- if (either.isLeft) Handler.fail(response) else Handler.succeed(response)
      } yield response
    }
```

But because`protocol.incomingHandler` requires `Request`, I endup with a result type of `Handler[Env1, Response, In with Request, Response]` instead of `Handler[Env1, Response, In, Response]`.

@jdegoes @vigoo If you see a way how to solve this, please let me know and I'll adjust the PR.

fixes #2527
/claim #2527