### PR TITLE
Speedup test suite execution

### DIFF
--- a/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/SocketContractSpec.scala
@@ -6,6 +6,7 @@ import zio.test.Assertion._
 import zio.test._
 
 import zio.http.ChannelEvent.{Read, Unregistered, UserEvent, UserEventTriggered}
+import zio.http.netty.NettyConfig
 import zio.http.netty.server.NettyDriver
 import zio.http.{Headers, Status, Version, ZIOHttpSpec}
 
@@ -104,7 +105,8 @@ object SocketContractSpec extends ZIOHttpSpec {
         } yield assert(response.status)(equalTo(Status.SwitchingProtocols))
       }.provideSome[Client](
         TestServer.layer,
-        NettyDriver.live,
+        NettyDriver.customized,
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
         ZLayer.succeed(Server.Config.default.onAnyOpenPort),
         Scope.default,
       ).provide(Client.default),

--- a/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestServerSpec.scala
@@ -3,6 +3,7 @@ package zio.http
 import zio._
 import zio.test._
 
+import zio.http.netty.NettyConfig
 import zio.http.netty.server.NettyDriver
 
 object TestServerSpec extends ZIOHttpSpec {
@@ -114,7 +115,8 @@ object TestServerSpec extends ZIOHttpSpec {
   ).provide(
     ZLayer.succeed(Server.Config.default.onAnyOpenPort),
     Client.default,
-    NettyDriver.live,
+    NettyDriver.customized,
+    ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
   )
 
   private def requestToCorrectPort =

--- a/zio-http/src/test/scala/zio/http/ClientProxySpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientProxySpec.scala
@@ -45,7 +45,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               ZLayer.succeed(ZClient.Config.default.proxy(Proxy(proxyUrl))),
               NettyClientDriver.live,
               DnsResolver.default,
-              ZLayer.succeed(NettyConfig.default),
+              ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
               Scope.default,
             )
         } yield out
@@ -87,7 +87,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               ZLayer.succeed(ZClient.Config.default.proxy(proxy)),
               NettyClientDriver.live,
               DnsResolver.default,
-              ZLayer.succeed(NettyConfig.default),
+              ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
               Scope.default,
             )
         } yield out
@@ -121,7 +121,7 @@ object ClientProxySpec extends HttpRunnableSpec {
               ZLayer.succeed(ZClient.Config.default.proxy(proxy)),
               NettyClientDriver.live,
               DnsResolver.default,
-              ZLayer.succeed(NettyConfig.default),
+              ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
               Scope.default,
             )
         } yield out

--- a/zio-http/src/test/scala/zio/http/ClientStreamingSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ClientStreamingSpec.scala
@@ -308,7 +308,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
       ),
     ).provide(
       DnsResolver.default,
-      ZLayer.succeed(NettyConfig.default),
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       ZLayer.succeed(Client.Config.default.connectionTimeout(100.seconds).idleTimeout(100.seconds)),
       Client.live,
       Scope.default,
@@ -322,7 +322,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
         .intoPromise(portPromise)
         .zipRight(ZIO.never)
         .provide(
-          ZLayer.succeed(NettyConfig.default.leakDetection(LeakDetectionLevel.PARANOID)),
+          ZLayer.succeed(NettyConfig.defaultWithFastShutdown.leakDetection(LeakDetectionLevel.PARANOID)),
           ZLayer.succeed(
             Server.Config.default.onAnyOpenPort
               .requestStreaming(

--- a/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
+++ b/zio-http/src/test/scala/zio/http/DynamicAppTest.scala
@@ -42,9 +42,9 @@ object DynamicAppTest extends ZIOHttpSpec {
       NettyClientDriver.live,
       Client.customized,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort),
-      Server.live,
+      Server.customized,
       DnsResolver.default,
-      ZLayer.succeed(NettyConfig.default),
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       Scope.default,
     )
 

--- a/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxHeaderLengthSpec.scala
@@ -20,6 +20,8 @@ import zio.test.TestAspect.withLiveClock
 import zio.test._
 import zio.{Scope, ZLayer}
 
+import zio.http.netty.NettyConfig
+
 object NettyMaxHeaderLengthSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
@@ -48,7 +50,8 @@ object NettyMaxHeaderLengthSpec extends ZIOHttpSpec {
       } yield assertTrue(extractStatus(res) == Status.InternalServerError, data == "")
     }.provide(
       Client.default,
-      Server.live,
+      Server.customized,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       ZLayer.succeed(serverConfig),
       Scope.default,
     ) @@ withLiveClock

--- a/zio-http/src/test/scala/zio/http/NettyMaxInitialLineLengthSpec.scala
+++ b/zio-http/src/test/scala/zio/http/NettyMaxInitialLineLengthSpec.scala
@@ -20,6 +20,8 @@ import zio.test.TestAspect.withLiveClock
 import zio.test._
 import zio.{Scope, ZLayer}
 
+import zio.http.netty.NettyConfig
+
 object NettyMaxInitialLineLength extends ZIOHttpSpec {
   val minimalInitialLineLength: Int = "GET / HTTP/1.1".getBytes.length
 
@@ -52,7 +54,8 @@ object NettyMaxInitialLineLength extends ZIOHttpSpec {
       } yield assertTrue(extractStatus(res) == Status.InternalServerError, data == "")
     }.provide(
       Client.default,
-      Server.live,
+      Server.customized,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       ZLayer.succeed(serverConfig),
       Scope.default,
     ) @@ withLiveClock

--- a/zio-http/src/test/scala/zio/http/RequestStreamingServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/RequestStreamingServerSpec.scala
@@ -18,11 +18,12 @@ package zio.http
 
 import zio._
 import zio.test.Assertion.equalTo
-import zio.test.TestAspect.{diagnose, sequential, shrinks, timeout, withLiveClock}
-import zio.test.{assertCompletes, assertTrue, assertZIO}
+import zio.test.TestAspect.{diagnose, sequential, shrinks, withLiveClock}
+import zio.test.{assertTrue, assertZIO}
 
 import zio.http.ServerSpec.requestBodySpec
 import zio.http.internal.{DynamicServer, HttpRunnableSpec}
+import zio.http.netty.NettyConfig
 
 object RequestStreamingServerSpec extends HttpRunnableSpec {
   def extractStatus(res: Response): Status = res.status
@@ -113,7 +114,8 @@ object RequestStreamingServerSpec extends HttpRunnableSpec {
       .provideShared(
         DynamicServer.live,
         ZLayer.succeed(configAppWithRequestStreaming),
-        Server.live,
+        Server.customized,
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
         Client.default,
       ) @@ diagnose(15.seconds) @@ sequential @@ shrinks(0) @@ withLiveClock
 

--- a/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ResponseCompressionSpec.scala
@@ -25,6 +25,8 @@ import zio.{Chunk, Scope, ZIO, ZInputStream, ZLayer}
 
 import zio.stream.ZStream
 
+import zio.http.netty.NettyConfig
+
 object ResponseCompressionSpec extends ZIOHttpSpec {
 
   private val text: HttpApp[Any] =
@@ -93,7 +95,8 @@ object ResponseCompressionSpec extends ZIOHttpSpec {
       },
     ).provide(
       ZLayer.succeed(serverConfig),
-      Server.live,
+      Server.customized,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       Client.default,
       Scope.default,
     ) @@ withLiveClock

--- a/zio-http/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/src/test/scala/zio/http/SSLSpec.scala
@@ -58,7 +58,7 @@ object SSLSpec extends ZIOHttpSpec {
             ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
             NettyClientDriver.live,
             DnsResolver.default,
-            ZLayer.succeed(NettyConfig.default),
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
             Scope.default,
           ),
           // Unfortunately if the channel closes before we create the request, we can't extract the DecoderException
@@ -81,7 +81,7 @@ object SSLSpec extends ZIOHttpSpec {
             ZLayer.succeed(ZClient.Config.default.ssl(clientSSL2)),
             NettyClientDriver.live,
             DnsResolver.default,
-            ZLayer.succeed(NettyConfig.default),
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
             Scope.default,
           ),
           test("succeed when client has default SSL") {
@@ -94,7 +94,7 @@ object SSLSpec extends ZIOHttpSpec {
             ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
             NettyClientDriver.live,
             DnsResolver.default,
-            ZLayer.succeed(NettyConfig.default),
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
             Scope.default,
           ),
           test("Https Redirect when client makes http request") {
@@ -107,13 +107,14 @@ object SSLSpec extends ZIOHttpSpec {
             ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
             NettyClientDriver.live,
             DnsResolver.default,
-            ZLayer.succeed(NettyConfig.default),
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
             Scope.default,
           ),
         ),
       ),
   ).provideShared(
-    Server.live,
+    Server.customized,
+    ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
     ZLayer.succeed(config),
   )
 

--- a/zio-http/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ServerSpec.scala
@@ -27,6 +27,7 @@ import zio.test._
 import zio.stream.{ZPipeline, ZStream}
 
 import zio.http.internal.{DynamicServer, HttpGen, HttpRunnableSpec}
+import zio.http.netty.NettyConfig
 import zio.http.template.{body, div, id}
 
 object ServerSpec extends HttpRunnableSpec {
@@ -495,7 +496,8 @@ object ServerSpec extends HttpRunnableSpec {
       .provideShared(
         DynamicServer.live,
         ZLayer.succeed(configApp),
-        Server.live,
+        Server.customized,
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
         Client.default,
       ) @@ sequential @@ withLiveClock
 

--- a/zio-http/src/test/scala/zio/http/ServerStartSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ServerStartSpec.scala
@@ -22,6 +22,7 @@ import zio.test._
 import zio.{Scope, ZIO, ZLayer}
 
 import zio.http.internal.{DynamicServer, HttpRunnableSpec}
+import zio.http.netty.NettyConfig
 
 object ServerStartSpec extends HttpRunnableSpec {
 
@@ -31,14 +32,24 @@ object ServerStartSpec extends HttpRunnableSpec {
       val config = Server.Config.default.port(port)
       serve(HttpApp.empty).flatMap { port =>
         assertZIO(ZIO.attempt(port))(equalTo(port))
-      }.provide(ZLayer.succeed(config), DynamicServer.live, Server.live)
+      }.provide(
+        ZLayer.succeed(config),
+        DynamicServer.live,
+        Server.customized,
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+      )
     },
     test("available port") {
       val port   = 0
       val config = Server.Config.default.port(port)
       serve(HttpApp.empty).flatMap { bindPort =>
         assertZIO(ZIO.attempt(bindPort))(not(equalTo(port)))
-      }.provide(ZLayer.succeed(config), DynamicServer.live, Server.live)
+      }.provide(
+        ZLayer.succeed(config),
+        DynamicServer.live,
+        Server.customized,
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+      )
     },
   )
 

--- a/zio-http/src/test/scala/zio/http/WebSocketConfig.scala
+++ b/zio-http/src/test/scala/zio/http/WebSocketConfig.scala
@@ -70,7 +70,7 @@ object WebSocketConfigSpec extends HttpRunnableSpec {
           .forwardCloseFrames(true),
       ),
     ) ++
-      ZLayer.succeed(NettyConfig.default) ++
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown) ++
       DnsResolver.default >>>
       Client.live
 

--- a/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -21,6 +21,7 @@ import zio.test._
 import zio.{Chunk, Scope, ZIO, ZLayer}
 
 import zio.http.URL.Location
+import zio.http.netty.NettyConfig
 
 object ZClientAspectSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
@@ -100,7 +101,8 @@ object ZClientAspectSpec extends ZIOHttpSpec {
       ),
     ).provide(
       ZLayer.succeed(Server.Config.default.onAnyOpenPort),
-      Server.live,
+      Server.customized,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       Client.default,
       Scope.default,
     ) @@ withLiveClock

--- a/zio-http/src/test/scala/zio/http/internal/package.scala
+++ b/zio-http/src/test/scala/zio/http/internal/package.scala
@@ -28,7 +28,11 @@ package object internal {
     ZLayer.succeed(Server.Config.default.onAnyOpenPort)
 
   val testNettyServerConfig: ZLayer[Any, Nothing, NettyConfig] =
-    ZLayer.succeed(NettyConfig.default.leakDetection(LeakDetectionLevel.PARANOID))
+    ZLayer.succeed(
+      NettyConfig.defaultWithFastShutdown
+        .copy(shutdownQuietPeriodDuration = zio.Duration.fromSeconds(0))
+        .leakDetection(LeakDetectionLevel.PARANOID),
+    )
 
   val serverTestLayer: ZLayer[Any, Throwable, Server.Config with Server] =
     ZLayer.make[Server.Config with Server](

--- a/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -35,7 +35,7 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
         .intoPromise(portPromise)
         .zipRight(ZIO.never)
         .provide(
-          ZLayer.succeed(NettyConfig.default.leakDetection(LeakDetectionLevel.PARANOID)),
+          ZLayer.succeed(NettyConfig.defaultWithFastShutdown.leakDetection(LeakDetectionLevel.PARANOID)),
           ZLayer.succeed(Server.Config.default.onAnyOpenPort),
           Server.customized,
         )
@@ -46,7 +46,7 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
   val singleConnectionClient: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
     (ZLayer.succeed(Config.default.copy(connectionPool = ConnectionPoolConfig.Fixed(1))) ++ ZLayer.succeed(
-      NettyConfig.default,
+      NettyConfig.defaultWithFastShutdown,
     ) ++
       DnsResolver.default) >>> Client.live
   }


### PR DESCRIPTION
While working on a different PR, I realised that many of the test suites were using the default Netty config, which has a long `shutdownQuietPeriodDuration`. This means that tests take a long time to execute due to waiting for the server / client to shut down.

In this PR, I changed the test suites (as many as I could find) to use `NettyConfig.defaultWithFastShutdown`. Running locally, the `zioHttp` module tests now execute in 1 minute (down from 3 minutes) which should make other devs a bit happier as they won't have to wait as long for CI to finish & potentially help with CI costs