### PR TITLE
Flaky JS Test

### DIFF
--- a/zio-http/js/src/test/scala/zio/http/JSClientSpec.scala
+++ b/zio-http/js/src/test/scala/zio/http/JSClientSpec.scala
@@ -1,6 +1,7 @@
 package zio.http
 
 import zio._
+import zio.test.TestAspect._
 import zio.test._
 
 object JSClientSpec extends ZIOSpecDefault {
@@ -12,7 +13,8 @@ object JSClientSpec extends ZIOSpecDefault {
             response <- ZIO.serviceWithZIO[Client] { _.url(url"https://www.google.com").get("") }
             string   <- response.body.asString
           } yield assertTrue(response.status.isSuccess, string.startsWith("<!doctype html>"))
-        },
+        } @@ flaky, // calling a real website is not the best idea.
+        // Should be replaced with a local server, as soon as we have js server support
       ),
 //      suite("WebSocket")(
 //        test("Echo") {


### PR DESCRIPTION
The real issue of this test is, that we have to call a remote address. But since we have no js backend, I don't see a easy way to create a local server. I don't expect that a different URL will help either, since this seems to be network hiccups of the runners. I guess `@ flaky` is our best option.

fixes #2645
/claim #2645