### PR TITLE
Remove README Check on Build Phase

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,11 +6,13 @@ name: Website
   workflow_dispatch: {}
   release:
     types:
-    - published
+      - published
   push:
     branches:
-    - main
-  pull_request: {}
+      - main
+  pull_request:
+    branches-ignore:
+      - gh-pages
 jobs:
   build:
     name: Build and Test
@@ -27,8 +29,6 @@ jobs:
         distribution: temurin
         java-version: 17
         check-latest: true
-    - name: Check if the README file is up to date
-      run: sbt  docs/checkReadme
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process


### PR DESCRIPTION
This check is no longer needed as zio-sbt-ci now has auto-update readmes.