### PR TITLE
Fix gen schema with scala keywords as fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -288,6 +288,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
+      scalameta % Test,
     ),
   )
   .dependsOn(zioHttpJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      scalameta.cross(CrossVersion.for3Use2_13),
+      scalameta % Test,
     ),
   )
   .dependsOn(zioHttpJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      scalameta % Test,
+      scalameta,
     ),
   )
   .dependsOn(zioHttpJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      scalameta % Test,
+      scalametaParsers.cross(CrossVersion.for3Use2_13).exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
     ),
   )
   .dependsOn(zioHttpJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -288,7 +288,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test`,
       `zio-test-sbt`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      scalameta,
+      scalameta.cross(CrossVersion.for3Use2_13),
     ),
   )
   .dependsOn(zioHttpJVM)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
   val scalafmt = "org.scalameta" %% "scalafmt-dynamic" % "3.8.1"
-  val scalameta = "org.scalameta" %% "scalameta" % "4.9.3"
+  val scalametaParsers = "org.scalameta" %% "parsers" % "4.9.3"
 
   val netty =
     Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
   val scalafmt = "org.scalameta" %% "scalafmt-dynamic" % "3.8.1"
+  val scalameta = "org.scalameta" %% "scalameta" % "4.9.3"
 
   val netty =
     Seq(

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -2,6 +2,9 @@ package zio.http.gen.scala
 
 import java.nio.file.Path
 
+import scala.meta.Term
+import scala.meta.prettyprinters.XtensionSyntax
+
 import zio.http.{Method, Status}
 
 sealed trait Code extends Product with Serializable
@@ -81,61 +84,9 @@ object Code {
 
   object Field {
 
-    // copied from scalameta scala.meta.tokens.Token (lines 55-99)
-    // I tried using `scala.meta.Term.Name(name).syntax`,
-    // but cross version build seems to be broken for scala 3 when scalameta dependency is added.
-    // Perhaps reflection can be used instead of manually hard coding the full list of keywords,
-    // but probably not worth the hassle…
-    private[this] val keywords = Set(
-      "abstract",
-      "case",
-      "catch",
-      "class",
-      "def",
-      "do",
-      "else",
-      "enum",
-      "export",
-      "extends",
-      "false",
-      "final",
-      "finally",
-      "for",
-      "forSome",
-      "given",
-      "if",
-      "implicit",
-      "import",
-      "lazy",
-      "match",
-      "macro",
-      "new",
-      "null",
-      "object",
-      "override",
-      "package",
-      "private",
-      "protected",
-      "return",
-      "sealed",
-      "super",
-      "then",
-      "this",
-      "throw",
-      "trait",
-      "true",
-      "try",
-      "type",
-      "val",
-      "var",
-      "while",
-      "with",
-      "yield",
-    )
-
     def apply(name: String): Field                       = apply(name, ScalaType.Inferred)
     def apply(name: String, fieldType: ScalaType): Field = {
-      val validScalaTermName = if (keywords(name)) s"`$name`" else name
+      val validScalaTermName = Term.Name(name).syntax
       new Field(validScalaTermName, fieldType) {}
     }
   }

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -80,10 +80,63 @@ object Code {
   }
 
   object Field {
+
+    // copied from scalameta scala.meta.tokens.Token (lines 55-99)
+    // I tried using `scala.meta.Term.Name(name).syntax`,
+    // but cross version build seems to be broken for scala 3 when scalameta dependency is added.
+    // Perhaps reflection can be used instead of manually hard coding the full list of keywords,
+    // but probably not worth the hassle…
+    private[this] val keywords = Set(
+      "abstract",
+      "case",
+      "catch",
+      "class",
+      "def",
+      "do",
+      "else",
+      "enum",
+      "export",
+      "extends",
+      "false",
+      "final",
+      "finally",
+      "for",
+      "forSome",
+      "given",
+      "if",
+      "implicit",
+      "import",
+      "lazy",
+      "match",
+      "macro",
+      "new",
+      "null",
+      "object",
+      "override",
+      "package",
+      "private",
+      "protected",
+      "return",
+      "sealed",
+      "super",
+      "then",
+      "this",
+      "throw",
+      "trait",
+      "true",
+      "try",
+      "type",
+      "val",
+      "var",
+      "while",
+      "with",
+      "yield",
+    )
+
     def apply(name: String): Field                       = apply(name, ScalaType.Inferred)
     def apply(name: String, fieldType: ScalaType): Field = {
-      // using scalameta to ensure name is valid (keywords wrapped with backticks)
-      new Field(scala.meta.Term.Name(name).syntax, fieldType) {}
+      val validScalaTermName = if (keywords(name)) s"`$name`" else name
+      new Field(validScalaTermName, fieldType) {}
     }
   }
 

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -74,10 +74,17 @@ object Code {
     schema: Boolean = true,
   ) extends ScalaType
 
-  final case class Field(name: String, fieldType: ScalaType) extends Code
+  sealed abstract case class Field private(name: String, fieldType: ScalaType) extends Code {
+    // only allow copy on fieldType, since name is mangled to be valid in smart constructor
+    def copy(fieldType: ScalaType): Field = new Field(name, fieldType) {}
+  }
 
   object Field {
-    def apply(name: String): Field = Field(name, ScalaType.Inferred)
+    def apply(name: String): Field = apply(name, ScalaType.Inferred)
+    def apply(name: String, fieldType: ScalaType): Field = {
+      // using scalameta to ensure name is valid (keywords wrapped with backticks)
+      new Field(scala.meta.Term.Name(name).syntax, fieldType){}
+    }
   }
 
   sealed trait Collection extends ScalaType {

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -74,16 +74,16 @@ object Code {
     schema: Boolean = true,
   ) extends ScalaType
 
-  sealed abstract case class Field private(name: String, fieldType: ScalaType) extends Code {
+  sealed abstract case class Field private (name: String, fieldType: ScalaType) extends Code {
     // only allow copy on fieldType, since name is mangled to be valid in smart constructor
     def copy(fieldType: ScalaType): Field = new Field(name, fieldType) {}
   }
 
   object Field {
-    def apply(name: String): Field = apply(name, ScalaType.Inferred)
+    def apply(name: String): Field                       = apply(name, ScalaType.Inferred)
     def apply(name: String, fieldType: ScalaType): Field = {
       // using scalameta to ensure name is valid (keywords wrapped with backticks)
-      new Field(scala.meta.Term.Name(name).syntax, fieldType){}
+      new Field(scala.meta.Term.Name(name).syntax, fieldType) {}
     }
   }
 

--- a/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyWithKeywordsInline.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyWithKeywordsInline.scala
@@ -1,0 +1,52 @@
+package test.api.v1
+
+import test.component._
+
+object Keywords {
+import zio.http._
+import zio.http.endpoint._
+import zio.http.codec._
+val post = Endpoint(Method.POST / "api" / "v1" / "keywords")
+
+
+  .in[POST.RequestBody]
+  .out[POST.ResponseBody](status = Status.Ok)
+
+
+object POST {
+
+
+
+case class RequestBody(
+`lazy`: Boolean,
+`case`: String,
+`match`: String,
+)
+object RequestBody {
+
+
+
+ implicit val codec: Schema[RequestBody] = DeriveSchema.gen[RequestBody]
+
+
+
+}
+case class ResponseBody(
+`protected`: Boolean,
+`trait`: String,
+`type`: String,
+)
+object ResponseBody {
+
+
+
+ implicit val codec: Schema[ResponseBody] = DeriveSchema.gen[ResponseBody]
+
+
+
+}
+
+}
+
+
+}

--- a/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyWithKeywordsInline.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyWithKeywordsInline.scala
@@ -3,50 +3,36 @@ package test.api.v1
 import test.component._
 
 object Keywords {
-import zio.http._
-import zio.http.endpoint._
-import zio.http.codec._
-val post = Endpoint(Method.POST / "api" / "v1" / "keywords")
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  val post = Endpoint(Method.POST / "api" / "v1" / "keywords")
+    .in[POST.RequestBody]
+    .out[POST.ResponseBody](status = Status.Ok)
 
+  object POST {
 
-  .in[POST.RequestBody]
-  .out[POST.ResponseBody](status = Status.Ok)
+    case class RequestBody(
+      `lazy`: Boolean,
+      `case`: String,
+      `match`: String,
+    )
+    object RequestBody {
 
+      implicit val codec: Schema[RequestBody] = DeriveSchema.gen[RequestBody]
 
-object POST {
+    }
+    case class ResponseBody(
+      `protected`: Boolean,
+      `trait`: String,
+      `type`: String,
+    )
+    object ResponseBody {
 
+      implicit val codec: Schema[ResponseBody] = DeriveSchema.gen[ResponseBody]
 
+    }
 
-case class RequestBody(
-`lazy`: Boolean,
-`case`: String,
-`match`: String,
-)
-object RequestBody {
-
-
-
- implicit val codec: Schema[RequestBody] = DeriveSchema.gen[RequestBody]
-
-
-
-}
-case class ResponseBody(
-`protected`: Boolean,
-`trait`: String,
-`type`: String,
-)
-object ResponseBody {
-
-
-
- implicit val codec: Schema[ResponseBody] = DeriveSchema.gen[ResponseBody]
-
-
-
-}
-
-}
-
+  }
 
 }

--- a/zio-http-gen/src/test/resources/inline_schema_with_keywords.json
+++ b/zio-http-gen/src/test/resources/inline_schema_with_keywords.json
@@ -1,0 +1,85 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "",
+    "version" : ""
+  },
+  "paths" : {
+    "/api/v1/keywords" : {
+      "post" : {
+        "requestBody" :
+        {
+          "content" : {
+            "application/json" : {
+              "schema" :
+              {
+                "type" :
+                "object",
+                "properties" : {
+                  "lazy" : {
+                    "type" :
+                    "boolean"
+                  },
+                  "case" : {
+                    "type" :
+                    "string"
+                  },
+                  "match" : {
+                    "type" :
+                    "string"
+                  }
+                },
+                "additionalProperties" :
+                true,
+                "required" : [
+                  "lazy",
+                  "case",
+                  "match"
+                ]
+              }
+
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" :
+          {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" :
+                {
+                  "type" :
+                  "object",
+                  "properties" : {
+                    "protected" : {
+                      "type" :
+                      "boolean"
+                    },
+                    "trait" : {
+                      "type" :
+                      "string"
+                    },
+                    "type" : {
+                      "type" :
+                      "string"
+                    }
+                  },
+                  "additionalProperties" :
+                  true,
+                  "required" : [
+                    "protected",
+                    "trait",
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : false
+      }
+    }
+  }
+}

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -2,10 +2,16 @@ package zio.http.gen.scala
 
 import java.io.File
 import java.nio.file._
+
 import scala.jdk.CollectionConverters._
+import scala.meta._
+import scala.meta.internal.tokens.fixed
+import scala.util.{Failure, Success, Try}
+
 import zio.Scope
 import zio.test.TestAspect.flaky
 import zio.test._
+
 import zio.http._
 import zio.http.codec._
 import zio.http.endpoint.Endpoint
@@ -14,18 +20,14 @@ import zio.http.endpoint.openapi.{OpenAPI, OpenAPIGen}
 import zio.http.gen.model._
 import zio.http.gen.openapi.EndpointGen
 
-import scala.meta._
-import scala.meta.internal.tokens.fixed
-import scala.util.{Failure, Success, Try}
-
 object CodeGenSpec extends ZIOSpecDefault {
 
   private def fileShouldBe(dir: java.nio.file.Path, subPath: String, expectedFile: String): TestResult = {
-    val filePath      = dir.resolve(Paths.get(subPath))
-    val generated     = Files.readAllLines(filePath).asScala.mkString("\n")
+    val filePath  = dir.resolve(Paths.get(subPath))
+    val generated = Files.readAllLines(filePath).asScala.mkString("\n")
     isValidScala(generated) && {
-      val url = getClass.getResource(expectedFile)
-      val expected = java.nio.file.Paths.get(url.toURI.getPath)
+      val url           = getClass.getResource(expectedFile)
+      val expected      = java.nio.file.Paths.get(url.toURI.getPath)
       val expectedLines = Files.readAllLines(expected).asScala.mkString("\n")
       assertTrue(generated == expectedLines)
     }
@@ -229,7 +231,10 @@ object CodeGenSpec extends ZIOSpecDefault {
       },
       test("OpenAPI spec with inline schema request and response body containing scala keywords") {
         val openAPIString =
-          Files.readAllLines(Paths.get(getClass.getResource("/inline_schema_with_keywords.json").toURI)).asScala.mkString("\n")
+          Files
+            .readAllLines(Paths.get(getClass.getResource("/inline_schema_with_keywords.json").toURI))
+            .asScala
+            .mkString("\n")
         val openAPI       = OpenAPI.fromJson(openAPIString).getOrElse(OpenAPI.empty)
         val code          = EndpointGen.fromOpenAPI(openAPI)
 

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -15,6 +15,7 @@ import zio.http.gen.model._
 import zio.http.gen.openapi.EndpointGen
 
 import scala.meta._
+import scala.meta.internal.tokens.fixed
 import scala.util.{Failure, Success, Try}
 
 object CodeGenSpec extends ZIOSpecDefault {
@@ -234,7 +235,7 @@ object CodeGenSpec extends ZIOSpecDefault {
 
         val tempDir = Files.createTempDirectory("codegen")
 
-        CodeGen.writeFiles(code, java.nio.file.Paths.get(tempDir.toString, "test"), "test", None)
+        CodeGen.writeFiles(code, java.nio.file.Paths.get(tempDir.toString, "test"), "test", Some(scalaFmtPath))
 
         fileShouldBe(tempDir, "test/api/v1/Keywords.scala", "/EndpointWithRequestResponseBodyWithKeywordsInline.scala")
       } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3


### PR DESCRIPTION
I needed to generate schema from an API that contained a field named `type`, resulting with generated code that looked like:
![Screenshot 2024-05-12 at 22 48 18](https://github.com/zio/zio-http/assets/881075/b17464f0-d68a-4b0b-80f6-57c52dced74b)
which obviously won't compile.

I added scalameta dependency, and using that to escape keyword with backticks.

PR has the following commits:
- adding a failed test
- fixing code to escape keywords, to make the test pass
- everything else is just battling build & CI 🤷‍♂️ 