### PR TITLE
Accept `octet-stream` as media type for multipart text fields (#2746)

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -57,7 +57,7 @@ private[cli] final case class CliEndpoint(
 
   lazy val getOptions: List[HttpOptions] = url ++ headers ++ body
 
-  def describeOptions(description: Doc) =
+  def describeOptions(description: Doc): CliEndpoint =
     self.copy(
       body = self.body.map(_ ?? description),
       headers = self.headers.map(_ ?? description),

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
@@ -119,7 +119,7 @@ object EndpointGen {
   )
 
   def withDoc[A] = Mapper[CliReprOf[Codec[A]], Doc](
-    (repr, doc) => CliRepr(repr.value ?? doc, repr.repr.copy(body = repr.repr.body.map(_ ?? doc))),
+    (repr, doc) => CliRepr(repr.value ?? doc, repr.repr.describeOptions(doc)),
     anyDoc,
   )
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
@@ -284,7 +284,9 @@ object HttpContentCodec {
     def only[A](implicit schema: Schema[A]): HttpContentCodec[A] = {
       HttpContentCodec(
         ListMap(
-          MediaType.text.`plain` ->
+          MediaType.text.`plain`               ->
+            BinaryCodecWithSchema(zio.http.codec.internal.TextBinaryCodec.fromSchema[A](schema), schema),
+          MediaType.application.`octet-stream` ->
             BinaryCodecWithSchema(zio.http.codec.internal.TextBinaryCodec.fromSchema[A](schema), schema),
         ),
       )


### PR DESCRIPTION
The endpoint defined in #2746 looks and works as expected. But during testing and debugging I realised that some tools (Postman, but also we in some internal code) default fields of multipart to `octet-stream`.
This we did not handle gracefully until now. For fields that have no explicit media type and expect a value that is parsable by `TextBinaryCodec` (aka all default types that can be represented as a String) we will accept `application/octet-stream` with this PR.

fixes #2746
/claim #2746