### PR TITLE
Fix streaming response compression

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -27,14 +27,27 @@ import zio.http.netty.NettyBody.{AsciiStringBody, AsyncBody, ByteBufBody, Unsafe
 import io.netty.buffer.Unpooled
 import io.netty.channel._
 import io.netty.handler.codec.http.{DefaultHttpContent, LastHttpContent}
+
 object NettyBodyWriter {
 
   def writeAndFlush(body: Body, contentLength: Option[Long], ctx: ChannelHandlerContext)(implicit
     trace: Trace,
-  ): Option[Task[Unit]] =
+  ): Option[Task[Unit]] = {
+
+    def writeArray(body: Array[Byte], isLast: Boolean) = {
+      val content = new DefaultHttpContent(Unpooled.wrappedBuffer(body))
+      if (isLast) {
+        // Flushes the last body content and LastHttpContent together to avoid race conditions.
+        ctx.write(content)
+        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+      } else {
+        ctx.writeAndFlush(content)
+      }
+    }
+
     body match {
       case body: ByteBufBody                  =>
-        ctx.write(body.byteBuf)
+        ctx.write(new DefaultHttpContent(body.byteBuf))
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
       case body: FileBody                     =>
@@ -46,45 +59,23 @@ object NettyBodyWriter {
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
       case AsyncBody(async, _, _, _)          =>
-        contentLength.orElse(body.knownContentLength) match {
-          case Some(_) =>
-            async(
-              new UnsafeAsync {
-                override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
-                  val nettyMsg = message match {
-                    case b: ByteArray => Unpooled.wrappedBuffer(b.array)
-                    case other        => Unpooled.wrappedBuffer(other.toArray)
-                  }
-                  ctx.writeAndFlush(nettyMsg)
-                  if (isLast) ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-                }
+        async(
+          new UnsafeAsync {
+            override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
+              val arr = message match {
+                case b: ByteArray => b.array
+                case other        => other.toArray
+              }
+              writeArray(arr, isLast)
+            }
 
-                override def fail(cause: Throwable): Unit =
-                  ctx.fireExceptionCaught(cause)
-              },
-            )
-            None
-          case None    =>
-            async(
-              new UnsafeAsync {
-                override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
-                  val nettyMsg = message match {
-                    case b: ByteArray => Unpooled.wrappedBuffer(b.array)
-                    case other        => Unpooled.wrappedBuffer(other.toArray)
-                  }
-                  ctx.writeAndFlush(new DefaultHttpContent(nettyMsg))
-                  if (isLast) ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-                }
-
-                override def fail(cause: Throwable): Unit =
-                  ctx.fireExceptionCaught(cause)
-              },
-            )
-            None
-        }
+            override def fail(cause: Throwable): Unit =
+              ctx.fireExceptionCaught(cause)
+          },
+        )
+        None
       case AsciiStringBody(asciiString, _, _) =>
-        ctx.write(Unpooled.wrappedBuffer(asciiString.array()))
-        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+        writeArray(asciiString.array(), isLast = true)
         None
       case StreamBody(stream, _, _, _)        =>
         Some(
@@ -95,14 +86,12 @@ object NettyBodyWriter {
                   remaining - bytes.size match {
                     case 0L =>
                       NettyFutureExecutor.executed {
-                        // Flushes the last body content and LastHttpContent together to avoid race conditions.
-                        ctx.write(Unpooled.wrappedBuffer(bytes.toArray))
-                        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+                        writeArray(bytes.toArray, isLast = true)
                       }.as(0L)
 
                     case n =>
                       NettyFutureExecutor.executed {
-                        ctx.writeAndFlush(Unpooled.wrappedBuffer(bytes.toArray))
+                        writeArray(bytes.toArray, isLast = false)
                       }.as(n)
                   }
                 }
@@ -120,7 +109,7 @@ object NettyBodyWriter {
             case None =>
               stream.chunks.mapZIO { bytes =>
                 NettyFutureExecutor.executed {
-                  ctx.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(bytes.toArray)))
+                  writeArray(bytes.toArray, isLast = false)
                 }
               }.runDrain.zipRight {
                 NettyFutureExecutor.executed {
@@ -130,14 +119,14 @@ object NettyBodyWriter {
           },
         )
       case ArrayBody(data, _, _)              =>
-        ctx.writeAndFlush(Unpooled.wrappedBuffer(data))
+        writeArray(data, isLast = true)
         None
       case ChunkBody(data, _, _)              =>
-        ctx.write(Unpooled.wrappedBuffer(data.toArray))
-        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
+        writeArray(data.toArray, isLast = true)
         None
       case EmptyBody                          =>
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
     }
+  }
 }


### PR DESCRIPTION
This PR fixes a bug where if a streaming response has a known size, netty fails to compress it and the response is all botched up. The main culprit is that the `ByteBuf` objects need to be wrapped in a `DefaultHttpResponse` prior to writing them to the Netty channel for Netty to be able to compress them properly.

In addition, there is also another minor bug where the content-length from headers is not being extracted correctly, as it seems that netty will mutate the response object after `writeAndFlush` has been invoked on it, which means we need to extract the content-length before we call it

To reproduce, run the following code and open `http://localhost:8080/foo` on a browser:

```scala
import zio.*
import zio.http.*
import zio.http.Server.Config.ResponseCompressionConfig
import zio.stream.ZStream

object Foo extends ZIOAppDefault {
  val body = Chunk.fromArray("hello world".getBytes)

  val foo =
    Method.GET / "foo" -> handler(
      ZIO.succeed(Response(body = Body.fromStream(ZStream.fromChunk(body), body.length)))
    )

  override val run =
    Server
      .serve(Routes(foo).toHttpApp)
      .provide(
        Server.live,
        ZLayer.succeed(Server.Config.default.port(8080).responseCompression(ResponseCompressionConfig.default)),
      )
}
```

