### PR TITLE
Avoid unnecessary parsing of `content-type` header in `ServerInboundHandler`

### DIFF
--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ProbeContentTypeBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ProbeContentTypeBenchmark.scala
@@ -25,6 +25,24 @@ class ProbeContentTypeBenchmark {
   }
 
   @Benchmark
+  def benchmarkParseMediaTypeSimple(): Unit = {
+    MediaType.forContentType("application/json")
+    ()
+  }
+
+  @Benchmark
+  def benchmarkParseMediaTypeNotLowerCase(): Unit = {
+    MediaType.forContentType("Application/json")
+    ()
+  }
+
+  @Benchmark
+  def benchmarkParseMediaTypeWithParams(): Unit = {
+    MediaType.forContentType("application/json; charset=utf-8")
+    ()
+  }
+
+  @Benchmark
   def benchmarkParseContentType(): Unit = {
     ContentType.parse("application/json; charset=utf-8")
     ()

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/ServerInboundHandlerBenchmark.scala
@@ -48,6 +48,8 @@ class ServerInboundHandlerBenchmark {
   private val testUrl      = s"$baseUrl/$testEndPoint"
   private val testRequest  = basicRequest.get(uri"$testUrl")
 
+  private val testContentTypeRequest = testRequest.contentType("application/json; charset=utf8")
+
   private val shutdownResponse = Response.text("shutting down")
   private val shutdownEndpoint = "shutdown"
   private val shutdownUrl      = s"http://localhost:8080/$shutdownEndpoint"
@@ -104,6 +106,13 @@ class ServerInboundHandlerBenchmark {
   @Benchmark
   def benchmarkSimple(): Unit = {
     val statusCode = testRequest.send(backend).code
+    if (!statusCode.isSuccess)
+      throw new RuntimeException(s"Received unexpected status code ${statusCode.code}")
+  }
+
+  @Benchmark
+  def benchmarkSimpleContentType(): Unit = {
+    val statusCode = testContentTypeRequest.send(backend).code
     if (!statusCode.isSuccess)
       throw new RuntimeException(s"Received unexpected status code ${statusCode.code}")
   }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
@@ -40,45 +40,41 @@ object NettyBody extends BodyEncoding {
   private[zio] def fromAsync(
     unsafeAsync: UnsafeAsync => Unit,
     knownContentLength: Option[Long],
-    contentTypeHeader: () => Option[Header.ContentType] = () => None,
+    contentTypeHeader: Option[String] = None,
   ): Body = {
-    lazy val cachedCt = contentTypeHeader()
+    val (mediaType, boundary) = mediaTypeAndBoundary(contentTypeHeader)
     AsyncBody(
       unsafeAsync,
       knownContentLength,
-      () => cachedCt.map(_.mediaType),
-      () => cachedCt.flatMap(_.boundary),
+      mediaType,
+      boundary,
     )
   }
 
   /**
    * Helper to create Body from ByteBuf
    */
-  def fromByteBuf(byteBuf: ByteBuf, contentTypeHeader: Option[Header.ContentType] = None): Body =
-    fromByteBufLazy(byteBuf, () => contentTypeHeader)
+  private[zio] def fromByteBuf(byteBuf: ByteBuf, contentTypeHeader: Option[String]): Body = {
+    val (mediaType, boundary) = mediaTypeAndBoundary(contentTypeHeader)
+    ByteBufBody(byteBuf, mediaType, boundary)
+  }
 
-  private[zio] def fromByteBufLazy(
-    byteBuf: ByteBuf,
-    contentTypeHeader: () => Option[Header.ContentType] = () => None,
-  ): Body = {
-    lazy val cachedCt = contentTypeHeader()
-    ByteBufBody(byteBuf, () => cachedCt.map(_.mediaType), () => cachedCt.flatMap(_.boundary))
+  private def mediaTypeAndBoundary(contentTypeHeader: Option[String]) = {
+    val mediaType = contentTypeHeader.flatMap(MediaType.forContentType)
+    val boundary  = mediaType.flatMap(_.parameters.get("boundary")).map(Boundary(_))
+    (mediaType, boundary)
   }
 
   override def fromCharSequence(charSequence: CharSequence, charset: Charset): Body =
     fromAsciiString(new AsciiString(charSequence, charset))
 
-  private[zio] final case class AsciiStringBody private[NettyBody] (
+  private[zio] final case class AsciiStringBody(
     asciiString: AsciiString,
-    private val mediaType0: () => Option[MediaType] = () => None,
-    private val boundary0: () => Option[Boundary] = () => None,
+    override val mediaType: Option[MediaType] = None,
+    override val boundary: Option[Boundary] = None,
   ) extends Body
       with UnsafeWriteable
       with UnsafeBytes {
-
-    override def mediaType: Option[MediaType] = mediaType0()
-
-    override def boundary: Option[Boundary] = boundary0()
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(asciiString.array())
 
@@ -96,25 +92,21 @@ object NettyBody extends BodyEncoding {
 
     private[zio] override def unsafeAsArray(implicit unsafe: Unsafe): Array[Byte] = asciiString.array()
 
-    override def contentType(newMediaType: MediaType): Body = copy(mediaType0 = () => Some(newMediaType))
+    override def contentType(newMediaType: MediaType): Body = copy(mediaType = Some(newMediaType))
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
-      copy(mediaType0 = () => Some(newMediaType), boundary0 = () => boundary.orElse(Some(newBoundary)))
+      copy(mediaType = Some(newMediaType), boundary = Some(newBoundary))
 
     override def knownContentLength: Option[Long] = Some(asciiString.length().toLong)
   }
 
-  private[zio] final case class ByteBufBody private[NettyBody] (
-    byteBuf: ByteBuf,
-    private val mediaType0: () => Option[MediaType] = () => None,
-    private val boundary0: () => Option[Boundary] = () => None,
+  private[zio] final case class ByteBufBody(
+    val byteBuf: ByteBuf,
+    override val mediaType: Option[MediaType] = None,
+    override val boundary: Option[Boundary] = None,
   ) extends Body
       with UnsafeWriteable
       with UnsafeBytes {
-
-    override def mediaType: Option[MediaType] = mediaType0()
-
-    override def boundary: Option[Boundary] = boundary0()
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(ByteBufUtil.getBytes(byteBuf))
 
@@ -132,26 +124,21 @@ object NettyBody extends BodyEncoding {
     override private[zio] def unsafeAsArray(implicit unsafe: Unsafe): Array[Byte] =
       ByteBufUtil.getBytes(byteBuf)
 
-    override def contentType(newMediaType: MediaType): Body = copy(mediaType0 = () => Some(newMediaType))
+    override def contentType(newMediaType: MediaType): Body = copy(mediaType = Some(newMediaType))
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
-      copy(mediaType0 = () => Some(newMediaType), boundary0 = () => boundary.orElse(Some(newBoundary)))
+      copy(mediaType = Some(newMediaType), boundary = Some(newBoundary))
 
     override def knownContentLength: Option[Long] = Some(byteBuf.readableBytes().toLong)
   }
 
-  private[zio] final case class AsyncBody private[NettyBody] (
+  private[zio] final case class AsyncBody(
     unsafeAsync: UnsafeAsync => Unit,
     knownContentLength: Option[Long],
-    private val mediaType0: () => Option[MediaType] = () => None,
-    private val boundary0: () => Option[Boundary] = () => None,
+    override val mediaType: Option[MediaType] = None,
+    override val boundary: Option[Boundary] = None,
   ) extends Body
       with UnsafeWriteable {
-
-    override def mediaType: Option[MediaType] = mediaType0()
-
-    override def boundary: Option[Boundary] = boundary0()
-
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = asChunk.map(_.toArray)
 
     override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = asStream.runCollect
@@ -183,10 +170,10 @@ object NettyBody extends BodyEncoding {
 
     override def toString(): String = s"AsyncBody($unsafeAsync)"
 
-    override def contentType(newMediaType: MediaType): Body = copy(mediaType0 = () => Some(newMediaType))
+    override def contentType(newMediaType: MediaType): Body = copy(mediaType = Some(newMediaType))
 
     override def contentType(newMediaType: MediaType, newBoundary: Boundary): Body =
-      copy(mediaType0 = () => Some(newMediaType), boundary0 = () => boundary.orElse(Some(newBoundary)))
+      copy(mediaType = Some(newMediaType), boundary = Some(newBoundary))
   }
 
   private[zio] trait UnsafeAsync {

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
@@ -34,7 +34,7 @@ object NettyResponse {
     val status       = Conversions.statusFromNetty(jRes.status())
     val headers      = Conversions.headersFromNetty(jRes.headers())
     val copiedBuffer = Unpooled.copiedBuffer(jRes.content())
-    val data         = NettyBody.fromByteBufLazy(copiedBuffer, () => headers.header(Header.ContentType))
+    val data         = NettyBody.fromByteBuf(copiedBuffer, headers.headers.get(Header.ContentType.name))
 
     Response(status, headers, data)
   }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
@@ -34,7 +34,7 @@ object NettyResponse {
     val status       = Conversions.statusFromNetty(jRes.status())
     val headers      = Conversions.headersFromNetty(jRes.headers())
     val copiedBuffer = Unpooled.copiedBuffer(jRes.content())
-    val data         = NettyBody.fromByteBuf(copiedBuffer, headers.header(Header.ContentType))
+    val data         = NettyBody.fromByteBufLazy(copiedBuffer, () => headers.header(Header.ContentType))
 
     Response(status, headers, data)
   }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -210,16 +210,13 @@ private[zio] final case class ServerInboundHandler(
       case _                    => None
     }
 
-    val headers     = Conversions.headersFromNetty(nettyReq.headers())
-    val contentType = () => headers.header(Header.ContentType)
+    val headers           = Conversions.headersFromNetty(nettyReq.headers())
+    val contentTypeHeader = headers.headers.get(Header.ContentType.name)
 
     nettyReq match {
       case nettyReq: FullHttpRequest =>
         Request(
-          body = NettyBody.fromByteBufLazy(
-            nettyReq.content(),
-            contentType,
-          ),
+          body = NettyBody.fromByteBuf(nettyReq.content(), contentTypeHeader),
           headers = headers,
           method = Conversions.methodFromNetty(nettyReq.method()),
           url = URL.decode(nettyReq.uri()).getOrElse(URL.empty),
@@ -229,7 +226,7 @@ private[zio] final case class ServerInboundHandler(
       case nettyReq: HttpRequest     =>
         val knownContentLength = headers.get(Header.ContentLength).map(_.length)
         val handler            = addAsyncBodyHandler(ctx)
-        val body               = NettyBody.fromAsync(async => handler.connect(async), knownContentLength, contentType)
+        val body = NettyBody.fromAsync(async => handler.connect(async), knownContentLength, contentTypeHeader)
 
         Request(
           body = body,

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -211,12 +211,12 @@ private[zio] final case class ServerInboundHandler(
     }
 
     val headers     = Conversions.headersFromNetty(nettyReq.headers())
-    val contentType = headers.header(Header.ContentType)
+    val contentType = () => headers.header(Header.ContentType)
 
     nettyReq match {
       case nettyReq: FullHttpRequest =>
         Request(
-          body = NettyBody.fromByteBuf(
+          body = NettyBody.fromByteBufLazy(
             nettyReq.content(),
             contentType,
           ),

--- a/zio-http/jvm/src/test/scala/zio/http/MediaTypeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/MediaTypeSpec.scala
@@ -25,6 +25,17 @@ object MediaTypeSpec extends ZIOHttpSpec {
     test("predefined mime type parsing") {
       assertTrue(MediaType.forContentType("application/json").contains(application.`json`))
     },
+    test("with boundary") {
+      // NOTE: Testing with non-lowercase values on purpose as spec requires MIME type and param keys to be case-insensitive,and param values case-sensitive
+      MediaType.forContentType("Multipart/form-data; Boundary=-A-") match {
+        case None     => assertNever("failed to parse media type")
+        case Some(mt) =>
+          assertTrue(
+            mt.fullType == "multipart/form-data",
+            mt.parameters.get("boundary").contains("-A-"),
+          )
+      }
+    },
     test("custom mime type parsing") {
       assertTrue(MediaType.parseCustomMediaType("custom/mime").contains(MediaType("custom", "mime")))
     },


### PR DESCRIPTION
While #2597 improved the performance of parsing the content-type header significantly, it is still a _relatively_ expensive computation (w.r.t everything else) so if we can avoid it, why not? While most applications won't see any measurable difference with this change, I'm certain it'll make a difference on benchmarks that include the content-type header as part of the request.

To demonstrate the difference, I added a benchmark in `ServerInboundHandlerBenchmark` that includes the content type header:

Before:
```
[info] Benchmark                                                  Mode  Cnt      Score     Error  Units
[info] ServerInboundHandlerBenchmark.benchmarkSimpleContentType  thrpt   10  30047.175 ± 245.613  ops/s
```

After:
```
[info] Benchmark                                                  Mode  Cnt      Score     Error  Units
[info] ServerInboundHandlerBenchmark.benchmarkSimpleContentType  thrpt   10  32728.912 ± 182.722  ops/s
```
 
I rerun the benchmark 5-10 times and it seems that avoiding the parsing of the content-type header is consistently 5-10% faster