### PR TITLE
Avoid allocation of new path when resolving path ambiguities

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -485,13 +485,17 @@ object PathCodec          {
     def add[A1 >: A](segments: Iterable[SegmentCodec[_]], value: A1): SegmentSubtree[A1] =
       self ++ SegmentSubtree.single(segments, value)
 
-    def get(path: Path): Chunk[A] = {
-      val segments = path.segments
-      var subtree  = self
-      var result   = subtree.value
-      var i        = 0
+    def get(path: Path): Chunk[A] =
+      get(path, 0)
 
-      while (i < segments.length) {
+    private def get(path: Path, from: Int): Chunk[A] = {
+      val segments  = path.segments
+      val nSegments = segments.length
+      var subtree   = self
+      var result    = subtree.value
+      var i         = from
+
+      while (i < nSegments) {
         val segment = segments(i)
 
         if (subtree.literals.contains(segment)) {
@@ -499,7 +503,7 @@ object PathCodec          {
           subtree = subtree.literals(segment)
 
           result = subtree.value
-          i = i + 1
+          i += 1
         } else {
           val flattened = subtree.othersFlat
 
@@ -512,7 +516,7 @@ object PathCodec          {
               if (matched > 0) {
                 subtree = subtree0
                 result = subtree0.value
-                i = i + matched
+                i += matched
               }
             case n => // Slowest fallback path. Have to to find the first predicate where the subpath returns a result
               val matches         = Array.ofDim[Int](n)
@@ -535,15 +539,15 @@ object PathCodec          {
                 case 1 =>
                   subtree = flattened(lastPositiveIdx)._2
                   result = subtree.value
-                  i = i + matches(lastPositiveIdx)
+                  i += matches(lastPositiveIdx)
                 case _ =>
                   index = 0
                   while (index < n && (subtree eq null)) {
                     val matched = matches(index)
                     if (matched > 0) {
                       val (_, subtree0) = flattened(index)
-                      val subpath       = path.dropLeadingSlash.drop(i + matched)
-                      if (subtree0.get(subpath).nonEmpty) {
+                      val from          = i + matched
+                      if (from >= nSegments || subtree0.get(path, from).nonEmpty) {
                         subtree = subtree0
                         result = subtree.value
                         i += matched
@@ -556,7 +560,7 @@ object PathCodec          {
 
           if (subtree eq null) {
             result = Chunk.empty
-            i = segments.length
+            i = nSegments
           }
         }
       }

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -546,8 +546,7 @@ object PathCodec          {
                     val matched = matches(index)
                     if (matched > 0) {
                       val (_, subtree0) = flattened(index)
-                      val from          = i + matched
-                      if (from >= nSegments || subtree0.get(path, from).nonEmpty) {
+                      if (subtree0.get(path, i + matched).nonEmpty) {
                         subtree = subtree0
                         result = subtree.value
                         i += matched


### PR DESCRIPTION
See [this comment](https://github.com/zio/zio-http/pull/2903/files/409d4ef89c04fe7d96d3c71f14079df48afc9e34#r1636989779).

Unfortunately I couldn't eliminate the allocation of the Chunk from `get` but that would require us to duplicate a lot of the logic. I think that since this branch is only executed when resolving ambiguities (which is quite rare) I think it's acceptable to leave it like this