### PR TITLE
fix: For multipart bodies the content CRLF after the last boundary should be ignored and not be mandatory

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
@@ -24,9 +24,9 @@ import zio.test._
 import zio.http.forms.Fixtures._
 
 object BoundarySpec extends ZIOHttpSpec {
-  val CRLF = "\r\n"
 
   val multipartFormBytes3 = Chunk.fromArray(s"""------heythere--${CRLF}""".getBytes(StandardCharsets.UTF_8))
+  val multipartFormBytes4 = Chunk.fromArray(s"""------heythere${CRLF}${CRLF}""".getBytes(StandardCharsets.UTF_8))
   val bad1                = Chunk.fromArray(s"""-heythere${CRLF}""".getBytes(StandardCharsets.UTF_8))
   val bad2                = Chunk.fromArray(s"""--heythere${CR}""".getBytes(StandardCharsets.UTF_8))
   val bad3                = Chunk.fromArray(s"--heythere\n".getBytes(StandardCharsets.UTF_8))
@@ -37,21 +37,22 @@ object BoundarySpec extends ZIOHttpSpec {
       val boundary1 = Boundary.fromContent(multipartFormBytes1)
       val boundary2 = Boundary.fromContent(multipartFormBytes2)
       val boundary3 = Boundary.fromContent(multipartFormBytes3)
+      val boundary4 = Boundary.fromContent(multipartFormBytes4)
       assertTrue(
         boundary1.get.id == "AaB03x",
         boundary2.get.id == "(((AaB03x)))",
         boundary3.get.id == "----heythere--",
         boundary3.get.encapsulationBoundary == "------heythere--",
         boundary3.get.closingBoundary == "------heythere----",
+        boundary4.get.encapsulationBoundary == "------heythere",
+        boundary4.get.closingBoundary == "------heythere--",
       )
     },
     test("parse failure") {
-
       val boundary1 = Boundary.fromContent(bad1)
       val boundary2 = Boundary.fromContent(bad2)
       val boundary3 = Boundary.fromContent(bad3)
       val boundary4 = Boundary.fromContent(bad4)
-
       assertTrue(
         boundary1.isEmpty,
         boundary2.isEmpty,

--- a/zio-http/jvm/src/test/scala/zio/http/FormSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/FormSpec.scala
@@ -168,7 +168,7 @@ object FormSpec extends ZIOHttpSpec {
           "octet-stream",
         )
       val testDataExpected                      = Chunk(multipartText, multipartBinary)
-      val shouldBeIgnored                       = Chunk(CRLF.getBytes, "some random text".getBytes)
+      val shouldBeIgnored                       = Chunk(CRLF.getBytes)
       val testSet: Chunk[(Chunk[Byte], String)] = for {
         be <- testDataExpected
         (bytes, expected) = be


### PR DESCRIPTION
see https://github.com/zio/zio-http/issues/2411