### PR TITLE
bump netty

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.Keys.scalaVersion
 
 object Dependencies {
   val JwtCoreVersion                = "9.1.1"
-  val NettyVersion                  = "4.1.101.Final"
+  val NettyVersion                  = "4.1.109.Final"
   val NettyIncubatorVersion         = "0.0.24.Final"
   val ScalaCompactCollectionVersion = "2.11.0"
   val ZioVersion                    = "2.0.22"


### PR DESCRIPTION
because netty has a CVE : https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-29025