### PR TITLE
Add the `Date` header to responses by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,40 @@ jobs:
         id: push_codecov
         run: 'bash <(curl -s https://codecov.io/bash)'
 
+  Jmh_CachedDateHeaderBenchmark:
+    name: Jmh CachedDateHeaderBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.12]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")' project/plugins.sbt
+          cat > Main_CachedDateHeaderBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 CachedDateHeaderBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_CachedDateHeaderBenchmark.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Jmh_Main_CachedDateHeaderBenchmark
+          path: Main_CachedDateHeaderBenchmark.txt
+
   Jmh_CookieDecodeBenchmark:
     name: Jmh CookieDecodeBenchmark
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -551,7 +585,7 @@ jobs:
 
   Jmh_cache:
     name: Cache Jmh benchmarks
-    needs: [Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
+    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
@@ -560,6 +594,13 @@ jobs:
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: Jmh_Main_CachedDateHeaderBenchmark
+
+      - name: Format_Main_CachedDateHeaderBenchmark
+        run: cat Main_CachedDateHeaderBenchmark.txt >> Main_benchmarks.txt
+
       - uses: actions/download-artifact@v3
         with:
           name: Jmh_Main_CookieDecodeBenchmark

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CachedDateHeaderBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CachedDateHeaderBenchmark.scala
@@ -1,0 +1,26 @@
+package zio.http.netty
+
+import org.openjdk.jmh.annotations._
+import zio.http.internal.DateEncoding
+
+import java.time.ZonedDateTime
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Threads(16)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+class CachedDateHeaderBenchmark {
+  private val dateHeaderCache = new CachedDateHeader()
+
+  @Benchmark
+  def benchmarkCached() =
+    dateHeaderCache.get()
+
+  @Benchmark
+  def benchmarkFresh() =
+    DateEncoding.default.encodeDate(ZonedDateTime.now())
+}

--- a/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CachedDateHeaderBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zhttp.benchmarks/CachedDateHeaderBenchmark.scala
@@ -1,10 +1,11 @@
 package zio.http.netty
 
-import org.openjdk.jmh.annotations._
-import zio.http.internal.DateEncoding
-
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
+
+import zio.http.internal.DateEncoding
+
+import org.openjdk.jmh.annotations._
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))

--- a/zio-http/jvm/src/main/scala/zio/http/netty/CachedDateHeader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/CachedDateHeader.scala
@@ -1,9 +1,9 @@
 package zio.http.netty
 
-import zio.http.internal.DateEncoding
-
 import java.time.{Clock, LocalDateTime, ZoneOffset}
 import java.util.concurrent.locks.LockSupport
+
+import zio.http.internal.DateEncoding
 
 private object CachedDateHeader {
   lazy val default: CachedDateHeader = new CachedDateHeader()

--- a/zio-http/jvm/src/main/scala/zio/http/netty/CachedDateHeader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/CachedDateHeader.scala
@@ -1,0 +1,51 @@
+package zio.http.netty
+
+import zio.http.internal.DateEncoding
+
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+import java.util.concurrent.locks.LockSupport
+
+private object CachedDateHeader {
+  lazy val default: CachedDateHeader = new CachedDateHeader()
+}
+
+final private class CachedDateHeader(
+  clock: Clock = Clock.tickSeconds(ZoneOffset.UTC),
+  dateEncoding: DateEncoding = DateEncoding.default,
+) {
+  private var _headerValue = renderDateHeaderValue(clock.millis())
+
+  {
+    val t = new Ticker
+    t.setDaemon(true)
+    t.setName(s"zio.http.netty.DateHeaderEncoder.Scheduler")
+    t.setPriority(Thread.MAX_PRIORITY)
+    t.start()
+  }
+
+  def get(): String = _headerValue
+
+  private final class Ticker extends Thread {
+    override def run(): Unit = {
+      val clock0        = clock
+      var currentMillis = clock0.millis()
+      while (!isInterrupted) {
+        LockSupport.parkUntil(currentMillis + 1000)
+        currentMillis = clock0.millis()
+        updateHeaderValue(currentMillis)
+      }
+    }
+  }
+
+  private def renderDateHeaderValue(epochMilli: Long): String = {
+    val dt = LocalDateTime
+      .ofEpochSecond(epochMilli / 1000L, 0, ZoneOffset.UTC)
+      .atZone(ZoneOffset.UTC)
+
+    dateEncoding.encodeDate(dt)
+  }
+
+  private def updateHeaderValue(epochMilli: Long): Unit =
+    _headerValue = renderDateHeaderValue(epochMilli)
+
+}

--- a/zio-http/jvm/src/test/scala/zio/http/netty/CachedDateHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/CachedDateHeaderSpec.scala
@@ -1,0 +1,34 @@
+package zio.http.netty
+
+import zio._
+import zio.http.ZIOHttpSpec
+import zio.http.internal.DateEncoding
+import zio.test.{Spec, TestAspect, TestEnvironment, assertCompletes}
+
+import java.time.ZonedDateTime
+
+object CachedDateHeaderSpec extends ZIOHttpSpec {
+  private val dateHeaderCache = CachedDateHeader.default
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("CachedDateHeader")(
+      test("yields the same date header value as DateEncoding") {
+        val f = ZIO.suspendSucceed {
+          val uncached = DateEncoding.default.encodeDate(ZonedDateTime.now())
+          val cached   = dateHeaderCache.get()
+
+          ZIO
+            .fail(
+              new Exception(s"Mismatch in cached and uncached date header value:\n\tuncached: $uncached\n\tcached: $cached",
+              ),
+            )
+            .unless(uncached == cached)
+        }
+          .delay(5.milli)
+          .retryN(1)
+
+        ZIO.foreachDiscard((1 to 300).toList)(_ => f) *> assertCompletes
+      }
+        @@ TestAspect.withLiveClock,
+    )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/netty/CachedDateHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/CachedDateHeaderSpec.scala
@@ -1,11 +1,12 @@
 package zio.http.netty
 
+import java.time.ZonedDateTime
+
 import zio._
-import zio.http.ZIOHttpSpec
-import zio.http.internal.DateEncoding
 import zio.test.{Spec, TestAspect, TestEnvironment, assertCompletes}
 
-import java.time.ZonedDateTime
+import zio.http.ZIOHttpSpec
+import zio.http.internal.DateEncoding
 
 object CachedDateHeaderSpec extends ZIOHttpSpec {
   private val dateHeaderCache = CachedDateHeader.default
@@ -19,7 +20,8 @@ object CachedDateHeaderSpec extends ZIOHttpSpec {
 
           ZIO
             .fail(
-              new Exception(s"Mismatch in cached and uncached date header value:\n\tuncached: $uncached\n\tcached: $cached",
+              new Exception(
+                s"Mismatch in cached and uncached date header value:\n\tuncached: $uncached\n\tcached: $cached",
               ),
             )
             .unless(uncached == cached)


### PR DESCRIPTION
Accoding to the [HTTP spec](https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.2), a server MUST generate a `Date` header unless it can't provide a reasonable approximation of the current instance in Coordinated Universal Time.

Since this doesn't apply to us, `zio-http` should be including the `Date` header by default to all responses (with the exception of 1xx and 5xx responses where the Date header can be omitted)

The main issue with providing a `Date` header, and why it was omitted in the past, is that it relies on retrieving the current date-time and rendering it. Since getting the date-time requires a system call, this is a somewhat expensive operation. In order to avoid it for every single request, this PR implements a date header value cache, which is refreshed by an single thread every 1 second (which is the granularity of the header value).

After testing this implementation, I found that in some very rare cases, the header value will be lagging 1 second from the actual time, and this is usually when the time is retrieved exactly at at the same time as the second changes. The scheduled thread will then refresh the cached value within less than 1ms in most cases

As the spec allows for a small error in the header value, I think that this error is acceptable given the performance benefit of this approach.

Based on the benchmark I added, this approach is ~250x faster than rendering the Date fresh each time, and adds virtually no overhead.

```
[info] Benchmark                                  Mode  Cnt    Score   Error  Units
[info] CachedDateHeaderBenchmark.benchmarkCached  avgt    5    1.576 ± 0.013  ns/op
[info] CachedDateHeaderBenchmark.benchmarkFresh   avgt    5  268.054 ± 4.272  ns/op
```

Happy to hear your thoughts on this!