### PR TITLE
Access latest route pattern when mapping route errors (#2823)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -159,8 +159,8 @@ object Response {
       case Left(failure: Throwable) => fromThrowable(failure)
       case Left(failure: Cause[_])  => fromCause(failure)
       case _                        =>
-        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint.take(100))
-        else error(Status.InternalServerError, cause.prettyPrint.take(100))
+        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint.take(10000))
+        else error(Status.InternalServerError, cause.prettyPrint.take(10000))
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -71,23 +71,26 @@ sealed trait Route[-Env, +Err] { self =>
       case Provided(route, env)                     => Provided(route.handleErrorCause(f), env)
       case Augmented(route, aspect)                 => Augmented(route.handleErrorCause(f), aspect)
       case Handled(routePattern, handler, location) =>
-        Handled(routePattern, handler.mapErrorCause(c => f(c.asInstanceOf[Cause[Nothing]])), location)
+        Handled(routePattern, handler.map(_.mapErrorCause(c => f(c.asInstanceOf[Cause[Nothing]]))), location)
 
       case Unhandled(rpm, handler, zippable, location) =>
-        val handler2: Handler[Env, Response, Request, Response] = {
-          val paramHandler =
-            Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
-              rpm.routePattern.decode(request.method, request.path) match {
-                case Left(error)  => ZIO.dieMessage(error)
-                case Right(value) =>
-                  val params = rpm.zippable.zip(value, ctx)
+        val handler2: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]] = {
+          Handler.fromFunction[RoutePattern[_]] { pattern =>
+            val paramHandler = {
+              Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
+                pattern.asInstanceOf[RoutePattern[rpm.PathInput]].decode(request.method, request.path) match {
+                  case Left(error)  => ZIO.dieMessage(error)
+                  case Right(value) =>
+                    val params = rpm.zippable.zip(value, ctx)
 
-                  handler(zippable.zip(params, request))
+                    handler(zippable.zip(params, request))
+                }
               }
             }
 
-          // Sandbox before applying aspect:
-          rpm.aspect.applyHandlerContext(paramHandler.mapErrorCause(f))
+            // Sandbox before applying aspect:
+            rpm.aspect.applyHandlerContext(paramHandler.mapErrorCause(f))
+          }
         }
 
         Handled(rpm.routePattern, handler2, location)
@@ -106,21 +109,23 @@ sealed trait Route[-Env, +Err] { self =>
       case Provided(route, env)                     => Provided(route.handleErrorCauseZIO(f), env)
       case Augmented(route, aspect)                 => Augmented(route.handleErrorCauseZIO(f), aspect)
       case Handled(routePattern, handler, location) =>
-        Handled(routePattern, handler.mapErrorCauseZIO(c => f(c.asInstanceOf[Cause[Nothing]])), location)
+        Handled[Env](routePattern, handler.map(_.mapErrorCauseZIO(c => f(c.asInstanceOf[Cause[Nothing]]))), location)
 
       case Unhandled(rpm, handler, zippable, location) =>
-        val handler2: Handler[Env, Response, Request, Response] = {
-          val paramHandler =
-            Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
-              rpm.routePattern.decode(request.method, request.path) match {
-                case Left(error)  => ZIO.dieMessage(error)
-                case Right(value) =>
-                  val params = rpm.zippable.zip(value, ctx)
+        val handler2: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]] = {
+          Handler.fromFunction[RoutePattern[_]] { pattern =>
+            val paramHandler =
+              Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
+                pattern.asInstanceOf[RoutePattern[rpm.PathInput]].decode(request.method, request.path) match {
+                  case Left(error)  => ZIO.dieMessage(error)
+                  case Right(value) =>
+                    val params = rpm.zippable.zip(value, ctx)
 
-                  handler(zippable.zip(params, request))
+                    handler(zippable.zip(params, request))
+                }
               }
-            }
-          rpm.aspect.applyHandlerContext(paramHandler.mapErrorCauseZIO(f))
+            rpm.aspect.applyHandlerContext(paramHandler.mapErrorCauseZIO(f))
+          }
         }
 
         Handled(rpm.routePattern, handler2, location)
@@ -134,7 +139,7 @@ sealed trait Route[-Env, +Err] { self =>
     self match {
       case Provided(route, env)                        => Provided(route.mapError(fxn), env)
       case Augmented(route, aspect)                    => Augmented(route.mapError(fxn), aspect)
-      case Handled(routePattern, handler, location)    => Handled(routePattern, handler, location)
+      case Handled(routePattern, handler, location)    => Handled[Env](routePattern, handler, location)
       case Unhandled(rpm, handler, zippable, location) => Unhandled(rpm, handler.mapError(fxn), zippable, location)
     }
 
@@ -149,7 +154,7 @@ sealed trait Route[-Env, +Err] { self =>
     self match {
       case Provided(route, env)                        => Provided(route.mapErrorZIO(fxn), env)
       case Augmented(route, aspect)                    => Augmented(route.mapErrorZIO(fxn), aspect)
-      case Handled(routePattern, handler, location)    => Handled(routePattern, handler, location)
+      case Handled(routePattern, handler, location)    => Handled[Env](routePattern, handler, location)
       case Unhandled(rpm, handler, zippable, location) => Unhandled(rpm, handler.mapErrorZIO(fxn), zippable, location)
     }
 
@@ -173,33 +178,37 @@ sealed trait Route[-Env, +Err] { self =>
       case Provided(route, env)                     => Provided(route.handleErrorRequestCause(f), env)
       case Augmented(route, aspect)                 => Augmented(route.handleErrorRequestCause(f), aspect)
       case Handled(routePattern, handler, location) =>
-        Handled(
+        Handled[Env](
           routePattern,
-          Handler.fromFunctionHandler[Request] { (req: Request) =>
-            handler.mapErrorCause(c => f(req, c.asInstanceOf[Cause[Nothing]]))
+          handler.map { handler =>
+            Handler.fromFunctionHandler[Request] { (req: Request) =>
+              handler.mapErrorCause(c => f(req, c.asInstanceOf[Cause[Nothing]]))
+            }
           },
           location,
         )
 
       case Unhandled(rpm, handler, zippable, location) =>
-        val handler2: Handler[Env, Response, Request, Response] = {
-          val paramHandler =
-            Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
-              rpm.routePattern.decode(request.method, request.path) match {
-                case Left(error)  => ZIO.dieMessage(error)
-                case Right(value) =>
-                  val params = rpm.zippable.zip(value, ctx)
+        val handler2: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]] = {
+          Handler.fromFunction[RoutePattern[_]] { pattern =>
+            val paramHandler =
+              Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
+                pattern.asInstanceOf[RoutePattern[rpm.PathInput]].decode(request.method, request.path) match {
+                  case Left(error)  => ZIO.dieMessage(error)
+                  case Right(value) =>
+                    val params = rpm.zippable.zip(value, ctx)
 
-                  handler(zippable.zip(params, request))
+                    handler(zippable.zip(params, request))
+                }
               }
-            }
 
-          // Sandbox before applying aspect:
-          rpm.aspect.applyHandlerContext(
-            Handler.fromFunctionHandler[(rpm.Context, Request)] { case (_, req) =>
-              paramHandler.mapErrorCause(f(req, _))
-            },
-          )
+            // Sandbox before applying aspect:
+            rpm.aspect.applyHandlerContext(
+              Handler.fromFunctionHandler[(rpm.Context, Request)] { case (_, req) =>
+                paramHandler.mapErrorCause(f(req, _))
+              },
+            )
+          }
         }
 
         Handled(rpm.routePattern, handler2, location)
@@ -219,31 +228,35 @@ sealed trait Route[-Env, +Err] { self =>
       case Provided(route, env)                     => Provided(route.handleErrorRequestCauseZIO(f), env)
       case Augmented(route, aspect)                 => Augmented(route.handleErrorRequestCauseZIO(f), aspect)
       case Handled(routePattern, handler, location) =>
-        Handled(
+        Handled[Env](
           routePattern,
-          Handler.fromFunctionHandler[Request] { (req: Request) =>
-            handler.mapErrorCauseZIO(c => f(req, c.asInstanceOf[Cause[Nothing]]))
+          handler.map { handler =>
+            Handler.fromFunctionHandler[Request] { (req: Request) =>
+              handler.mapErrorCauseZIO(c => f(req, c.asInstanceOf[Cause[Nothing]]))
+            }
           },
           location,
         )
 
       case Unhandled(rpm, handler, zippable, location) =>
-        val handler2: Handler[Env, Response, Request, Response] = {
-          val paramHandler =
-            Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
-              rpm.routePattern.decode(request.method, request.path) match {
-                case Left(error)  => ZIO.dieMessage(error)
-                case Right(value) =>
-                  val params = rpm.zippable.zip(value, ctx)
+        val handler2: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]] = {
+          Handler.fromFunction[RoutePattern[_]] { pattern =>
+            val paramHandler =
+              Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
+                pattern.asInstanceOf[RoutePattern[rpm.PathInput]].decode(request.method, request.path) match {
+                  case Left(error)  => ZIO.dieMessage(error)
+                  case Right(value) =>
+                    val params = rpm.zippable.zip(value, ctx)
 
-                  handler(zippable.zip(params, request))
+                    handler(zippable.zip(params, request))
+                }
               }
-            }
-          rpm.aspect.applyHandlerContext(
-            Handler.fromFunctionHandler[(rpm.Context, Request)] { case (_, req) =>
-              paramHandler.mapErrorCauseZIO(f(req, _))
-            },
-          )
+            rpm.aspect.applyHandlerContext(
+              Handler.fromFunctionHandler[(rpm.Context, Request)] { case (_, req) =>
+                paramHandler.mapErrorCauseZIO(f(req, _))
+              },
+            )
+          }
         }
 
         Handled(rpm.routePattern, handler2, location)
@@ -264,7 +277,7 @@ sealed trait Route[-Env, +Err] { self =>
     self match {
       case Provided(route, env)                     => Provided(route.nest(prefix), env)
       case Augmented(route, aspect)                 => Augmented(route.nest(prefix), aspect)
-      case Handled(routePattern, handler, location) => Handled(routePattern.nest(prefix), handler, location)
+      case Handled(routePattern, handler, location) => Handled[Env](routePattern.nest(prefix), handler, location)
 
       case Unhandled(rpm, handler, zippable, location) =>
         Unhandled(rpm.prefix(prefix), handler, zippable, location)
@@ -312,14 +325,14 @@ object Route                   {
     routePattern: RoutePattern[_],
   )(handler: Handler[Env, Response, Request, Response])(implicit trace: Trace): Route[Env, Nothing] = {
     // Sandbox before constructing:
-    Route.Handled(routePattern, handler.sandbox, Trace.empty)
+    Route.Handled(routePattern, Handler.fromFunction[RoutePattern[_]](_ => handler.sandbox), Trace.empty)
   }
 
   def handled[Params, Env](rpm: Route.Builder[Env, Params]): HandledConstructor[Env, Params] =
     new HandledConstructor[Env, Params](rpm)
 
   val notFound: Route[Any, Nothing] =
-    Handled(RoutePattern.any, Handler.notFound, Trace.empty)
+    Handled(RoutePattern.any, Handler.fromFunction[RoutePattern[_]](_ => Handler.notFound), Trace.empty)
 
   def route[Params](routePattern: RoutePattern[Params]): UnhandledConstructor[Any, Params] =
     route(Route.Builder(routePattern, HandlerAspect.identity))
@@ -331,20 +344,22 @@ object Route                   {
     def apply[Env1 <: Env, In](
       handler: Handler[Env1, Response, In, Response],
     )(implicit zippable: Zippable.Out[Params, Request, In], trace: Trace): Route[Env1, Nothing] = {
-      val handler2: Handler[Env1, Response, Request, Response] = {
-        val paramHandler =
-          Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
-            rpm.routePattern.decode(request.method, request.path) match {
-              case Left(error)  => ZIO.dieMessage(error)
-              case Right(value) =>
-                val params = rpm.zippable.zip(value, ctx)
+      val handler2: Handler[Any, Nothing, RoutePattern[_], Handler[Env1, Response, Request, Response]] = {
+        Handler.fromFunction[RoutePattern[_]] { _ =>
+          val paramHandler =
+            Handler.fromFunctionZIO[(rpm.Context, Request)] { case (ctx, request) =>
+              rpm.routePattern.decode(request.method, request.path) match {
+                case Left(error)  => ZIO.dieMessage(error)
+                case Right(value) =>
+                  val params = rpm.zippable.zip(value, ctx)
 
-                handler(zippable.zip(params, request))
+                  handler(zippable.zip(params, request))
+              }
             }
-          }
 
-        // Sandbox before applying aspect:
-        rpm.aspect.applyHandlerContext(paramHandler.sandbox)
+          // Sandbox before applying aspect:
+          rpm.aspect.applyHandlerContext(paramHandler.sandbox)
+        }
       }
 
       Handled(rpm.routePattern, handler2, trace)
@@ -442,11 +457,11 @@ object Route                   {
 
   private final case class Handled[-Env](
     routePattern: RoutePattern[_],
-    handler: Handler[Env, Response, Request, Response],
+    handler: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]],
     location: Trace,
   ) extends Route[Env, Nothing] {
     override def toHandler(implicit ev: Nothing <:< Response, trace: Trace): Handler[Env, Response, Request, Response] =
-      handler
+      Handler.fromZIO(handler(routePattern)).flatten
 
     override def toString() = s"Route.Handled(${routePattern}, ${location})"
   }


### PR DESCRIPTION
@jdegoes When handling errors of `Route.Unhandled`, we accessed the current route pattern to decode it based on the incoming `Request`. When nesting, the route pattern of the handler changes, but the decoding was already constructed based on the pre-nesting route pattern.

I fixed this by changed the handler in `Route.Handled` to `handler: Handler[Any, Nothing, RoutePattern[_], Handler[Env, Response, Request, Response]]` and when calling `toHandler`, handing over the latest route pattern.

I considered instead manipulating the Request to remove the prefix when nesting, but decided that this is a bad idea, since the `Request` that the user might access would have a path, that does not reflect the path of the remote request.

fixes #2823
/claim #2823