### PR TITLE
Ignore non-content codecs when building multipart OpenAPI spec (#2745)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -2442,6 +2442,18 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                                        |    "components" : {}
                                        |}""".stripMargin))
       },
+      test("Non content codecs are ignored when building multipart schema") {
+        // We only test there is no exception when building the schema
+        val endpoint =
+          Endpoint(RoutePattern.POST / "post")
+            .in[Int]("foo")
+            .in[Boolean]("bar")
+            .query(QueryCodec.query("q"))
+            .out[Unit]
+
+        SwaggerUI.routes("docs/openapi", OpenAPIGen.fromEndpoints(endpoint))
+        assertCompletes
+      },
     )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -340,6 +340,20 @@ object OpenAPIGen {
                   .nullable(optional(metadata))
                   .description(description(metadata))
                   .annotate(annotations)
+              case (JsonSchema.Object(p, _, r), JsonSchema.Null)                =>
+                JsonSchema
+                  .Object(p, Left(false), r)
+                  .deprecated(deprecated(metadata))
+                  .nullable(optional(metadata))
+                  .description(description(metadata))
+                  .annotate(annotations)
+              case (JsonSchema.Null, JsonSchema.Object(p, _, r))                =>
+                JsonSchema
+                  .Object(p, Left(false), r)
+                  .deprecated(deprecated(metadata))
+                  .nullable(optional(metadata))
+                  .description(description(metadata))
+                  .annotate(annotations)
               case _ => throw new IllegalArgumentException("Multipart content without name.")
             }
 
@@ -798,8 +812,7 @@ object OpenAPIGen {
         (
           statusOrDefault,
           (
-            AtomizedMetaCodecs
-              .flatten(codec),
+            AtomizedMetaCodecs.flatten(codec),
             contentAsJsonSchema(codec, referenceType = referenceType) _,
           ),
         )


### PR DESCRIPTION
fixes #2745
/claim #2745