### PR TITLE
Avoid copying of the underlying array in `AsyncBody#asArray`

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
@@ -137,7 +137,10 @@ object NettyBody extends BodyEncoding {
     override val boundary: Option[Boundary] = None,
   ) extends Body {
 
-    override def asArray(implicit trace: Trace): Task[Array[Byte]] = asChunk.map(_.toArray)
+    override def asArray(implicit trace: Trace): Task[Array[Byte]] = asChunk.map {
+      case b: Chunk.ByteArray => b.array
+      case other              => other.toArray
+    }
 
     override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] =
       ZIO.async { cb =>


### PR DESCRIPTION
Micro-optimization to avoid copying the underlying array when the user wants to extract the body as an `Array[Byte]`