### PR TITLE
Documentation of Routes, RoutePattern and PathCodec

### DIFF
--- a/docs/dsl/path_codec.md
+++ b/docs/dsl/path_codec.md
@@ -1,0 +1,163 @@
+---
+id: path_codec
+title: PathCodec
+---
+
+`PathCodec[A]` represents a codec for paths of type `A`, comprising segments where each segment can be a literal, an integer, a long, a string, a UUID, or the trailing path.
+
+## Building PathCodecs
+
+The `PathCodec` data type offers several predefined codecs for common types:
+
+| PathCodec           | Description                         |
+|---------------------|-------------------------------------|
+| `PathCodec.bool`    | A codec for a boolean path segment. |
+| `PathCodec.empty`   | A codec for an empty path.          |
+| `PathCodec.literal` | A codec for a literal path segment. |
+| `PathCodec.long`    | A codec for a long path segment.    |
+| `PathCodec.string`  | A codec for a string path segment.  |
+| `PathCodec.uuid`    | A codec for a UUID path segment.    |
+
+Complex `PathCodecs` can be constructed by combining them using the `/` operator:
+
+```scala mdoc:compile-only
+import zio.http.codec.PathCodec
+import PathCodec._
+
+val pathCodec = empty / "users" / int("user-id") / "posts" / string("post-id")
+```
+
+By combining `PathCodec` values, the resulting `PathCodec` type reflects the types of the path segments it matches. In the provided example, the type of `pathCodec` is `(Int, String)` because it matches a path with two segments of type `Int` and `String`, respectively.
+
+## Using Value Objects with PathCodecs
+
+Other than the common `PathCodec` constructors, it's also possible to transform a `PathCodec` into a more specific data type using the `transform` method.
+
+This becomes particularly useful when adhering to domain-driven design principles and opting for value objects instead of primitive types:
+
+```scala mdoc:compile-only
+import zio.http.codec.PathCodec
+import PathCodec._
+
+case class UserId private(value: Int)
+
+object UserId {
+  def apply(value: Int): UserId =
+    if (value > 0) 
+      new UserId(value)
+    else 
+      throw new IllegalArgumentException("User id must be positive")
+}
+
+
+val userIdPathCodec: PathCodec[UserId] = int("user-id").transform(UserId.apply)(_.value)
+```
+
+This approach enables us to utilize the `UserId` value object in our routes, and the `PathCodec` will take care of the conversion between the path segment and the value object.
+
+In the previous example, instead of throwing an exception, we can model the failure using the `Either` data type and then use the `transformOrFailLeft` to create a `PathCodec`:
+
+```scala mdoc:compile-only
+import zio.http.codec.PathCodec
+import PathCodec._
+
+case class UserId private(value: Int)
+object UserId {
+  def apply(value: Int): Either[String, UserId] =
+    if (value > 0) 
+      Right(new UserId(value))
+    else 
+      Left("User id must be positive")
+}
+
+val userIdPathCodec: PathCodec[UserId] = int("user-id").transformOrFailLeft(UserId.apply)(_.value)
+```
+
+Here is a list of the available transformation methods:
+
+```scala
+trait PathCodec[A] {
+  def transform[A2](f: A => A2)(g: A2 => A): PathCodec[A2]
+  def transformOrFail[A2](f: A => Either[String, A2])(g: A2 => Either[String, A]): PathCodec[A2]
+  def transformOrFailLeft[A2](f: A => Either[String, A2])(g: A2 => A): PathCodec[A2]
+  def transformOrFailRight[A2](f: A => A2)(g: A2 => Either[String, A]): PathCodec[A2]
+}
+```
+
+Here is a complete example:
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+import zio.Cause.{Die, Stackless}
+import zio.http.codec.PathCodec
+
+object Main extends ZIOAppDefault {
+
+  import zio.http.codec.PathCodec
+  import PathCodec._
+
+  case class UserId private (value: Int)
+
+  object UserId {
+    def apply(value: Int): Either[String, UserId] =
+      if (value > 0)
+        Right(new UserId(value))
+      else
+        Left("User id must be greater than zero")
+  }
+
+  val userId: PathCodec[UserId] = int("user-id").transformOrFailLeft(UserId.apply)(_.value)
+
+  val httpApp: HttpApp[Any] =
+    Routes(
+      Method.GET / "users" / userId ->
+        Handler.fromFunctionHandler[(UserId, Request)] { case (userId: UserId, request: Request) =>
+          Handler.text(userId.value.toString)
+        },
+    ).handleErrorCause { case Stackless(cause, _) =>
+      cause match {
+        case Die(value, _) =>
+          if (value.getMessage == "User id must be greater than zero")
+            Response.badRequest(value.getMessage)
+          else
+            Response.internalServerError
+      }
+    }.toHttpApp
+
+  def run = Server.serve(httpApp).provide(Server.default)
+}
+```
+
+## Trailing Path Segments
+
+Sometimes, there may be a need to match a path with a trailing segment, regardless of the number of segments it contains. This is where the trailing codec comes into play:
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+
+object TrailingExample extends ZIOAppDefault {
+  def staticFileHandler(path: Path): Handler[Any, Throwable, Request, Response] =
+    for {
+      file <- Handler.getResourceAsFile(path.encode)
+      http <-
+        if (file.isFile)
+          Handler.fromFile(file)
+        else
+          Handler.notFound
+    } yield http
+
+  val app =
+    Routes(
+      Method.GET / "static" / trailing ->
+        Handler.fromFunctionHandler[(Path, Request)] { case (path: Path, _: Request) =>
+          staticFileHandler(path).contramap[(Path, Request)](_._2)
+        },
+    ).sandbox.toHttpApp @@ HandlerAspect.requestLogging()
+
+  val run = Server.serve(app).provide(Server.default)
+}
+```
+
+In the provided example, if an incoming request matches the route pattern `GET /static/*`, the `trailing` codec will match the remaining path segments and bind them to the `Path` type. Therefore, a request to `/static/foo/bar/baz.txt` will match the route pattern, and the `Path` will be `foo/bar/baz.txt`.

--- a/docs/dsl/route_pattern.md
+++ b/docs/dsl/route_pattern.md
@@ -1,0 +1,63 @@
+---
+id: route_pattern
+title: RoutePattern
+---
+
+`RoutePattern` defines a pattern for matching routes by examining both the HTTP method and the path. In addition to specifying a method, patterns contain segment patterns, which can consist of literals, integers, longs, and other segment types.
+
+A `RoutePattern` is composed of a `Method` and a `PathCodec`:
+
+```scala
+case class RoutePattern[A](method: Method, pathCodec: PathCodec[A])
+```
+
+To create a `Route` we need to create a `RoutePattern` and then bind it to a handler using the `->` operator:
+
+```scala mdoc:silent
+import zio.http._
+
+Routes(
+  Method.GET / "health-check" -> Handler.ok,
+)
+```
+
+In the above example, `Method.Get / "health-check"` represents a `RoutePattern` used to match incoming requests with the appropriate path and method.
+
+## Building RoutePatterns
+
+Typically, the entry point for creating a route pattern is `Method`:
+
+```scala mdoc:compile-only
+// GET /users
+val pattern: RoutePattern[Unit] =
+  Method.GET / "users"   
+```
+
+To match a path segment, various methods like `string`, `int`, `long`, and `uuid` are available.
+
+For example, let's enhance the previous example to match a user id of type `Int`:
+
+```scala mdoc:compile-only
+// GET /users/:user-id
+val pattern2: RoutePattern[Int] =
+  Method.GET / "users" / int("user-id")
+```
+
+The type of the `RoutePattern` becomes `Int` because it matches a path segment of type `Int`.
+
+Multiple path segments can be matched by combining multiple `PathCodec` values. Let's extend the example to match a post id of type `String`:
+
+
+```scala mdoc:compile-only
+// GET /users/:user-id/posts/:post-id
+val pattern2: RoutePattern[(Int, String)] =
+  Method.GET / "users" / int("user-id") / "posts" / string("post-id")
+```
+
+With more path segments, the type of the `RoutePattern` becomes a tuple of the types of the path segments, in this case, (Int, String).
+
+## Matching Methods
+
+The `Method` data type represent an HTTP method, and it offers the following predefined HTTP methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `DELETE`, `TRACE`, `OPTIONS`, `HEAD`, `TRACE` and `CONNECT`.
+
+The `METHOD.ANY` is a wildcard method that matches any method.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -15,6 +15,8 @@ const sidebars = {
           items: [
             "dsl/server",
             "dsl/routes",
+            "dsl/route_pattern",
+            "dsl/path_codec",
             "dsl/request",
             "dsl/response",
             "dsl/handler",


### PR DESCRIPTION
In this PR I refined and extended the `Routes` article and added two new pages for `RoutePattern` and `PathCodec` data types.