### PR TITLE
Fix OpenAPI example extraction

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -7,9 +7,7 @@ import zio.cli._
 import zio.schema._
 
 import zio.http._
-import zio.http.codec.HttpCodec.Metadata
 import zio.http.codec._
-import zio.http.codec.internal._
 import zio.http.endpoint._
 
 /**
@@ -90,16 +88,16 @@ private[cli] object CliEndpoint {
 
   def fromCodec[Input](input: HttpCodec[_, Input]): CliEndpoint = {
     input match {
-      case atom: HttpCodec.Atom[_, _]           => fromAtom(atom)
-      case HttpCodec.TransformOrFail(api, _, _) => fromCodec(api)
-      case HttpCodec.Annotated(in, metadata)    =>
+      case atom: HttpCodec.Atom[_, _]            => fromAtom(atom)
+      case HttpCodec.TransformOrFail(api, _, _)  => fromCodec(api)
+      case HttpCodec.Annotated(in, metadata)     =>
         metadata match {
           case HttpCodec.Metadata.Documented(doc) => fromCodec(in) describeOptions doc
           case _                                  => fromCodec(in)
         }
-      case HttpCodec.Fallback(left, right, _)   => fromCodec(left) ++ fromCodec(right)
-      case HttpCodec.Combine(left, right, _)    => fromCodec(left) ++ fromCodec(right)
-      case _                                    => CliEndpoint.empty
+      case HttpCodec.Fallback(left, right, _, _) => fromCodec(left) ++ fromCodec(right)
+      case HttpCodec.Combine(left, right, _)     => fromCodec(left) ++ fromCodec(right)
+      case _                                     => CliEndpoint.empty
     }
   }
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -1,11 +1,5 @@
 package zio.http.endpoint.cli
 
-import scala.util.Try
-
-import zio.cli._
-
-import zio.schema._
-
 import zio.http._
 import zio.http.codec._
 import zio.http.endpoint._
@@ -103,21 +97,19 @@ private[cli] object CliEndpoint {
 
   private def fromAtom[Input](input: HttpCodec.Atom[_, Input]): CliEndpoint = {
     input match {
-      case HttpCodec.Content(schema, mediaType, nameOption, _) => {
+      case HttpCodec.Content(schema, mediaType, nameOption, _) =>
         val name = nameOption match {
           case Some(x) => x
           case None    => ""
         }
         CliEndpoint(body = HttpOptions.Body(name, mediaType, schema) :: List())
-      }
 
-      case HttpCodec.ContentStream(schema, mediaType, nameOption, _) => {
+      case HttpCodec.ContentStream(schema, mediaType, nameOption, _) =>
         val name = nameOption match {
           case Some(x) => x
           case None    => ""
         }
         CliEndpoint(body = HttpOptions.Body(name, mediaType, schema) :: List())
-      }
 
       case HttpCodec.Header(name, textCodec, _) =>
         CliEndpoint(headers = HttpOptions.Header(name, textCodec) :: List())

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -312,10 +312,9 @@ private[cli] object HttpOptions {
     }
 
   private[cli] def optionsFromSegment(segment: SegmentCodec[_]): Options[String] = {
-    @tailrec
     def fromSegment[A](segment: SegmentCodec[A]): Options[String] =
       segment match {
-        case SegmentCodec.UUID(name)          =>
+        case SegmentCodec.UUID(name)     =>
           Options
             .text(name)
             .mapOrFail(str =>
@@ -327,14 +326,13 @@ private[cli] object HttpOptions {
               },
             )
             .map(_.toString)
-        case SegmentCodec.Text(name)          => Options.text(name)
-        case SegmentCodec.IntSeg(name)        => Options.integer(name).map(_.toInt).map(_.toString)
-        case SegmentCodec.LongSeg(name)       => Options.integer(name).map(_.toInt).map(_.toString)
-        case SegmentCodec.BoolSeg(name)       => Options.boolean(name).map(_.toString)
-        case SegmentCodec.Literal(value)      => Options.Empty.map(_ => value)
-        case SegmentCodec.Trailing            => Options.none.map(_.toString)
-        case SegmentCodec.Empty               => Options.none.map(_.toString)
-        case SegmentCodec.Annotated(codec, _) => fromSegment(codec)
+        case SegmentCodec.Text(name)     => Options.text(name)
+        case SegmentCodec.IntSeg(name)   => Options.integer(name).map(_.toInt).map(_.toString)
+        case SegmentCodec.LongSeg(name)  => Options.integer(name).map(_.toInt).map(_.toString)
+        case SegmentCodec.BoolSeg(name)  => Options.boolean(name).map(_.toString)
+        case SegmentCodec.Literal(value) => Options.Empty.map(_ => value)
+        case SegmentCodec.Trailing       => Options.none.map(_.toString)
+        case SegmentCodec.Empty          => Options.none.map(_.toString)
       }
 
     fromSegment(segment)

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
@@ -20,18 +20,16 @@ import zio.http.endpoint.cli.EndpointGen._
 object CommandGen {
 
   def getSegment(segment: SegmentCodec[_]): (String, String) = {
-    @tailrec
     def fromSegment[A](segment: SegmentCodec[A]): (String, String) =
       segment match {
-        case SegmentCodec.UUID(name)          => (name, "text")
-        case SegmentCodec.Text(name)          => (name, "text")
-        case SegmentCodec.IntSeg(name)        => (name, "integer")
-        case SegmentCodec.LongSeg(name)       => (name, "integer")
-        case SegmentCodec.BoolSeg(name)       => (name, "boolean")
-        case SegmentCodec.Literal(_)          => ("", "")
-        case SegmentCodec.Trailing            => ("", "")
-        case SegmentCodec.Empty               => ("", "")
-        case SegmentCodec.Annotated(codec, _) => fromSegment(codec)
+        case SegmentCodec.UUID(name)    => (name, "text")
+        case SegmentCodec.Text(name)    => (name, "text")
+        case SegmentCodec.IntSeg(name)  => (name, "integer")
+        case SegmentCodec.LongSeg(name) => (name, "integer")
+        case SegmentCodec.BoolSeg(name) => (name, "boolean")
+        case SegmentCodec.Literal(_)    => ("", "")
+        case SegmentCodec.Trailing      => ("", "")
+        case SegmentCodec.Empty         => ("", "")
       }
 
     fromSegment(segment)

--- a/zio-http/jvm/src/test/resources/endpoint/openapi/multiple-methods-on-same-path.json
+++ b/zio-http/jvm/src/test/resources/endpoint/openapi/multiple-methods-on-same-path.json
@@ -19,7 +19,6 @@
         },
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "text/plain": {
                 "schema": {
@@ -44,7 +43,6 @@
         },
         "responses": {
           "201": {
-            "description": "",
             "content": {
               "text/plain": {
                 "schema": {

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -16,23 +16,18 @@
 
 package zio.http.codec
 
-import java.util.concurrent.ConcurrentHashMap
-
-import scala.annotation.tailrec
-import scala.language.implicitConversions
-import scala.reflect.ClassTag
-
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
-
-import zio.stream.ZStream
-
-import zio.schema.Schema
-
 import zio.http.Header.Accept.MediaTypeWithQFactor
 import zio.http._
 import zio.http.codec.HttpCodec.{Annotated, Metadata}
 import zio.http.codec.internal.EncoderDecoder
+import zio.schema.Schema
+import zio.stream.ZStream
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.annotation.tailrec
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
 
 /**
  * A [[zio.http.codec.HttpCodec]] represents a codec for a part of an HTTP
@@ -93,7 +88,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
     if (self eq HttpCodec.Halt) that.asInstanceOf[HttpCodec[AtomTypes1, alternator.Out]]
     else {
       HttpCodec
-        .Fallback(self, that, HttpCodec.Fallback.Condition.IsHttpCodecError)
+        .Fallback(self, that, alternator, HttpCodec.Fallback.Condition.IsHttpCodecError)
         .transform[alternator.Out](either => either.fold(alternator.left(_), alternator.right(_)))(value =>
           alternator
             .unleft(value)
@@ -288,7 +283,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
       if (self eq HttpCodec.Halt) HttpCodec.empty.asInstanceOf[HttpCodec[AtomTypes, Option[Value]]]
       else {
         HttpCodec
-          .Fallback(self, HttpCodec.empty, HttpCodec.Fallback.Condition.isMissingDataOnly)
+          .Fallback(self, HttpCodec.empty, Alternator.either, HttpCodec.Fallback.Condition.isMissingDataOnly)
           .transform[Option[Value]](either => either.fold(Some(_), _ => None))(_.toLeft(()))
       },
       Metadata.Optional(),
@@ -633,12 +628,21 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
       }
   }
 
-  sealed trait Metadata[Value]
+  sealed trait Metadata[Value] {
+    def transform[Value2](f: Value => Value2): Metadata[Value2] =
+      this match {
+        case Metadata.Named(name)     => Metadata.Named(name)
+        case Metadata.Optional()      => Metadata.Optional()
+        case Metadata.Examples(ex)    => Metadata.Examples(ex.map { case (k, v) => k -> f(v) })
+        case Metadata.Documented(doc) => Metadata.Documented(doc)
+        case Metadata.Deprecated(doc) => Metadata.Deprecated(doc)
+      }
+  }
 
   object Metadata {
     final case class Named[A](name: String) extends Metadata[A]
 
-    final case class Optional[A]() extends Metadata[Option[A]]
+    final case class Optional[A]() extends Metadata[A]
 
     final case class Examples[A](examples: Map[String, A]) extends Metadata[A]
 
@@ -673,6 +677,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   private[http] final case class Fallback[AtomType, A, B](
     left: HttpCodec[AtomType, A],
     right: HttpCodec[AtomType, B],
+    alternator: Alternator[A, B],
     condition: Fallback.Condition,
   ) extends HttpCodec[AtomType, Either[A, B]] {
     type Left  = A
@@ -720,37 +725,98 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   private[http] def flattenFallbacks[AtomTypes, A](
     api: HttpCodec[AtomTypes, A],
   ): Chunk[(HttpCodec[AtomTypes, A], Fallback.Condition)] = {
-    def rewrite[T, B](api: HttpCodec[T, B]): Chunk[(HttpCodec[T, B], Fallback.Condition)] =
+
+    def rewrite[T, B](
+      api: HttpCodec[T, B],
+      annotations: Chunk[HttpCodec.Metadata[B]],
+    ): Chunk[(HttpCodec[T, B], Fallback.Condition)] =
       api match {
-        case fallback @ HttpCodec.Fallback(left, right, condition) =>
-          rewrite[T, fallback.Left](left).map { case (codec, condition) =>
+        case fallback @ HttpCodec.Fallback(left, right, alternator, condition) =>
+          rewrite[T, fallback.Left](left, reduceExamplesLeft(annotations, alternator)).map { case (codec, condition) =>
             codec.toLeft[fallback.Right] -> condition
           } ++
-            rewrite[T, fallback.Right](right).map { case (codec, _) =>
+            rewrite[T, fallback.Right](right, reduceExamplesRight(annotations, alternator)).map { case (codec, _) =>
               codec.toRight[fallback.Left] -> condition
             }
 
         case transform @ HttpCodec.TransformOrFail(codec, f, g) =>
-          rewrite[T, transform.In](codec).map { case (codec, condition) =>
+          rewrite[T, transform.In](codec, annotations.map(_.transform(g))).map { case (codec, condition) =>
             HttpCodec.TransformOrFail(codec, f, g) -> condition
           }
 
         case combine @ HttpCodec.Combine(left, right, combiner) =>
           for {
-            (l, lCondition) <- rewrite[T, combine.Left](left)
-            (r, rCondition) <- rewrite[T, combine.Right](right)
+            (l, lCondition) <- rewrite[T, combine.Left](left, reduceExamplesLeft(annotations, combiner))
+            (r, rCondition) <- rewrite[T, combine.Right](right, reduceExamplesRight(annotations, combiner))
           } yield HttpCodec.Combine(l, r, combiner) -> lCondition.combine(rCondition)
 
         case HttpCodec.Annotated(in, metadata) =>
-          rewrite[T, B](in).map { case (codec, missingDataOnly) => codec.annotate(metadata) -> missingDataOnly }
+          rewrite[T, B](in, metadata +: annotations)
 
         case HttpCodec.Empty => Chunk.single(HttpCodec.Empty -> Fallback.Condition.IsHttpCodecError)
 
         case HttpCodec.Halt => Chunk.empty
 
-        case atom: Atom[_, _] => Chunk.single(atom -> Fallback.Condition.IsHttpCodecError)
+        case atom: Atom[_, _] =>
+          Chunk.single(annotations.foldLeft[HttpCodec[T, B]](atom)(_ annotate _) -> Fallback.Condition.IsHttpCodecError)
       }
 
-    rewrite(api)
+    rewrite(api, Chunk.empty)
   }
+
+  private[http] def reduceExamplesLeft[T, L, R](
+    annotations: Chunk[HttpCodec.Metadata[T]],
+    combiner: Combiner[L, R],
+  ): Chunk[HttpCodec.Metadata[L]] =
+    annotations.map {
+      case HttpCodec.Metadata.Examples(examples) =>
+        HttpCodec.Metadata.Examples(examples.map { case (name, value) =>
+          name -> combiner.separate(value.asInstanceOf[combiner.Out])._1
+        })
+      case other                                 =>
+        other.asInstanceOf[HttpCodec.Metadata[L]]
+    }
+
+  private[http] def reduceExamplesLeft[T, L, R](
+    annotations: Chunk[HttpCodec.Metadata[T]],
+    alternator: Alternator[L, R],
+  ): Chunk[HttpCodec.Metadata[L]] =
+    annotations.map {
+      case HttpCodec.Metadata.Examples(examples) =>
+        HttpCodec.Metadata.Examples(examples.map { case (name, value) =>
+          name -> alternator
+            .unleft(value.asInstanceOf[alternator.Out])
+            .getOrElse(throw new Exception("Unexpected error: Could not take left of alternating example."))
+        })
+      case other                                 =>
+        other.asInstanceOf[HttpCodec.Metadata[L]]
+    }
+
+  private[http] def reduceExamplesRight[T, L, R](
+    annotations: Chunk[HttpCodec.Metadata[T]],
+    combiner: Combiner[L, R],
+  ): Chunk[HttpCodec.Metadata[R]] =
+    annotations.map {
+      case HttpCodec.Metadata.Examples(examples) =>
+        HttpCodec.Metadata.Examples(examples.map { case (name, value) =>
+          name -> combiner.separate(value.asInstanceOf[combiner.Out])._2
+        })
+      case other                                 =>
+        other.asInstanceOf[HttpCodec.Metadata[R]]
+    }
+
+  private[http] def reduceExamplesRight[T, L, R](
+    annotations: Chunk[HttpCodec.Metadata[T]],
+    alternator: Alternator[L, R],
+  ): Chunk[HttpCodec.Metadata[R]] =
+    annotations.map {
+      case HttpCodec.Metadata.Examples(examples) =>
+        HttpCodec.Metadata.Examples(examples.map { case (name, value) =>
+          name -> alternator
+            .unright(value.asInstanceOf[alternator.Out])
+            .getOrElse(throw new Exception("Unexpected error: Could not take right of alternating example."))
+        })
+      case other                                 =>
+        other.asInstanceOf[HttpCodec.Metadata[R]]
+    }
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
@@ -85,6 +85,6 @@ private[http] object AtomizedCodecs {
       case Annotated(api, _)             => flattenedAtoms(api)
       case Empty                         => Chunk.empty
       case Halt                          => Chunk.empty
-      case Fallback(_, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
+      case Fallback(_, _, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/Mechanic.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/Mechanic.scala
@@ -45,7 +45,7 @@ private[http] object Mechanic {
       case Annotated(api, _) => indexedImpl(api.asInstanceOf[HttpCodec[R, A]], indices)
       case Empty             => (Empty.asInstanceOf[HttpCodec[R, A]], indices)
       case Halt              => (Halt.asInstanceOf[HttpCodec[R, A]], indices)
-      case Fallback(_, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
+      case Fallback(_, _, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
 
   def makeConstructor[R, A](
@@ -101,7 +101,7 @@ private[http] object Mechanic {
 
       case Halt => throw HaltException
 
-      case Fallback(_, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
+      case Fallback(_, _, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
   }
 
@@ -143,7 +143,7 @@ private[http] object Mechanic {
 
       case Halt => (_, _) => ()
 
-      case Fallback(_, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
+      case Fallback(_, _, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
   }
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/Mechanic.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/Mechanic.scala
@@ -42,9 +42,9 @@ private[http] object Mechanic {
         val (api2, resultIndices) = indexedImpl(api, indices)
         (TransformOrFail(api2, f, g).asInstanceOf[HttpCodec[R, A]], resultIndices)
 
-      case Annotated(api, _) => indexedImpl(api.asInstanceOf[HttpCodec[R, A]], indices)
-      case Empty             => (Empty.asInstanceOf[HttpCodec[R, A]], indices)
-      case Halt              => (Halt.asInstanceOf[HttpCodec[R, A]], indices)
+      case Annotated(api, _)    => indexedImpl(api.asInstanceOf[HttpCodec[R, A]], indices)
+      case Empty                => (Empty.asInstanceOf[HttpCodec[R, A]], indices)
+      case Halt                 => (Halt.asInstanceOf[HttpCodec[R, A]], indices)
       case Fallback(_, _, _, _) => throw new UnsupportedOperationException("Cannot handle fallback at this level")
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -297,39 +297,15 @@ object JsonSchema {
 
   def fromSegmentCodec(codec: SegmentCodec[_]): JsonSchema =
     codec match {
-      case SegmentCodec.BoolSeg(_)                    => JsonSchema.Boolean
-      case SegmentCodec.IntSeg(_)                     => JsonSchema.Integer(JsonSchema.IntegerFormat.Int32)
-      case SegmentCodec.LongSeg(_)                    => JsonSchema.Integer(JsonSchema.IntegerFormat.Int64)
-      case SegmentCodec.Text(_)                       => JsonSchema.String()
-      case SegmentCodec.UUID(_)                       => JsonSchema.String(JsonSchema.StringFormat.UUID)
-      case SegmentCodec.Annotated(codec, annotations) =>
-        fromSegmentCodec(codec).description(segmentDoc(annotations)).examples(segmentExamples(codec, annotations))
+      case SegmentCodec.BoolSeg(_) => JsonSchema.Boolean
+      case SegmentCodec.IntSeg(_)  => JsonSchema.Integer(JsonSchema.IntegerFormat.Int32)
+      case SegmentCodec.LongSeg(_) => JsonSchema.Integer(JsonSchema.IntegerFormat.Int64)
+      case SegmentCodec.Text(_)    => JsonSchema.String()
+      case SegmentCodec.UUID(_)    => JsonSchema.String(JsonSchema.StringFormat.UUID)
       case SegmentCodec.Literal(_) => throw new IllegalArgumentException("Literal segment is not supported.")
       case SegmentCodec.Empty      => throw new IllegalArgumentException("Empty segment is not supported.")
       case SegmentCodec.Trailing   => throw new IllegalArgumentException("Trailing segment is not supported.")
     }
-
-  private def segmentDoc(annotations: Chunk[SegmentCodec.MetaData[_]]) =
-    annotations.collect { case SegmentCodec.MetaData.Documented(doc) => doc }.reduceOption(_ + _).map(_.toCommonMark)
-
-  private def segmentExamples(codec: SegmentCodec[_], annotations: Chunk[SegmentCodec.MetaData[_]]) =
-    Chunk.fromIterable(
-      annotations.collect { case SegmentCodec.MetaData.Examples(example) => example.values }.flatten.map { value =>
-        codec match {
-          case SegmentCodec.Empty           => throw new IllegalArgumentException("Empty segment is not supported.")
-          case SegmentCodec.Literal(_)      => throw new IllegalArgumentException("Literal segment is not supported.")
-          case SegmentCodec.BoolSeg(_)      => Json.Bool(value.asInstanceOf[Boolean])
-          case SegmentCodec.IntSeg(_)       => Json.Num(value.asInstanceOf[Int])
-          case SegmentCodec.LongSeg(_)      => Json.Num(value.asInstanceOf[Long])
-          case SegmentCodec.Text(_)         => Json.Str(value.asInstanceOf[java.lang.String])
-          case SegmentCodec.UUID(_)         => Json.Str(value.asInstanceOf[java.util.UUID].toString)
-          case SegmentCodec.Trailing        =>
-            throw new IllegalArgumentException("Trailing segment is not supported.")
-          case SegmentCodec.Annotated(_, _) =>
-            throw new IllegalStateException("Annotated SegmentCodec should never be nested.")
-        }
-      },
-    )
 
   def fromZSchemaMulti(schema: Schema[_], refType: SchemaStyle = SchemaStyle.Inline): JsonSchemas = {
     val ref = nominal(schema, refType)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
@@ -992,7 +992,7 @@ object OpenAPI {
    *   of the names for Component Objects.
    */
   final case class Response(
-    description: Doc = Doc.Empty,
+    description: Option[Doc] = None,
     headers: Map[String, ReferenceOr[Header]] = Map.empty,
     content: Map[String, MediaType] = Map.empty,
     links: Map[String, ReferenceOr[Link]] = Map.empty,


### PR DESCRIPTION
fixes #2609
/claim #2609

- [x] fix example tuple deconstruction
- [x] fix example either deconstruction
- [x] handover examples correctly to path codecs

@jdegoes I see how I can deconstruct tuple examples for combined codecs. But for alternation, we don't have a type class that helps us to deconstruct.
I would add in the docs, that we don't support this for open api gen and that instead of calling `inExamples` on the endpoint, ppl should call `ContentCodec.content[A].examples(...) | ContentCodec.content[B].examples(...)`.
wdyt?