### PR TITLE
Fix serving of static files over SSL

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -40,7 +40,6 @@ object NettyBodyWriter {
     body: Body,
     contentLength: Option[Long],
     ctx: ChannelHandlerContext,
-    compressionEnabled: Boolean,
   )(implicit
     trace: Trace,
   ): Option[Task[Unit]] = {
@@ -57,21 +56,17 @@ object NettyBodyWriter {
     }
 
     body match {
-      case body: ByteBufBody                    =>
+      case body: ByteBufBody                  =>
         ctx.write(new DefaultHttpContent(body.byteBuf))
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
-      case body: FileBody if compressionEnabled =>
+      case body: FileBody                     =>
         // We need to stream the file when compression is enabled otherwise the response encoding fails
         val stream = ZStream.fromFile(body.file)
         val size   = Some(body.fileSize)
         val s      = StreamBody(stream, knownContentLength = size, mediaType = body.mediaType)
-        NettyBodyWriter.writeAndFlush(s, size, ctx, compressionEnabled)
-      case body: FileBody                       =>
-        ctx.write(new DefaultFileRegion(body.file, 0, body.fileSize))
-        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-        None
-      case AsyncBody(async, _, _, _)            =>
+        NettyBodyWriter.writeAndFlush(s, size, ctx)
+      case AsyncBody(async, _, _, _)          =>
         async(
           new UnsafeAsync {
             override def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
@@ -87,10 +82,10 @@ object NettyBodyWriter {
           },
         )
         None
-      case AsciiStringBody(asciiString, _, _)   =>
+      case AsciiStringBody(asciiString, _, _) =>
         writeArray(asciiString.array(), isLast = true)
         None
-      case StreamBody(stream, _, _, _)          =>
+      case StreamBody(stream, _, _, _)        =>
         Some(
           contentLength.orElse(body.knownContentLength) match {
             case Some(length) =>
@@ -131,13 +126,13 @@ object NettyBodyWriter {
               }
           },
         )
-      case ArrayBody(data, _, _)                =>
+      case ArrayBody(data, _, _)              =>
         writeArray(data, isLast = true)
         None
-      case ChunkBody(data, _, _)                =>
+      case ChunkBody(data, _, _)              =>
         writeArray(data.toArray, isLast = true)
         None
-      case EmptyBody                            =>
+      case EmptyBody                          =>
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
     }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -63,9 +63,8 @@ object NettyBodyWriter {
       case body: FileBody                     =>
         // We need to stream the file when compression is enabled otherwise the response encoding fails
         val stream = ZStream.fromFile(body.file)
-        val size   = Some(body.fileSize)
-        val s      = StreamBody(stream, knownContentLength = size, mediaType = body.mediaType)
-        NettyBodyWriter.writeAndFlush(s, size, ctx)
+        val s      = StreamBody(stream, None, mediaType = body.mediaType)
+        NettyBodyWriter.writeAndFlush(s, None, ctx)
       case AsyncBody(async, _, _, _)          =>
         async(
           new UnsafeAsync {

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientInboundHandler.scala
@@ -52,7 +52,7 @@ final class ClientInboundHandler(
         ctx.writeAndFlush(fullRequest): Unit
       case _: HttpRequest               =>
         ctx.write(jReq)
-        NettyBodyWriter.writeAndFlush(req.body, None, ctx, compressionEnabled = false).foreach { effect =>
+        NettyBodyWriter.writeAndFlush(req.body, None, ctx).foreach { effect =>
           rtm.run(ctx, NettyRuntime.noopEnsuring)(effect)(Unsafe.unsafe, trace)
         }
     }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -187,7 +187,7 @@ private[zio] final case class ServerInboundHandler(
               }
 
             ctx.writeAndFlush(jResponse)
-            NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx, isResponseCompressible(jRequest))
+            NettyBodyWriter.writeAndFlush(response.body, contentLength, ctx)
           } else {
             ctx.writeAndFlush(jResponse)
             None

--- a/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
@@ -17,11 +17,12 @@
 package zio.http
 
 import zio.test.Assertion.equalTo
+import zio.test.TestAspect.withLiveClock
 import zio.test.{Gen, assertCompletes, assertNever, assertZIO}
 import zio.{Scope, ZLayer}
+
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
-import zio.test.TestAspect.withLiveClock
 
 object SSLSpec extends ZIOHttpSpec {
 

--- a/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
@@ -19,9 +19,9 @@ package zio.http
 import zio.test.Assertion.equalTo
 import zio.test.{Gen, assertCompletes, assertNever, assertZIO}
 import zio.{Scope, ZLayer}
-
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
+import zio.test.TestAspect.withLiveClock
 
 object SSLSpec extends ZIOHttpSpec {
 
@@ -35,6 +35,7 @@ object SSLSpec extends ZIOHttpSpec {
 
   val app: Routes[Any, Response] = Routes(
     Method.GET / "success" -> handler(Response.ok),
+    Method.GET / "file"    -> Handler.fromResource("TestStatic/TestFile1.txt"),
   ).sandbox
 
   val httpUrl =
@@ -42,6 +43,9 @@ object SSLSpec extends ZIOHttpSpec {
 
   val httpsUrl =
     URL.decode("https://localhost:8073/success").toOption.get
+
+  val staticFileUrl =
+    URL.decode("https://localhost:8073/file").toOption.get
 
   override def spec = suite("SSL")(
     Server
@@ -110,6 +114,19 @@ object SSLSpec extends ZIOHttpSpec {
             ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
             Scope.default,
           ),
+          test("static files") {
+            val actual = Client
+              .request(Request.get(staticFileUrl))
+              .flatMap(_.body.asString)
+            assertZIO(actual)(equalTo("This file is added for testing Static File Server."))
+          }.provide(
+            Client.customized,
+            ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
+            NettyClientDriver.live,
+            DnsResolver.default,
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+            Scope.default,
+          ) @@ withLiveClock,
         ),
       ),
   ).provideShared(


### PR DESCRIPTION
/fix #2875
/claim #2875

Unfortunately serving static files in any encoded format (compressed, ssl, etc.) doesn't seem to work. With this PR, we serve files as a stream which we can wrap in a `DefaultHttpResponse` so that Netty can properly encode it