### PR TITLE
Add finalizer for Netty channels created via `NettyConnectionPool`

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -122,7 +122,7 @@ object NettyConnectionPool {
       }
       _             <- NettyFutureExecutor.executed(channelFuture)
       ch            <- ZIO.attempt(channelFuture.channel())
-      _             <- Scope.addFinalizer(NettyFutureExecutor.executed(ch.disconnect()).when(ch.isOpen).ignoreLogged)
+      _             <- Scope.addFinalizer(NettyFutureExecutor.executed(ch.close()).when(ch.isOpen).ignoreLogged)
     } yield ch
   }
 


### PR DESCRIPTION
Currently there's no finalizer for shutting down netty's channels created by the connection pool, which might lead to memory leaks in certain situations such as when connection pool's are recreated or when connections are expired via the TTL param