### PR TITLE
Improve performance & memory usage of `asMultipartFormStream`

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -81,8 +81,8 @@ trait Body { self =>
    */
   def asMultipartForm(implicit trace: Trace): Task[Form] = {
     boundary match {
-      case Some(boundary0) => Form.fromMultipartStream(asStream, boundary0)
-      case _               =>
+      case Some(boundary) => StreamingForm(asStream, boundary).collectAll
+      case _              =>
         for {
           bytes <- asChunk
           form  <- Form.fromMultipartBytes(bytes, Charsets.Http, boundary)

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -79,11 +79,16 @@ trait Body { self =>
    * Note that attempting to decode a large stream of bytes into a form could
    * result in an out of memory error.
    */
-  def asMultipartForm(implicit trace: Trace): Task[Form] =
-    for {
-      bytes <- asChunk
-      form  <- Form.fromMultipartBytes(bytes, Charsets.Http, boundary)
-    } yield form
+  def asMultipartForm(implicit trace: Trace): Task[Form] = {
+    boundary match {
+      case Some(boundary0) => Form.fromMultipartStream(asStream, boundary0)
+      case _               =>
+        for {
+          bytes <- asChunk
+          form  <- Form.fromMultipartBytes(bytes, Charsets.Http, boundary)
+        } yield form
+    }
+  }
 
   /**
    * Returns an effect that decodes the streaming body as a multipart form.

--- a/zio-http/shared/src/main/scala/zio/http/Form.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Form.scala
@@ -213,6 +213,12 @@ object Form {
       form     <- StreamingForm(ZStream.fromChunk(bytes), boundary).collectAll
     } yield form
 
+  def fromMultipartStream(
+    bytes: ZStream[Any, Throwable, Byte],
+    boundary: Boundary,
+  )(implicit trace: Trace): ZIO[Any, Throwable, Form] =
+    StreamingForm(bytes, boundary).collectAll
+
   def fromQueryParams(queryParams: QueryParams): Form = {
     queryParams.seq.foldLeft[Form](Form.empty) { case (acc, entry) =>
       acc + FormField.simpleField(entry.getKey, entry.getValue.asScala.mkString(","))

--- a/zio-http/shared/src/main/scala/zio/http/Form.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Form.scala
@@ -213,12 +213,6 @@ object Form {
       form     <- StreamingForm(ZStream.fromChunk(bytes), boundary).collectAll
     } yield form
 
-  def fromMultipartStream(
-    bytes: ZStream[Any, Throwable, Byte],
-    boundary: Boundary,
-  )(implicit trace: Trace): ZIO[Any, Throwable, Form] =
-    StreamingForm(bytes, boundary).collectAll
-
   def fromQueryParams(queryParams: QueryParams): Form = {
     queryParams.seq.foldLeft[Form](Form.empty) { case (acc, entry) =>
       acc + FormField.simpleField(entry.getKey, entry.getValue.asScala.mkString(","))

--- a/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
@@ -30,7 +30,7 @@ private[http] object FormState {
     boundary: Boundary,
   ) extends FormState { self =>
 
-    private val tree0: ChunkBuilder[FormAST] = ChunkBuilder.make[FormAST]
+    private val tree0: ChunkBuilder[FormAST] = ChunkBuilder.make[FormAST]()
     private val buffer: ChunkBuilder.Byte    = new ChunkBuilder.Byte
 
     private var isBufferEmpty = true
@@ -117,7 +117,7 @@ private[http] object FormState {
   }
 
   // Avoids boxing of Byte values
-  private sealed abstract class OptionalByte {
+  sealed abstract class OptionalByte {
     def get: Byte
     final def isEmpty: Boolean = this eq OptionalByte.None
   }

--- a/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
@@ -30,7 +30,7 @@ private[http] object FormState {
     boundary: Boundary,
   ) extends FormState { self =>
 
-    private val tree0: ChunkBuilder[FormAST] = ChunkBuilder.make
+    private val tree0: ChunkBuilder[FormAST] = ChunkBuilder.make[FormAST]
     private val buffer: ChunkBuilder.Byte    = new ChunkBuilder.Byte
 
     private var isBufferEmpty = true

--- a/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
@@ -25,69 +25,88 @@ private[http] sealed trait FormState
 
 private[http] object FormState {
 
-  final case class FormStateBuffer(
-    tree: Chunk[FormAST],
-    phase: FormState.Phase,
-    buffer: Chunk[Byte],
-    lastByte: Option[Byte],
+  final class FormStateBuffer(
+    private var lastByte: OptionalByte,
     boundary: Boundary,
-    dropContents: Boolean,
   ) extends FormState { self =>
+
+    private val tree0: ChunkBuilder[FormAST] = ChunkBuilder.make
+    private val buffer: ChunkBuilder.Byte    = new ChunkBuilder.Byte
+
+    private var isBufferEmpty = true
+    private var dropContents  = false
+    private var phase0: Phase = Phase.Part1
+    private var lastTree      = null.asInstanceOf[Chunk[FormAST]]
+
+    private def addToTree(ast: FormAST): Unit = {
+      if (lastTree ne null) lastTree = null
+      tree0 += ast
+    }
+
+    def tree: Chunk[FormAST] = {
+      if (lastTree eq null) lastTree = tree0.result()
+      lastTree
+    }
+
+    def phase: Phase = phase0
 
     def append(byte: Byte): FormState = {
 
-      val crlf = lastByte.contains('\r') && byte == '\n'
+      val crlf = byte == '\n' && !lastByte.isEmpty && lastByte.get == '\r'
 
-      val phase0 =
-        if (crlf && buffer.isEmpty && phase == Phase.Part1) Phase.Part2
-        else phase
+      def flush(ast: FormAST): Unit = {
+        buffer.clear()
+        lastByte = OptionalByte.None
+        if (crlf && isBufferEmpty && (phase eq Phase.Part1)) phase0 = Phase.Part2
+        if (ast.isContent && dropContents) () else addToTree(ast)
+        isBufferEmpty = true
+      }
 
-      def flush(ast: FormAST): FormStateBuffer =
-        self.copy(
-          tree = if (ast.isContent && dropContents) tree else tree :+ ast,
-          buffer = Chunk.empty,
-          lastByte = None,
-          phase = phase0,
-        )
-
-      if (crlf && phase == Phase.Part1) {
-        val ast = FormAST.makePart1(buffer, boundary)
+      if (crlf && (phase eq Phase.Part1)) {
+        val ast = FormAST.makePart1(buffer.result(), boundary)
 
         ast match {
-          case content: Content         => flush(content)
-          case header: Header           => flush(header)
+          case content: Content         => flush(content); self
+          case header: Header           => flush(header); self
           case EncapsulatingBoundary(_) => BoundaryEncapsulated(tree)
           case ClosingBoundary(_)       => BoundaryClosed(tree)
         }
 
-      } else if (crlf && phase == Phase.Part2) {
-        val ast = FormAST.makePart2(buffer, boundary)
+      } else if (crlf && (phase eq Phase.Part2)) {
+        val ast = FormAST.makePart2(buffer.result(), boundary)
 
         ast match {
           case content: Content         =>
-            val next = flush(content)
-            next.copy(tree = next.tree :+ EoL) // preserving EoL for multiline content
+            flush(content)
+            addToTree(EoL) // preserving EoL for multiline content
+            self
           case EncapsulatingBoundary(_) => BoundaryEncapsulated(tree)
           case ClosingBoundary(_)       => BoundaryClosed(tree)
         }
       } else {
-        self.copy(
-          buffer = lastByte.map(buffer :+ _).getOrElse(buffer),
-          lastByte = Some(byte),
-        )
+        if (!lastByte.isEmpty) {
+          if (isBufferEmpty) isBufferEmpty = false
+          buffer += lastByte.get
+        }
+        lastByte = OptionalByte.Some(byte)
+        self
       }
 
     }
 
-    def startIgnoringContents: FormStateBuffer = self.copy(dropContents = true)
+    def startIgnoringContents: FormStateBuffer = {
+      if (!dropContents) dropContents = true
+      self
+    }
   }
 
   final case class BoundaryEncapsulated(buffer: Chunk[FormAST]) extends FormState
 
   final case class BoundaryClosed(buffer: Chunk[FormAST]) extends FormState
 
-  def fromBoundary(boundary: Boundary, lastByte: Option[Byte] = None): FormState =
-    FormStateBuffer(Chunk.empty, Phase.Part1, Chunk.empty, lastByte, boundary, dropContents = false)
+  def fromBoundary(boundary: Boundary, lastByte: Option[Byte] = None): FormState = {
+    new FormStateBuffer(lastByte.fold[OptionalByte](OptionalByte.None)(OptionalByte.Some.apply), boundary)
+  }
 
   sealed trait Phase
 
@@ -95,6 +114,19 @@ private[http] object FormState {
 
     case object Part1 extends Phase
     case object Part2 extends Phase
+  }
+
+  // Avoids boxing of Byte values
+  private sealed abstract class OptionalByte {
+    def get: Byte
+    final def isEmpty: Boolean = this eq OptionalByte.None
+  }
+
+  private object OptionalByte {
+    case object None                 extends OptionalByte {
+      def get: Byte = throw new NoSuchElementException("None.get")
+    }
+    final case class Some(get: Byte) extends OptionalByte
   }
 
 }


### PR DESCRIPTION
/claim #2660
/fixes #2660

I managed to reproduce the issue using [this file](https://upload.wikimedia.org/wikipedia/commons/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg) (warning, it's a ~350MB image) and the code below

<details close>
  <summary>Code (click to expand)</summary>
  
```scala
package zio.http.netty

import zio.{Scope, ZIO, ZIOAppArgs, ZIOAppDefault}

import zio.http.Server.RequestStreaming
import zio.http._

object TestMultipartFormData extends ZIOAppDefault {

  private val app: HttpApp[Any] =
    Routes(
      Method.POST / "upload" ->
        handler { (req: Request) =>
          if (req.header(Header.ContentType).exists(_.mediaType == MediaType.multipart.`form-data`))
            for {
              _        <- ZIO.unit
              form     <- req.body.asMultipartForm
                .mapError(ex =>
                  Response(
                    Status.InternalServerError,
                    body = Body.fromString(s"Failed to decode body as multipart/form-data (${ex.getMessage}"),
                  ),
                )
              response <- form.get("file") match {
                case Some(file) =>
                  file match {
                    case FormField.Binary(_, data, contentType, transferEncoding, filename) =>
                      ZIO.succeed(
                        Response.text(
                          s"Received ${data.length} bytes of $contentType filename $filename and transfer encoding $transferEncoding",
                        ),
                      )
                    case _                                                                  =>
                      ZIO.fail(
                        Response(Status.BadRequest, body = Body.fromString("Parameter 'file' must be a binary file")),
                      )
                  }
                case None       =>
                  ZIO.fail(Response(Status.BadRequest, body = Body.fromString("Missing 'file' from body")))
              }
            } yield response
          else ZIO.succeed(Response(status = Status.NotFound))
        },
    ).sandbox.toHttpApp

  private def program: ZIO[Client with Server with Scope, Throwable, Unit] =
    for {
      port <- Server.install(app)
      _    <- ZIO.logInfo(s"Server started on port $port")
      _    <- ZIO.never
    } yield ()

  override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
    program
      .provide(
        Server.defaultWith(config => config.port(8080).requestStreaming(RequestStreaming.Enabled)),
        Client.default,
        Scope.default,
      )
}
```
</details>

After initializing the server with a profiler attached (I used the IntelliJ profiler for this), one can upload the file using curl:

```shell
curl -F "file=@Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg" http://localhost:8080/upload
```

The changes in this PR drastically improve both the execution time and memory usage of the program:

- Execution time: ~30s -> ~7s
- Memory usage: (whatever -Xmx would be set to) -> ~500-600mb