### PR TITLE
Use current runtime when initializing AppRef

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -117,7 +117,7 @@ object NettyDriver {
   val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] = {
     implicit val trace: Trace = Trace.empty
     ZLayer.makeSome[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Driver](
-      ZLayer.succeed(AppRef.empty),
+      ZLayer(AppRef.empty),
       ServerChannelInitializer.layer,
       ServerInboundHandler.live,
       ZLayer(make),

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -27,7 +27,10 @@ package object server {
   private[server] type AppRef = AtomicReference[(Routes[Any, Response], Runtime[Any])]
 
   private[server] object AppRef {
-    def empty: AppRef = new AtomicReference((Routes.empty, Runtime.default))
+    val empty: UIO[AppRef] = {
+      implicit val trace: Trace = Trace.empty
+      ZIO.runtime[Any].map(rt => new AtomicReference((Routes.empty, rt)))
+    }
   }
 
   val live: ZLayer[Server.Config, Throwable, Driver] =


### PR DESCRIPTION
I accidentally introduced a bug in #2800 where a custom bootstrapped runtime wasn't propagated to the request execution 🤦. We need to make sure that `AppRef` is initialized with the current Runtime, not the default one.

PS: I tried to add a unit test for this but I'm struggling a little bit with writing one. I'll give it another go with adding a test, but in the meantime opening this PR as it's a pretty severe bug