### PR TITLE
Select codec based on response status for endpoint client (#2727)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
@@ -63,7 +63,7 @@ final case class EndpointExecutor[+MI](
     alt: Alternator[E, invocation.middleware.Err],
     ev: MI <:< invocation.middleware.In,
     trace: Trace,
-  ): ZIO[Scope, alt.Out, B] = {
+  ): ZIO[Scope, E, B] = {
     middlewareInput.flatMap { mi =>
       getClient(invocation.endpoint).orDie.flatMap { endpointClient =>
         endpointClient.execute(client, invocation)(ev(mi))


### PR DESCRIPTION
@jdegoes I already removed the usage of EndpointMiddleware here, since I plan to remove it over the weekend anyway.

fixes #2727
/claim #2727