### PR TITLE
Don't share the Scope in `ContentTypeSpec`

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
@@ -74,6 +74,8 @@ object ContentTypeSpec extends HttpRunnableSpec {
   override def spec = {
     suite("Content-type") {
       serve.as(List(contentSpec))
-    }.provideShared(DynamicServer.live, serverTestLayer, Client.default, Scope.default) @@ withLiveClock
+    }
+      .provideSome[DynamicServer & Server & Client](Scope.default)
+      .provideShared(DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock
   }
 }

--- a/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
@@ -18,7 +18,7 @@ package zio.http
 
 import zio._
 import zio.test.Assertion.{equalTo, isNone, isSome}
-import zio.test.TestAspect.withLiveClock
+import zio.test.TestAspect.{sequential, withLiveClock}
 import zio.test._
 
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, serverTestLayer}
@@ -76,6 +76,6 @@ object ContentTypeSpec extends HttpRunnableSpec {
       serve.as(List(contentSpec))
     }
       .provideSome[DynamicServer & Server & Client](Scope.default)
-      .provideShared(DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock
+      .provideShared(DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock @@ sequential
   }
 }

--- a/zio-http/jvm/src/test/scala/zio/http/KeepAliveSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/KeepAliveSpec.scala
@@ -16,7 +16,7 @@
 
 package zio.http
 
-import zio.Scope
+import zio._
 import zio.test.Assertion.{equalTo, isNone, isSome}
 import zio.test.TestAspect.{sequential, withLiveClock}
 import zio.test.{Spec, assert}
@@ -66,7 +66,9 @@ object KeepAliveSpec extends HttpRunnableSpec {
   override def spec: Spec[Any, Throwable] = {
     suite("KeepAliveSpec") {
       keepAliveSpec
-    }.provide(DynamicServer.live, serverTestLayer, Client.default, Scope.default) @@ withLiveClock @@ sequential
+    }
+      .provideSome[DynamicServer & Server & Client](Scope.default)
+      .provide(DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock @@ sequential
   }
 
 }

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import zio._
 import zio.test.Assertion._
-import zio.test.TestAspect.{unix, withLiveClock}
+import zio.test.TestAspect.{sequential, unix, withLiveClock}
 import zio.test.assertZIO
 
 import zio.http.internal.{DynamicServer, HttpRunnableSpec, serverTestLayer}
@@ -46,7 +46,9 @@ object StaticFileServerSpec extends HttpRunnableSpec {
 
   override def spec = suite("StaticFileServerSpec") {
     serve.as(List(staticSpec))
-  }.provideShared(DynamicServer.live, serverTestLayer, Client.default, Scope.default) @@ withLiveClock
+  }
+    .provideSome[DynamicServer & Server & Client](Scope.default)
+    .provideShared(DynamicServer.live, serverTestLayer, Client.default) @@ withLiveClock @@ sequential
 
   private def staticSpec = suite("Static RandomAccessFile Server")(
     suite("fromResource")(

--- a/zio-http/jvm/src/test/scala/zio/http/WebSocketSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/WebSocketSpec.scala
@@ -211,7 +211,8 @@ object WebSocketSpec extends HttpRunnableSpec {
   override def spec = suite("Server") {
     serve.as(List(websocketSpec))
   }
-    .provideShared(DynamicServer.live, serverTestLayer, Client.default, Scope.default) @@
+    .provideSome[DynamicServer & Server & Client](Scope.default)
+    .provideShared(DynamicServer.live, serverTestLayer, Client.default) @@
     diagnose(30.seconds) @@ withLiveClock @@ sequential
 
   final class MessageCollector[A](ref: Ref[List[A]], promise: Promise[Nothing, Unit]) {


### PR DESCRIPTION
/fix #2885
/claim #2885

@jdegoes I'm fairly certain that this fixes the issue, but it's hard to tell because I can't replicate it locally. I'll run CI 5-10 times (assuming it passes the first time 😅) to make sure it doesn't happen again.

The reason that this started failing now is that since files are served as streams, my assuption is that sharing the same Scope causes issues as the connections are not properly managed across the different test suites. Note that all the other test suites don't share the same Scope