### PR TITLE
Fix for routes with different parameter names

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -540,7 +540,6 @@ object PathCodec          {
                   index = 0
                   while (index < n && (subtree eq null)) {
                     val matched = matches(index)
-                    // Checking whether we got a match alone is
                     if (matched > 0) {
                       val (_, subtree0) = flattened(index)
                       val subpath       = path.dropLeadingSlash.drop(i + matched)

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -514,24 +514,44 @@ object PathCodec          {
                 result = subtree0.value
                 i = i + matched
               }
-            case _ => // Slowest fallback path. Have to to find the first predicate where the subpath returns a result
-              var index = 0
-              val size  = flattened.length
-              while (index <= size && (subtree eq null)) {
-                val (codec, subtree0) = flattened(index)
-                val matched           = codec.matches(segments, i)
-                // Checking whether we got a match alone is
-                if (
-                  matched > 0 && {
-                    val subpath = path.dropLeadingSlash.drop(i + matched)
-                    subtree0.get(subpath).nonEmpty
-                  }
-                ) {
-                  subtree = subtree0
-                  result = subtree.value
-                  i += matched
+            case n => // Slowest fallback path. Have to to find the first predicate where the subpath returns a result
+              val matches         = Array.ofDim[Int](n)
+              var index           = 0
+              var nPositive       = 0
+              var lastPositiveIdx = -1
+              while (index < n) {
+                val (codec, _) = flattened(index)
+                val n          = codec.matches(segments, i)
+                if (n > 0) {
+                  matches(index) = n
+                  nPositive += 1
+                  lastPositiveIdx = index
                 }
                 index += 1
+              }
+
+              nPositive match {
+                case 0 => ()
+                case 1 =>
+                  subtree = flattened(lastPositiveIdx)._2
+                  result = subtree.value
+                  i = i + matches(lastPositiveIdx)
+                case _ =>
+                  index = 0
+                  while (index < n && (subtree eq null)) {
+                    val matched = matches(index)
+                    // Checking whether we got a match alone is
+                    if (matched > 0) {
+                      val (_, subtree0) = flattened(index)
+                      val subpath       = path.dropLeadingSlash.drop(i + matched)
+                      if (subtree0.get(subpath).nonEmpty) {
+                        subtree = subtree0
+                        result = subtree.value
+                        i += matched
+                      }
+                    }
+                    index += 1
+                  }
               }
           }
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -18,10 +18,10 @@ package zio.http.codec
 
 import scala.collection.immutable.ListMap
 import scala.language.implicitConversions
-import zio._
-import zio.http._
 
-import scala.annotation.nowarn
+import zio._
+
+import zio.http._
 
 /**
  * A codec for paths, which consists of segments, where each segment may be a
@@ -485,7 +485,6 @@ object PathCodec          {
     def add[A1 >: A](segments: Iterable[SegmentCodec[_]], value: A1): SegmentSubtree[A1] =
       self ++ SegmentSubtree.single(segments, value)
 
-    @nowarn
     def get(path: Path): Chunk[A] = {
       val segments = path.segments
       var subtree  = self


### PR DESCRIPTION
/fixes #2728
/claim #2728

The solution to the linked issue is when we have multiple segment codecs that match the predicate, to evaluate them all by passing the partial path to their `get` method, and find the one that returns a result.

In order to avoid adding performance overhead, this evaluation is done only when we determined that we have ambiguities