### PR TITLE
Fix error when extracting examples (#2789)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -714,6 +714,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                   .content[NotFoundError]
                   .examples("not found" -> NotFoundError("not found")),
             )
+            .examplesOut("other" -> Right(NotFoundError("other")))
 
         val generated    = OpenAPIGen.fromEndpoints("Simple Endpoint", "1.0", endpoint)
         val json         = toJsonAst(generated)
@@ -727,24 +728,20 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |  "paths" : {
             |    "/static" : {
             |      "get" : {
-            |        "requestBody" :
-            |          {
+            |        "requestBody" : {
             |          "content" : {
             |            "application/json" : {
-            |              "schema" :
-            |                {
+            |              "schema" : {
             |                "$ref" : "#/components/schemas/SimpleInputBody"
             |              },
             |              "examples" : {
-            |                "john" :
-            |                  {
+            |                "john" : {
             |                  "value" : {
             |                    "name" : "John",
             |                    "age" : 42
             |                  }
             |                },
-            |                "jane" :
-            |                  {
+            |                "jane" : {
             |                  "value" : {
             |                    "name" : "Jane",
             |                    "age" : 43
@@ -756,12 +753,10 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "required" : true
             |        },
             |        "responses" : {
-            |          "default" :
-            |            {
+            |          "default" : {
             |            "content" : {
             |              "application/json" : {
-            |                "schema" :
-            |                  {
+            |                "schema" : {
             |                  "anyOf" : [
             |                    {
             |                      "$ref" : "#/components/schemas/SimpleOutputBody"
@@ -773,22 +768,24 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |                  "description" : ""
             |                },
             |                "examples" : {
-            |                  "john" :
-            |                    {
+            |                  "john" : {
             |                    "value" : {
             |                      "userName" : "John",
             |                      "score" : 42
             |                    }
             |                  },
-            |                  "jane" :
-            |                    {
+            |                  "jane" : {
             |                    "value" : {
             |                      "userName" : "Jane",
             |                      "score" : 43
             |                    }
             |                  },
-            |                  "not found" :
-            |                    {
+            |                  "other" : {
+            |                    "value" : {
+            |                      "message" : "other"
+            |                    }
+            |                  },
+            |                  "not found" : {
             |                    "value" : {
             |                      "message" : "not found"
             |                    }
@@ -803,32 +800,25 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |  },
             |  "components" : {
             |    "schemas" : {
-            |      "NotFoundError" :
-            |        {
-            |        "type" :
-            |          "object",
+            |      "NotFoundError" : {
+            |        "type" : "object",
             |        "properties" : {
             |          "message" : {
-            |            "type" :
-            |              "string"
+            |            "type" : "string"
             |          }
             |        },
             |        "required" : [
             |          "message"
             |        ]
             |      },
-            |      "SimpleInputBody" :
-            |        {
-            |        "type" :
-            |          "object",
+            |      "SimpleInputBody" : {
+            |        "type" : "object",
             |        "properties" : {
             |          "name" : {
-            |            "type" :
-            |              "string"
+            |            "type" : "string"
             |          },
             |          "age" : {
-            |            "type" :
-            |              "integer",
+            |            "type" : "integer",
             |            "format" : "int32"
             |          }
             |        },
@@ -837,18 +827,14 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |          "age"
             |        ]
             |      },
-            |      "SimpleOutputBody" :
-            |        {
-            |        "type" :
-            |          "object",
+            |      "SimpleOutputBody" : {
+            |        "type" : "object",
             |        "properties" : {
             |          "userName" : {
-            |            "type" :
-            |              "string"
+            |            "type" : "string"
             |          },
             |          "score" : {
-            |            "type" :
-            |              "integer",
+            |            "type" : "integer",
             |            "format" : "int32"
             |          }
             |        },

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -59,6 +59,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
     that: HttpCodec[AtomTypes1, Value2],
   )(implicit alternator: Alternator[Value, Value2]): HttpCodec[AtomTypes1, alternator.Out] = {
     if (self eq HttpCodec.Halt) that.asInstanceOf[HttpCodec[AtomTypes1, alternator.Out]]
+    else if (that eq HttpCodec.Halt) self.asInstanceOf[HttpCodec[AtomTypes1, alternator.Out]]
     else {
       HttpCodec
         .Fallback(self, that, alternator, HttpCodec.Fallback.Condition.IsHttpCodecError)


### PR DESCRIPTION
~~@jdegoes this is a fix, but seems fishy.
I debugged and realised, that we have in the changed line an alternator of type right empty. Which comes from the call of `outCodec`. This is correct, since the type of out before is empty. But the example value is wrapped in a left it needs to be unwrapped. Which only happens for an either alternator. Maybe you have an idea what could go wrong here?~~

@jdegoes I found the actual issue. The `def |` only throw aways an incoming `HttpCodec.Halt`, but it needs to ignore self if it is `HttpCodec.Halt` as well.

Question:
Does it make more sense to check `self eq Halt` or override `def |` for `Halt`?
 
fixes #2789
/claim #2789