### PR TITLE
Remove leading/trailing whitespaces from rendered authorization header

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ClientSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ClientSpec.scala
@@ -106,6 +106,13 @@ object ClientSpec extends HttpRunnableSpec {
       val resp = ZIO.scoped(ZClient.request(Request.get(url))).timeout(500.millis)
       assertZIO(resp)(isNone)
     } @@ timeout(5.seconds) @@ flaky(5),
+    test("authorization header without scheme") {
+      val app             =
+        Handler.fromFunction[Request](h => Response.text(h.headers.get("authorization").getOrElse(""))).sandbox.toRoutes
+      val responseContent =
+        app.deploy(Request(headers = Headers(Header.Authorization.Unparsed("", "my-token")))).flatMap(_.body.asString)
+      assertZIO(responseContent)(equalTo("my-token"))
+    } @@ timeout(5.seconds),
   )
 
   override def spec = {

--- a/zio-http/jvm/src/test/scala/zio/http/headers/AuthorizationSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/headers/AuthorizationSpec.scala
@@ -32,7 +32,7 @@ object AuthorizationSpec extends ZIOHttpSpec {
       test("parsing of invalid Authorization values") {
         assertTrue(
           Authorization.parse("").isLeft,
-          Authorization.parse("something").isLeft,
+          Authorization.parse("something").isRight,
         )
       },
       test("parsing and encoding is symmetrical") {

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -1074,7 +1074,7 @@ object Header {
         s"""Digest response="$response",username="$username",realm="$realm",uri=${uri.toString},opaque="$opaque",algorithm=$algo,""" +
           s"""qop=$qop,cnonce="$cnonce",nonce="$nonce",nc=$nc,userhash=${userhash.toString}"""
       case Bearer(token)            => s"Bearer ${token.value.asString}"
-      case Unparsed(scheme, params) => s"$scheme ${params.value.asString}"
+      case Unparsed(scheme, params) => s"$scheme ${params.value.asString}".strip()
     }
 
     private def parseBasic(value: String): Either[String, Authorization] = {

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -1055,7 +1055,7 @@ object Header {
     }
 
     def parse(value: String): Either[String, Authorization] = {
-      val parts  = value.strip().split(" ")
+      val parts  = value.split(" ").filter(_.nonEmpty)
       val nParts = parts.length
       if (nParts == 1) {
         Right(Unparsed("", parts(0)))

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -1055,8 +1055,11 @@ object Header {
     }
 
     def parse(value: String): Either[String, Authorization] = {
-      val parts = value.split(" ")
-      if (parts.length >= 2) {
+      val parts  = value.strip().split(" ")
+      val nParts = parts.length
+      if (nParts == 1) {
+        Right(Unparsed("", parts(0)))
+      } else if (nParts >= 2) {
         parts(0).toLowerCase match {
           case "basic"  => parseBasic(parts(1))
           case "digest" => parseDigest(parts.tail.mkString(" "))


### PR DESCRIPTION
/fixes #2742
/claim #2742

Seems that Netty doesn't like the leading whitespace in the Authorization header, which is causing the client to hang