### PR TITLE
fixes #2963: PartialBooleanAttribute (support no value)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/template/DomSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/template/DomSpec.scala
@@ -80,6 +80,22 @@ object DomSpec extends ZIOHttpSpec {
         assertTrue(dom.encode == """<a href="https://www.zio-http.com" title="click me!"></a>""")
       },
     ),
+    test("element with non value required attribute") {
+      val dom = Dom.element(
+        "input",
+        Dom.booleanAttr("required"),
+      )
+
+      assertTrue(dom.encode == """<input required/>""")
+    },
+    test("element with value required attribute") {
+      val dom = Dom.element(
+        "input",
+        Dom.booleanAttr("required", Some(true)),
+      )
+
+      assertTrue(dom.encode == """<input required="true"/>""")
+    },
     test("element with attribute & children") {
       val dom = Dom.element(
         "a",

--- a/zio-http/jvm/src/test/scala/zio/http/template/HtmlSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/template/HtmlSpec.scala
@@ -63,6 +63,16 @@ case object HtmlSpec extends ZIOHttpSpec {
         val expected = """<div class="container">Hello!</div>"""
         assert(view.encode)(equalTo(expected.stripMargin))
       },
+      test("tags with default boolean attributes") {
+        val view     = input(typeAttr := "text", requiredAttr)
+        val expected = """<input type="text" required/>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
+      test("tags with boolean attributes") {
+        val view     = input(typeAttr := "text", requiredAttr := false)
+        val expected = """<input type="text" required="false"/>"""
+        assert(view.encode)(equalTo(expected.stripMargin))
+      },
       suite("implicit conversions")(
         test("from unit") {
           val view: Html = {}

--- a/zio-http/shared/src/main/scala/zio/http/template/Attributes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/template/Attributes.scala
@@ -16,7 +16,9 @@
 
 package zio.http.template
 
-import zio.http.template.Attributes.PartialAttribute
+import scala.language.implicitConversions
+
+import zio.http.template.Attributes.{PartialAttribute, PartialBooleanAttribute}
 
 trait Attributes {
   final def acceptAttr: PartialAttribute[String] = PartialAttribute("accept")
@@ -301,7 +303,7 @@ trait Attributes {
 
   final def relAttr: PartialAttribute[String] = PartialAttribute("rel")
 
-  final def requiredAttr: PartialAttribute[String] = PartialAttribute("required")
+  final def requiredAttr: PartialBooleanAttribute = PartialBooleanAttribute("required")
 
   final def reversedAttr: PartialAttribute[String] = PartialAttribute("reversed")
 
@@ -365,9 +367,16 @@ trait Attributes {
 
   final def cellspacingAttr: PartialAttribute[String] = PartialAttribute("cellspacing")
 
+  implicit def partialBooleanToHtml(attr: PartialBooleanAttribute): Html = attr.apply()
 }
 
 object Attributes {
+  case class PartialBooleanAttribute(name: String) {
+    def :=(value: Boolean): Html    = Dom.booleanAttr(name, Some(value))
+    def apply(value: Boolean): Html = Dom.booleanAttr(name, Some(value))
+    def apply(): Html               = Dom.booleanAttr(name, None)
+  }
+
   case class PartialAttribute[A](name: String) {
     def :=(value: A)(implicit ev: IsAttributeValue[A]): Html    = Dom.attr(name, ev(value))
     def apply(value: A)(implicit ev: IsAttributeValue[A]): Html = Dom.attr(name, ev(value))


### PR DESCRIPTION
fixes #2963
/claim #2963

Added PartialBooleanAttribute, so we can use boolean attributes without specifying a value (optionally).

```scala
input(typeAttr := "text", requiredAttr)
input(typeAttr := "text", requiredAttr := false)
```

If this is a valid approach we can extend it to all 
[boolean attributes](https://html.spec.whatwg.org/#attributes-3)