### PR TITLE
Override URL's toString with encode

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -93,6 +93,8 @@ final case class URL(
     hash
   }
 
+  override def toString(): String = encode
+
   def host: Option[String] = kind match {
     case URL.Location.Relative      => None
     case abs: URL.Location.Absolute => Option(abs.host)


### PR DESCRIPTION
It's quite common to include a `URL` in the log message, but it's easy to forget to add `.encode` in the string interpolator.

The default `toString` method produces strings like `URL(/api/some/endpoint,Relative,JavaLinkedHashMapQueryParams({}),None)`, which are difficult to comprehend.