### PR TITLE
rename enumValues to enum to comply with OSA 3

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -1774,7 +1774,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                          |        {
                          |        "type" :
                          |          "string",
-                         |        "enumValues" : [
+                         |        "enum" : [
                          |          "One",
                          |          "Two",
                          |          "Three"

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -18,7 +18,7 @@ private[openapi] case class SerializableJsonSchema(
   oneOf: Option[Chunk[SerializableJsonSchema]] = None,
   allOf: Option[Chunk[SerializableJsonSchema]] = None,
   anyOf: Option[Chunk[SerializableJsonSchema]] = None,
-  enumValues: Option[Chunk[Json]] = None,
+  @fieldName("enum") enumValues: Option[Chunk[Json]] = None,
   properties: Option[Map[String, SerializableJsonSchema]] = None,
   additionalProperties: Option[BoolOrSchema] = None,
   required: Option[Chunk[String]] = None,


### PR DESCRIPTION
Rename enumValues to enum to comply with OSA 3 as described here - https://swagger.io/docs/specification/data-models/enums/

The current generated code for enums look like
```
"ProductType":{"type":"string","enumValues":["Electronics","Clothes","VideoGames","Toys"]}
```
which is not rendering correct in Swagger UI - there are not enum values listed in the UI, just the type "string". 

However if I change "enumValues" to "enum", then the Sagger UI correctly shows the possible values and tags the type as enumeration. 