### PR TITLE
Use `fork` instead of `runOrFork` in NettyRuntime

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
@@ -49,6 +49,7 @@ private[zio] trait NettyRuntime { self =>
     // When connection closes, interrupt the program
     var close: GenericFutureListener[Future[_ >: Void]] = null
 
+    // See https://github.com/zio/zio-http/pull/2782 on why forking is preferable over runOrFork
     val fiber = rtm.unsafe.fork(program)
 
     if (interruptOnClose) {

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
@@ -49,28 +49,21 @@ private[zio] trait NettyRuntime { self =>
     // When connection closes, interrupt the program
     var close: GenericFutureListener[Future[_ >: Void]] = null
 
-    rtm.unsafe.runOrFork(program) match {
-      case Left(fiber) =>
-        if (interruptOnClose) {
-          close = closeListener(rtm, fiber)
-          ctx.channel().closeFuture.addListener(close)
-        }
-        fiber.unsafe.addObserver {
-          case Exit.Success(_)     =>
-            removeListener(close)
-            ensured()
-          case Exit.Failure(cause) =>
-            removeListener(close)
-            onFailure(cause, ctx)
-            ensured()
-        }
-      case Right(exit) =>
+    val fiber = rtm.unsafe.fork(program)
+
+    if (interruptOnClose) {
+      close = closeListener(rtm, fiber)
+      ctx.channel().closeFuture.addListener(close)
+    }
+
+    fiber.unsafe.addObserver {
+      case Exit.Success(_)     =>
+        removeListener(close)
         ensured()
-        exit match {
-          case Exit.Success(_)     =>
-          case Exit.Failure(cause) =>
-            onFailure(cause, ctx)
-        }
+      case Exit.Failure(cause) =>
+        removeListener(close)
+        onFailure(cause, ctx)
+        ensured()
     }
   }
 


### PR DESCRIPTION
/claim #2577
/fixes #2577

I'll also need to backport https://github.com/zio/zio/pull/8752 to 2.0.x since that bug is preventing us from getting the benefit of this change