### PR TITLE
Add `Server.serve` variant that accepts `Route` (#2805)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -408,6 +408,13 @@ object Server extends ServerPlatformSpecific {
       ZIO.never
   }
 
+  def serve[R](
+    route: Route[R, Response],
+    routes: Route[R, Response]*,
+  )(implicit trace: Trace, tag: EnvironmentTag[R]): URIO[R with Server, Nothing] = {
+    serve(Routes(route, routes: _*))
+  }
+
   def install[R](
     httpApp: Routes[R, Response],
   )(implicit trace: Trace, tag: EnvironmentTag[R]): URIO[R with Server, Int] = {


### PR DESCRIPTION
fixes #2805
/claim #2805