### PR TITLE
Simplify running ZIO effects

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponseEncoder.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponseEncoder.scala
@@ -29,15 +29,11 @@ import io.netty.handler.codec.http._
 private[zio] object NettyResponseEncoder {
   private val dateHeaderCache = CachedDateHeader.default
 
-  def encode(
-    ctx: ChannelHandlerContext,
-    response: Response,
-    runtime: NettyRuntime,
-  )(implicit unsafe: Unsafe, trace: Trace): HttpResponse = {
+  def encode(response: Response)(implicit unsafe: Unsafe): HttpResponse = {
     val body = response.body
     if (body.isComplete) {
-      val bytes = runtime.runtime(ctx).unsafe.run(body.asArray).getOrThrow()
-      fastEncode(response, bytes)
+      assert(body.isInstanceOf[Body.UnsafeBytes], "expected completed body to implement UnsafeBytes")
+      fastEncode(response, body.asInstanceOf[Body.UnsafeBytes].unsafeAsArray)
     } else {
       val status   = response.status
       val jHeaders = Conversions.headersToNetty(response.headers)


### PR DESCRIPTION
Heya folks, I've noticed that there are a few places where ZIO effects are run "synchronously" either unnecessarily or not composed together, so I thought to make a PR for it.

Also, I removed the `NettyRuntime#runtime` method as discussed here: https://github.com/zio/zio-http/pull/2800#discussion_r1579175167. This also allows us to do an ultra-micro-optimization by not having to create the `Runtime#UnsafeAPI` on each invocation of `run`