### PR TITLE
changed test site from google.com to example.com

### DIFF
--- a/zio-http/js/src/test/scala/zio/http/JSClientSpec.scala
+++ b/zio-http/js/src/test/scala/zio/http/JSClientSpec.scala
@@ -9,7 +9,7 @@ object JSClientSpec extends ZIOSpecDefault {
       suite("HTTP")(
         test("Get") {
           for {
-            response <- ZIO.serviceWithZIO[Client] { _.url(url"https://www.google.com").get("") }
+            response <- ZIO.serviceWithZIO[Client] { _.url(url"https://example.com").get("") }
             string   <- response.body.asString
           } yield assertTrue(response.status.isSuccess, string.startsWith("<!doctype html>"))
         },


### PR DESCRIPTION
/claim #2645 

I don't think example.com has the same rate-limits, however long-term I think it would be best if we setup a page on zio.dev that the runner can ping without limits for 100% stability.