### PR TITLE
Generate http-file standard from Endpoint definitions (#2876)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -627,6 +627,19 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
         case Metadata.Documented(doc) => Metadata.Documented(doc)
         case Metadata.Deprecated(doc) => Metadata.Deprecated(doc)
       }
+
+    def transformOrFail[Value2](f: Value => Either[String, Value2]): Metadata[Value2] =
+      this match {
+        case Metadata.Named(name)     => Metadata.Named(name)
+        case Metadata.Optional()      => Metadata.Optional()
+        case Metadata.Examples(ex)    =>
+          Metadata.Examples(ex.collect {
+            case (k, v) if f(v).isRight =>
+              k -> f(v).toOption.get
+          })
+        case Metadata.Documented(doc) => Metadata.Documented(doc)
+        case Metadata.Deprecated(doc) => Metadata.Deprecated(doc)
+      }
   }
 
   object Metadata {

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -313,14 +313,21 @@ sealed trait PathCodec[A] { self =>
   /**
    * Renders the path codec as a string.
    */
-  def render: String = {
+  def render: String =
+    render("{", "}")
+
+  /**
+   * Renders the path codec as a string. Surrounds the path variables with the
+   * specified prefix and suffix.
+   */
+  def render(prefix: String, suffix: String): String = {
     def loop(path: PathCodec[_]): String = path match {
       case PathCodec.Annotated(codec, _)    =>
         loop(codec)
       case PathCodec.Concat(left, right, _) =>
         loop(left) + loop(right)
 
-      case PathCodec.Segment(segment) => segment.render
+      case PathCodec.Segment(segment) => segment.render(prefix, suffix)
 
       case PathCodec.TransformOrFail(api, _, _) =>
         loop(api)
@@ -329,7 +336,10 @@ sealed trait PathCodec[A] { self =>
     loop(self)
   }
 
-  private[zio] def renderIgnoreTrailing: String = {
+  private[zio] def renderIgnoreTrailing: String =
+    renderIgnoreTrailing("{", "}")
+
+  private[zio] def renderIgnoreTrailing(prefix: String, suffix: String): String = {
     def loop(path: PathCodec[_]): String = path match {
       case PathCodec.Annotated(codec, _)    =>
         loop(codec)
@@ -338,7 +348,7 @@ sealed trait PathCodec[A] { self =>
 
       case PathCodec.Segment(SegmentCodec.Trailing) => ""
 
-      case PathCodec.Segment(segment) => segment.render
+      case PathCodec.Segment(segment) => segment.render(prefix, suffix)
 
       case PathCodec.TransformOrFail(api, _, _) => loop(api)
     }

--- a/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -50,18 +50,21 @@ sealed trait SegmentCodec[A] { self =>
   final def nonEmpty: Boolean = !isEmpty
 
   final def render: String = {
-    if (_render == "") _render = self.asInstanceOf[SegmentCodec[_]] match {
-      case _: SegmentCodec.Empty.type    => s""
-      case SegmentCodec.Literal(value)   => s"/$value"
-      case SegmentCodec.IntSeg(name)     => s"/{$name}"
-      case SegmentCodec.LongSeg(name)    => s"/{$name}"
-      case SegmentCodec.Text(name)       => s"/{$name}"
-      case SegmentCodec.BoolSeg(name)    => s"/{$name}"
-      case SegmentCodec.UUID(name)       => s"/{$name}"
-      case _: SegmentCodec.Trailing.type => s"/..."
-    }
+    if (_render == "") _render = render("{", "}")
     _render
   }
+
+  final def render(prefix: String, suffix: String): String =
+    self.asInstanceOf[SegmentCodec[_]] match {
+      case _: SegmentCodec.Empty.type    => s""
+      case SegmentCodec.Literal(value)   => s"/$value"
+      case SegmentCodec.IntSeg(name)     => s"/$prefix$name$suffix"
+      case SegmentCodec.LongSeg(name)    => s"/$prefix$name$suffix"
+      case SegmentCodec.Text(name)       => s"/$prefix$name$suffix"
+      case SegmentCodec.BoolSeg(name)    => s"/$prefix$name$suffix"
+      case SegmentCodec.UUID(name)       => s"/$prefix$name$suffix"
+      case _: SegmentCodec.Trailing.type => s"/..."
+    }
 
   final def transform[A2](f: A => A2)(g: A2 => A): PathCodec[A2] =
     PathCodec.Segment(self).transform(f)(g)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpFile.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpFile.scala
@@ -1,0 +1,91 @@
+package zio.http.endpoint.http
+
+import zio.http._
+import zio.http.endpoint.openapi.JsonSchema
+
+final case class HttpFile(endpoints: List[HttpEndpoint]) {
+  def ++(that: HttpFile): HttpFile = HttpFile(endpoints ++ that.endpoints)
+
+  def render: String = endpoints.map(_.render).mkString("\n\n")
+}
+
+final case class HttpEndpoint(
+  method: Method,
+  path: String,
+  headers: Seq[String],
+  requestBody: Option[JsonSchema],
+  variables: Seq[HttpVariable],
+  docString: Option[String],
+) {
+  def render: String =
+    renderDoc + renderVariables + renderPath + renderHeaders + renderRequestBody
+
+  private def renderRequestBody: String = {
+    requestBody match {
+      case None         => ""
+      case Some(schema) =>
+        renderSchema(schema)
+    }
+  }
+
+  private def renderSchema(schema: JsonSchema, name: Option[String] = None): String =
+    schema match {
+      case JsonSchema.AnnotatedSchema(schema, _) => renderSchema(schema)
+      case JsonSchema.RefSchema(_)               => throw new Exception("RefSchema not supported")
+      case JsonSchema.OneOfSchema(_)             => throw new Exception("OneOfSchema not supported")
+      case JsonSchema.AllOfSchema(_)             => throw new Exception("AllOfSchema not supported")
+      case JsonSchema.AnyOfSchema(_)             => throw new Exception("AnyOfSchema not supported")
+      case JsonSchema.Number(_)                  => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.Integer(_)                 => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.String(_, _)               => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.Boolean                    => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.ArrayType(_)               => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.Object(properties, _, _)   =>
+        if (properties.isEmpty) ""
+        else {
+          val fields = properties.map { case (name, schema) => renderSchema(schema, Some(name)) }.mkString(",\n")
+          // TODO: This has to be removed when we support other content types
+          if (name.isEmpty) s"\nContent-type: application/json\n\n{\n$fields\n}"
+          else s""""${getName(name)}": {\n$fields\n}"""
+        }
+      case JsonSchema.Enum(_)                    => s""""${getName(name)}": {{${getName(name)}}}"""
+      case JsonSchema.Null                       => ""
+      case JsonSchema.AnyJson                    => ""
+    }
+
+  private def getName(name: Option[String]) = { name.getOrElse(throw new IllegalArgumentException("name is required")) }
+
+  private def renderDoc =
+    docString match {
+      case None      =>
+        ""
+      case Some(doc) =>
+        doc.split("\n").map(line => s"# $line").mkString("\n", "\n", "\n")
+    }
+
+  private def renderVariables =
+    if (variables.isEmpty) ""
+    else variables.distinct.map(_.render).mkString("\n", "\n", "\n\n")
+
+  private def renderHeaders =
+    if (headers.isEmpty) ""
+    else headers.map(h => s"${h.capitalize}: {{${h.capitalize}}}").mkString("\n", "\n", "")
+
+  private def renderPath = {
+    if (method == Method.ANY) {
+      s"POST $path"
+    } else {
+      s"${method.render} $path"
+    }
+  }
+}
+
+final case class HttpVariable(name: String, value: Option[String], docString: Option[String] = None) {
+  def render = {
+    val variable = s"@$name=${value.getOrElse("<no value>")}"
+    if (docString.isDefined) {
+      docString.get.split("\n").map(line => s"# $line").mkString("", "\n", "\n") + variable
+    } else variable
+  }
+
+}

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -1,0 +1,192 @@
+package zio.http.endpoint.http
+
+import zio.http.MediaType
+import zio.http.codec._
+import zio.http.endpoint.Endpoint
+import zio.http.endpoint.openapi.OpenAPIGen.{AtomizedMetaCodecs, MetaCodec}
+import zio.http.endpoint.openapi.{JsonSchema, OpenAPIGen}
+
+object HttpGen {
+
+  private val PathWildcard = "pathWildcard"
+
+  def fromEndpoints(
+    endpoint1: Endpoint[_, _, _, _, _],
+    endpoints: Endpoint[_, _, _, _, _]*,
+  ): HttpFile = {
+    HttpFile((endpoint1 +: endpoints).map(fromEndpoint).toList)
+  }
+
+  def fromEndpoint(endpoint: Endpoint[_, _, _, _, _]): HttpEndpoint = {
+    val atomizedInput = AtomizedMetaCodecs.flatten(endpoint.input)
+    HttpEndpoint(
+      OpenAPIGen.method(atomizedInput.method),
+      buildPath(endpoint.input),
+      headersVariables(atomizedInput).map(_.name),
+      bodySchema(atomizedInput),
+      variables(atomizedInput),
+      doc(endpoint),
+    )
+  }
+
+  private def bodySchema(inAtoms: AtomizedMetaCodecs) = {
+    // currently only json support. No multipart/form-data or x-www-form-urlencoded
+    if (inAtoms.content.size != 1) None
+    else
+      inAtoms.content.collect {
+        case MetaCodec(HttpCodec.Content(codec, _, _), _) if codec.choices.contains(MediaType.application.json) =>
+          val schema     = codec.choices(MediaType.application.json).schema
+          val jsonSchema = JsonSchema.fromZSchema(schema)
+          jsonSchema
+      }.headOption
+  }
+
+  private def doc(endpoint: Endpoint[_, _, _, _, _]) =
+    if (endpoint.doc == Doc.empty) None else Some(endpoint.doc.toPlaintext(color = false))
+
+  def variables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] =
+    pathVariables(inAtoms) ++ queryVariables(inAtoms) ++ headersVariables(inAtoms) ++ bodyVariables(inAtoms)
+
+  def bodyVariables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
+    val bodySchema0 = bodySchema(inAtoms)
+
+    def loop(schema: JsonSchema, name: Option[String]): Seq[HttpVariable] = schema match {
+      case JsonSchema.AnnotatedSchema(schema, _) => loop(schema, name)
+      case JsonSchema.RefSchema(_)               => throw new Exception("RefSchema not supported")
+      case JsonSchema.OneOfSchema(_)             => throw new Exception("OneOfSchema not supported")
+      case JsonSchema.AllOfSchema(_)             => throw new Exception("AllOfSchema not supported")
+      case JsonSchema.AnyOfSchema(_)             => throw new Exception("AnyOfSchema not supported")
+      case JsonSchema.Number(format)             =>
+        val typeHint = format match {
+          case JsonSchema.NumberFormat.Float  => "type: Float"
+          case JsonSchema.NumberFormat.Double => "type: Double"
+        }
+        Seq(HttpVariable(getName(name), None, Some(typeHint)))
+      case JsonSchema.Integer(format)            =>
+        val typeHint = format match {
+          case JsonSchema.IntegerFormat.Int32     => "type: Int"
+          case JsonSchema.IntegerFormat.Int64     => "type: Long"
+          case JsonSchema.IntegerFormat.Timestamp => "type: Timestamp in milliseconds"
+        }
+        Seq(HttpVariable(getName(name), None, Some(typeHint)))
+      case JsonSchema.String(format, pattern)    =>
+        val formatHint: String  = format match {
+          case Some(value) => s" format: ${value.value}"
+          case None        => ""
+        }
+        val patternHint: String = pattern match {
+          case Some(value) => s" pattern: ${value.value}"
+          case None        => ""
+        }
+        Seq(HttpVariable(getName(name), None, Some(s"type: String$formatHint$patternHint")))
+      case JsonSchema.Boolean                    => Seq(HttpVariable(getName(name), None, Some("type: Boolean")))
+      case JsonSchema.ArrayType(items)           =>
+        val typeHint =
+          items match {
+            case Some(schema) =>
+              loop(schema, Some("notUsed")).map(_.render).mkString(";")
+            case None         =>
+              ""
+          }
+
+        Seq(HttpVariable(getName(name), None, Some(s"type: array of $typeHint")))
+      case JsonSchema.Object(properties, _, _)   =>
+        properties.flatMap { case (key, value) => loop(value, Some(key)) }.toSeq
+      case JsonSchema.Enum(values) => Seq(HttpVariable(getName(name), None, Some(s"enum: ${values.mkString(",")}")))
+      case JsonSchema.Null         => Seq.empty
+      case JsonSchema.AnyJson      => Seq.empty
+    }
+
+    bodySchema0 match {
+      case Some(schema) => loop(schema, None)
+      case None         => Seq.empty
+    }
+  }
+
+  private def getName(name: Option[String]) = { name.getOrElse(throw new IllegalArgumentException("name is required")) }
+
+  def headersVariables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] =
+    inAtoms.header.collect { case mc @ MetaCodec(HttpCodec.Header(name, codec, _), _) =>
+      HttpVariable(
+        name.capitalize,
+        mc.examples.values.headOption.map(e => codec.asInstanceOf[TextCodec[Any]].encode(e)),
+      )
+    }
+
+  def queryVariables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
+    inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(name, _, _, _), _) =>
+      HttpVariable(
+        name,
+        mc.examples.values.headOption.map(_.toString),
+      )
+//      OpenAPI.ReferenceOr.Or(
+//        OpenAPI.Parameter.queryParameter(
+//          name = name,
+//          description = mc.docsOpt,
+//          schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromTextCodec(codec))),
+//          deprecated = mc.deprecated,
+//          style = OpenAPI.Parameter.Style.Form,
+//          explode = false,
+//          allowReserved = false,
+//          examples = mc.examples.map { case (name, value) =>
+//            name -> OpenAPI.ReferenceOr.Or(OpenAPI.Example(value = Json.Str(value.toString)))
+//          },
+//          required = mc.required,
+//          ),
+//        )
+    }
+  }
+
+  private def pathVariables(inAtoms: AtomizedMetaCodecs) = {
+    inAtoms.path.collect {
+      case mc @ MetaCodec(codec, _) if codec != SegmentCodec.Empty && !codec.isInstanceOf[SegmentCodec.Literal] =>
+        HttpVariable(
+          mc.name.getOrElse(throw new Exception("Path parameter must have a name")),
+          mc.examples.values.headOption.map(_.toString),
+        )
+      //        OpenAPI.ReferenceOr.Or(
+      //          OpenAPI.Parameter.pathParameter(
+      //            name = mc.name.getOrElse(throw new Exception("Path parameter must have a name")),
+      //            description = mc.docsOpt.flatMap(_.flattened.filterNot(_ == pathDoc).reduceOption(_ + _)),
+      //            definition = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromSegmentCodec(codec))),
+      //            deprecated = mc.deprecated,
+      //            style = OpenAPI.Parameter.Style.Simple,
+      //            examples = mc.examples.map { case (name, value) =>
+      //              name -> OpenAPI.ReferenceOr.Or(OpenAPI.Example(segmentToJson(codec, value)))
+      //            },
+      //            ),
+      //          )
+    }
+  }
+
+  def buildPath(in: HttpCodec[_, _]): String = {
+
+    def pathCodec(in1: HttpCodec[_, _]): Option[HttpCodec.Path[_]] = in1 match {
+      case atom: HttpCodec.Atom[_, _]            =>
+        atom match {
+          case codec @ HttpCodec.Path(_, _) => Some(codec)
+          case _                            => None
+        }
+      case HttpCodec.Annotated(in, _)            => pathCodec(in)
+      case HttpCodec.TransformOrFail(api, _, _)  => pathCodec(api)
+      case HttpCodec.Empty                       => None
+      case HttpCodec.Halt                        => None
+      case HttpCodec.Combine(left, right, _)     => pathCodec(left).orElse(pathCodec(right))
+      case HttpCodec.Fallback(left, right, _, _) => pathCodec(left).orElse(pathCodec(right))
+    }
+
+    val atomizedInput = AtomizedMetaCodecs.flatten(in)
+    val queryNames    = queryVariables(atomizedInput).map(_.name)
+
+    val pathString = {
+      val codec = pathCodec(in).getOrElse(throw new Exception("No path found.")).pathCodec
+      if (codec.render("{{", "}}").endsWith(SegmentCodec.Trailing.render))
+        codec.renderIgnoreTrailing("{{", "}}") + s"{{$PathWildcard}}"
+      else codec.render("{{", "}}")
+    }
+
+    if (queryNames.nonEmpty) pathString + "?" + queryNames.map(name => s"$name={{$name}}").mkString("&")
+    else pathString
+  }
+
+}

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
@@ -1,0 +1,191 @@
+package zio.http.endpoint.http
+
+import zio.test._
+
+import zio.schema._
+
+import zio.http._
+import zio.http.codec._
+import zio.http.endpoint._
+
+object HttpGenSpec extends ZIOSpecDefault {
+  case class User(name: String, age: Int)
+
+  object User {
+    implicit val schema: Schema[User] = DeriveSchema.gen[User]
+  }
+
+  val spec = suite("HttpGenSpec")(
+    test("Method and Path") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo")
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      assertTrue(rendered == "GET /api/foo")
+    },
+    test("POST for Method.ANY") {
+      val endpoint     = Endpoint(Method.ANY / "api" / "foo")
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      assertTrue(rendered == "POST /api/foo")
+    },
+    test("Path with path parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId"))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@userId=<no value>
+          |
+          |GET /api/foo/{{userId}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Path with query parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo").query[Int](QueryCodec.queryInt("userId"))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@userId=<no value>
+          |
+          |GET /api/foo?userId={{userId}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Path with path and query parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("pageId")).query[Int](QueryCodec.queryInt("userId"))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@pageId=<no value>
+          |@userId=<no value>
+          |
+          |GET /api/foo/{{pageId}}?userId={{userId}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Path with path and query parameter with the same name") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId")).query[Int](QueryCodec.queryInt("userId"))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@userId=<no value>
+          |
+          |GET /api/foo/{{userId}}?userId={{userId}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Header") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo").header(HeaderCodec.authorization)
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@Authorization=<no value>
+          |
+          |GET /api/foo
+          |Authorization: {{Authorization}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Header with example") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo")
+        .header(HeaderCodec.authorization.examples("default" -> Header.Authorization.Basic("admin", "admin")))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@Authorization=Basic YWRtaW46YWRtaW4=
+          |
+          |GET /api/foo
+          |Authorization: {{Authorization}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Other header with example") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo")
+        .header(HeaderCodec.contentType.examples("default" -> Header.ContentType(MediaType.application.json)))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@Content-type=application/json
+          |
+          |GET /api/foo
+          |Content-type: {{Content-type}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Header with path parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId")).header(HeaderCodec.authorization)
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@userId=<no value>
+          |@Authorization=<no value>
+          |
+          |GET /api/foo/{{userId}}
+          |Authorization: {{Authorization}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Endpoint with doc") {
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId")) ?? Doc.p("Get user by id")
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |# Get user by id
+          |
+          |@userId=<no value>
+          |
+          |GET /api/foo/{{userId}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Endpoint with json payload") {
+      val endpoint     = Endpoint(Method.POST / "api" / "foo" / int("userId")).in[User]
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@userId=<no value>
+          |# type: String
+          |@name=<no value>
+          |# type: Int
+          |@age=<no value>
+          |
+          |POST /api/foo/{{userId}}
+          |Content-type: application/json
+          |
+          |{
+          |"name": {{name}},
+          |"age": {{age}}
+          |}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Multiple endpoints") {
+      val endpoint1     = Endpoint(Method.GET / "api" / "foo" / int("userId")) ?? Doc.p("Get user by id")
+      val endpoint2     = Endpoint(Method.POST / "api" / "foo" / int("userId")).in[User]
+      val httpEndpoint1 = HttpGen.fromEndpoints(endpoint1, endpoint2)
+      val rendered      = httpEndpoint1.render
+      val expected1     =
+        """
+          |# Get user by id
+          |
+          |@userId=<no value>
+          |
+          |GET /api/foo/{{userId}}""".stripMargin
+      val expected2     =
+        """
+          |@userId=<no value>
+          |# type: String
+          |@name=<no value>
+          |# type: Int
+          |@age=<no value>
+          |
+          |POST /api/foo/{{userId}}
+          |Content-type: application/json
+          |
+          |{
+          |"name": {{name}},
+          |"age": {{age}}
+          |}""".stripMargin
+      assertTrue(rendered == expected1 + "\n\n" + expected2)
+    },
+  )
+}


### PR DESCRIPTION
@jdegoes This focuses on a data structure for the http-file format and the ability to render it.
Code that generates fiels and integrets this in either sbt or the zio-plugin should be follow-up work.

fixes #2876
/claim #2876