### PR TITLE
Run Benchmark Tests Only for Pull Request Events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,7 @@ jobs:
 
   runBenchmarks-simple:
     name: Performance Benchmarks (PlainTextBenchmarkServer)
+    if: ${{ github.event_name == 'pull_request'}}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -770,6 +771,7 @@ jobs:
 
   runBenchmarks-effectful:
     name: Performance Benchmarks (SimpleEffectBenchmarkServer)
+    if: ${{ github.event_name == 'pull_request'}}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/project/BenchmarkWorkFlow.scala
+++ b/project/BenchmarkWorkFlow.scala
@@ -23,9 +23,9 @@ object BenchmarkWorkFlow {
       id = id,
       name = name,
       oses = List("ubuntu-latest"),
-//      cond = Some(
-//        "${{ github.event_name == 'pull_request'}}",
-//      ),
+      cond = Some(
+        "${{ github.event_name == 'pull_request'}}",
+      ),
       scalas = List(Scala213),
       steps = List(
         WorkflowStep.Run(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val NettyIncubatorVersion         = "0.0.24.Final"
   val ScalaCompactCollectionVersion = "2.11.0"
   val ZioVersion                    = "2.0.22"
-  val ZioCliVersion                 = "0.6.0"
+  val ZioCliVersion                 = "0.5.0"
   val ZioSchemaVersion              = "1.1.1"
   val SttpVersion                   = "3.3.18"
   val ZioConfigVersion              = "4.0.2"


### PR DESCRIPTION
Currently benchmark tests are triggered on main events that are meaningless.

cc @987Nabil 