### PR TITLE
Simplify style attributes

### DIFF
--- a/docs/dsl/template.md
+++ b/docs/dsl/template.md
@@ -51,7 +51,7 @@ are suffixed `attr` to easily distinguish those from html elements:
 import zio.http.template._
 
 val divHtml3: Html = div(
-  classAttr := "container1" :: "container2" :: Nil,
+  classAttr := "container1 container2",
   a(hrefAttr := "http://zio.dev", "ZIO Homepage")
 )
 ```

--- a/zio-http-example/src/main/scala/example/HtmlTemplating.scala
+++ b/zio-http-example/src/main/scala/example/HtmlTemplating.scala
@@ -21,11 +21,11 @@ object HtmlTemplating extends ZIOAppDefault {
         body(
           div(
             // Support for css class names
-            css := "container" :: "text-align-left" :: Nil,
+            css := "container text-align-left",
             h1("Hello World"),
             ul(
               // Support for inline css
-              styles := Seq("list-style" -> "none"),
+              styles := "list-style: none",
               li(
                 // Support for attributes
                 a(href := "/hello/world", "Hello World"),

--- a/zio-http/jvm/src/test/scala/zio/http/FlashSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/FlashSpec.scala
@@ -92,8 +92,8 @@ object FlashSpec extends ZIOHttpSpec {
         object ui {
           def flashEmpty                                 = Html.fromString("no-flash")
           def flashBoth(notice: Html, alert: Html): Html = notice ++ alert
-          def flashNotice(html: Html): Html              = div(styleAttr := Seq("background" -> "green"), html)
-          def flashAlert(html: Html): Html               = div(styleAttr := Seq("background" -> "red"), html)
+          def flashNotice(html: Html): Html              = div(styleAttr := "background: green", html)
+          def flashAlert(html: Html): Html               = div(styleAttr := "background: red", html)
         }
 
         val routeUserSavePath = Method.POST / "users" / "save"

--- a/zio-http/jvm/src/test/scala/zio/http/codec/DocSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/DocSpec.scala
@@ -62,7 +62,7 @@ object DocSpec extends ZIOHttpSpec {
                        |
                        |[https://www.google.com](https://www.google.com)
                        |
-                       |<span style="color:red">This is an error</span>
+                       |<span style="color: red">This is an error</span>
                        |
                        |`ZIO.succeed(1)`
                        |
@@ -114,7 +114,7 @@ object DocSpec extends ZIOHttpSpec {
                         |  <a href="https://www.google.com">https://www.google.com</a>
                         |</p>
                         |<p>
-                        |  <span style="color:red">This is an error</span>
+                        |  <span style="color: red">This is an error</span>
                         |</p>
                         |<p>
                         |  <code>ZIO.succeed(1)</code>

--- a/zio-http/jvm/src/test/scala/zio/http/template/HtmlSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/template/HtmlSpec.scala
@@ -30,36 +30,36 @@ case object HtmlSpec extends ZIOHttpSpec {
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!")))
+        val view     = html(body(div(css := "container", "Hello!")))
         val expected = """<html><body><div class="container">Hello!</div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html(body(div(css := "container", "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html(body(div(css := "container", "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html(body(div(css := "container", "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = html(body(div(css := "container" :: Nil, "Hello!", span("World!"))))
+        val view     = html(body(div(css := "container", "Hello!", span("World!"))))
         val expected =
           """<html><body><div class="container">Hello!<span>World!</span></div></body></html>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
       test("tags with attributes and children") {
-        val view     = div("Hello!", css := "container" :: Nil)
+        val view     = div("Hello!", css := "container")
         val expected = """<div class="container">Hello!</div>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },

--- a/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
@@ -840,8 +840,8 @@ private[http] trait HandlerAspects extends zio.http.internal.HeaderModifier[Hand
       val data            = Template.container(s"${response.status}") {
         div(
           div(
-            styles := Seq("text-align" -> "center"),
-            div(s"${response.status.code}", styles := Seq("font-size" -> "20em")),
+            styles := "text-align: center",
+            div(s"${response.status.code}", styles := "font-size: 20em"),
             div(message),
           ),
         )

--- a/zio-http/shared/src/main/scala/zio/http/codec/Doc.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/Doc.scala
@@ -70,7 +70,7 @@ sealed trait Doc { self =>
         case Span.Italic(value)                 =>
           s"${render("*")}${renderSpan(value, indent).trim}${render("*")}"
         case Span.Error(value)                  =>
-          s"${render(s"""<span style="color:red">""")}${render(value)}${render("</span>")}"
+          s"${render(s"""<span style="color: red">""")}${render(value)}${render("</span>")}"
         case Span.Sequence(left, right)         =>
           val l = renderSpan(left, indent)
           val r = renderSpan(right, indent)
@@ -408,7 +408,7 @@ object Doc {
         case Span.Text(value)                   => value
         case Span.Code(value, CodeStyle.Block)  => pre(code(value))
         case Span.Code(value, CodeStyle.Inline) => code(value)
-        case Span.Error(value)                  => span(styleAttr := ("color", "red") :: Nil, value)
+        case Span.Error(value)                  => span(styleAttr := "color: red", value)
         case Span.Bold(value)                   => b(value.toHtml)
         case Span.Italic(value)                 => i(value.toHtml)
         case Span.Link(value, text)             =>

--- a/zio-http/shared/src/main/scala/zio/http/template/Attributes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/template/Attributes.scala
@@ -49,7 +49,7 @@ trait Attributes {
 
   final def citeAttr: PartialAttribute[String] = PartialAttribute("cite")
 
-  final def classAttr: PartialAttribute[List[String]] = PartialAttribute("class")
+  final def classAttr: PartialAttribute[String] = PartialAttribute("class")
 
   final def colSpanAttr: PartialAttribute[String] = PartialAttribute("colspan")
 
@@ -65,7 +65,7 @@ trait Attributes {
 
   final def coordsAttr: PartialAttribute[String] = PartialAttribute("coords")
 
-  final def css: PartialAttribute[List[String]] = classAttr
+  final def css: PartialAttribute[String] = classAttr
 
   final def dataAttr(name: String): PartialAttribute[String] = PartialAttribute("data-" + name)
 
@@ -337,9 +337,9 @@ trait Attributes {
 
   final def stepAttr: PartialAttribute[String] = PartialAttribute("step")
 
-  final def styleAttr: PartialAttribute[Seq[(String, String)]] = PartialAttribute("style")
+  final def styleAttr: PartialAttribute[String] = PartialAttribute("style")
 
-  final def styles: PartialAttribute[Seq[(String, String)]] = styleAttr
+  final def styles: PartialAttribute[String] = styleAttr
 
   final def tabIndexAttr: PartialAttribute[String] = PartialAttribute("tabindex")
 

--- a/zio-http/shared/src/main/scala/zio/http/template/Template.scala
+++ b/zio-http/shared/src/main/scala/zio/http/template/Template.scala
@@ -35,7 +35,7 @@ object Template {
       ),
       body(
         div(
-          styles := Seq("margin" -> "auto", "padding" -> "2em 4em", "max-width" -> "80%"),
+          styles := "margin: auto; padding: 2em 4em; max-width: 80%",
           h1(heading),
           element,
         ),


### PR DESCRIPTION

In the age of Tailwind and long class chains in HTML, it's a bit cumbersome to wrap every class name in quotes, especially when copying styles and classes from tutorials or documentation. This PR changes the value type to `String` for `class` and `style` attributes in the HTML templates.