### PR TITLE
#2948: Remove new line character from sandbox warning header

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/HandlerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HandlerSpec.scala
@@ -30,6 +30,22 @@ object HandlerSpec extends ZIOHttpSpec with ExitAssertion {
 
   def spec = suite("Handler")(
     suite("sandbox")(
+      test("response failure with exception is passed through") {
+        val message = "long exception\nwith multiple\nlines"
+        val agent   = "ZIO HTTP"
+        val handler =
+          Handler
+            .fromFunctionZIO[Any] { _ =>
+              ZIO.fail(new Exception(message))
+            }
+            .sandbox
+
+        for {
+          result <- handler.merge.headers.run()
+        } yield {
+          assert(result.headers)(contains(Header.Warning(199, agent, message.replace('\n', ' '), None)))
+        }
+      },
       test("response failure is passed through") {
         val handler =
           Handler

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -136,7 +136,7 @@ object Response {
   def error(status: Status.Error, message: String): Response = {
     import zio.http.internal.OutputEncoder
 
-    val message2 = OutputEncoder.encodeHtml(if (message == null) status.text else message)
+    val message2 = OutputEncoder.encodeHtml(if (message == null) status.text else message).replace("\n", " ")
 
     Response(status = status, headers = Headers(Header.Warning(199, "ZIO HTTP", message2)))
   }


### PR DESCRIPTION
Removes new line characters (invalid in header values) when using sandbox to expose exceptions as warning headers.


fixes #2948 