### PR TITLE
Mark `application/json` as NotBinary (#2752)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/MultipartSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/MultipartSpec.scala
@@ -80,8 +80,8 @@ object MultipartSpec extends ZIOHttpSpec {
             form.get("title").map(_.asInstanceOf[FormField.Text].value) == Some(title),
             form.get("width").map(_.asInstanceOf[FormField.Text].value) == Some(width.toString),
             form.get("height").map(_.asInstanceOf[FormField.Text].value) == Some(height.toString),
-            form.get("metadata").map(_.asInstanceOf[FormField.Binary].data) == Some(
-              Chunk.fromArray(s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes),
+            form.get("metadata").map(_.asInstanceOf[FormField.Text].value) == Some(
+              s"""{"description":"$description","createdAt":"$createdAt"}""",
             ),
           )
         }
@@ -136,8 +136,8 @@ object MultipartSpec extends ZIOHttpSpec {
             form.get("field1").map(_.asInstanceOf[FormField.Text].value) == Some(title),
             form.get("field2").map(_.asInstanceOf[FormField.Text].value) == Some(width.toString),
             form.get("field3").map(_.asInstanceOf[FormField.Text].value) == Some(height.toString),
-            form.get("field4").map(_.asInstanceOf[FormField.Binary].data) == Some(
-              Chunk.fromArray(s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes),
+            form.get("field4").map(_.asInstanceOf[FormField.Text].value) == Some(
+              s"""{"description":"$description","createdAt":"$createdAt"}""",
             ),
           )
         }
@@ -159,11 +159,9 @@ object MultipartSpec extends ZIOHttpSpec {
                 }
             form  = Form(
               FormField.simpleField("title", title),
-              FormField.binaryField(
+              FormField.textField(
                 "metadata",
-                Chunk.fromArray(
-                  s"""{"description":"$description","createdAt":"$createdAt"}""".getBytes,
-                ),
+                s"""{"description":"$description","createdAt":"$createdAt"}""",
                 MediaType.application.json,
               ),
               FormField.binaryField("uploaded-image", bytes, MediaType.image.png),

--- a/zio-http/shared/src/main/scala/zio/http/MediaTypes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/MediaTypes.scala
@@ -375,7 +375,7 @@ private[zio] trait MediaTypes {
       lazy val `jscalendar+json`: MediaType          =
         new MediaType("application", "jscalendar+json", Compressible, NotBinary)
       lazy val `json`: MediaType                     =
-        new MediaType("application", "json", Compressible, Binary, List("json", "map"))
+        new MediaType("application", "json", Compressible, NotBinary, List("json", "map"))
       lazy val `json-patch+json`: MediaType          =
         new MediaType("application", "json-patch+json", Compressible, NotBinary)
       lazy val `json-seq`: MediaType                 =

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
@@ -193,7 +193,7 @@ object HttpContentCodec {
       ZPipeline.identity[Chunk[Byte]].flattenChunks
   }
 
-  val byteChunkCodec: HttpContentCodec[Chunk[Byte]] = {
+  implicit val byteChunkCodec: HttpContentCodec[Chunk[Byte]] = {
     HttpContentCodec(
       ListMap(
         MediaType.allMediaTypes.filter(_.binary).map(mt => mt -> ByteChunkBinaryCodec): _*,
@@ -216,7 +216,7 @@ object HttpContentCodec {
       ZPipeline.identity[Byte]
   }
 
-  val byteCodec: HttpContentCodec[Byte] = {
+  implicit val byteCodec: HttpContentCodec[Byte] = {
     HttpContentCodec(
       ListMap(
         MediaType.allMediaTypes.filter(_.binary).map(mt => mt -> ByteBinaryCodec): _*,


### PR DESCRIPTION
/fix #2752

#899 marked `application/json` as binary, but it seems to be a mistake considering the other JSON variants are marked as not binary.