### PR TITLE
[gen] fix codegen to reference subtypes nested with their encapsulating object when referenced directly

### DIFF
--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -235,8 +235,7 @@ final case class EndpointGen(config: Config) {
    * @param f
    *   a function that may alter the type, None means no altering is needed.
    * @return
-   *   [[scala.Option]] of the altered type, or None if no modification was
-   *   needed.
+   *   The altered type, or gives back the input if no modification was needed.
    */
   def mapTypeRef(sType: Code.ScalaType)(f: Code.TypeRef => Code.TypeRef): Code.ScalaType =
     sType match {

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -235,7 +235,8 @@ final case class EndpointGen(config: Config) {
    * @param f
    *   a function that may alter the type, None means no altering is needed.
    * @return
-   *   [[Option]] of the altered type, or None if no modification was needed.
+   *   [[scala.Option]] of the altered type, or None if no modification was
+   *   needed.
    */
   def mapTypeRef(sType: Code.ScalaType)(f: Code.TypeRef => Code.TypeRef): Code.ScalaType =
     sType match {
@@ -252,7 +253,7 @@ final case class EndpointGen(config: Config) {
    * structure recursively.
    *
    * @param f
-   *   function to transform a [[Code.CaseClass]]
+   *   function to transform a [[zio.http.gen.scala.Code.CaseClass]]
    * @param code
    *   the structure to apply transformation of case classes on
    * @return

--- a/zio-http-gen/src/test/resources/ComponentAnimalWithFieldsReferencingSubs.scala
+++ b/zio-http-gen/src/test/resources/ComponentAnimalWithFieldsReferencingSubs.scala
@@ -1,0 +1,36 @@
+package test.component
+
+import zio.schema._
+import zio.schema.annotation._
+import zio.Chunk
+
+@noDiscriminator
+sealed trait Animal {
+  def age: Int
+  def weight: Float
+}
+object Animal       {
+
+  implicit val codec: Schema[Animal] = DeriveSchema.gen[Animal]
+  case class Alligator(
+    age: Int,
+    weight: Float,
+    num_teeth: Int,
+  ) extends Animal
+  object Alligator {
+
+    implicit val codec: Schema[Alligator] = DeriveSchema.gen[Alligator]
+
+  }
+  case class Zebra(
+    age: Int,
+    weight: Float,
+    num_stripes: Int,
+    dazzle: Chunk[Zebra],
+  ) extends Animal
+  object Zebra {
+
+    implicit val codec: Schema[Zebra] = DeriveSchema.gen[Zebra]
+
+  }
+}

--- a/zio-http-gen/src/test/resources/ComponentLion.scala
+++ b/zio-http-gen/src/test/resources/ComponentLion.scala
@@ -1,0 +1,12 @@
+package test.component
+
+import zio.schema._
+
+case class Lion(
+  eats: Animal.Zebra,
+)
+object Lion {
+
+  implicit val codec: Schema[Lion] = DeriveSchema.gen[Lion]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentLion.scala
+++ b/zio-http-gen/src/test/resources/ComponentLion.scala
@@ -4,6 +4,7 @@ import zio.schema._
 
 case class Lion(
   eats: Animal.Zebra,
+  enemy: Option[Animal.Alligator],
 )
 object Lion {
 

--- a/zio-http-gen/src/test/resources/inline_schema_sumtype_with_subtype_referenced_directly.yaml
+++ b/zio-http-gen/src/test/resources/inline_schema_sumtype_with_subtype_referenced_directly.yaml
@@ -1,0 +1,79 @@
+info:
+  title: Animals Service
+  version: 0.0.1
+servers:
+  - url: http://127.0.0.1:5000/
+tags:
+  - name: Animals_API
+paths:
+  /api/v1/zoo/{animal}:
+    get:
+      operationId: get_animal
+      parameters:
+        - in: path
+          name: animal
+          schema:
+            type: string
+          required: true
+      tags:
+        - Animals_API
+      description: Get animals by species name
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Animal'
+          description: OK
+openapi: 3.0.3
+components:
+  schemas:
+    Animal:
+      oneOf:
+        - $ref: '#/components/schemas/Alligator'
+        - $ref: '#/components/schemas/Zebra'
+    AnimalSharedFields:
+      type: object
+      required:
+        - age
+        - weight
+      properties:
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+        weight:
+          type: number
+          format: float
+          minimum: 0
+    Alligator:
+      allOf:
+        - $ref: '#/components/schemas/AnimalSharedFields'
+        - type: object
+          required:
+            - num_teeth
+          properties:
+            num_teeth:
+              type: integer
+              format: int32
+              minimum: 0
+    Zebra:
+      allOf:
+        - $ref: '#/components/schemas/AnimalSharedFields'
+        - type: object
+          required:
+            - num_stripes
+          properties:
+            num_stripes:
+              type: integer
+              format: int32
+              minimum: 0
+    Lion:
+      type: object
+      required:
+        - eats
+      properties:
+        eats:
+          $ref: '#/components/schemas/Zebra'

--- a/zio-http-gen/src/test/resources/inline_schema_sumtype_with_subtype_referenced_directly.yaml
+++ b/zio-http-gen/src/test/resources/inline_schema_sumtype_with_subtype_referenced_directly.yaml
@@ -65,11 +65,16 @@ components:
         - type: object
           required:
             - num_stripes
+            - dazzle
           properties:
             num_stripes:
               type: integer
               format: int32
               minimum: 0
+            dazzle:
+              type: array
+              items:
+                $ref: '#/components/schemas/Zebra'
     Lion:
       type: object
       required:
@@ -77,3 +82,5 @@ components:
       properties:
         eats:
           $ref: '#/components/schemas/Zebra'
+        enemy:
+          $ref: '#/components/schemas/Alligator'

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -533,7 +533,7 @@ object CodeGenSpec extends ZIOSpecDefault {
               ) && fileShouldBe(
                 testDir,
                 "component/Animal.scala",
-                "/ComponentAnimalWithAbstractMembers.scala",
+                "/ComponentAnimalWithFieldsReferencingSubs.scala",
               ) && fileShouldBe(
                 testDir,
                 "component/Lion.scala",

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -556,5 +556,5 @@ object CodeGenSpec extends ZIOSpecDefault {
           "/GeneratedUserNameArray.scala",
         )
       },
-    ) @@ java11OrNewer /*@@ flaky*/ @@ blocking // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer @@ flaky @@ blocking // Downloading scalafmt on CI is flaky
 }


### PR DESCRIPTION
fixes #2868

This code will:
- nest when subtypes are referenced directly (e.g. `Animal.Zebra` as in the added test)
- avoid nesting when the encapsulating object reside under same object (i.e. everything defined inside the encapsulating `Animal` object, does not need to prepend `Animal.` to any subtypes referenced directly)
- also deal with type arguments, e.g. `Option[Animal.Alligator]` as in the added tests