### PR TITLE
feat: Proper imports for generated openapi code 

### DIFF
--- a/zio-http-gen/src/test/resources/GeneratedUserNameArray.scala
+++ b/zio-http-gen/src/test/resources/GeneratedUserNameArray.scala
@@ -1,7 +1,7 @@
 package test.component
 
-import zio._
 import zio.schema._
+import zio.Chunk
 
 case class UserNameArray(
   id: Int,

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -602,7 +602,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
           val expected = Code.File(
             List("api", "v1", "Users.scala"),
             pkgPath = List("api", "v1"),
-            imports = List(Code.Import.FromBase(path = "component._")),
+            imports = List(Code.Import.FromBase(path = "component._"), Code.Import("zio.Chunk")),
             objects = List(
               Code.Object(
                 "Users",
@@ -633,7 +633,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
           val expected = Code.File(
             List("api", "v1", "Users.scala"),
             pkgPath = List("api", "v1"),
-            imports = List(Code.Import.FromBase(path = "component._")),
+            imports = List(Code.Import.FromBase(path = "component._"), Code.Import("zio.Chunk")),
             objects = List(
               Code.Object(
                 "Users",


### PR DESCRIPTION
Extend the code generator, such that each generation step
can add imports, which are then rendered at the file or object level.

This fixes a few issues where imports were missing for generated case
classes, that had `Chunk` fields. It also unifies the handling of UUIDs
and opens the door for additional future configuration options. For
example the collection type can be made configurable, or user defined
types can be added to the imports.

`writeFiles` now returns a list of written files. This allows for use
in sbt code generation tasks. I will add an sbt plugin in a later PR.