### PR TITLE
Use text over application media type for file serving; add charset

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ContentTypeSpec.scala
@@ -34,7 +34,9 @@ object ContentTypeSpec extends HttpRunnableSpec {
     test("js") {
       val res =
         Handler.fromResource("TestFile3.js").sandbox.toRoutes.deploy(Request()).map(_.header(Header.ContentType))
-      assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.application.`javascript`))))
+      assertZIO(res)(
+        isSome(equalTo(Header.ContentType(MediaType.application.`javascript`, charset = Some(Charsets.Utf8)))),
+      )
     },
     test("no extension") {
       val res = Handler.fromResource("TestFile4").sandbox.toRoutes.deploy(Request()).map(_.header(Header.ContentType))
@@ -43,7 +45,7 @@ object ContentTypeSpec extends HttpRunnableSpec {
     test("css") {
       val res =
         Handler.fromResource("TestFile5.css").sandbox.toRoutes.deploy(Request()).map(_.header(Header.ContentType))
-      assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.text.`css`))))
+      assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.text.`css`, charset = Some(Charsets.Utf8)))))
     },
     test("mp3") {
       val res =

--- a/zio-http/shared/src/main/scala/zio/http/MediaType.scala
+++ b/zio-http/shared/src/main/scala/zio/http/MediaType.scala
@@ -36,7 +36,12 @@ final case class MediaType(
 }
 
 object MediaType extends MediaTypes {
-  private val extensionMap: Map[String, MediaType] = allMediaTypes.flatMap(m => m.fileExtensions.map(_ -> m)).toMap
+  private val extensionMap: Map[String, MediaType] =
+    // Some extensions are mapped to multiple media types.
+    // We prefer the text media types, since this is the correct default for the most common extensions
+    // like html, xml, javascript, etc.
+    allMediaTypes.flatMap(m => m.fileExtensions.map(_ -> m)).toMap ++
+      text.all.flatMap(m => m.fileExtensions.map(_ -> m)).toMap
   private[http] val contentTypeMap: Map[String, MediaType] = allMediaTypes.map(m => m.fullType -> m).toMap
   val mainTypeMap                                          = allMediaTypes.map(m => m.mainType -> m).toMap
 

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -16,6 +16,7 @@
 package zio.http
 
 import java.io.File
+import java.nio.charset.Charset
 
 import scala.annotation.nowarn
 
@@ -325,8 +326,9 @@ object Middleware extends HandlerAspects {
       }
 
     def fromDirectory(docRoot: File)(implicit trace: Trace): StaticServe[Any, Throwable] = make { (path, _) =>
-      val target = new File(docRoot.getAbsolutePath() + path.encode)
-      if (target.getCanonicalPath.startsWith(docRoot.getCanonicalPath)) Handler.fromFile(target)
+      val target = new File(docRoot.getAbsolutePath + path.encode)
+      if (target.getCanonicalPath.startsWith(docRoot.getCanonicalPath))
+        Handler.fromFile(target, Charset.defaultCharset())
       else {
         Handler.fromZIO(
           ZIO.logWarning(s"attempt to access file outside of docRoot: ${target.getAbsolutePath}"),


### PR DESCRIPTION
I added charsets to the methods for file serving and used UTF-8 as a default.
The charset will only be set in the content type, if it is either `text/x` or not binary.
fixes #2855
/claim #2855