### PR TITLE
Provide HandlerAspect context via env instead of function param (#2488)

### DIFF
--- a/zio-http-example/src/main/scala/example/AuthenticationServer.scala
+++ b/zio-http-example/src/main/scala/example/AuthenticationServer.scala
@@ -46,8 +46,8 @@ object AuthenticationServer extends ZIOAppDefault {
   def app: HttpApp[Any] =
     Routes(
       // A route that is accessible only via a jwt token
-      Method.GET / "profile" / "me" -> handler { (name: String, _: Request) =>
-        ZIO.succeed(Response.text(s"Welcome $name!"))
+      Method.GET / "profile" / "me" -> handler { (_: Request) =>
+        ZIO.serviceWith[String](name => Response.text(s"Welcome $name!"))
       } @@ bearerAuthWithContext,
 
       // A login route that is successful only if the password is the reverse of the username

--- a/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
@@ -1,0 +1,50 @@
+package zio.http
+
+import zio._
+import zio.test._
+
+object HandlerAspectSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("HandlerAspect")(
+      test("HandlerAspect with context can eliminate environment type") {
+        val handler0 = handler((_: Request) => ZIO.serviceWith[Int](i => Response.text(i.toString))) @@
+          HandlerAspect.interceptIncomingHandler(handler((req: Request) => (req, req.headers.size)))
+        for {
+          response   <- handler0(Request(headers = Headers("accept", "*")))
+          bodyString <- response.body.asString
+        } yield assertTrue(bodyString == "1")
+      },
+      // format: off
+      test("HandlerAspect with context can eliminate environment type partially") {
+        val handlerAspect = HandlerAspect.interceptIncomingHandler(handler((req: Request) => (req, req.headers.size)))
+        val handler0 = handler { (_: Request) =>
+          ZIO.service[Boolean] *> ZIO.serviceWith[Int](i => Response.text(i.toString))
+          //leftover type is only needed in Scala 2
+          //can't be infix because of Scala 3
+        }.@@[Boolean](handlerAspect)
+        for {
+          response   <- handler0(Request(headers = Headers("accept", "*"))).provideEnvironment(ZEnvironment(true))
+          bodyString <- response.body.asString
+        } yield assertTrue(bodyString == "1")
+      },
+      test("HandlerAspect with context can eliminate environment type partially while requiring an additional environment") {
+        val handlerAspect: HandlerAspect[String, Int] = HandlerAspect.interceptIncomingHandler {
+          handler((req: Request) => ZIO.serviceWith[String](s => (req.withBody(Body.fromString(s)), req.headers.size)))
+        }
+        val handler0: Handler[Boolean with String, Response, Request, Response] = handler { (r: Request) =>
+          ZIO.service[Boolean] *> ZIO.serviceWithZIO[Int] { i =>
+            for {
+              body <- r.body.asString.orDie
+            } yield Response.text(s"$i $body")
+          }
+          //leftover type is only needed in Scala 2
+          //can't be infix because of Scala 3
+        }.@@[Boolean](handlerAspect)
+        for {
+          response   <- handler0(Request(headers = Headers("accept", "*"))).provideEnvironment(ZEnvironment(true) ++ ZEnvironment("test"))
+          bodyString <- response.body.asString
+        } yield assertTrue(bodyString == "1 test")
+      },
+      // format: on
+    )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
@@ -1,0 +1,47 @@
+package zio.http.endpoint
+
+import zio.Config.Secret
+import zio.test._
+import zio.{Scope, ZIO}
+
+import zio.http._
+import zio.http.internal.middlewares.AuthSpec.AuthContext
+
+object AuthSpec extends ZIOSpecDefault {
+
+  private val basicAuthContext = HandlerAspect.customAuthProviding[AuthContext] { r =>
+    {
+      r.headers.get(Header.Authorization).flatMap {
+        case Header.Authorization.Basic(uname, password) if Secret(uname.reverse) == password =>
+          Some(AuthContext(uname))
+        case _                                                                                =>
+          None
+      }
+
+    }
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("AuthSpec")(
+      test("Auth with context") {
+        val endpoint = Endpoint(Method.GET / "test").out[String](MediaType.text.`plain`)
+        val routes   =
+          Routes(endpoint.implement(handler((_: Unit) => ZIO.serviceWith[AuthContext](_.value)))) @@ basicAuthContext
+        val response = routes.run(
+          Request(
+            method = Method.GET,
+            url = url"/test",
+            headers = Headers(
+              Header.Authorization.Basic("admin", "admin".reverse),
+              Header.Accept(MediaType.text.`plain`),
+            ),
+          ),
+        )
+        for {
+          response <- response
+          body     <- response.body.asString
+        } yield assertTrue(body == "admin")
+      },
+    )
+
+}

--- a/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
@@ -1,0 +1,22 @@
+package zio.http
+
+import zio._
+
+trait HandlerVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](private val self: Handler[Env, Err, In, Out]) {
+    def apply[Env1, Ctx: Tag, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
+      in: Handler.IsRequest[In1],
+      ev: Env0 with Ctx <:< Env,
+      out: Out <:< Response,
+      err: Err <:< Response,
+      trace: Trace,
+    ): Handler[Env0 with Env1, Response, Request, Response] =
+      aspect.applyHandlerContext {
+        handler { (ctx: Ctx, req: Request) =>
+          val handler: ZIO[Env, Response, Response] = self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
+          handler.provideSomeEnvironment[Env0](_.add[Ctx](ctx).asInstanceOf[ZEnvironment[Env]])
+        }
+      }
+  }
+
+}

--- a/zio-http/shared/src/main/scala-2/zio/http/RoutesVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/RoutesVersionSpecific.scala
@@ -1,0 +1,14 @@
+package zio.http
+
+import zio.Tag
+
+trait RoutesVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, Env0](private val self: Routes[Env, Err]) {
+    def apply[Env1, Env2 <: Env, Ctx: Tag](aspect: HandlerAspect[Env1, Ctx])(implicit
+      ev: Env0 with Ctx <:< Env,
+      tag: Tag[Env0],
+      tag1: Tag[Env1],
+    ): Routes[Env0 with Env1, Err] = self.transform(_.@@[Env0](aspect))
+  }
+
+}

--- a/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
@@ -1,0 +1,22 @@
+package zio.http
+
+import zio.*
+
+trait HandlerVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](self: Handler[Env, Err, In, Out]) {
+    transparent inline def apply[Env1, Ctx, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
+      in: Handler.IsRequest[In1],
+      ev: Env0 with Ctx <:< Env,
+      out: Out <:< Response,
+      err: Err <:< Response,
+      trace: Trace,
+    ): Handler[Env0 with Env1, Response, Request, Response] =
+      aspect.applyHandlerContext {
+        handler { (ctx: Ctx, req: Request) =>
+          val handler: ZIO[Env, Response, Response] = self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
+          handler.provideSomeEnvironment[Env0](_.add(ctx).asInstanceOf[ZEnvironment[Env]])
+        }
+      }
+  }
+
+}

--- a/zio-http/shared/src/main/scala-3/zio/http/RoutesVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/RoutesVersionSpecific.scala
@@ -1,0 +1,10 @@
+package zio.http
+
+trait RoutesVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, Env0](private val self: Routes[Env, Err]) {
+    transparent inline def apply[Env1, Env2 <: Env, Ctx](aspect: HandlerAspect[Env1, Ctx])(implicit
+      ev: Env0 with Ctx <:< Env,
+    ): Routes[Env0 with Env1, Err] = self.transform(_.@@[Env0](aspect))
+  }
+
+}

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -17,6 +17,7 @@ package zio.http
 
 import zio._
 
+import zio.http.Routes.ApplyContextAspect
 import zio.http.codec.PathCodec
 
 /**
@@ -57,6 +58,17 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
 
   def @@[Env1 <: Env](aspect: Middleware[Env1]): Routes[Env1, Err] =
     aspect(self)
+
+  def @@[Env0](aspect: HandlerAspect[Env0, Unit]): Routes[Env with Env0, Err] =
+    aspect(self)
+
+  def @@[Env0, Ctx <: Env](
+    aspect: HandlerAspect[Env0, Ctx],
+  )(implicit tag: Tag[Ctx]): Routes[Env0, Err] =
+    self.transform(_ @@ aspect)
+
+  def @@[Env0]: ApplyContextAspect[Env, Err, Env0] =
+    new ApplyContextAspect[Env, Err, Env0](self)
 
   def apply(request: Request)(implicit ev: Err <:< Response, trace: Trace): ZIO[Env, Response, Response] =
     self.toHttpApp.apply(request)
@@ -211,7 +223,7 @@ final class Routes[-Env, +Err] private (val routes: Chunk[zio.http.Route[Env, Er
   ): Routes[Env1, Err] =
     new Routes(routes.map(_.transform(f)))
 }
-object Routes {
+object Routes extends RoutesVersionSpecific {
 
   /**
    * Constructs new routes from a varargs of individual routes.


### PR DESCRIPTION
This PR is a different way of solving #2488 that seems to me to be superior to #2553 

With this PR, the context provided by a `HandlerAspec` is no longer injected via the function param if a `handler`/`Handler.fromFunction` but instead via the environment. So users would just require context via `ZIO.serviceX`.
The implementation is such, that `h: Handler[Env with Ctx, _, _, _] @@ aspect: HandlerAspect[_, Ctx]` would eliminate the  `Ctx` from the env of the handler. The aspect may add new `Env` requirements as well. Only for partial `Env` providing in Scala 2, an explicit param needs to be handed over to `@@`. For all other cases inference works fine.

This change also enables auth context to be handed over to handlers of endpoint API implementations, since it does not require the context to be known while creating the endpoint. There is an example in the added tests.

This seems to be the most consistent way to provide context via an aspect that works for all use cases
 * single handler
 * Routes
 * Endpoint API

fixes #2488
/claim #2488