### PR TITLE
chore: cache jmh benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,9 @@ jobs:
         id: push_codecov
         run: 'bash <(curl -s https://codecov.io/bash)'
 
-  Jmh_publish:
-    name: Jmh Publish
-    if: ${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}
+  Jmh_CookieDecodeBenchmark:
+    name: Jmh CookieDecodeBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -219,43 +219,432 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Format Output
-        id: fomat_output
-        run: |
-          cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
-                    while IFS= read -r line; do
-                    if grep -q "$line" Current.txt
-                    then
-                    grep "$line" Current.txt | sed 's/^.*: //' >> finalCurrent.txt;
-                    else
-                    echo "" >> finalCurrent.txt;
-                    fi
-                      if grep -q "$line" Main.txt
-                    then
-                    grep "$line" Main.txt | sed 's/^.*: //' >> finalMain.txt;
-                    else
-                    echo "" >> finalMain.txt;
-                    fi
-                     done < c.txt
-          paste -d '|' c.txt finalCurrent.txt finalMain.txt > FinalOutput.txt
-           sed -i -e 's/^/|/' FinalOutput.txt
-           sed -i -e 's/$/|/' FinalOutput.txt
-           body=$(cat FinalOutput.txt)
-           body="${body//'%'/'%25'}"
-           body="${body//$'\n'/'%0A'}"
-           body="${body//$'\r'/'%0D'}"
-           echo $body
-           echo ::set-output name=body::$(echo $body)
-
-      
-      - uses: peter-evans/commit-comment@v1
+      - uses: actions/checkout@v2
         with:
-          sha: ${{github.sha}}
-          body: |
+          path: zio-http
 
-            **🚀 Jmh Benchmark:**
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
 
-            |Name |Current| Main|
-            |-----|----| ----|
-             ${{steps.fomat_output.outputs.body}}
-             
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_CookieDecodeBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 CookieDecodeBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_CookieDecodeBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_CookieDecodeBenchmark
+          path: Main_CookieDecodeBenchmark.txt
+
+  Jmh_EndpointBenchmark:
+    name: Jmh EndpointBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_EndpointBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 EndpointBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_EndpointBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_EndpointBenchmark
+          path: Main_EndpointBenchmark.txt
+
+  Jmh_HttpCollectEval:
+    name: Jmh HttpCollectEval
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_HttpCollectEval.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCollectEval" | grep -e "thrpt" -e "avgt" >> ../Main_HttpCollectEval.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_HttpCollectEval
+          path: Main_HttpCollectEval.txt
+
+  Jmh_HttpCombineEval:
+    name: Jmh HttpCombineEval
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_HttpCombineEval.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpCombineEval" | grep -e "thrpt" -e "avgt" >> ../Main_HttpCombineEval.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_HttpCombineEval
+          path: Main_HttpCombineEval.txt
+
+  Jmh_HttpNestedFlatMapEval:
+    name: Jmh HttpNestedFlatMapEval
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_HttpNestedFlatMapEval.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpNestedFlatMapEval" | grep -e "thrpt" -e "avgt" >> ../Main_HttpNestedFlatMapEval.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_HttpNestedFlatMapEval
+          path: Main_HttpNestedFlatMapEval.txt
+
+  Jmh_HttpRouteTextPerf:
+    name: Jmh HttpRouteTextPerf
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_HttpRouteTextPerf.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 HttpRouteTextPerf" | grep -e "thrpt" -e "avgt" >> ../Main_HttpRouteTextPerf.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_HttpRouteTextPerf
+          path: Main_HttpRouteTextPerf.txt
+
+  Jmh_ProbeContentTypeBenchmark:
+    name: Jmh ProbeContentTypeBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_ProbeContentTypeBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 ProbeContentTypeBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_ProbeContentTypeBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_ProbeContentTypeBenchmark
+          path: Main_ProbeContentTypeBenchmark.txt
+
+  Jmh_SchemeDecodeBenchmark:
+    name: Jmh SchemeDecodeBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_SchemeDecodeBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 SchemeDecodeBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_SchemeDecodeBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark
+          path: Main_SchemeDecodeBenchmark.txt
+
+  Jmh_ServerInboundHandlerBenchmark:
+    name: Jmh ServerInboundHandlerBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_ServerInboundHandlerBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 ServerInboundHandlerBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_ServerInboundHandlerBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_ServerInboundHandlerBenchmark
+          path: Main_ServerInboundHandlerBenchmark.txt
+
+  Jmh_UtilBenchmark:
+    name: Jmh UtilBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_UtilBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 UtilBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_UtilBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_UtilBenchmark
+          path: Main_UtilBenchmark.txt
+
+  Jmh_cache:
+    name: Cache Jmh benchmarks
+    needs: [Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.10]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_CookieDecodeBenchmark
+
+      - name: Format_Main_CookieDecodeBenchmark
+        run: cat Main_CookieDecodeBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_EndpointBenchmark
+
+      - name: Format_Main_EndpointBenchmark
+        run: cat Main_EndpointBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_HttpCollectEval
+
+      - name: Format_Main_HttpCollectEval
+        run: cat Main_HttpCollectEval.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_HttpCombineEval
+
+      - name: Format_Main_HttpCombineEval
+        run: cat Main_HttpCombineEval.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_HttpNestedFlatMapEval
+
+      - name: Format_Main_HttpNestedFlatMapEval
+        run: cat Main_HttpNestedFlatMapEval.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_HttpRouteTextPerf
+
+      - name: Format_Main_HttpRouteTextPerf
+        run: cat Main_HttpRouteTextPerf.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_ProbeContentTypeBenchmark
+
+      - name: Format_Main_ProbeContentTypeBenchmark
+        run: cat Main_ProbeContentTypeBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_SchemeDecodeBenchmark
+
+      - name: Format_Main_SchemeDecodeBenchmark
+        run: cat Main_SchemeDecodeBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_ServerInboundHandlerBenchmark
+
+      - name: Format_Main_ServerInboundHandlerBenchmark
+        run: cat Main_ServerInboundHandlerBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_UtilBenchmark
+
+      - name: Format_Main_UtilBenchmark
+        run: cat Main_UtilBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - name: Main Result
+        id: Main_Result
+        run: |
+          while IFS= read -r line; do
+             IFS=' ' read -ra PARSED_RESULT <<< "$line"
+             echo ${PARSED_RESULT[1]} >> parsed_Main.txt
+             B_VALUE=$(echo ${PARSED_RESULT[1]}": "${PARSED_RESULT[4]}" ops/sec")
+             echo $B_VALUE >> Main.txt
+           done < Main_benchmarks.txt
+
+      - uses: actions/cache@v4
+        with:
+          path: Main.txt
+          key: jmh_benchmarks_${{ github.sha }}

--- a/project/JmhBenchmarkWorkflow.scala
+++ b/project/JmhBenchmarkWorkflow.scala
@@ -7,8 +7,11 @@ object JmhBenchmarkWorkflow {
 
   val jmhPlugin                = s"""addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "$JmhVersion")"""
   val scalaSources: PathFilter = ** / "*.scala"
-  val files = FileTreeView.default.list(Glob("./zio-http-benchmarks/src/main/scala/zio.benchmarks/**"), scalaSources)
-
+  val files = FileTreeView.default.list(Seq(
+    Glob("zio-http-benchmarks/src/main/scala-2.13/**"),
+    Glob("zio-http-benchmarks/src/main/scala/**")),scalaSources
+    )
+ 
   /**
    * Get zioHttpBenchmark file names
    */
@@ -23,7 +26,7 @@ object JmhBenchmarkWorkflow {
    * Run jmh benchmarks and store result
    */
   def runSBT(list: Seq[String], branch: String) = list.map(str =>
-    s"""sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 $str" | grep "thrpt" >> ../${branch}_${list.head}.txt""".stripMargin,
+    s"""sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 $str" | grep -e "thrpt" -e "avgt" >> ../${branch}_${list.head}.txt""".stripMargin,
   )
 
   /**
@@ -39,7 +42,7 @@ object JmhBenchmarkWorkflow {
   /**
    * Download Artifacts and parse result
    */
-  def downloadArtifacts(branch: String, batchSize: Int) = groupedBenchmarks(batchSize).flatMap(l => {
+ def downloadArtifacts(branch: String, batchSize: Int) = groupedBenchmarks(batchSize).flatMap(l => {
     Seq(
       WorkflowStep.Use(
         ref = UseRef.Public("actions", "download-artifact", "v3"),
@@ -48,82 +51,52 @@ object JmhBenchmarkWorkflow {
         ),
       ),
       WorkflowStep.Run(
+          commands = List(
+            s"""cat ${branch}_${l.head}.txt >> ${branch}_benchmarks.txt""".stripMargin,
+          ),
+          name = Some(s"Format_${branch}_${l.head}"),
+      ),
+    )
+  })
+
+  def parse_results(branch: String) = WorkflowStep.Run(
         commands = List(s"""while IFS= read -r line; do
                            |   IFS=' ' read -ra PARSED_RESULT <<< "$$line"
                            |   echo $${PARSED_RESULT[1]} >> parsed_$branch.txt
                            |   B_VALUE=$$(echo $${PARSED_RESULT[1]}": "$${PARSED_RESULT[4]}" ops/sec")
                            |   echo $$B_VALUE >> $branch.txt
-                           | done < ${branch}_${l.head}.txt""".stripMargin),
-        id = Some(s"Result_${branch}_${l.head}"),
-        name = Some(s"Result $branch ${l.head}"),
-      ),
-    )
-  })
+                           | done < ${branch}_benchmarks.txt""".stripMargin),
+        id = Some(s"${branch}_Result"),
+        name = Some(s"$branch Result"),
+      )
 
   /**
-   * Format result and set output
+   * Workflow Job to cache benchmark results
    */
-  def formatOutput() = WorkflowStep.Run(
-    commands = List(
-      s"""cat parsed_Current.txt parsed_Main.txt | sort -u > c.txt
-         |          while IFS= read -r line; do
-         |          if grep -q "$$line" Current.txt
-         |          then
-         |          grep "$$line" Current.txt | sed 's/^.*: //' >> finalCurrent.txt;
-         |          else
-         |          echo "" >> finalCurrent.txt;
-         |          fi
-         |            if grep -q "$$line" Main.txt
-         |          then
-         |          grep "$$line" Main.txt | sed 's/^.*: //' >> finalMain.txt;
-         |          else
-         |          echo "" >> finalMain.txt;
-         |          fi
-         |           done < c.txt
-         |paste -d '|' c.txt finalCurrent.txt finalMain.txt > FinalOutput.txt
-         | sed -i -e 's/^/|/' FinalOutput.txt
-         | sed -i -e 's/$$/|/' FinalOutput.txt
-         | body=$$(cat FinalOutput.txt)
-         | body="$${body//'%'/'%25'}"
-         | body="$${body//$$'\\n'/'%0A'}"
-         | body="$${body//$$'\\r'/'%0D'}"
-         | echo $$body
-         | echo ::set-output name=body::$$(echo $$body)
-         | """.stripMargin,
-    ),
-    id = Some(s"fomat_output"),
-    name = Some(s"Format Output"),
-  )
-
-  /**
-   * Workflow Job to publish benchmark results in the comment
-   */
-  def publish(batchSize: Int) = Seq(
+  def cache(batchSize: Int) = Seq(
     WorkflowJob(
-      id = "Jmh_publish",
-      name = "Jmh Publish",
-      scalas = List(Scala213),
+      id = "Jmh_cache",
+      name = "Cache Jmh benchmarks",
       cond = Some(
-        "${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}",
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
       ),
       needs = dependencies(batchSize),
-      steps = downloadArtifacts("Current", batchSize) ++ downloadArtifacts("Main", batchSize) ++
+      steps =  downloadArtifacts("Main", batchSize) ++
         Seq(
-          formatOutput(),
+        WorkflowStep.Use(
+          UseRef.Public("actions", "checkout", "v2"),
+          Map(
+            "path" -> "zio-http"
+          )
+        ),
+          parse_results("Main"),
           WorkflowStep.Use(
-            ref = UseRef.Public("peter-evans", "commit-comment", "v1"),
-            params = Map(
-              "sha"  -> "${{github.sha}}",
-              "body" ->
-                """
-                  |**\uD83D\uDE80 Jmh Benchmark:**
-                  |
-                  ||Name |Current| Main|
-                  ||-----|----| ----|
-                  | ${{steps.fomat_output.outputs.body}}
-                  | """.stripMargin,
-            ),
+          UseRef.Public("actions", "cache", "v4"),
+          Map(
+            "path" -> "Main.txt",
+            "key" -> "jmh_benchmarks_${{ github.sha }}"
           ),
+        ),
         ),
     ),
   )
@@ -135,10 +108,10 @@ object JmhBenchmarkWorkflow {
     WorkflowJob(
       id = s"Jmh_${l.head}",
       name = s"Jmh ${l.head}",
-      scalas = List(Scala213),
       cond = Some(
-        "${{ github.event.label.name == 'run jmh' && github.event_name == 'pull_request' }}",
+        "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}",
       ),
+      scalas = List(Scala213),
       steps = List(
         WorkflowStep.Use(
           UseRef.Public("actions", "checkout", "v2"),
@@ -150,31 +123,7 @@ object JmhBenchmarkWorkflow {
           UseRef.Public("actions", "setup-java", "v2"),
           Map(
             "distribution" -> "temurin",
-            "java-version" -> "8",
-          ),
-        ),
-        WorkflowStep.Run(
-          env = Map("GITHUB_TOKEN" -> "${{secrets.ACTIONS_PAT}}"),
-          commands = List(
-            "cd zio-http",
-            s"sed -i -e '$$a${jmhPlugin}' project/plugins.sbt",
-            s"cat > Current_${l.head}.txt",
-          ) ++ runSBT(l, "Current"),
-          id = Some("Benchmark_Current"),
-          name = Some("Benchmark_Current"),
-        ),
-        WorkflowStep.Use(
-          UseRef.Public("actions", "upload-artifact", "v3"),
-          Map(
-            "name" -> s"Jmh_Current_${l.head}",
-            "path" -> s"Current_${l.head}.txt",
-          ),
-        ),
-        WorkflowStep.Use(
-          UseRef.Public("actions", "checkout", "v2"),
-          Map(
-            "path" -> "zio-http",
-            "ref"  -> "main",
+            "java-version" -> "11",
           ),
         ),
         WorkflowStep.Run(
@@ -198,6 +147,5 @@ object JmhBenchmarkWorkflow {
     )
   })
 
-  def apply(batchSize: Int): Seq[WorkflowJob] = run(batchSize) ++ publish(batchSize)
-
+  def apply(batchSize: Int): Seq[WorkflowJob] = run(batchSize)  ++ cache(batchSize) // ++ jmh_compare(batchSize)
 }


### PR DESCRIPTION
@jdegoes This pr enables caching off jmh benchmarks on each push to main.
On successful merge the results would look like [result](https://github.com/alankritdabral/zio-http/actions/runs/8478407808/job/23230891607#step:47:5)

The next pr will include comparison of jmh benchmarks on each pull_request run. #2751  

Issue Reference(s):
Relates to: #2265, [comment](https://github.com/zio/zio-http/issues/2265#issuecomment-2016836314)
Fixes : [#2265 comment](https://github.com/zio/zio-http/issues/2265#issuecomment-2016822862)
