### PR TITLE
Htmx attributes are unimportable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -267,6 +267,10 @@ lazy val zioHttpHtmx = (project in file("zio-http-htmx"))
   .settings(
     stdSettings("zio-http-htmx"),
     publishSetting(true),
+    libraryDependencies ++= Seq(
+      `zio-test`,
+      `zio-test-sbt`,
+    ),
   )
   .dependsOn(zioHttpJVM)
 

--- a/zio-http-htmx/src/main/scala/zio/http/htmx/package.scala
+++ b/zio-http-htmx/src/main/scala/zio/http/htmx/package.scala
@@ -1,0 +1,3 @@
+package zio.http
+
+package object htmx extends Attributes

--- a/zio-http-htmx/src/test/scala/zio/http/htmx/HtmxSpec.scala
+++ b/zio-http-htmx/src/test/scala/zio/http/htmx/HtmxSpec.scala
@@ -1,0 +1,14 @@
+package zio.http.htmx
+
+import zio.http.template.button
+import zio.test.{ZIOSpecDefault, assertTrue}
+
+case object HtmxSpec extends ZIOSpecDefault {
+  override def spec = suite("HtmxSpec")(
+    test("hx-get attribute") {
+      val view     = button(hxGetAttr := "/test", "click")
+      val expected = """<button hx-get="/test">click</button>"""
+      assertTrue(view.encode == expected.stripMargin)
+    },
+  )
+}

--- a/zio-http-htmx/src/test/scala/zio/http/htmx/HtmxSpec.scala
+++ b/zio-http-htmx/src/test/scala/zio/http/htmx/HtmxSpec.scala
@@ -1,7 +1,8 @@
 package zio.http.htmx
 
-import zio.http.template.button
 import zio.test.{ZIOSpecDefault, assertTrue}
+
+import zio.http.template.button
 
 case object HtmxSpec extends ZIOSpecDefault {
   override def spec = suite("HtmxSpec")(


### PR DESCRIPTION
I was trying to use the _htmx_ library and noticed that the attributes could not be used as-is, because it didn't have a package object like the `zio.http.template` package.

I also added a test.
The test fails without the `zio-http-htmx/src/main/scala/zio/http/htmx/package.scala` file.