### PR TITLE
Rename `Handler.response` to `Handler.fromResponse`

### DIFF
--- a/docs/dsl/routes.md
+++ b/docs/dsl/routes.md
@@ -99,12 +99,12 @@ Creates a `Handler` that always fails with the given error.
 Handler.error(Status.Forbidden)
 ```
 
-### Handler.response
+### Handler.fromResponse
 
 Creates an `Handler` that always responds with the same `Response`.
 
 ```scala mdoc:silent
-Handler.response(Response.ok)
+Handler.fromResponse(Response.ok)
 ```
 
 ## Special operators on Handler
@@ -125,7 +125,7 @@ handler11.method(Method.POST)
 Patches the response produced by the request handler using a `Patch`.
 
 ```scala mdoc:silent
-val handler12 = Handler.response(Response.text("Hello World!"))
+val handler12 = Handler.fromResponse(Response.text("Hello World!"))
 val handler13 = handler12.patch(Response.Patch.status(Status.Accepted))
 ```
 

--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -30,10 +30,10 @@ object PlainTextBenchmarkServer extends ZIOAppDefault {
     .addHeader(Header.Server(STATIC_SERVER_NAME))
 
   private def plainTextApp(response: Response): HttpApp[Any] =
-    Routes(Method.GET / plaintextPath -> Handler.response(response)).toHttpApp
+    Routes(Method.GET / plaintextPath -> Handler.fromResponse(response)).toHttpApp
 
   private def jsonApp(json: Response): HttpApp[Any] =
-    Routes(Method.GET / jsonPath -> Handler.response(json)).toHttpApp
+    Routes(Method.GET / jsonPath -> Handler.fromResponse(json)).toHttpApp
 
   val app: HttpApp[Any] = plainTextApp(frozenPlainTextResponse) ++ jsonApp(frozenJsonResponse)
 

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
@@ -450,7 +450,13 @@ object ServerSpec extends HttpRunnableSpec {
         val server = "ZIO-Http"
         val res    = Response.text("abc")
         for {
-          actual <- Handler.fromResponse(res).addHeader(Header.Server(server)).toHttpApp.deploy.header(Header.Server).run()
+          actual <- Handler
+            .fromResponse(res)
+            .addHeader(Header.Server(server))
+            .toHttpApp
+            .deploy
+            .header(Header.Server)
+            .run()
         } yield assertTrue(actual.get == Header.Server(server))
       },
     ),

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
@@ -141,7 +141,7 @@ object ServerSpec extends HttpRunnableSpec {
           assertZIO(res)(isSome(equalTo("Bar")))
         }
       } + suite("response") {
-        val app = Handler.response(Response(status = Status.Ok, body = Body.fromString("abc"))).toHttpApp
+        val app = Handler.fromResponse(Response(status = Status.Ok, body = Body.fromString("abc"))).toHttpApp
         test("body is set") {
           val res = app.deploy.body.mapZIO(_.asString).run()
           assertZIO(res)(equalTo("abc"))
@@ -443,14 +443,14 @@ object ServerSpec extends HttpRunnableSpec {
         val expected = (0 to size) map (_ => Status.Ok)
         val response = Response.text("abc")
         for {
-          actual <- ZIO.foreachPar(0 to size)(_ => Handler.response(response).toHttpApp.deploy.status.run())
+          actual <- ZIO.foreachPar(0 to size)(_ => Handler.fromResponse(response).toHttpApp.deploy.status.run())
         } yield assertTrue(actual == expected)
       },
       test("update after cache") {
         val server = "ZIO-Http"
         val res    = Response.text("abc")
         for {
-          actual <- Handler.response(res).addHeader(Header.Server(server)).toHttpApp.deploy.header(Header.Server).run()
+          actual <- Handler.fromResponse(res).addHeader(Header.Server(server)).toHttpApp.deploy.header(Header.Server).run()
         } yield assertTrue(actual.get == Header.Server(server))
       },
     ),

--- a/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -27,11 +27,11 @@ object ZClientAspectSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   val app: HttpApp[Any] = {
-    Route.handled(Method.GET / "hello")(Handler.response(Response.text("hello")))
+    Route.handled(Method.GET / "hello")(Handler.fromResponse(Response.text("hello")))
   }.toHttpApp
 
   val redir: HttpApp[Any] = {
-    Route.handled(Method.GET / "redirect")(Handler.response(Response.redirect(URL.empty / "hello")))
+    Route.handled(Method.GET / "redirect")(Handler.fromResponse(Response.redirect(URL.empty / "hello")))
   }.toHttpApp
 
   override def spec: Spec[TestEnvironment with Scope, Any] =

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -734,13 +734,13 @@ object Handler extends HandlerPlatformSpecific {
    * Creates a handler with an error and the default error message.
    */
   def error(status: => Status.Error): Handler[Any, Nothing, Any, Response] =
-    response(Response.error(status))
+    fromResponse(Response.error(status))
 
   /**
    * Creates a handler with an error and the specified error message.
    */
   def error(status: => Status.Error, message: => String): Handler[Any, Nothing, Any, Response] =
-    response(Response.error(status, message))
+    fromResponse(Response.error(status, message))
 
   /**
    * Creates a Handler that always fails
@@ -785,7 +785,7 @@ object Handler extends HandlerPlatformSpecific {
    * code
    */
   def fromBody(body: => Body): Handler[Any, Nothing, Any, Response] =
-    response(Response(body = body))
+    fromResponse(Response(body = body))
 
   /**
    * Lifts an `Either` into a `Handler` alue.
@@ -924,7 +924,7 @@ object Handler extends HandlerPlatformSpecific {
    * Creates a handler which always responds with the provided Html page.
    */
   def html(view: => Html): Handler[Any, Nothing, Any, Response] =
-    response(Response.html(view))
+    fromResponse(Response.html(view))
 
   /**
    * Creates a pass thru Handler instance
@@ -983,13 +983,13 @@ object Handler extends HandlerPlatformSpecific {
   /**
    * Creates a handler which always responds with the same value.
    */
-  def response(response: => Response): Handler[Any, Nothing, Any, Response] =
+  def fromResponse(response: => Response): Handler[Any, Nothing, Any, Response] =
     succeed(response)
 
   /**
    * Converts a ZIO to a handler type
    */
-  def responseZIO[R, Err](getResponse: ZIO[R, Err, Response]): Handler[R, Err, Any, Response] =
+  def fromResponseZIO[R, Err](getResponse: ZIO[R, Err, Response]): Handler[R, Err, Any, Response] =
     fromZIO(getResponse)
 
   def stackTrace(implicit trace: Trace): Handler[Any, Nothing, Any, StackTrace] =
@@ -1013,13 +1013,13 @@ object Handler extends HandlerPlatformSpecific {
    * template.
    */
   def template(heading: => CharSequence)(view: Html): Handler[Any, Nothing, Any, Response] =
-    response(Response.html(Template.container(heading)(view)))
+    fromResponse(Response.html(Template.container(heading)(view)))
 
   /**
    * Creates a handler which always responds with the same plain text.
    */
   def text(text: => CharSequence): Handler[Any, Nothing, Any, Response] =
-    response(Response.text(text))
+    fromResponse(Response.text(text))
 
   /**
    * Creates a handler that responds with a 408 status code after the provided

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -71,7 +71,7 @@ final case class Response(
   /**
    * Creates an Http from a Response
    */
-  def toHandler(implicit trace: Trace): Handler[Any, Nothing, Any, Response] = Handler.response(self)
+  def toHandler(implicit trace: Trace): Handler[Any, Nothing, Any, Response] = Handler.fromResponse(self)
 
   /**
    * Updates the current Headers with new one, using the provided update


### PR DESCRIPTION
I suggest renaming `Handler.response` to `Handler.fromResponse` and `Handler.responseZIO` to `Handler.fromResponseZIO` to make the naming more consistent with `Handler.fromZIO` and other `from*` constructors.