### PR TITLE
Try all resolved IP addresses when client fails to connect

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -106,29 +106,39 @@ object NettyConnectionPool {
 
     for {
       resolvedHosts <- dnsResolver.resolve(location.host)
-      pickedHost    <- Random.nextIntBounded(resolvedHosts.size)
-      host = resolvedHosts(pickedHost)
-      channelFuture <- ZIO.attempt {
-        val bootstrap = new Bootstrap()
-          .channelFactory(channelFactory)
-          .group(eventLoopGroup)
-          .remoteAddress(new InetSocketAddress(host, location.port))
-          .withOption[Integer](ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionTimeout.map(_.toMillis.toInt))
-          .handler(initializer)
-        (localAddress match {
-          case Some(addr) => bootstrap.localAddress(addr)
-          case _          => bootstrap
-        }).connect()
+      hosts         <- Random.shuffle(resolvedHosts.toList)
+      hostsNec      <- ZIO.succeed(NonEmptyChunk.fromIterable(hosts.head, hosts.tail))
+      ch            <- collectFirstSuccess(hostsNec) { host =>
+        ZIO.suspend {
+          val bootstrap = new Bootstrap()
+            .channelFactory(channelFactory)
+            .group(eventLoopGroup)
+            .remoteAddress(new InetSocketAddress(host, location.port))
+            .withOption[Integer](ChannelOption.CONNECT_TIMEOUT_MILLIS, connectionTimeout.map(_.toMillis.toInt))
+            .handler(initializer)
+          localAddress.foreach(bootstrap.localAddress)
+
+          val channelFuture = bootstrap.connect()
+          val ch            = channelFuture.channel()
+          Scope.addFinalizer {
+            NettyFutureExecutor.executed {
+              channelFuture.cancel(true)
+              ch.close()
+            }.when(ch.isOpen).ignoreLogged
+          } *> NettyFutureExecutor.executed(channelFuture).as(ch)
+        }
       }
-      ch            <- ZIO.attempt(channelFuture.channel())
-      _             <- Scope.addFinalizer {
-        NettyFutureExecutor.executed {
-          channelFuture.cancel(true)
-          ch.close()
-        }.when(ch.isOpen).ignoreLogged
-      }
-      _             <- NettyFutureExecutor.executed(channelFuture)
     } yield ch
+  }
+
+  private def collectFirstSuccess[R, E, A, B](
+    as: NonEmptyChunk[A],
+  )(f: A => ZIO[R, E, B])(implicit trace: Trace): ZIO[R, E, B] = {
+    ZIO.suspendSucceed {
+      val it                 = as.iterator
+      def loop: ZIO[R, E, B] = f(it.next()).catchAll(e => if (it.hasNext) loop else ZIO.fail(e))
+      loop
+    }
   }
 
   /**

--- a/zio-http/jvm/src/test/scala/zio/http/ClientConnectionSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ClientConnectionSpec.scala
@@ -51,6 +51,8 @@ object ClientConnectionSpec extends HttpRunnableSpec {
   }
 
   private object TestResolver extends DnsResolver {
+    import scala.collection.compat._
+
     override def resolve(host: String)(implicit trace: Trace): ZIO[Any, UnknownHostException, Chunk[InetAddress]] = {
       ZIO.succeed {
         Chunk.from((0 to 10).map { i =>

--- a/zio-http/jvm/src/test/scala/zio/http/ClientConnectionSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ClientConnectionSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http
+
+import java.net.{InetAddress, UnknownHostException}
+
+import zio._
+import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.test._
+
+import zio.http.internal.{DynamicServer, HttpRunnableSpec, serverTestLayer}
+import zio.http.netty.NettyConfig
+
+object ClientConnectionSpec extends HttpRunnableSpec {
+
+  private def tests =
+    List(
+      test("tries a different IP address when the connection fails") {
+        val app = Handler.ok.toRoutes.deploy(Request()).map(_.status)
+        assertZIO(app)(equalTo(Status.Ok))
+      } @@ nonFlaky(10),
+    )
+
+  override def spec = {
+    suite("ClientConnectionSpec") {
+      serve.as(tests)
+    }.provideSome[DynamicServer & Server & Client](Scope.default)
+      .provideShared(
+        DynamicServer.live,
+        serverTestLayer,
+        Client.live,
+        ZLayer.succeed(Client.Config.default.connectionTimeout(10.millis)),
+        ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+        ZLayer.succeed(TestResolver),
+      ) @@ sequential @@ withLiveClock @@ withLiveRandom
+  }
+
+  private object TestResolver extends DnsResolver {
+    override def resolve(host: String)(implicit trace: Trace): ZIO[Any, UnknownHostException, Chunk[InetAddress]] = {
+      ZIO.succeed {
+        Chunk.from((0 to 10).map { i =>
+          InetAddress.getByAddress(Array(127, 0, 0, i.toByte))
+        })
+      }
+    }
+  }
+}


### PR DESCRIPTION
/fixes #2902
/claim #2902

The issue that #2902 faced was that the DnsResolver would return 2 addresses for `localhost`:
1. 127.0.0.1
2. 0:0:0:0:0:0:0:1

The mock server however was not reachable on the IPv6 address. While this issue could be worked-around by using `127.0.0.1` or `0.0.0.0` as the hostname, it's quite possible for a host to be unavailable in one of the resolved addresses. Instead of failing the request, we should try all of the resolved IP addresses to see if we can connect to any of them, and throw an error only when we've exhausted all of the possible IP addresses