### PR TITLE
Avoid providing the ZEnvironment on very request

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
@@ -16,15 +16,17 @@
 
 package zio.http.netty
 
+import scala.annotation.unused
+
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import io.netty.channel._
 import io.netty.util.concurrent.{Future, GenericFutureListener}
 
-private[zio] trait NettyRuntime { self =>
+private[zio] final class NettyRuntime(zRuntime: Runtime[Any]) {
 
-  def runtime(ctx: ChannelHandlerContext): Runtime[Any]
+  def runtime(@unused ctx: ChannelHandlerContext): Runtime[Any] = zRuntime
 
   def run(ctx: ChannelHandlerContext, ensured: () => Unit, interruptOnClose: Boolean = true)(
     program: ZIO[Any, Throwable, Any],
@@ -41,21 +43,21 @@ private[zio] trait NettyRuntime { self =>
     }
 
     def removeListener(close: GenericFutureListener[Future[_ >: Void]]): Unit = {
-      if (close != null)
+      if (close ne null)
         ctx.channel().closeFuture().removeListener(close): Unit
     }
-
-    // Close the connection if the program fails
-    // When connection closes, interrupt the program
-    var close: GenericFutureListener[Future[_ >: Void]] = null
 
     // See https://github.com/zio/zio-http/pull/2782 on why forking is preferable over runOrFork
     val fiber = rtm.unsafe.fork(program)
 
-    if (interruptOnClose) {
-      close = closeListener(rtm, fiber)
-      ctx.channel().closeFuture.addListener(close)
-    }
+    // Close the connection if the program fails
+    // When connection closes, interrupt the program
+    val close: GenericFutureListener[Future[_ >: Void]] =
+      if (interruptOnClose) {
+        val close0 = closeListener(rtm, fiber)
+        ctx.channel().closeFuture.addListener(close0)
+        close0
+      } else null
 
     fiber.unsafe.addObserver {
       case Exit.Success(_)     =>
@@ -95,11 +97,7 @@ private[zio] object NettyRuntime {
     ZLayer.fromZIO {
       ZIO
         .runtime[Any]
-        .map { rtm =>
-          new NettyRuntime {
-            def runtime(ctx: ChannelHandlerContext): Runtime[Any] = rtm
-          }
-        }
+        .map(new NettyRuntime(_))
     }
   }
 }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -53,19 +53,23 @@ private[zio] final case class NettyDriver(
       )
     } yield StartResult(port, serverInboundHandler.inFlightRequests)
 
-  def addApp[R](newApp: Routes[R, Response], env: ZEnvironment[R])(implicit trace: Trace): UIO[Unit] = ZIO.succeed {
-    var loop = true
-    while (loop) {
-      val oldAppAndEnv     = appRef.get()
-      val (oldApp, oldEnv) = oldAppAndEnv
-      val updatedApp       = (oldApp ++ newApp).asInstanceOf[Routes[Any, Response]]
-      val updatedEnv       = oldEnv.unionAll(env)
-      val updatedAppAndEnv = (updatedApp, updatedEnv)
+  def addApp[R](newApp: Routes[R, Response], env: ZEnvironment[R])(implicit trace: Trace): UIO[Unit] =
+    ZIO.fiberId.map { fiberId =>
+      var loop = true
+      while (loop) {
+        val oldAppAndRt     = appRef.get()
+        val (oldApp, oldRt) = oldAppAndRt
+        val updatedApp      = (oldApp ++ newApp).asInstanceOf[Routes[Any, Response]]
+        val updatedEnv      = oldRt.environment.unionAll(env)
+        // Update the fiberRefs with the new environment to avoid doing this every time we run / fork a fiber
+        val updatedFibRefs  = oldRt.fiberRefs.updatedAs(fiberId)(FiberRef.currentEnvironment, updatedEnv)
+        val updatedRt       = Runtime(updatedEnv, updatedFibRefs, oldRt.runtimeFlags)
+        val updatedAppAndRt = (updatedApp, updatedRt)
 
-      if (appRef.compareAndSet(oldAppAndEnv, updatedAppAndEnv)) loop = false
+        if (appRef.compareAndSet(oldAppAndRt, updatedAppAndRt)) loop = false
+      }
+      serverInboundHandler.refreshApp()
     }
-    serverInboundHandler.refreshApp()
-  }
 
   override def createClientDriver()(implicit trace: Trace): ZIO[Scope, Throwable, ClientDriver] =
     for {
@@ -113,10 +117,9 @@ object NettyDriver {
   val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.makeSome[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Driver](
-      ZLayer.succeed(
-        new AtomicReference[(Routes[Any, Response], ZEnvironment[Any])]((Routes.empty, ZEnvironment.empty)),
-      ),
-      NettyRuntime.live,
+      ZLayer(ZIO.runtime[Any].map { rt =>
+        new AtomicReference[(Routes[Any, Response], Runtime[Any])]((Routes.empty, rt))
+      }),
       ServerChannelInitializer.layer,
       ServerInboundHandler.live,
       ZLayer(make),

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -117,9 +117,7 @@ object NettyDriver {
   val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.makeSome[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Driver](
-      ZLayer(ZIO.runtime[Any].map { rt =>
-        new AtomicReference[(Routes[Any, Response], Runtime[Any])]((Routes.empty, rt))
-      }),
+      ZLayer.succeed(AppRef.empty),
       ServerChannelInitializer.layer,
       ServerInboundHandler.live,
       ZLayer(make),

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -43,14 +43,13 @@ import io.netty.handler.timeout.ReadTimeoutException
 private[zio] final case class ServerInboundHandler(
   appRef: AppRef,
   config: Server.Config,
-  runtime: NettyRuntime,
 )(implicit trace: Trace)
     extends SimpleChannelInboundHandler[HttpObject](false) { self =>
 
   implicit private val unsafe: Unsafe = Unsafe.unsafe
 
   private var app: Routes[Any, Response] = _
-  private var env: ZEnvironment[Any]     = _
+  private var runtime: NettyRuntime      = _
 
   val inFlightRequests: LongAdder = new LongAdder()
   val readClientCert              = config.sslConfig.exists(_.includeClientCert)
@@ -59,11 +58,11 @@ private[zio] final case class ServerInboundHandler(
     val pair = appRef.get()
 
     this.app = pair._1
-    this.env = pair._2
+    this.runtime = new NettyRuntime(pair._2)
   }
 
   private def ensureHasApp(): Unit = {
-    if (app eq null) {
+    if (runtime eq null) {
       refreshApp()
     }
   }
@@ -95,7 +94,7 @@ private[zio] final case class ServerInboundHandler(
           } else
             app(req)
         if (!attemptImmediateWrite(ctx, exit)) {
-          writeResponse(ctx, env, exit, jReq)(releaseRequest)
+          writeResponse(ctx, runtime, exit, jReq)(releaseRequest)
         } else {
           releaseRequest()
         }
@@ -116,7 +115,7 @@ private[zio] final case class ServerInboundHandler(
             (msg ne null) && msg.contains("Connection reset")
           } =>
       case t =>
-        if (app ne null) {
+        if (runtime ne null) {
           runtime.run(ctx, () => {}) {
             // We cannot return the generated response from here, but still calling the handler for its side effect
             // for example logging.
@@ -166,6 +165,7 @@ private[zio] final case class ServerInboundHandler(
 
   private def attemptFullWrite(
     ctx: ChannelHandlerContext,
+    runtime: NettyRuntime,
     response: Response,
     jRequest: HttpRequest,
   ): Option[Task[Unit]] = {
@@ -309,12 +309,12 @@ private[zio] final case class ServerInboundHandler(
 
   private def writeResponse(
     ctx: ChannelHandlerContext,
-    env: ZEnvironment[Any],
+    runtime: NettyRuntime,
     exit: ZIO[Any, Response, Response],
     jReq: HttpRequest,
   )(ensured: () => Unit): Unit = {
     runtime.run(ctx, ensured) {
-      val pgm = exit.sandbox.catchAll { error =>
+      exit.sandbox.catchAll { error =>
         error.failureOrCause
           .fold[UIO[Response]](
             response => ZIO.succeed(response),
@@ -330,7 +330,7 @@ private[zio] final case class ServerInboundHandler(
           if (response ne null) {
             val done = attemptFastWrite(ctx, response)
             if (!done)
-              attemptFullWrite(ctx, response, jReq)
+              attemptFullWrite(ctx, runtime, response, jReq)
             else
               None
           } else {
@@ -347,8 +347,6 @@ private[zio] final case class ServerInboundHandler(
           },
         )
       }
-
-      pgm.provideEnvironment(env)
     }
   }
 
@@ -364,7 +362,7 @@ private[zio] final case class ServerInboundHandler(
 object ServerInboundHandler {
 
   val live: ZLayer[
-    Server.Config with NettyRuntime with AppRef,
+    AppRef & Server.Config,
     Nothing,
     ServerInboundHandler,
   ] = {
@@ -372,10 +370,9 @@ object ServerInboundHandler {
     ZLayer.fromZIO {
       for {
         appRef <- ZIO.service[AppRef]
-        rtm    <- ZIO.service[NettyRuntime]
         config <- ZIO.service[Server.Config]
 
-      } yield ServerInboundHandler(appRef, config, rtm)
+      } yield ServerInboundHandler(appRef, config)
     }
   }
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -26,6 +26,10 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 package object server {
   private[server] type AppRef = AtomicReference[(Routes[Any, Response], Runtime[Any])]
 
+  private[server] object AppRef {
+    def empty: AppRef = new AtomicReference((Routes.empty, Runtime.default))
+  }
+
   val live: ZLayer[Server.Config, Throwable, Driver] =
     NettyDriver.live
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -22,9 +22,9 @@ import zio.http._
 
 import java.util.concurrent.atomic.AtomicReference // scalafix:ok;
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+
 package object server {
-  private[server] type AppRef = AtomicReference[(Routes[Any, Response], ZEnvironment[Any])]
-  private[server] type EnvRef = AtomicReference[ZEnvironment[Any]]
+  private[server] type AppRef = AtomicReference[(Routes[Any, Response], Runtime[Any])]
 
   val live: ZLayer[Server.Config, Throwable, Driver] =
     NettyDriver.live


### PR DESCRIPTION
Currently, we provide the `ZEnvironment` to every request, even though that in almost all cases it'll only change during app wiring. Since the ZEnvironment is part of `Runtime` used by `NettyRuntime`, we can avoid doing this on every request and save ourselves modifying `FiberRefs`