### PR TITLE
Release Netty requests prior to forking ZIO effects

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -26,12 +26,11 @@ import zio.stream.ZStream
 
 import zio.http.Body
 import zio.http.Body._
-import zio.http.netty.NettyBody.{AsciiStringBody, AsyncBody, ByteBufBody, UnsafeAsync}
+import zio.http.netty.NettyBody.{AsciiStringBody, AsyncBody, UnsafeAsync}
 
 import io.netty.buffer.Unpooled
 import io.netty.channel._
 import io.netty.handler.codec.http.{DefaultHttpContent, LastHttpContent}
-import io.netty.handler.stream.ChunkedNioFile
 
 object NettyBodyWriter {
 
@@ -56,10 +55,6 @@ object NettyBodyWriter {
     }
 
     body match {
-      case body: ByteBufBody                  =>
-        ctx.write(new DefaultHttpContent(body.byteBuf))
-        ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
-        None
       case body: FileBody                     =>
         // We need to stream the file when compression is enabled otherwise the response encoding fails
         val stream = ZStream.fromFile(body.file)

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
@@ -24,17 +24,16 @@ import zio.http.netty.client.ClientResponseStreamHandler
 import zio.http.netty.model.Conversions
 import zio.http.{Body, Header, Response}
 
-import io.netty.buffer.Unpooled
+import io.netty.buffer.{ByteBufUtil, Unpooled}
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{FullHttpResponse, HttpResponse}
 
 object NettyResponse {
 
   def apply(jRes: FullHttpResponse)(implicit unsafe: Unsafe): Response = {
-    val status       = Conversions.statusFromNetty(jRes.status())
-    val headers      = Conversions.headersFromNetty(jRes.headers())
-    val copiedBuffer = Unpooled.copiedBuffer(jRes.content())
-    val data         = NettyBody.fromByteBuf(copiedBuffer, headers.headers.get(Header.ContentType.name))
+    val status  = Conversions.statusFromNetty(jRes.status())
+    val headers = Conversions.headersFromNetty(jRes.headers())
+    val data    = NettyBody.fromByteBuf(jRes.content(), headers.headers.get(Header.ContentType.name))
 
     Response(status, headers, data)
   }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyClientDriver.scala
@@ -62,8 +62,8 @@ final case class NettyClientDriver private[netty] (
     onComplete: Promise[Throwable, ChannelState],
     enableKeepAlive: Boolean,
   )(implicit trace: Trace): RIO[Scope, ChannelInterface] =
-    NettyRequestEncoder
-      .encode(req)
+    ZIO
+      .succeed(NettyRequestEncoder.encode(req))
       .tapSome { case fullReq: FullHttpRequest =>
         Scope.addFinalizer {
           ZIO.succeed {

--- a/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyRequestEncoderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyRequestEncoderSpec.scala
@@ -16,11 +16,11 @@
 
 package zio.http.netty.client
 
+import zio.ZIO
 import zio.test.Assertion._
 import zio.test._
 
 import zio.http.internal.HttpGen
-import zio.http.netty._
 import zio.http.netty.model.Conversions
 import zio.http.{Body, QueryParams, Request, URL, ZIOHttpSpec}
 
@@ -59,68 +59,72 @@ object NettyRequestEncoderSpec extends ZIOHttpSpec {
   def spec = suite("EncodeClientParams")(
     test("method") {
       check(anyClientParam) { params =>
-        val req = encode(params).map(_.method())
+        val req = ZIO.succeed(encode(params)).map(_.method())
         assertZIO(req)(equalTo(Conversions.methodToNetty(params.method)))
       }
     },
     test("method on Body.RandomAccessFile") {
       check(HttpGen.clientParamsForFileBody()) { params =>
-        val req = encode(params).map(_.method())
+        val req = ZIO.succeed(encode(params)).map(_.method())
         assertZIO(req)(equalTo(Conversions.methodToNetty(params.method)))
       }
     },
     suite("uri")(
       test("uri") {
         check(anyClientParam) { params =>
-          val req = encode(params).map(_.uri())
+          val req = ZIO.succeed(encode(params)).map(_.uri())
           assertZIO(req)(equalTo(params.url.relative.addLeadingSlash.encode))
         }
       },
       test("uri on Body.RandomAccessFile") {
         check(HttpGen.clientParamsForFileBody()) { params =>
-          val req = encode(params).map(_.uri())
+          val req = ZIO.succeed(encode(params)).map(_.uri())
           assertZIO(req)(equalTo(params.url.relative.addLeadingSlash.encode))
         }
       },
     ),
     test("content-length") {
       check(clientParamWithFiniteData(5)) { params =>
-        val req = encode(params).map(
-          _.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).toLong,
-        )
+        val req = ZIO
+          .succeed(encode(params))
+          .map(
+            _.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).toLong,
+          )
         assertZIO(req)(equalTo(5L))
       }
     },
     test("host header") {
       check(anyClientParam) { params =>
         val req =
-          encode(params).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
+          ZIO.succeed(encode(params)).map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
         assertZIO(req)(equalTo(params.url.hostPort))
       }
     },
     test("host header when absolute url") {
       check(clientParamWithAbsoluteUrl) { params =>
-        val req = encode(params)
+        val req = ZIO
+          .succeed(encode(params))
           .map(i => Option(i.headers().get(HttpHeaderNames.HOST)))
         assertZIO(req)(equalTo(params.url.hostPort))
       }
     },
     test("only one host header exists") {
       check(clientParamWithAbsoluteUrl) { params =>
-        val req = encode(params)
+        val req = ZIO
+          .succeed(encode(params))
           .map(_.headers().getAll(HttpHeaderNames.HOST).size)
         assertZIO(req)(equalTo(1))
       }
     },
     test("http version") {
       check(anyClientParam) { params =>
-        val req = encode(params).map(i => i.protocolVersion())
+        val req = ZIO.succeed(encode(params)).map(i => i.protocolVersion())
         assertZIO(req)(equalTo(Conversions.versionToNetty(params.version)))
       }
     },
     test("url with an empty path and query params") {
       check(clientParamWithEmptyPathAndQueryParams) { params =>
-        val uri = encode(params).map(_.uri)
+        val uri = ZIO.succeed(encode(params)).map(_.uri)
         assertZIO(uri)(not(equalTo(params.url.encode))) &&
         assertZIO(uri)(equalTo(params.url.addLeadingSlash.encode))
       }
@@ -128,7 +132,7 @@ object NettyRequestEncoderSpec extends ZIOHttpSpec {
     test("leading slash added to path") {
       val url     = URL.decode("https://api.github.com").toOption.get / "something" / "else"
       val req     = Request(url = url)
-      val encoded = encode(req).map(_.uri)
+      val encoded = ZIO.succeed(encode(req)).map(_.uri)
       assertZIO(encoded)(equalTo("/something/else"))
     },
   )


### PR DESCRIPTION
While running benchmarks on some of my previous PRs, I've noticed on occasion Netty's leak detection logging warnings for `ByteBuf`s being garbage collected (as opposed to having their reference count go to 0). After looking into it, the culprit seems to be that we're passing Netty's objects to the effects that end up being forked and run on ZIO's executor. I'm still not 100% sure why the warnings are logged only some times (who knows what the garbage collector is doing 🤷) but in order to avoid this we ensure that the Netty objects are dereferenced prior to us handing over the request handling to ZIO's executor. 

I rerun a bunch of benchmarks and the test suite multiple times with this PR, and the warnings are now gone 😮‍💨

The only small downside is that for Websocket requests we end up re-encoding the `zio.http.Request` to a Netty request, but I think that's a small price to pay for avoiding additional GC due to Netty's objects being GC'd.