### PR TITLE
Update path regex to support RFC1738 safe chars and properly escape forward slash

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -2445,6 +2445,29 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |}""".stripMargin
         assertTrue(json == toJsonAst(expectedJson))
       },
+      test("example with safe characters in path") {
+        val endpoint = Endpoint(Method.GET / "simple/api/v1.0/$name/plus+some_stuff-etc")
+        val openApi  =
+          OpenAPIGen.fromEndpoints(
+            title = "Safe path examples",
+            version = "1.0",
+            endpoint,
+          )
+        val json     = toJsonAst(openApi)
+        assertTrue(json == toJsonAst("""{
+                                       |  "openapi" : "3.1.0",
+                                       |    "info" : {
+                                       |      "title" : "Safe path examples",
+                                       |      "version" : "1.0"
+                                       |    },
+                                       |    "paths" : {
+                                       |      "/simple/api/v1.0/$name/plus+some_stuff-etc" : {
+                                       |        "get" : {}
+                                       |      }
+                                       |    },
+                                       |    "components" : {}
+                                       |}""".stripMargin))
+      },
     )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
@@ -449,7 +449,8 @@ object OpenAPI {
     )
 
     // todo maybe not the best regex, but the old one was not working at all
-    val validPath: Regex = """/[/a-zA-Z0-9\-_{}]*""".r
+    // safe chars from RFC1738 "$" | "-" | "_" | "." | "+"
+    val validPath: Regex = """\/[\/a-zA-Z0-9\-_{}$.+]*""".r
 
     def fromString(name: String): Option[Path] = name match {
       case validPath() => Some(Path(name))


### PR DESCRIPTION
Addresses #2759 

This change permits valid path segments like `/api/v1.0/foo/bar` to work as expected. Such paths currently fail in OpenAPIGen. 