### PR TITLE
Use `Exit.succeed` when body extraction is side-effect free

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -383,13 +383,13 @@ object Body {
   ) extends Body
       with UnsafeBytes { self =>
 
-    override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(data.toArray)
+    override def asArray(implicit trace: Trace): Task[Array[Byte]] = Exit.succeed(data.toArray)
 
     override def isComplete: Boolean = true
 
     override def isEmpty: Boolean = data.isEmpty
 
-    override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = ZIO.succeed(data)
+    override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = Exit.succeed(data)
 
     override def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte] =
       ZStream.unwrap(asChunk.map(ZStream.fromChunk(_)))
@@ -413,13 +413,13 @@ object Body {
   ) extends Body
       with UnsafeBytes { self =>
 
-    override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(data)
+    override def asArray(implicit trace: Trace): Task[Array[Byte]] = Exit.succeed(data)
 
     override def isComplete: Boolean = true
 
     override def isEmpty: Boolean = data.isEmpty
 
-    override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = ZIO.succeed(Chunk.fromArray(data))
+    override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = Exit.succeed(Chunk.fromArray(data))
 
     override def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte] =
       ZStream.unwrap(asChunk.map(ZStream.fromChunk(_)))
@@ -531,8 +531,8 @@ object Body {
 
   }
 
-  private val zioEmptyArray = ZIO.succeed(Array.empty[Byte])(Trace.empty)
+  private val zioEmptyArray = Exit.succeed(Array.emptyByteArray)
 
-  private val zioEmptyChunk = ZIO.succeed(Chunk.empty[Byte])(Trace.empty)
+  private val zioEmptyChunk = Exit.succeed(Chunk.empty[Byte])
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -383,7 +383,7 @@ object Body {
   ) extends Body
       with UnsafeBytes { self =>
 
-    override def asArray(implicit trace: Trace): Task[Array[Byte]] = Exit.succeed(data.toArray)
+    override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(data.toArray)
 
     override def isComplete: Boolean = true
 


### PR DESCRIPTION
When the server evaluates a ZIO effect, if the effect is an `Exit` (i.e., its value is known without evaluating the effect) then we shortcut the effect forking and respond immediately within Netty's event loop.

The issue this PR is trying to address is that this shortcut optimization is currently only possible with `GET` requests. Any kind of request that requires us to extract the body of the request immediately becomes effectful due to `ZIO.succeed`. With this change, we allow for POST requests to also be shortcut by returning an `Exit` when there are no side-effects or copying of arrays that are being captured by `ZIO.succeed`