### PR TITLE
Fix memory leak in netty connection pool

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
@@ -44,6 +44,7 @@ abstract class AsyncBodyReader extends SimpleChannelInboundHandler[HttpContent](
             case None              => false
             case Some((_, isLast)) => isLast
           }
+          buffer.clear() // GC
 
           if (ctx.channel.isOpen || readingDone) {
             state = State.Direct(callback)

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -16,8 +16,6 @@
 
 package zio.http.netty.client
 
-import scala.collection.mutable
-
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -28,11 +26,10 @@ import zio.http.netty._
 import zio.http.netty.model.Conversions
 import zio.http.netty.socket.NettySocketProtocol
 
-import io.netty.channel.{Channel, ChannelFactory, ChannelFuture, ChannelHandler, EventLoopGroup}
+import io.netty.channel.{Channel, ChannelFactory, EventLoopGroup}
 import io.netty.handler.codec.PrematureChannelClosureException
 import io.netty.handler.codec.http.websocketx.{WebSocketClientProtocolHandler, WebSocketFrame => JWebSocketFrame}
-import io.netty.handler.codec.http.{FullHttpRequest, HttpObjectAggregator, HttpRequest}
-import io.netty.util.concurrent.GenericFutureListener
+import io.netty.handler.codec.http.{FullHttpRequest, HttpObjectAggregator}
 
 final case class NettyClientDriver private[netty] (
   channelFactory: ChannelFactory[Channel],
@@ -51,120 +48,115 @@ final case class NettyClientDriver private[netty] (
     enableKeepAlive: Boolean,
     createSocketApp: () => WebSocketApp[Any],
     webSocketConfig: WebSocketConfig,
-  )(implicit trace: Trace): ZIO[Scope, Throwable, ChannelInterface] = {
-    NettyRequestEncoder.encode(req).flatMap { jReq =>
-      for {
-        _     <- Scope.addFinalizer {
-          ZIO.attempt {
-            jReq match {
-              case fullRequest: FullHttpRequest =>
-                if (fullRequest.refCnt() > 0)
-                  fullRequest.release(fullRequest.refCnt())
-              case _                            =>
+  )(implicit trace: Trace): ZIO[Scope, Throwable, ChannelInterface] =
+    if (location.scheme.isWebSocket)
+      requestWebsocket(channel, req, onResponse, onComplete, createSocketApp, webSocketConfig)
+    else
+      requestHttp(channel, req, onResponse, onComplete, enableKeepAlive)
+
+  private def requestHttp(
+    channel: Channel,
+    req: Request,
+    onResponse: Promise[Throwable, Response],
+    onComplete: Promise[Throwable, ChannelState],
+    enableKeepAlive: Boolean,
+  )(implicit trace: Trace): RIO[Scope, ChannelInterface] =
+    NettyRequestEncoder
+      .encode(req)
+      .tapSome { case fullReq: FullHttpRequest =>
+        Scope.addFinalizer {
+          ZIO.succeed {
+            val refCount = fullReq.refCnt()
+            if (refCount > 0) fullReq.release(refCount) else ()
+          }
+        }
+      }
+      .map { jReq =>
+        val pipeline = channel.pipeline()
+
+        pipeline.addLast(
+          Names.ClientInboundHandler,
+          new ClientInboundHandler(nettyRuntime, req, jReq, onResponse, onComplete, enableKeepAlive),
+        )
+
+        pipeline.addLast(
+          Names.ClientFailureHandler,
+          new ClientFailureHandler(onResponse, onComplete),
+        )
+
+        pipeline
+          .fireChannelRegistered()
+          .fireUserEventTriggered(ClientInboundHandler.SendRequest)
+
+        new ChannelInterface {
+          override def resetChannel: ZIO[Any, Throwable, ChannelState] = {
+            ZIO.attempt {
+              pipeline.remove(Names.ClientInboundHandler)
+              pipeline.remove(Names.ClientFailureHandler)
+              ChannelState.Reusable // channel can be reused
             }
-          }.ignore
-        }
-        queue <- Queue.unbounded[WebSocketChannelEvent]
-        nettyChannel     = NettyChannel.make[JWebSocketFrame](channel)
-        webSocketChannel = WebSocketChannel.make(nettyChannel, queue)
-        app              = createSocketApp()
-        _ <- app.handler.runZIO(webSocketChannel).ignoreLogged.interruptible.forkScoped
-      } yield {
-        val pipeline                              = channel.pipeline()
-        val toRemove: mutable.Set[ChannelHandler] = new mutable.HashSet[ChannelHandler]()
-
-        if (location.scheme.isWebSocket) {
-          val httpObjectAggregator = new HttpObjectAggregator(Int.MaxValue)
-          val inboundHandler       = new WebSocketClientInboundHandler(onResponse, onComplete)
-
-          pipeline.addLast(Names.HttpObjectAggregator, httpObjectAggregator)
-          pipeline.addLast(Names.ClientInboundHandler, inboundHandler)
-
-          toRemove.add(httpObjectAggregator)
-          toRemove.add(inboundHandler)
-
-          val headers = Conversions.headersToNetty(req.headers)
-          val config  = NettySocketProtocol
-            .clientBuilder(app.customConfig.getOrElse(webSocketConfig))
-            .customHeaders(headers)
-            .webSocketUri(req.url.encode)
-            .build()
-
-          // Handles the heavy lifting required to upgrade the connection to a WebSocket connection
-
-          val webSocketClientProtocol = new WebSocketClientProtocolHandler(config)
-          val webSocket               = new WebSocketAppHandler(nettyRuntime, queue, Some(onComplete))
-
-          pipeline.addLast(Names.WebSocketClientProtocolHandler, webSocketClientProtocol)
-          pipeline.addLast(Names.WebSocketHandler, webSocket)
-
-          toRemove.add(webSocketClientProtocol)
-          toRemove.add(webSocket)
-
-          pipeline.fireChannelRegistered()
-          pipeline.fireChannelActive()
-
-          new ChannelInterface {
-            override def resetChannel: ZIO[Any, Throwable, ChannelState] =
-              ZIO.succeed(
-                ChannelState.Invalid,
-              ) // channel becomes invalid - reuse of websocket channels not supported currently
-
-            override def interrupt: ZIO[Any, Throwable, Unit] =
-              NettyFutureExecutor.executed(channel.disconnect())
           }
-        } else {
-          val clientInbound =
-            new ClientInboundHandler(
-              nettyRuntime,
-              req,
-              jReq,
-              onResponse,
-              onComplete,
-              enableKeepAlive,
-            )
 
-          pipeline.addLast(Names.ClientInboundHandler, clientInbound)
-          toRemove.add(clientInbound)
-
-          val clientFailureHandler = new ClientFailureHandler(onResponse, onComplete)
-          pipeline.addLast(Names.ClientFailureHandler, clientFailureHandler)
-          toRemove.add(clientFailureHandler)
-
-          pipeline.fireChannelRegistered()
-          pipeline.fireUserEventTriggered(ClientInboundHandler.SendRequest)
-
-          val frozenToRemove = toRemove.toSet
-
-          val closeListener: GenericFutureListener[ChannelFuture] = (_: ChannelFuture) =>
-            // If onComplete was already set, it means another fiber is already in the process of fulfilling the promises
-            // so we don't need to fulfill `onResponse`
-            nettyRuntime.unsafeRunSync {
-              ZIO
-                .whenZIO(onComplete.interrupt)(
-                  onResponse.fail(
-                    new PrematureChannelClosureException(
-                      "Channel closed while executing the request. This is likely caused due to a client connection misconfiguration",
-                    ),
-                  ),
-                )
-                .unit
-            }(Unsafe.unsafe, trace)
-
-          channel.closeFuture().addListener(closeListener)
-
-          new ChannelInterface {
-            override def resetChannel: ZIO[Any, Throwable, ChannelState] =
-              ZIO.attempt {
-                channel.closeFuture().removeListener(closeListener)
-                frozenToRemove.foreach(pipeline.remove)
-                ChannelState.Reusable // channel can be reused
-              }
-
-            override def interrupt: ZIO[Any, Throwable, Unit] =
-              NettyFutureExecutor.executed(channel.disconnect())
-          }
+          override def interrupt: ZIO[Any, Throwable, Unit] =
+            NettyFutureExecutor.executed(channel.disconnect())
         }
+      }
+      .ensuring(
+        NettyFutureExecutor
+          .executed(channel.closeFuture())
+          .interruptible
+          .zipRight(onComplete.interrupt && onResponse.fail(NettyClientDriver.PrematureChannelClosure))
+          .forkScoped,
+      )
+
+  private def requestWebsocket(
+    channel: Channel,
+    req: Request,
+    onResponse: Promise[Throwable, Response],
+    onComplete: Promise[Throwable, ChannelState],
+    createSocketApp: () => WebSocketApp[Any],
+    webSocketConfig: WebSocketConfig,
+  )(implicit trace: Trace): RIO[Scope, ChannelInterface] = {
+    for {
+      queue <- Queue.unbounded[WebSocketChannelEvent]
+      nettyChannel     = NettyChannel.make[JWebSocketFrame](channel)
+      webSocketChannel = WebSocketChannel.make(nettyChannel, queue)
+      app              = createSocketApp()
+      _ <- app.handler.runZIO(webSocketChannel).ignoreLogged.interruptible.forkScoped
+    } yield {
+      val pipeline = channel.pipeline()
+
+      val httpObjectAggregator = new HttpObjectAggregator(Int.MaxValue)
+      val inboundHandler       = new WebSocketClientInboundHandler(onResponse, onComplete)
+
+      pipeline.addLast(Names.HttpObjectAggregator, httpObjectAggregator)
+      pipeline.addLast(Names.ClientInboundHandler, inboundHandler)
+
+      val headers = Conversions.headersToNetty(req.headers)
+      val config  = NettySocketProtocol
+        .clientBuilder(app.customConfig.getOrElse(webSocketConfig))
+        .customHeaders(headers)
+        .webSocketUri(req.url.encode)
+        .build()
+
+      // Handles the heavy lifting required to upgrade the connection to a WebSocket connection
+
+      val webSocketClientProtocol = new WebSocketClientProtocolHandler(config)
+      val webSocket               = new WebSocketAppHandler(nettyRuntime, queue, Some(onComplete))
+
+      pipeline.addLast(Names.WebSocketClientProtocolHandler, webSocketClientProtocol)
+      pipeline.addLast(Names.WebSocketHandler, webSocket)
+
+      pipeline.fireChannelRegistered()
+      pipeline.fireChannelActive()
+
+      new ChannelInterface {
+        override def resetChannel: ZIO[Any, Throwable, ChannelState] =
+          // channel becomes invalid - reuse of websocket channels not supported currently
+          Exit.succeed(ChannelState.Invalid)
+
+        override def interrupt: ZIO[Any, Throwable, Unit] =
+          NettyFutureExecutor.executed(channel.disconnect())
       }
     }
   }
@@ -189,5 +181,9 @@ object NettyClientDriver {
           nettyRuntime   <- ZIO.service[NettyRuntime]
         } yield NettyClientDriver(channelFactory, eventLoopGroup, nettyRuntime)
       }
+
+  private val PrematureChannelClosure = new PrematureChannelClosureException(
+    "Channel closed while executing the request. This is likely caused due to a client connection misconfiguration",
+  )
 
 }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -18,12 +18,14 @@ package zio.http.netty.client
 
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+
 import zio.http.ClientDriver.ChannelInterface
 import zio.http._
 import zio.http.internal.ChannelState
 import zio.http.netty._
 import zio.http.netty.model.Conversions
 import zio.http.netty.socket.NettySocketProtocol
+
 import io.netty.channel.{Channel, ChannelFactory, ChannelFuture, EventLoopGroup}
 import io.netty.handler.codec.PrematureChannelClosureException
 import io.netty.handler.codec.http.websocketx.{WebSocketClientProtocolHandler, WebSocketFrame => JWebSocketFrame}

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -61,7 +61,7 @@ final case class NettyClientDriver private[netty] (
     onResponse: Promise[Throwable, Response],
     onComplete: Promise[Throwable, ChannelState],
     enableKeepAlive: Boolean,
-  )(implicit trace: Trace): RIO[Scope, ChannelInterface] = ZIO.suspendSucceed {
+  )(implicit trace: Trace): RIO[Scope, ChannelInterface] =
     NettyRequestEncoder
       .encode(req)
       .tapSome { case fullReq: FullHttpRequest =>
@@ -115,7 +115,6 @@ final case class NettyClientDriver private[netty] (
             }
         }
       }
-  }
 
   private def requestWebsocket(
     channel: Channel,


### PR DESCRIPTION
/fixes #2906

This is totally on me, big apologies on this one. In #2843 I changed the logic to use a listener on Netty's close future instead of forking a fiber to await on the future. However, I was not removing the listener when the channel would be reset. This is causing the `onResult` promise to being referenced and doesn't allow the response to be GC'd, causing a rather severe memory leak until the channel is closed.

In addition, I found that one of the main things that was contributing massively to the memory leak was using a much-bigger-than-needed ZStream buffer in `AsyncBody`. I added dynamic sizing of the buffer when the content length of the response is known. This way we reduce memory allocations significantly for small requests.

Edit:
1. ~~After feedback from @Not-Aru, I reverted the implementation of listening to the closeFuture back to the one used in versions <= 3.0.0-RC6~~
2. I split the logic for handling http / websocket requests `NettyClientDriver#requestOnChannel`. It was making things difficult to reason with plus we were executing effects that were only meant for running websockets when handling http requests and vice-versa. I think the new implementation is much cleaner and easier to follow

Edit 2:
1. After some more extensive testing, I found a small race condition when interrupting the channel and fixed it
2. Using a FutureListener is much more performant than forking a scoped effect to monitor the closeFuture so I changed the implementation back