### PR TITLE
Fix application shutdown issue when `Server#install` is not called

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ServerStartSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerStartSpec.scala
@@ -51,6 +51,15 @@ object ServerStartSpec extends HttpRunnableSpec {
         ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
       )
     },
+    test("application can shutdown if server is not started") {
+      ZIO
+        .succeed(assertCompletes)
+        .provide(
+          Server.customized.unit,
+          ZLayer.succeed(Server.Config.default.port(8089)),
+          ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+        )
+    },
   )
 
   override def spec: Spec[TestEnvironment with Scope, Any] = serverStartSpec @@ withLiveClock

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -446,18 +446,16 @@ object Server extends ServerPlatformSpecific {
         initialInstall   <- Promise.make[Nothing, Unit]
         serverStarted    <- Promise.make[Throwable, Int]
         _                <-
-          (
-            initialInstall.await *>
-              driver.start.flatMap { result =>
-                inFlightRequests.succeed(result.inFlightRequests) &>
-                  serverStarted.succeed(result.port)
-              }
-                .catchAll(serverStarted.fail)
-          )
+          (for {
+            _      <- initialInstall.await
+            result <- driver.start
+            _      <- inFlightRequests.succeed(result.inFlightRequests)
+            _      <- serverStarted.succeed(result.port)
+          } yield ())
             // In the case of failure of `Driver#.start` or interruption while we are waiting to be
-            // installed for the first time, we should should always fail the `serverStarted`
-            // promise to allow the finalizers to make progress.
-            .catchAllCause(cause => inFlightRequests.failCause(cause))
+            // installed for the first time, we should always fail the `serverStarted` and 'inFlightRequests'
+            // promises to allow the finalizers to make progress.
+            .onError(c => inFlightRequests.refailCause(c) *> serverStarted.refailCause(c))
             .forkScoped
       } yield ServerLive(driver, initialInstall, serverStarted)
     }

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -447,7 +447,7 @@ object Server extends ServerPlatformSpecific {
         serverStarted    <- Promise.make[Throwable, Int]
         _                <-
           (for {
-            _      <- initialInstall.await
+            _      <- initialInstall.await.interruptible
             result <- driver.start
             _      <- inFlightRequests.succeed(result.inFlightRequests)
             _      <- serverStarted.succeed(result.port)


### PR DESCRIPTION
/fixes #2961

Issue is that we're not interrupting the `initialInstall` and `serverStarted` promises when the forked fiber is interrupted