### PR TITLE
Streaming response body content type

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
@@ -55,7 +55,7 @@ object NettyResponse {
       onComplete.unsafe.done(Exit.succeed(ChannelState.forStatus(status)))
       Response(status, headers, Body.empty)
     } else {
-      val contentType = headers.get(Header.ContentType)
+      val contentType     = headers.get(Header.ContentType)
       val responseHandler = new ClientResponseStreamHandler(onComplete, keepAlive, status)
       ctx
         .pipeline()
@@ -65,7 +65,11 @@ object NettyResponse {
           responseHandler,
         ): Unit
 
-      val data = NettyBody.fromAsync(callback => responseHandler.connect(callback), knownContentLength, contentType.map(_.renderedValue))
+      val data = NettyBody.fromAsync(
+        callback => responseHandler.connect(callback),
+        knownContentLength,
+        contentType.map(_.renderedValue),
+      )
       Response(status, headers, data)
     }
   }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyResponse.scala
@@ -55,6 +55,7 @@ object NettyResponse {
       onComplete.unsafe.done(Exit.succeed(ChannelState.forStatus(status)))
       Response(status, headers, Body.empty)
     } else {
+      val contentType = headers.get(Header.ContentType)
       val responseHandler = new ClientResponseStreamHandler(onComplete, keepAlive, status)
       ctx
         .pipeline()
@@ -64,7 +65,7 @@ object NettyResponse {
           responseHandler,
         ): Unit
 
-      val data = NettyBody.fromAsync(callback => responseHandler.connect(callback), knownContentLength)
+      val data = NettyBody.fromAsync(callback => responseHandler.connect(callback), knownContentLength, contentType.map(_.renderedValue))
       Response(status, headers, data)
     }
   }

--- a/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -3,13 +3,13 @@ package zio.http.netty
 import zio._
 import zio.test.TestAspect.withLiveClock
 import zio.test.{Spec, TestEnvironment, assertTrue}
-
-import zio.stream.{ZStream, ZStreamAspect}
-
+import zio.stream.{ZPipeline, ZStream, ZStreamAspect}
 import zio.http.ZClient.Config
 import zio.http._
 import zio.http.internal.HttpRunnableSpec
+import zio.http.multipart.mixed.MultipartMixed
 import zio.http.netty.NettyConfig.LeakDetectionLevel
+import zio.http.netty.NettyStreamBodySpec.app
 
 object NettyStreamBodySpec extends HttpRunnableSpec {
 
@@ -101,6 +101,79 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
           )
         }
       },
+      test("properly decodes body's boundary") {
+        def trackablePart(content : String): ZIO[Any, Nothing, (MultipartMixed.Part, Promise[Nothing, Boolean])] = {
+          zio.Promise.make[Nothing, Boolean].map{ p =>
+            MultipartMixed.Part(
+              Headers(Header.ContentType(MediaType.text.`plain`)),
+              ZStream(content)
+                .via(ZPipeline.utf8Encode)
+                .ensuring(p.succeed(true))
+            ) ->
+            p
+          }
+        }
+        def trackableMultipartMixed(b : Boundary)(partsContents : String*): ZIO[Any, Nothing, (MultipartMixed, Seq[Promise[Nothing, Boolean]])] = {
+          ZIO
+            .foreach(partsContents)(trackablePart)
+            .map{ tps =>
+              val (parts, promisises) = tps.unzip
+              val mpm = MultipartMixed.fromParts(ZStream.fromIterable(parts), b, 10)
+              (mpm, promisises)
+            }
+        }
+
+        def serve(resp : Response): ZIO[Any, Throwable, RuntimeFlags] = {
+          val app = Routes( Method.GET / "it" -> handler( resp ) )
+          for {
+            portPromise <- Promise.make[Throwable, Int]
+            _           <- Server
+              .install(app)
+              .intoPromise(portPromise)
+              .zipRight(ZIO.never)
+              .provide(
+                ZLayer.succeed(NettyConfig.defaultWithFastShutdown.leakDetection(LeakDetectionLevel.PARANOID)),
+                ZLayer.succeed(Server.Config.default.onAnyOpenPort),
+                Server.customized,
+              )
+              .fork
+            port        <- portPromise.await
+          } yield port
+        }
+
+        for{
+          mpmAndPromises <- trackableMultipartMixed(Boundary("this_is_a_boundary"))("this is the boring part 1", "and this is the boring part two")
+          (mpm, promises) = mpmAndPromises
+          resp = Response(body = Body.fromStreamChunked(mpm.source).contentType(MediaType.multipart.`mixed`, mpm.boundary))
+            .addHeader(Header.ContentType(MediaType.multipart.`mixed`, Some(mpm.boundary)))
+          port <- serve(resp)
+          client                   <- ZIO.service[Client]
+          req = Request.get(s"http://localhost:$port/it")
+          actualResp <- client(req)
+          actualMpm <- actualResp.body.asMultipartMixed
+          partsResults <- actualMpm
+            .parts
+            .zipWithIndex
+            .mapZIO{
+              case (part, idx) =>
+                val pr = promises(idx.toInt)
+                pr.isDone <*>
+                part.toBody.asString  <*>
+                pr.isDone
+            }
+            .runCollect
+        } yield {
+          zio.test.assertTrue{
+            actualResp.headers(Header.ContentType) == resp.headers(Header.ContentType)  &&
+              actualResp.body.boundary == Some(mpm.boundary)  &&
+              actualMpm.boundary == mpm.boundary  &&
+              partsResults == Chunk(
+                (false, "this is the boring part 1", true),
+                (false, "and this is the boring part two", true)
+              )
+          }
+        }
+      }
     ).provide(
       singleConnectionClient,
       Scope.default,

--- a/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -162,8 +162,8 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
           actualMpm    <- actualResp.body.asMultipartMixed
           partsResults <- actualMpm.parts.zipWithIndex.mapZIO { case (part, idx) =>
             val pr = promises(idx.toInt)
-            pr.isDone <*>
-              part.toBody.asString <*>
+            // todo: due to server side buffering can't really expect the promises to be uncompleted BEFORE pulling on the client side
+            part.toBody.asString <*>
               pr.isDone
           }.runCollect
         } yield {
@@ -173,8 +173,8 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
             actualMpm.boundary == mpm.boundary &&
             partsResults == Chunk(
               // todo: due to server side buffering can't really expect the promises to be uncompleted BEFORE pulling on the client side
-              (true, "this is the boring part 1", true),
-              (true, "and this is the boring part two", true),
+              ("this is the boring part 1", true),
+              ("and this is the boring part two", true),
             )
           }
         }

--- a/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/NettyStreamBodySpec.scala
@@ -118,7 +118,7 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
             .foreach(partsContents)(trackablePart)
             .map{ tps =>
               val (parts, promisises) = tps.unzip
-              val mpm = MultipartMixed.fromParts(ZStream.fromIterable(parts), b, 10)
+              val mpm = MultipartMixed.fromParts(ZStream.fromIterable(parts), b, 1)
               (mpm, promisises)
             }
         }
@@ -168,8 +168,9 @@ object NettyStreamBodySpec extends HttpRunnableSpec {
               actualResp.body.boundary == Some(mpm.boundary)  &&
               actualMpm.boundary == mpm.boundary  &&
               partsResults == Chunk(
-                (false, "this is the boring part 1", true),
-                (false, "and this is the boring part two", true)
+                //todo: due to server side buffering can't really expect the promises to be uncompleted BEFORE pulling on the client side
+                (true, "this is the boring part 1", true),
+                (true, "and this is the boring part two", true)
               )
           }
         }


### PR DESCRIPTION
streaming responses doesn't properly populate the media-type and boundary for the response's body.
This is especially an issue for `MultipartMixed` as it relies on the boundary in order to be able to parse the response stream into parts.

this PR introduces a test and a fix, the test initially fails with:
```Assertion failed:
  Exception in thread "zio-fiber-71" java.lang.IllegalStateException: Cannot decode body as multipart/mixed without a known boundary
  	at zio.http.Body.$anonfun$asMultipartMixed$2(Body.scala:126)
  	at zio.ZIO$.$anonfun$fail$1(ZIO.scala:3164)
  	at zio.ZIO$.$anonfun$failCause$3(ZIO.scala:3173)
  	at zio.http.netty.NettyStreamBodySpec.spec(NettyStreamBodySpec.scala:153)
  	at zio.http.netty.NettyStreamBodySpec.spec(NettyStreamBodySpec.scala:104)```

applying the one-liner fix in `NettyResponse`, resolves the issue.