### PR TITLE
Code generator for protobuf specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
 
       - name: Compress target directories
-        run: tar cf targets.tar zio-http-cli/target target zio-http/jvm/target zio-http-docs/target zio-http-gen/target zio-http-benchmarks/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
+        run: tar cf targets.tar sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-gen/target zio-http-benchmarks/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v4

--- a/build.sbt
+++ b/build.sbt
@@ -289,7 +289,6 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      "com.google.protobuf"                      % "protobuf-java"           % "4.26.1",
     ),
   )
   .settings(
@@ -312,6 +311,15 @@ lazy val sbtZioHttpGrpc = (project in file("sbt-zio-http-grpc"))
       "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.15" % "protobuf",
       "com.google.protobuf"  %  "protobuf-java"   % "4.26.1" % "protobuf"
     )
+  )
+  .settings(
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n <= 12 =>
+          Seq(`scala-compact-collection`)
+        case _                       => Seq.empty
+      }
+    },
   )
   .dependsOn(zioHttpJVM, zioHttpGen)
 

--- a/build.sbt
+++ b/build.sbt
@@ -118,6 +118,8 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
       zioHttpBenchmarks,
       zioHttpCli,
       zioHttpGen,
+      sbtZioHttpGrpc,
+      sbtZioHttpGrpcTests,
       zioHttpHtmx,
       zioHttpExample,
       zioHttpTestkit,
@@ -287,9 +289,57 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
+      "com.google.protobuf"                      % "protobuf-java"           % "4.26.1",
     ),
   )
+  .settings(
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n <= 12 =>
+          Seq(`scala-compact-collection`)
+        case _                       => Seq.empty
+      }
+    },
+  )
   .dependsOn(zioHttpJVM)
+
+lazy val sbtZioHttpGrpc = (project in file("sbt-zio-http-grpc"))
+  .settings(stdSettings("sbt-zio-http-grpc"))
+  .settings(publishSetting(true))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.thesamet.scalapb" %% "compilerplugin"  % "0.11.15",
+      "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.15" % "protobuf",
+      "com.google.protobuf"  %  "protobuf-java"   % "4.26.1" % "protobuf"
+    )
+  )
+  .dependsOn(zioHttpJVM, zioHttpGen)
+
+lazy val sbtZioHttpGrpcTests = (project in file("sbt-zio-http-grpc-tests"))
+    .enablePlugins(LocalCodeGenPlugin)
+    .settings(stdSettings("sbt-zio-http-grpc-tests"))
+    .settings(publishSetting(false))
+    .settings(
+      libraryDependencies ++= Seq(
+        `zio-test-sbt`,
+        `zio-test`,
+        "com.google.protobuf"  % "protobuf-java"    % "4.26.1" % "protobuf",
+        "com.thesamet.scalapb" %% "scalapb-runtime" % "0.11.15" % "protobuf",
+      ),
+      Compile / run / fork := true,
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+      Compile / PB.targets := {
+        if (CrossVersion.partialVersion(scalaVersion.value) == Some((2, 12)))
+          Seq(
+          scalapb.gen(grpc = false)      -> (Compile / sourceManaged).value,
+          genModule("zio.http.grpc.ZIOHttpGRPCGen$")-> (Compile / sourceManaged).value
+        ) 
+        else Seq.empty
+      },
+      codeGenClasspath     := (sbtZioHttpGrpc / Compile / fullClasspath).value
+    )
+    .dependsOn(zioHttpJVM, sbtZioHttpGrpc)
+    .disablePlugins(ScalafixPlugin)
 
 lazy val zioHttpTestkit = (project in file("zio-http-testkit"))
   .enablePlugins(Shading.plugins(): _*)

--- a/build.sbt
+++ b/build.sbt
@@ -320,6 +320,7 @@ lazy val sbtZioHttpGrpcTests = (project in file("sbt-zio-http-grpc-tests"))
     .settings(stdSettings("sbt-zio-http-grpc-tests"))
     .settings(publishSetting(false))
     .settings(
+      Test / skip := (CrossVersion.partialVersion(scalaVersion.value) != Some((2, 12))),
       libraryDependencies ++= Seq(
         `zio-test-sbt`,
         `zio-test`,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,6 @@ addSbtPlugin("io.get-coursier"    % "sbt-shading"               % "2.1.4")
 addSbtPlugin("com.github.cb372"   % "sbt-explicit-dependencies" % "0.3.1")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "1.16.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "1.3.2")
+addSbtPlugin("com.thesamet"       % "sbt-protoc"                % "1.0.7")
+addSbtPlugin("com.thesamet"       % "sbt-protoc-gen-project"    % "0.1.8")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"

--- a/sbt-zio-http-grpc-tests/src/main/protobuf/api.proto
+++ b/sbt-zio-http-grpc-tests/src/main/protobuf/api.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package zio.http.grpc;
+
+service v1 {
+    rpc test (TestMsg) returns (TestMsg);
+}
+
+message TestMsg {
+    string a = 1;
+}

--- a/sbt-zio-http-grpc-tests/src/main/protobuf/package.proto
+++ b/sbt-zio-http-grpc-tests/src/main/protobuf/package.proto
@@ -1,0 +1,8 @@
+import "scalapb/scalapb.proto";
+
+package zio.http.grpc;
+
+option (scalapb.options) = {
+  scope: PACKAGE
+  preserve_unknown_fields: false
+};

--- a/sbt-zio-http-grpc-tests/src/test/scala/zio/http/grpc/ZIOHttpGRPCGenSpec.scala
+++ b/sbt-zio-http-grpc-tests/src/test/scala/zio/http/grpc/ZIOHttpGRPCGenSpec.scala
@@ -1,0 +1,25 @@
+package zio.http.grpc
+
+import zio.test._
+import zio.http.grpc.api._
+import zio.http._
+
+object ZIOHttpGRPCGenSpec extends ZIOSpecDefault {
+
+  override def spec =
+    suite("ZIOHttpGRPCGenSpec")(
+      test("plugin generates Message") {
+        val msg = TestMsg("msg")
+        assertTrue(true)
+      },
+      test("plugin generates Endpoint") {
+        val impl = V1.test.implement {
+          Handler.fromFunction[TestMsg] { msg =>
+            msg
+          }
+        }
+        assertTrue(true)
+      },
+    )
+
+}

--- a/sbt-zio-http-grpc/src/main/scala/zio/http/grpc/ZIOHttpGRPCGen.scala
+++ b/sbt-zio-http-grpc/src/main/scala/zio/http/grpc/ZIOHttpGRPCGen.scala
@@ -11,8 +11,6 @@ import scalapb.compiler.{DescriptorImplicits, ProtobufGenerator}
 import scalapb.options.Scalapb
 
 object ZIOHttpGRPCGen extends CodeGenApp {
-  override def registerExtensions(registry: ExtensionRegistry): Unit =
-    Scalapb.registerAllExtensions(registry)
 
   def process(request: CodeGenRequest): CodeGenResponse =
     ProtobufGenerator.parseParameters(request.parameter) match {

--- a/sbt-zio-http-grpc/src/main/scala/zio/http/grpc/ZIOHttpGRPCGen.scala
+++ b/sbt-zio-http-grpc/src/main/scala/zio/http/grpc/ZIOHttpGRPCGen.scala
@@ -1,0 +1,69 @@
+package zio.http.grpc
+
+import zio.http.gen.grpc.EndpointGen
+import zio.http.gen.scala.{Code, CodeGen}
+
+import com.google.protobuf.Descriptors.FileDescriptor
+import com.google.protobuf.ExtensionRegistry
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
+import protocgen.{CodeGenApp, CodeGenRequest, CodeGenResponse}
+import scalapb.compiler.{DescriptorImplicits, ProtobufGenerator}
+import scalapb.options.Scalapb
+
+object ZIOHttpGRPCGen extends CodeGenApp {
+  override def registerExtensions(registry: ExtensionRegistry): Unit =
+    Scalapb.registerAllExtensions(registry)
+
+  def process(request: CodeGenRequest): CodeGenResponse =
+    ProtobufGenerator.parseParameters(request.parameter) match {
+      case Right(params) =>
+        val services = request.filesToGenerate.flatMap(fromProtobuf(_).files)
+        val schemas  = services.map(getImplicitSchemas(_)).map { case (pkg, tpes) =>
+          schemasFile(pkg, tpes)
+        }
+        CodeGenResponse.succeed(
+          schemas ++ services.map(fileToPluginCode(_)),
+          Set(CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL),
+        )
+      case Left(error)   =>
+        CodeGenResponse.fail(error)
+    }
+
+  def fromProtobuf(file: FileDescriptor): Code.Files = {
+    EndpointGen.fromProtobuf(file)
+  }
+
+  def fileToPluginCode(file: Code.File): CodeGeneratorResponse.File = {
+    val b = CodeGeneratorResponse.File.newBuilder()
+    b.setName(file.path.mkString("/"))
+    b.setContent(CodeGen.render(file.path.dropRight(2).mkString("."))(file)._2)
+    b.build
+  }
+
+  def getImplicitSchemas(file: Code.File): (List[String], List[String]) = {
+    val msgs = file.objects
+      .flatMap(_.endpoints.toList.map(_._2))
+      .flatMap { endpoint =>
+        endpoint.inCode.inType :: endpoint.outCodes.map(_.outType)
+      }
+
+    (file.path.init, msgs)
+  }
+
+  def schemasFile(pkg: List[String], tpes: List[String]): CodeGeneratorResponse.File = {
+    val b       = CodeGeneratorResponse.File.newBuilder()
+    b.setName((pkg ++ List("Schemas.scala")).mkString("/"))
+    val content =
+      s"package ${pkg.mkString(".")} \nobject Schemas {\n" +
+        "import zio.schema.{DeriveSchema, Schema}\n" +
+        tpes.distinct.map(tpeToSchema(_)).mkString("") +
+        "\n}"
+    b.setContent(content)
+    b.build
+  }
+
+  def tpeToSchema(tpe: String): String = {
+    s"\n\n implicit val ${tpe}Codec: Schema[$tpe] = DeriveSchema.gen[$tpe]"
+  }
+
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
@@ -1,0 +1,95 @@
+package zio.http.gen.grpc
+
+import scala.jdk.CollectionConverters._
+
+import zio.http.Method
+import zio.http.gen.scala.Code
+import zio.http.gen.scala.Code.ScalaType
+
+import com.google.protobuf.Descriptors
+
+object EndpointGen {
+
+  def fromProtobuf(protobuf: Descriptors.FileDescriptor): Code.Files = {
+    val imports = protobuf
+      .getDependencies()
+      .asScala
+      .toList
+      .map(_.getName())
+      .flatMap(dep => Code.Import.FromBase(s"$dep._") :: Code.Import.FromBase(s"$dep.Schemas._") :: Nil)
+    val opt     = protobuf.getOptions()
+    val pkg  = if (opt.hasJavaPackage() && opt.getJavaPackage() != "") opt.getJavaPackage() else protobuf.getPackage()
+    val name =
+      if (opt.hasJavaOuterClassname() && opt.getJavaOuterClassname() != "") opt.getJavaOuterClassname()
+      else protobuf.getName()
+    val pkgPath = if (pkg == "") Nil else pkg.split('.').toList
+
+    Code.Files {
+      protobuf.getServices().asScala.toList.map { s =>
+        fromService(s, pkgPath, if (name.endsWith(".proto")) name.dropRight(6) else name, imports)
+      }
+    }
+  }
+
+  private def fromService(
+    service: Descriptors.ServiceDescriptor,
+    pkg: List[String],
+    name: String,
+    imports: List[Code.Import],
+  ): Code.File = {
+    val className = service.getName().capitalize
+    val obj       = objFromService(service)
+    Code.File(
+      path = pkg ++ List(name, s"$className.scala"),
+      pkgPath = List(name),
+      imports = (Code.Import("zio.http.endpoint.grpc.GRPC._") :: Code.Import
+        .FromBase(s"$name._") :: Code.Import.FromBase(s"$name.Schemas._") :: imports).distinct,
+      objects = List(obj),
+      caseClasses = Nil,
+      enums = Nil,
+    )
+  }
+
+  private def objFromService(service: Descriptors.ServiceDescriptor): Code.Object = {
+    val name      = service.getName()
+    val endpoints = service.getMethods.asScala.toList.map { m =>
+      Code.Field(m.getName()) -> endpoint(name, m)
+    }
+    val obj       = Code.Object(
+      name.capitalize,
+      schema = false,
+      endpoints = endpoints.toMap,
+      objects = Nil,
+      caseClasses = Nil,
+      enums = Nil,
+    )
+    obj
+  }
+
+  private def endpoint(
+    service: String,
+    method: Descriptors.MethodDescriptor,
+  ): Code.EndpointCode = {
+    val pathSegments = List(service, method.getName()).map(Code.PathSegmentCode.apply)
+    val imports      = Nil
+    val endpoint     = Code.EndpointCode(
+      method = Method.POST,
+      pathPatternCode = Code.PathPatternCode(pathSegments),
+      queryParamsCode = Set.empty,
+      headersCode = Code.HeadersCode.empty,
+      inCode = Code.InCode(method.getInputType().getName()).copy(streaming = method.isClientStreaming()),
+      outCodes = List(
+        Code.OutCode(
+          method.getOutputType().getName(),
+          zio.http.Status.Ok,
+          Some("application/grpc"),
+          None,
+          method.isServerStreaming(),
+        ),
+      ),
+      errorsCode = Nil,
+    )
+    endpoint
+  }
+
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/grpc/Protobuf.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/grpc/Protobuf.scala
@@ -1,0 +1,17 @@
+package zio.http.gen.grpc
+
+sealed trait Protobuf
+
+object Protobuf {
+
+  case class File(name: String, pkgPath: List[String], dependencies: List[String], services: List[Service])
+      extends Protobuf
+  case class Service(name: String, methods: List[Method]) extends Protobuf
+  case class Method(
+    name: String,
+    inputType: String,
+    outputType: String,
+    clientStreaming: Boolean,
+    serverStreaming: Boolean,
+  ) extends Protobuf
+}

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -238,6 +238,7 @@ final case class EndpointGen() {
               status = status,
               mediaType = Some("application/json"),
               doc = None,
+              false,
             )
         case (OpenAPI.StatusOrDefault.StatusValue(status), OpenAPI.ReferenceOr.Or(response: OpenAPI.Response))    =>
           val (imports, code) =
@@ -283,6 +284,7 @@ final case class EndpointGen() {
             status = status,
             mediaType = Some("application/json"),
             doc = None,
+            false,
           )
       }.unzip
 
@@ -292,7 +294,7 @@ final case class EndpointGen() {
       pathPatternCode = Code.PathPatternCode(segments),
       queryParamsCode = queryParams,
       headersCode = Code.HeadersCode(headers),
-      inCode = Code.InCode(inType, None, None),
+      inCode = Code.InCode(inType),
       outCodes = outCodes.filterNot(_.status.isError).toList,
       errorsCode = outCodes.filter(_.status.isError).toList,
     )

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -238,7 +238,7 @@ final case class EndpointGen() {
               status = status,
               mediaType = Some("application/json"),
               doc = None,
-              false,
+              streaming = false,
             )
         case (OpenAPI.StatusOrDefault.StatusValue(status), OpenAPI.ReferenceOr.Or(response: OpenAPI.Response))    =>
           val (imports, code) =
@@ -284,7 +284,7 @@ final case class EndpointGen() {
             status = status,
             mediaType = Some("application/json"),
             doc = None,
-            false,
+            streaming = false,
           )
       }.unzip
 

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -133,7 +133,7 @@ object Code {
   }
   final case class QueryParamCode(name: String, queryType: CodecType)
   final case class HeadersCode(headers: List[HeaderCode])
-  object HeadersCode     { val empty: HeadersCode = HeadersCode(Nil)                             }
+  object HeadersCode     { val empty: HeadersCode = HeadersCode(Nil)                                         }
   final case class HeaderCode(name: String)
   final case class InCode(
     inType: String,
@@ -141,7 +141,7 @@ object Code {
     doc: Option[String],
     streaming: Boolean,
   )
-  object InCode          { def apply(inType: String): InCode = InCode(inType, None, None, false) }
+  object InCode          { def apply(inType: String): InCode = InCode(inType, None, None, streaming = false) }
   final case class OutCode(
     outType: String,
     status: Status,
@@ -150,8 +150,9 @@ object Code {
     streaming: Boolean,
   )
   object OutCode         {
-    def apply(outType: String, status: Status): OutCode = OutCode(outType, status, None, None, false)
-    def json(outType: String, status: Status): OutCode = OutCode(outType, status, Some("application/json"), None, false)
+    def apply(outType: String, status: Status): OutCode = OutCode(outType, status, None, None, streaming = false)
+    def json(outType: String, status: Status): OutCode  =
+      OutCode(outType, status, Some("application/json"), None, streaming = false)
   }
 
 }

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -133,23 +133,25 @@ object Code {
   }
   final case class QueryParamCode(name: String, queryType: CodecType)
   final case class HeadersCode(headers: List[HeaderCode])
-  object HeadersCode     { val empty: HeadersCode = HeadersCode(Nil)                      }
+  object HeadersCode     { val empty: HeadersCode = HeadersCode(Nil)                             }
   final case class HeaderCode(name: String)
   final case class InCode(
     inType: String,
     name: Option[String],
     doc: Option[String],
+    streaming: Boolean,
   )
-  object InCode          { def apply(inType: String): InCode = InCode(inType, None, None) }
+  object InCode          { def apply(inType: String): InCode = InCode(inType, None, None, false) }
   final case class OutCode(
     outType: String,
     status: Status,
     mediaType: Option[String],
     doc: Option[String],
+    streaming: Boolean,
   )
   object OutCode         {
-    def apply(outType: String, status: Status): OutCode = OutCode(outType, status, None, None)
-    def json(outType: String, status: Status): OutCode  = OutCode(outType, status, Some("application/json"), None)
+    def apply(outType: String, status: Status): OutCode = OutCode(outType, status, None, None, false)
+    def json(outType: String, status: Status): OutCode = OutCode(outType, status, Some("application/json"), None, false)
   }
 
 }

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -295,29 +295,38 @@ object CodeGen {
       imports -> s""".query(QueryCodec.queryTo[$tpe]("$name"))"""
   }
 
-  def renderInCode(inCode: Code.InCode): String = inCode match {
-    case Code.InCode(inType, Some(name), Some(doc)) =>
-      s""".in[$inType](name = "$name", doc = md""\"$doc"\"")"""
-    case Code.InCode(inType, Some(name), None)      =>
-      s""".in[$inType](name = "$name")"""
-    case Code.InCode(inType, None, Some(doc))       =>
-      s""".in[$inType](doc = md""\"$doc"\"")"""
-    case Code.InCode(inType, None, None)            =>
-      s".in[$inType]"
+  def renderInCode(inCode: Code.InCode): String = {
+    val stream = if (inCode.streaming) "Stream" else ""
+    inCode match {
+      case Code.InCode(inType, Some(name), Some(doc), _) =>
+        s""".in$stream[$inType](name = "$name", doc = md""\"$doc"\"")"""
+      case Code.InCode(inType, Some(name), None, _)      =>
+        s""".in$stream[$inType](name = "$name")"""
+      case Code.InCode(inType, None, Some(doc), _)       =>
+        s""".in$stream[$inType](doc = md""\"$doc"\"")"""
+      case Code.InCode(inType, None, None, _)            =>
+        s".in$stream[$inType]"
+    }
   }
 
-  def renderOutCode(outCode: Code.OutCode): String = outCode match {
-    case Code.OutCode(outType, status, _, Some(doc)) =>
-      s""".out[$outType](status = Status.$status, doc = md""\"$doc"\"")"""
-    case Code.OutCode(outType, status, _, None)      =>
-      s""".out[$outType](status = Status.$status)"""
+  def renderOutCode(outCode: Code.OutCode): String = {
+    val stream = if (outCode.streaming) "Stream" else ""
+    outCode match {
+      case Code.OutCode(outType, status, _, Some(doc), _) =>
+        s""".out$stream[$outType](status = Status.$status, doc = md""\"$doc"\"")"""
+      case Code.OutCode(outType, status, _, None, _)      =>
+        s""".out$stream[$outType](status = Status.$status)"""
+    }
   }
 
-  def renderOutErrorCode(errOutCode: Code.OutCode): String = errOutCode match {
-    case Code.OutCode(outType, status, _, Some(doc)) =>
-      s""".outError[$outType](status = Status.$status, doc = md""\"$doc"\"")"""
-    case Code.OutCode(outType, status, _, None)      =>
-      s""".outError[$outType](status = Status.$status)"""
+  def renderOutErrorCode(errOutCode: Code.OutCode): String = {
+    val stream = if (errOutCode.streaming) "Stream" else ""
+    errOutCode match {
+      case Code.OutCode(outType, status, _, Some(doc), _) =>
+        s""".outError$stream[$outType](status = Status.$status, doc = md""\"$doc"\"")"""
+      case Code.OutCode(outType, status, _, None, _)      =>
+        s""".outError$stream[$outType](status = Status.$status)"""
+    }
   }
 
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/grpc/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/grpc/EndpointGenSpec.scala
@@ -1,0 +1,171 @@
+package zio.http.gen.grpc
+
+import java.nio.file._
+
+import scala.jdk.CollectionConverters._
+
+import zio._
+import zio.test._
+
+import zio.http._
+import zio.http.codec.HeaderCodec
+import zio.http.codec.HttpCodec.{query, queryInt}
+import zio.http.endpoint._
+import zio.http.gen.model._
+import zio.http.gen.scala.Code
+import zio.http.gen.scala.Code.Collection.Opt
+
+import com.google.protobuf.{DescriptorProtos, Descriptors}
+
+object EndpointGenSpec extends ZIOSpecDefault {
+
+  def toDescriptor(
+    file: DescriptorProtos.FileDescriptorProto,
+    imports: Array[Descriptors.FileDescriptor] = Array.empty,
+  ): Descriptors.FileDescriptor = {
+    Descriptors.FileDescriptor.buildFrom(file, imports, true)
+  }
+
+  def file(
+    name: String,
+    services: List[DescriptorProtos.ServiceDescriptorProto],
+  ): DescriptorProtos.FileDescriptorProto = {
+    val builder = DescriptorProtos.FileDescriptorProto.newBuilder
+    builder.setName(name)
+    builder.addAllService(services.toSeq.asJava)
+    builder.build
+  }
+
+  def service(
+    name: String,
+    methods: List[DescriptorProtos.MethodDescriptorProto],
+  ): DescriptorProtos.ServiceDescriptorProto = {
+    val builder = DescriptorProtos.ServiceDescriptorProto.newBuilder
+    builder.setName(name)
+    builder.addAllMethod(methods.toSeq.asJava)
+    builder.build
+  }
+
+  def method(name: String, in: String, out: String): DescriptorProtos.MethodDescriptorProto = {
+    val builder = DescriptorProtos.MethodDescriptorProto.newBuilder
+    builder.setName(name)
+    builder.setInputType(in)
+    builder.setOutputType(out)
+    builder.build
+  }
+
+  def protobuf(in: String, out: String, imports: Array[Descriptors.FileDescriptor] = Array.empty) =
+    toDescriptor(
+      file(
+        "api",
+        service(
+          "v1",
+          method(
+            "users",
+            in,
+            out,
+          ) :: Nil,
+        ) :: Nil,
+      ),
+      imports,
+    )
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("EndpointGenSpec")(
+      test("right package and file name") {
+        val scala     = EndpointGen.fromProtobuf(protobuf("Unit", "Unit"))
+        val filePath  = Paths.get("/api", "V1.scala")
+        val pkgPath   = List("api")
+        val firstFile = scala.files.head
+        assertTrue(firstFile.pkgPath == pkgPath, firstFile.path.mkString("/", "/", "") == filePath.toString)
+      },
+      test("request and response") {
+        val scala    = EndpointGen.fromProtobuf(protobuf("Request", "Response"))
+        val expected = Code.File(
+          List("api", "V1.scala"),
+          pkgPath = List("api"),
+          imports = List(
+            Code.Import("zio.http.endpoint.grpc.GRPC._"),
+            Code.Import.FromBase(path = "api._"),
+            Code.Import.FromBase(path = "api.Schemas._"),
+          ),
+          objects = List(
+            Code.Object(
+              "V1",
+              Map(
+                Code.Field("users") -> Code.EndpointCode(
+                  Method.POST,
+                  Code.PathPatternCode(segments = List(Code.PathSegmentCode("v1"), Code.PathSegmentCode("users"))),
+                  queryParamsCode = Set.empty,
+                  headersCode = Code.HeadersCode.empty,
+                  inCode = Code.InCode("Request"),
+                  outCodes = List(
+                    Code.OutCode(
+                      outType = "Response",
+                      status = Status.Ok,
+                      mediaType = Some("application/grpc"),
+                      doc = None,
+                      streaming = false,
+                    ),
+                  ),
+                  errorsCode = Nil,
+                ),
+              ),
+            ),
+          ),
+          Nil,
+          Nil,
+        )
+        assertTrue(scala.files.head == expected)
+      },
+      test("adding imports") {
+        val dependency =
+          toDescriptor(
+            file(
+              "dep",
+              Nil,
+            ),
+          )
+        val scala      = EndpointGen.fromProtobuf(protobuf("Request", "Response", Array(dependency)))
+        val expected   = Code.File(
+          List("api", "V1.scala"),
+          pkgPath = List("api"),
+          imports = List(
+            Code.Import("zio.http.endpoint.grpc.GRPC._"),
+            Code.Import.FromBase(path = "api._"),
+            Code.Import.FromBase(path = "api.Schemas._"),
+            Code.Import.FromBase(path = "dep._"),
+            Code.Import.FromBase(path = "dep.Schemas._"),
+          ),
+          objects = List(
+            Code.Object(
+              "V1",
+              Map(
+                Code.Field("users") -> Code.EndpointCode(
+                  Method.POST,
+                  Code.PathPatternCode(segments = List(Code.PathSegmentCode("v1"), Code.PathSegmentCode("users"))),
+                  queryParamsCode = Set.empty,
+                  headersCode = Code.HeadersCode.empty,
+                  inCode = Code.InCode("Request"),
+                  outCodes = List(
+                    Code.OutCode(
+                      outType = "Response",
+                      status = Status.Ok,
+                      mediaType = Some("application/grpc"),
+                      doc = None,
+                      streaming = false,
+                    ),
+                  ),
+                  errorsCode = Nil,
+                ),
+              ),
+            ),
+          ),
+          Nil,
+          Nil,
+        )
+        assertTrue(scala.files.head == expected)
+      },
+    )
+
+}

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/grpc/GRPCSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/grpc/GRPCSpec.scala
@@ -1,0 +1,43 @@
+package zio.http.endpoint.grpc
+
+import zio.test._
+
+import zio.schema._
+
+import zio.http._
+import zio.http.codec.HttpContentCodec
+
+object GRPCSpec extends ZIOSpecDefault {
+
+  import zio.http.endpoint.grpc.GRPC._
+
+  case class Person(name: String, id: Int)
+
+  implicit val schema: Schema[Person] = DeriveSchema.gen[Person]
+
+  val codec = implicitly[HttpContentCodec[Person]]
+
+  override def spec =
+    suite("GRPC imports")(
+      test("correct mediatype") {
+
+        assertTrue(!codec.lookup(MediaType.parseCustomMediaType("application/grpc").get).isEmpty)
+
+      },
+      test("encode and decode") {
+        import zio.http.endpoint.grpc.GRPC.fromSchema
+
+        val person   = Person("somePerson", 1)
+        val encoded  = codec.encode(person).getOrElse(Body.empty)
+        val response = Response(
+          Status.Ok,
+          Headers(Header.ContentType(MediaType.parseCustomMediaType("application/grpc").get)),
+          encoded,
+        )
+        for {
+          decoded <- codec.decodeResponse(response)
+        } yield assertTrue(decoded == person)
+      },
+    )
+
+}

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
@@ -6,7 +6,7 @@ import zio.schema.Schema
 import zio.schema.codec.ProtobufCodec
 
 import zio.http.MediaType
-import zio.http.codec.HttpContentCodec
+import zio.http.codec.{BinaryCodecWithSchema, HttpContentCodec}
 
 object GRPC {
 
@@ -14,9 +14,8 @@ object GRPC {
     HttpContentCodec(
       ListMap(
         MediaType.parseCustomMediaType("application/grpc").get ->
-          ProtobufCodec.protobufCodec[A],
+          BinaryCodecWithSchema(ProtobufCodec.protobufCodec[A], schema),
       ),
-      schema,
     )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
@@ -1,0 +1,22 @@
+package zio.http.endpoint.grpc
+
+import scala.collection.immutable.ListMap
+
+import zio.schema.Schema
+import zio.schema.codec.ProtobufCodec
+
+import zio.http.MediaType
+import zio.http.codec.HttpContentCodec
+
+object GRPC {
+
+  implicit def fromSchema[A](implicit schema: Schema[A]): HttpContentCodec[A] =
+    HttpContentCodec(
+      ListMap(
+        MediaType.parseCustomMediaType("application/grpc").get ->
+          ProtobufCodec.protobufCodec[A],
+      ),
+      schema,
+    )
+
+}


### PR DESCRIPTION
/claim #1521

Generates ZIO Http endpoints from services with the Protobuf codec from ZIO Schema. Messages can be generated with scalapb. Technically, it could be already published as a sbt plugin using the project `sbt-zio-http-grpc`, but I think that it could make more sense to have a common sbt plugin with the OpenAPI generator.