### PR TITLE
OpenAPI: Don't generate request body, if it would be the Annotated null schema by

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -579,12 +579,7 @@ object OpenAPIGen {
         )
       }.filter(_.value.content.exists {
         case (_, OpenAPI.MediaType(OpenAPI.ReferenceOr.Or(schema), _, _)) =>
-          schema match {
-            case JsonSchema.AnnotatedSchema(s, _) =>
-              schema.withoutAnnotations != JsonSchema.Null
-            case s =>
-              s != JsonSchema.Null
-          }
+          schema.withoutAnnotations != JsonSchema.Null
         case _                                                            => true
       })
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -579,7 +579,12 @@ object OpenAPIGen {
         )
       }.filter(_.value.content.exists {
         case (_, OpenAPI.MediaType(OpenAPI.ReferenceOr.Or(schema), _, _)) =>
-          schema != JsonSchema.Null
+          schema match {
+            case JsonSchema.AnnotatedSchema(s, _) =>
+              schema.withoutAnnotations != JsonSchema.Null
+            case s =>
+              s != JsonSchema.Null
+          }
         case _                                                            => true
       })
 


### PR DESCRIPTION
https://github.com/zio/zio-http/pull/2672

The original fix didn't take into consideration the if the JsonSchema was annotated. Swapped to using schema.withoutAnnotations

---

Some info here: https://discord.com/channels/629491597070827530/819703129267372113/1220702716280442961
