### PR TITLE
Intoroduce query parameters with multiple values to Endpoint API

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -123,7 +123,7 @@ private[cli] object CliEndpoint {
       case HttpCodec.Path(pathCodec, _) =>
         CliEndpoint(url = HttpOptions.Path(pathCodec) :: List())
 
-      case HttpCodec.Query(name, textCodec, _) =>
+      case HttpCodec.Query(name, textCodec, _, _) =>
         textCodec.asInstanceOf[TextCodec[_]] match {
           case TextCodec.Constant(value) => CliEndpoint(url = HttpOptions.QueryConstant(name, value) :: List())
           case _                         => CliEndpoint(url = HttpOptions.Query(name, textCodec) :: List())

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
@@ -7,6 +7,7 @@ import zio.test._
 import zio.schema._
 
 import zio.http._
+import zio.http.codec.HttpCodec.Query.QueryParamHint
 import zio.http.codec._
 import zio.http.endpoint._
 import zio.http.endpoint.cli.AuxGen._
@@ -93,7 +94,7 @@ object EndpointGen {
   lazy val anyQuery: Gen[Any, CliReprOf[Codec[_]]] =
     Gen.alphaNumericStringBounded(1, 30).zip(anyTextCodec).map { case (name, codec) =>
       CliRepr(
-        HttpCodec.Query(name, codec),
+        HttpCodec.Query(name, codec, QueryParamHint.Any),
         codec match {
           case TextCodec.Constant(value) => CliEndpoint(url = HttpOptions.QueryConstant(name, value) :: Nil)
           case _                         => CliEndpoint(url = HttpOptions.Query(name, codec) :: Nil)

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/EndpointSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/EndpointSpec.scala
@@ -21,19 +21,9 @@ import java.time.Instant
 import zio._
 import zio.test._
 
-import zio.stream.ZStream
-
-import zio.schema.annotation.validate
-import zio.schema.validation.Validation
 import zio.schema.{DeriveSchema, Schema}
 
-import zio.http.Header.ContentType
-import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt}
-import zio.http.codec._
-import zio.http.endpoint._
-import zio.http.forms.Fixtures.formField
 
 object EndpointSpec extends ZIOHttpSpec {
   def spec = suite("EndpointSpec")()

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
@@ -23,7 +23,7 @@ import zio.test._
 
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt, queryAll, queryAllBool, queryAllInt}
+import zio.http.codec.HttpCodec.{query, queryAll, queryAllBool, queryAllInt, queryInt}
 import zio.http.endpoint.EndpointSpec.testEndpoint
 
 object QueryParameterSpec extends ZIOHttpSpec {

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
@@ -23,7 +23,7 @@ import zio.test._
 
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt, queryMultiValue, queryMultiValueBool, queryMultiValueInt}
+import zio.http.codec.HttpCodec.{query, queryInt, queryAll, queryAllBool, queryAllInt}
 import zio.http.endpoint.EndpointSpec.testEndpoint
 
 object QueryParameterSpec extends ZIOHttpSpec {
@@ -101,7 +101,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
-              .query(queryMultiValue("key"))
+              .query(queryAll("key"))
               .out[String]
               .implement {
                 Handler.fromFunction { case (userId, keys) =>
@@ -130,7 +130,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
-              .query(queryMultiValue("key").optional)
+              .query(queryAll("key").optional)
               .out[String]
               .implement {
                 Handler.fromFunction { case (userId, keys) =>
@@ -160,7 +160,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
           val testRoutes = testEndpoint(
             Routes(
               Endpoint(GET / "users" / int("userId"))
-                .query(queryMultiValue("key") & queryMultiValue("value"))
+                .query(queryAll("key") & queryAll("value"))
                 .out[String]
                 .implement {
                   Handler.fromFunction { case (userId, keys, values) =>
@@ -185,7 +185,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
-              .query(queryMultiValue("multi") & query("single"))
+              .query(queryAll("multi") & query("single"))
               .out[String]
               .implement {
                 Handler.fromFunction { case (userId, multi, single) =>
@@ -206,7 +206,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
-              .query(queryMultiValue("left") | queryMultiValueBool("right"))
+              .query(queryAll("left") | queryAllBool("right"))
               .out[String]
               .implement {
                 Handler.fromFunction { case (userId, eitherOfParameters) =>
@@ -236,7 +236,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
           val testRoutes = testEndpoint(
             Routes(
               Endpoint(GET / "users" / int("userId"))
-                .query(queryMultiValue("left") | queryMultiValue("right"))
+                .query(queryAll("left") | queryAll("right"))
                 .out[String]
                 .implement {
                   Handler.fromFunction { case (userId, queryParams) =>
@@ -265,7 +265,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
-              .query(queryMultiValue("left") | query("right"))
+              .query(queryAll("left") | query("right"))
               .out[String]
               .implement {
                 Handler.fromFunction { case (userId, queryParams) =>
@@ -293,7 +293,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
       val testRoutes = testEndpoint(
         Routes(
           Endpoint(GET / "users")
-            .query(queryMultiValueInt("ints"))
+            .query(queryAllInt("ints"))
             .out[String]
             .implement {
               Handler.fromFunction { case queryParams =>
@@ -311,7 +311,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
     test("no specified query parameters for multi value query") {
       val testRoutes = Routes(
         Endpoint(GET / "users")
-          .query(queryMultiValueInt("ints"))
+          .query(queryAllInt("ints"))
           .out[String]
           .implement {
             Handler.fromFunction { case queryParams =>

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
@@ -30,7 +30,7 @@ import zio.schema.{DeriveSchema, Schema}
 import zio.http.Header.ContentType
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt}
+import zio.http.codec.HttpCodec.{query, queryInt, queryMultiValue, queryMultiValueBool}
 import zio.http.codec._
 import zio.http.endpoint.EndpointSpec.testEndpoint
 import zio.http.forms.Fixtures.formField
@@ -103,6 +103,199 @@ object QueryParameterSpec extends ZIOHttpSpec {
         testRoutes(s"/users/$userId?key=&value=", s"path(users, $userId, Some(), Some())") &&
         testRoutes(s"/users/$userId?key=&value=$value", s"path(users, $userId, Some(), Some($value))") &&
         testRoutes(s"/users/$userId?key=$key&value=$value", s"path(users, $userId, Some($key), Some($value))")
+      }
+    },
+    test("query parameters with multiple values") {
+      check(Gen.int, Gen.listOfN(3)(Gen.alphaNumericString)) { (userId, keys) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(queryMultiValue("key"))
+              .out[String]
+              .implement {
+                Handler.fromFunction { case (userId, keys) =>
+                  s"""path(users, $userId, ${keys.mkString(", ")})"""
+                }
+              },
+          ),
+        ) _
+
+        testRoutes(
+          s"/users/$userId?key=${keys(0)}&key=${keys(1)}&key=${keys(2)}",
+          s"path(users, $userId, ${keys(0)}, ${keys(1)}, ${keys(2)})",
+        ) &&
+        testRoutes(
+          s"/users/$userId?key=${keys(0)}&key=${keys(1)}",
+          s"path(users, $userId, ${keys(0)}, ${keys(1)})",
+        ) &&
+        testRoutes(
+          s"/users/$userId?key=${keys(0)}",
+          s"path(users, $userId, ${keys(0)})",
+        )
+      }
+    },
+    test("optional query parameters with multiple values") {
+      check(Gen.int, Gen.listOfN(3)(Gen.alphaNumericString)) { (userId, keys) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(queryMultiValue("key").optional)
+              .out[String]
+              .implement {
+                Handler.fromFunction { case (userId, keys) =>
+                  s"""path(users, $userId, $keys)"""
+                }
+              },
+          ),
+        ) _
+
+        testRoutes(
+          s"/users/$userId?key=${keys(0)}&key=${keys(1)}&key=${keys(2)}",
+          s"path(users, $userId, Some(${NonEmptyChunk.fromIterable(keys.head, keys.tail)}))",
+        ) &&
+        testRoutes(
+          s"/users/$userId",
+          s"path(users, $userId, None)",
+        ) &&
+        testRoutes(
+          s"/users/$userId?key=",
+          s"path(users, $userId, Some(NonEmptyChunk()))",
+        )
+      }
+    },
+    test("multiple query parameters with multiple values") {
+      check(Gen.int, Gen.listOfN(3)(Gen.alphaNumericString), Gen.listOfN(2)(Gen.alphaNumericString)) {
+        (userId, keys, values) =>
+          val testRoutes = testEndpoint(
+            Routes(
+              Endpoint(GET / "users" / int("userId"))
+                .query(queryMultiValue("key") & queryMultiValue("value"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, keys, values) =>
+                    s"""path(users, $userId, $keys, $values)"""
+                  }
+                },
+            ),
+          ) _
+
+          testRoutes(
+            s"/users/$userId?key=${keys(0)}&key=${keys(1)}&key=${keys(2)}&value=${values(0)}&value=${values(1)}",
+            s"path(users, $userId, NonEmptyChunk(${keys(0)}, ${keys(1)}, ${keys(2)}), NonEmptyChunk(${values(0)}, ${values(1)}))",
+          ) &&
+          testRoutes(
+            s"/users/$userId?key=${keys(0)}&key=${keys(1)}&value=${values(0)}",
+            s"path(users, $userId, NonEmptyChunk(${keys(0)}, ${keys(1)}), NonEmptyChunk(${values(0)}))",
+          )
+      }
+    },
+    test("mix of multi value and single value query parameters") {
+      check(Gen.int, Gen.listOfN(2)(Gen.alphaNumericString), Gen.alphaNumericString) { (userId, multi, single) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(queryMultiValue("multi") & query("single"))
+              .out[String]
+              .implement {
+                Handler.fromFunction { case (userId, multi, single) =>
+                  s"""path(users, $userId, $multi, $single)"""
+                }
+              },
+          ),
+        ) _
+
+        testRoutes(
+          s"/users/$userId?multi=${multi(0)}&multi=${multi(1)}&single=$single",
+          s"path(users, $userId, NonEmptyChunk(${multi(0)}, ${multi(1)}), $single)",
+        )
+      }
+    },
+    test("either of two multi value query parameters") {
+      check(Gen.int, Gen.listOfN(2)(Gen.alphaNumericString), Gen.listOfN(2)(Gen.boolean)) { (userId, left, right) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(queryMultiValue("left") | queryMultiValueBool("right"))
+              .out[String]
+              .implement {
+                Handler.fromFunction { case (userId, eitherOfParameters) =>
+                  s"path(users, $userId, $eitherOfParameters)"
+                }
+              },
+          ),
+        ) _
+
+        testRoutes(
+          s"/users/$userId?left=${left(0)}&left=${left(1)}",
+          s"path(users, $userId, Left(NonEmptyChunk(${left(0)}, ${left(1)})))",
+        ) &&
+        testRoutes(
+          s"/users/$userId?right=${right(0)}&right=${right(1)}",
+          s"path(users, $userId, Right(NonEmptyChunk(${right(0)}, ${right(1)})))",
+        ) &&
+        testRoutes(
+          s"/users/$userId?right=${right(0)}&right=${right(1)}&left=${left(0)}&left=${left(1)}",
+          s"path(users, $userId, Left(NonEmptyChunk(${left(0)}, ${left(1)})))",
+        )
+      }
+    },
+    test("either of two multi value query parameters of the same type") {
+      check(Gen.int, Gen.listOfN(2)(Gen.alphaNumericString), Gen.listOfN(2)(Gen.alphaNumericString)) {
+        (userId, left, right) =>
+          val testRoutes = testEndpoint(
+            Routes(
+              Endpoint(GET / "users" / int("userId"))
+                .query(queryMultiValue("left") | queryMultiValue("right"))
+                .out[String]
+                .implement {
+                  Handler.fromFunction { case (userId, queryParams) =>
+                    s"path(users, $userId, $queryParams)"
+                  }
+                },
+            ),
+          ) _
+
+          testRoutes(
+            s"/users/$userId?left=${left(0)}&left=${left(1)}",
+            s"path(users, $userId, NonEmptyChunk(${left(0)}, ${left(1)}))",
+          ) &&
+          testRoutes(
+            s"/users/$userId?right=${right(0)}&right=${right(1)}",
+            s"path(users, $userId, NonEmptyChunk(${right(0)}, ${right(1)}))",
+          ) &&
+          testRoutes(
+            s"/users/$userId?right=${right(0)}&right=${right(1)}&left=${left(0)}&left=${left(1)}",
+            s"path(users, $userId, NonEmptyChunk(${left(0)}, ${left(1)}))",
+          )
+      }
+    },
+    test("either of multi value or single value query parameter") {
+      check(Gen.int, Gen.listOfN(2)(Gen.alphaNumericString), Gen.alphaNumericString) { (userId, left, right) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(queryMultiValue("left") | query("right"))
+              .out[String]
+              .implement {
+                Handler.fromFunction { case (userId, queryParams) =>
+                  s"path(users, $userId, $queryParams)"
+                }
+              },
+          ),
+        ) _
+
+        testRoutes(
+          s"/users/$userId?left=${left(0)}&left=${left(1)}",
+          s"path(users, $userId, Left(NonEmptyChunk(${left(0)}, ${left(1)})))",
+        ) &&
+        testRoutes(
+          s"/users/$userId?right=$right",
+          s"path(users, $userId, Right($right))",
+        ) &&
+        testRoutes(
+          s"/users/$userId?right=$right&left=${left(0)}&left=${left(1)}",
+          s"path(users, $userId, Left(NonEmptyChunk(${left(0)}, ${left(1)})))",
+        )
       }
     },
   )

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -591,7 +591,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
     def index(index: Int): ContentStream[A] = copy(index = index)
   }
   private[http] final case class Query[A](name: String, textCodec: TextCodec[A], index: Int = 0)
-      extends Atom[HttpCodecType.Query, NonEmptyChunk[A]] {
+      extends Atom[HttpCodecType.Query, Chunk[A]] {
     self =>
     def erase: Query[Any] = self.asInstanceOf[Query[Any]]
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -591,7 +591,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
     def index(index: Int): ContentStream[A] = copy(index = index)
   }
   private[http] final case class Query[A](name: String, textCodec: TextCodec[A], index: Int = 0)
-      extends Atom[HttpCodecType.Query, A]  {
+      extends Atom[HttpCodecType.Query, NonEmptyChunk[A]] {
     self =>
     def erase: Query[Any] = self.asInstanceOf[Query[Any]]
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -553,7 +553,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   }
 
   private[http] final case class Status[A](codec: SimpleCodec[zio.http.Status, A], index: Int = 0)
-      extends Atom[HttpCodecType.Status, A]       {
+      extends Atom[HttpCodecType.Status, A] {
     self =>
     def erase: Status[Any] = self.asInstanceOf[Status[Any]]
 
@@ -590,14 +590,33 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
 
     def index(index: Int): ContentStream[A] = copy(index = index)
   }
-  private[http] final case class Query[A](name: String, textCodec: TextCodec[A], index: Int = 0)
-      extends Atom[HttpCodecType.Query, Chunk[A]] {
+  private[http] final case class Query[A](
+    name: String,
+    textCodec: TextCodec[A],
+    hint: Query.QueryParamHint,
+    index: Int = 0,
+  ) extends Atom[HttpCodecType.Query, Chunk[A]] {
     self =>
     def erase: Query[Any] = self.asInstanceOf[Query[Any]]
 
     def tag: AtomTag = AtomTag.Query
 
     def index(index: Int): Query[A] = copy(index = index)
+  }
+
+  private[http] object Query {
+
+    // Hint on how many query parameters codec expects
+    sealed trait QueryParamHint
+    object QueryParamHint {
+      case object One extends QueryParamHint
+
+      case object Many extends QueryParamHint
+
+      case object Zero extends QueryParamHint
+
+      case object Any extends QueryParamHint
+    }
   }
 
   private[http] final case class Method[A](codec: SimpleCodec[zio.http.Method, A], index: Int = 0)

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -553,7 +553,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   }
 
   private[http] final case class Status[A](codec: SimpleCodec[zio.http.Status, A], index: Int = 0)
-      extends Atom[HttpCodecType.Status, A]               {
+      extends Atom[HttpCodecType.Status, A]       {
     self =>
     def erase: Status[Any] = self.asInstanceOf[Status[Any]]
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -553,7 +553,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   }
 
   private[http] final case class Status[A](codec: SimpleCodec[zio.http.Status, A], index: Int = 0)
-      extends Atom[HttpCodecType.Status, A] {
+      extends Atom[HttpCodecType.Status, A]               {
     self =>
     def erase: Status[Any] = self.asInstanceOf[Status[Any]]
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -21,24 +21,16 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 private[codec] trait QueryCodecs {
 
   def query(name: String): QueryCodec[String] =
-    HttpCodec
-      .Query(name, TextCodec.string)
-      .transform[String] { (c: NonEmptyChunk[String]) => c.head }(s => NonEmptyChunk(s))
+    toSingleValue(HttpCodec.Query(name, TextCodec.string))
 
   def queryBool(name: String): QueryCodec[Boolean] =
-    HttpCodec
-      .Query(name, TextCodec.boolean)
-      .transform { (c: NonEmptyChunk[Boolean]) => c.head }(s => NonEmptyChunk(s))
+    toSingleValue(HttpCodec.Query(name, TextCodec.boolean))
 
   def queryInt(name: String): QueryCodec[Int] =
-    HttpCodec
-      .Query(name, TextCodec.int)
-      .transform { (c: NonEmptyChunk[Int]) => c.head }(s => NonEmptyChunk(s))
+    toSingleValue(HttpCodec.Query(name, TextCodec.int))
 
   def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
-    HttpCodec
-      .Query(name, codec)
-      .transform { (c: NonEmptyChunk[A]) => c.head }(s => NonEmptyChunk(s))
+    toSingleValue(HttpCodec.Query(name, codec))
 
   def queryMultiValue(name: String): QueryCodec[NonEmptyChunk[String]] =
     HttpCodec.Query(name, TextCodec.string)
@@ -51,5 +43,8 @@ private[codec] trait QueryCodecs {
 
   def queryMultiValueTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[NonEmptyChunk[A]] =
     HttpCodec.Query(name, codec)
+
+  private def toSingleValue[A](queryCodec: QueryCodec[NonEmptyChunk[A]]): QueryCodec[A] =
+    queryCodec.transform { (c: NonEmptyChunk[A]) => c.head }(s => NonEmptyChunk(s))
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -23,22 +23,22 @@ private[codec] trait QueryCodecs {
   def query(name: String): QueryCodec[String] =
     HttpCodec
       .Query(name, TextCodec.string)
-      .transform[String] { c: NonEmptyChunk[String] => c.head }(s => NonEmptyChunk(s))
+      .transform[String] { (c: NonEmptyChunk[String]) => c.head }(s => NonEmptyChunk(s))
 
   def queryBool(name: String): QueryCodec[Boolean] =
     HttpCodec
       .Query(name, TextCodec.boolean)
-      .transform { c: NonEmptyChunk[Boolean] => c.head }(s => NonEmptyChunk(s))
+      .transform { (c: NonEmptyChunk[Boolean]) => c.head }(s => NonEmptyChunk(s))
 
   def queryInt(name: String): QueryCodec[Int] =
     HttpCodec
       .Query(name, TextCodec.int)
-      .transform { c: NonEmptyChunk[Int] => c.head }(s => NonEmptyChunk(s))
+      .transform { (c: NonEmptyChunk[Int]) => c.head }(s => NonEmptyChunk(s))
 
   def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
     HttpCodec
       .Query(name, codec)
-      .transform { c: NonEmptyChunk[A] => c.head }(s => NonEmptyChunk(s))
+      .transform { (c: NonEmptyChunk[A]) => c.head }(s => NonEmptyChunk(s))
 
   def queryMultiValue(name: String): QueryCodec[NonEmptyChunk[String]] =
     HttpCodec.Query(name, TextCodec.string)

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -15,19 +15,41 @@
  */
 
 package zio.http.codec
+import zio.NonEmptyChunk
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[codec] trait QueryCodecs {
+
   def query(name: String): QueryCodec[String] =
-    HttpCodec.Query(name, TextCodec.string)
+    HttpCodec
+      .Query(name, TextCodec.string)
+      .transform[String] { c: NonEmptyChunk[String] => c.head }(s => NonEmptyChunk(s))
 
   def queryBool(name: String): QueryCodec[Boolean] =
-    HttpCodec.Query(name, TextCodec.boolean)
+    HttpCodec
+      .Query(name, TextCodec.boolean)
+      .transform { c: NonEmptyChunk[Boolean] => c.head }(s => NonEmptyChunk(s))
 
   def queryInt(name: String): QueryCodec[Int] =
-    HttpCodec.Query(name, TextCodec.int)
+    HttpCodec
+      .Query(name, TextCodec.int)
+      .transform { c: NonEmptyChunk[Int] => c.head }(s => NonEmptyChunk(s))
 
   def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
+    HttpCodec
+      .Query(name, codec)
+      .transform { c: NonEmptyChunk[A] => c.head }(s => NonEmptyChunk(s))
+
+  def queryMultiValue(name: String): QueryCodec[NonEmptyChunk[String]] =
+    HttpCodec.Query(name, TextCodec.string)
+
+  def queryMultiValueBool(name: String): QueryCodec[NonEmptyChunk[Boolean]] =
+    HttpCodec.Query(name, TextCodec.boolean)
+
+  def queryMultiValueInt(name: String): QueryCodec[NonEmptyChunk[Int]] =
+    HttpCodec.Query(name, TextCodec.int)
+
+  def queryMultiValueTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[NonEmptyChunk[A]] =
     HttpCodec.Query(name, codec)
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -32,21 +32,21 @@ private[codec] trait QueryCodecs {
   def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
     toSingleValue(name, HttpCodec.Query(name, codec))
 
-  def queryMultiValue(name: String): QueryCodec[Chunk[String]] =
+  def queryAll(name: String): QueryCodec[Chunk[String]] =
     HttpCodec.Query(name, TextCodec.string)
 
-  def queryMultiValueBool(name: String): QueryCodec[Chunk[Boolean]] =
+  def queryAllBool(name: String): QueryCodec[Chunk[Boolean]] =
     HttpCodec.Query(name, TextCodec.boolean)
 
-  def queryMultiValueInt(name: String): QueryCodec[Chunk[Int]] =
+  def queryAllInt(name: String): QueryCodec[Chunk[Int]] =
     HttpCodec.Query(name, TextCodec.int)
 
-  def queryMultiValueTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[Chunk[A]] =
+  def queryAllTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[Chunk[A]] =
     HttpCodec.Query(name, codec)
 
   private def toSingleValue[A](name: String, queryCodec: QueryCodec[Chunk[A]]): QueryCodec[A] =
     queryCodec.transformOrFail {
-      case chunk: Chunk[A] if chunk.size == 1 => Right(chunk.head)
+      case chunk if chunk.size == 1 => Right(chunk.head)
       case chunk => Left(s"Expected single value for query parameter $name, but got ${chunk.size} instead")
     }(s => Right(Chunk(s)))
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -15,7 +15,7 @@
  */
 
 package zio.http.codec
-import zio.NonEmptyChunk
+import zio.{Chunk, NonEmptyChunk}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[codec] trait QueryCodecs {
@@ -32,19 +32,19 @@ private[codec] trait QueryCodecs {
   def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
     toSingleValue(HttpCodec.Query(name, codec))
 
-  def queryMultiValue(name: String): QueryCodec[NonEmptyChunk[String]] =
+  def queryMultiValue(name: String): QueryCodec[Chunk[String]] =
     HttpCodec.Query(name, TextCodec.string)
 
-  def queryMultiValueBool(name: String): QueryCodec[NonEmptyChunk[Boolean]] =
+  def queryMultiValueBool(name: String): QueryCodec[Chunk[Boolean]] =
     HttpCodec.Query(name, TextCodec.boolean)
 
-  def queryMultiValueInt(name: String): QueryCodec[NonEmptyChunk[Int]] =
+  def queryMultiValueInt(name: String): QueryCodec[Chunk[Int]] =
     HttpCodec.Query(name, TextCodec.int)
 
-  def queryMultiValueTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[NonEmptyChunk[A]] =
+  def queryMultiValueTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[Chunk[A]] =
     HttpCodec.Query(name, codec)
 
-  private def toSingleValue[A](queryCodec: QueryCodec[NonEmptyChunk[A]]): QueryCodec[A] =
-    queryCodec.transform { (c: NonEmptyChunk[A]) => c.head }(s => NonEmptyChunk(s))
+  private def toSingleValue[A](queryCodec: QueryCodec[Chunk[A]]): QueryCodec[A] =
+    queryCodec.transform { (c: Chunk[A]) => c.head }(s => NonEmptyChunk(s))
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -15,38 +15,37 @@
  */
 
 package zio.http.codec
+import zio.Chunk
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Chunk, NonEmptyChunk}
+
+import zio.http.codec.HttpCodec.Query.QueryParamHint
 
 private[codec] trait QueryCodecs {
 
-  def query(name: String): QueryCodec[String] =
-    toSingleValue(name, HttpCodec.Query(name, TextCodec.string))
+  def query(name: String): QueryCodec[String] = singleValueCodec(name, TextCodec.string)
 
-  def queryBool(name: String): QueryCodec[Boolean] =
-    toSingleValue(name, HttpCodec.Query(name, TextCodec.boolean))
+  def queryBool(name: String): QueryCodec[Boolean] = singleValueCodec(name, TextCodec.boolean)
 
-  def queryInt(name: String): QueryCodec[Int] =
-    toSingleValue(name, HttpCodec.Query(name, TextCodec.int))
+  def queryInt(name: String): QueryCodec[Int] = singleValueCodec(name, TextCodec.int)
 
-  def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] =
-    toSingleValue(name, HttpCodec.Query(name, codec))
+  def queryTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[A] = singleValueCodec(name, codec)
 
-  def queryAll(name: String): QueryCodec[Chunk[String]] =
-    HttpCodec.Query(name, TextCodec.string)
+  def queryAll(name: String): QueryCodec[Chunk[String]] = multiValueCodec(name, TextCodec.string)
 
-  def queryAllBool(name: String): QueryCodec[Chunk[Boolean]] =
-    HttpCodec.Query(name, TextCodec.boolean)
+  def queryAllBool(name: String): QueryCodec[Chunk[Boolean]] = multiValueCodec(name, TextCodec.boolean)
 
-  def queryAllInt(name: String): QueryCodec[Chunk[Int]] =
-    HttpCodec.Query(name, TextCodec.int)
+  def queryAllInt(name: String): QueryCodec[Chunk[Int]] = multiValueCodec(name, TextCodec.int)
 
-  def queryAllTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[Chunk[A]] =
-    HttpCodec.Query(name, codec)
+  def queryAllTo[A](name: String)(implicit codec: TextCodec[A]): QueryCodec[Chunk[A]] = multiValueCodec(name, codec)
 
-  private def toSingleValue[A](name: String, queryCodec: QueryCodec[Chunk[A]]): QueryCodec[A] =
-    queryCodec.transformOrFail {
-      case chunk if chunk.size == 1 => Right(chunk.head)
-      case chunk => Left(s"Expected single value for query parameter $name, but got ${chunk.size} instead")
-    }(s => Right(Chunk(s)))
+  private def singleValueCodec[A](name: String, textCodec: TextCodec[A]): QueryCodec[A] =
+    HttpCodec
+      .Query(name, textCodec, QueryParamHint.One)
+      .transformOrFail {
+        case chunk if chunk.size == 1 => Right(chunk.head)
+        case chunk => Left(s"Expected single value for query parameter $name, but got ${chunk.size} instead")
+      }(s => Right(Chunk(s)))
+
+  private def multiValueCodec[A](name: String, textCodec: TextCodec[A]): QueryCodec[Chunk[A]] =
+    HttpCodec.Query(name, textCodec, QueryParamHint.Many)
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -509,7 +509,6 @@ private[codec] object EncoderDecoder {
         val input = inputs(i)
 
         val inputCoerced = input.asInstanceOf[Chunk[Any]]
-        pprint.pprintln(inputCoerced)
 
         if (inputCoerced.isEmpty)
           queryParams.addAll(query.name, Chunk.empty[String])

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -601,7 +601,7 @@ object OpenAPIGen {
       queryParams ++ pathParams ++ headerParams
 
     def queryParams: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]] = {
-      inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(name, codec, _), _) =>
+      inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(name, codec, _, _), _) =>
         OpenAPI.ReferenceOr.Or(
           OpenAPI.Parameter.queryParameter(
             name = name,


### PR DESCRIPTION
Introduce query codec for multi value query parameters. Now `HttpCodec.Query[A]` returns `Chunk[A]` as a result value. Add new query codecs to describe these multi value parameters to `QueryCodecs` preserving old ones(`query` etc), which are now a transformed versions of multi value codecs.

Now single value codecs fail if endpoint receives multiple values for this query

/claim #2321