### PR TITLE
Skip Publishing Jar Files for Documentation Project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -317,6 +317,7 @@ lazy val docs = project
       `jwt-core`,
       "dev.zio" %% "zio-test" % ZioVersion,
     ),
+    publish / skip                             := true,
   )
   .dependsOn(zioHttpJVM)
   .enablePlugins(WebsitePlugin)


### PR DESCRIPTION
When the CI tries to run the `sbt +publishLocal` command, it isn't necessary to have a jar file for the documentation project.