### PR TITLE
Fix sbt module compilation issue when using IntelliJ IDE

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -350,6 +350,7 @@ lazy val sbtZioHttpGrpcTests = (project in file("sbt-zio-http-grpc-tests"))
   .settings(publishSetting(false))
   .settings(
     Test / skip          := (CrossVersion.partialVersion(scalaVersion.value) != Some((2, 12))),
+    ideSkipProject       := (CrossVersion.partialVersion(scalaVersion.value) != Some((2, 12))),
     libraryDependencies ++= Seq(
       `zio-test-sbt`,
       `zio-test`,
@@ -417,3 +418,8 @@ lazy val docs = project
   .dependsOn(zioHttpJVM)
   .enablePlugins(WebsitePlugin)
   .dependsOn(zioHttpTestkit)
+
+Global / excludeLintKeys ++= Set(
+  sbtZioHttpGrpcTests / autoAPIMappings,
+  ideSkipProject,
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,7 @@ addSbtPlugin("org.scala-js"       % "sbt-scalajs"               % "1.16.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"  % "1.3.2")
 addSbtPlugin("com.thesamet"       % "sbt-protoc"                % "1.0.7")
 addSbtPlugin("com.thesamet"       % "sbt-protoc-gen-project"    % "0.1.8")
+
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
+
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.15"


### PR DESCRIPTION
See https://discord.com/channels/629491597070827530/629491597070827534/1262347147517628486

When compiling via IntelliJ, compilation fails for the `sbt-zio-http-grpc-tests` module as the files are only generated for Scala 2.12. To improve DX when using IntelliJ IDE, we exclude this module when we're working via the IDE.

Note that this change will have no effect via sbt, so we won't see any changes in CI or when using the sbt shell directly