### PR TITLE
Reduce verbosity of test suites

### DIFF
--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -182,7 +182,6 @@ object CodeGenSpec extends ZIOSpecDefault {
         val code     = EndpointGen.fromOpenAPI(openAPI)
 
         val tempDir = Files.createTempDirectory("codegen")
-        println(tempDir)
         CodeGen.writeFiles(code, java.nio.file.Paths.get(tempDir.toString, "test"), "test", Some(scalaFmtPath))
 
         fileShouldBe(
@@ -240,7 +239,6 @@ object CodeGenSpec extends ZIOSpecDefault {
         val code     = EndpointGen.fromOpenAPI(openAPI)
 
         val tempDir = Files.createTempDirectory("codegen")
-        println(tempDir)
         CodeGen.writeFiles(code, java.nio.file.Paths.get(tempDir.toString, "test"), "test", Some(scalaFmtPath))
 
         fileShouldBe(

--- a/zio-http/jvm/src/test/scala/zio/http/ClientStreamingSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ClientStreamingSpec.scala
@@ -208,7 +208,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
           port   <- server(streamingServer)
           client <- ZIO.service[Client]
           result <- check(Gen.int(1, N)) { chunkSize =>
-            (for {
+            for {
               bytes <- Random.nextBytes(N)
               form = Form(
                 Chunk(
@@ -233,7 +233,7 @@ object ClientStreamingSpec extends HttpRunnableSpec {
               collected.map.contains("file"),
               collected.map.contains("foo"),
               collected.get("file").get.asInstanceOf[FormField.Binary].data == bytes,
-            )).tapErrorCause(cause => ZIO.debug(cause.prettyPrint))
+            )
           }
         } yield result
       } @@ samples(20) @@ TestAspect.ifEnvNotSet("CI"),

--- a/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
@@ -50,7 +50,7 @@ object DualSSLSpec extends ZIOHttpSpec {
     includeClientCert = true,
   )
 
-  val config = Server.Config.default.port(8073).ssl(sslConfigWithTrustedClient)
+  val config = Server.Config.default.port(8073).ssl(sslConfigWithTrustedClient).logWarningOnFatalError(false)
 
   val payload = Gen.alphaNumericStringBounded(10000, 20000)
 

--- a/zio-http/jvm/src/test/scala/zio/http/MultipartMixedSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/MultipartMixedSpec.scala
@@ -210,7 +210,7 @@ object MultipartMixedSpec extends ZIOHttpSpec {
 
     test("property") {
       check(gens.genTestCase) { testCase =>
-        zio.Console.printLine(testCase) *> testCase.runTests
+        testCase.runTests
       }
     } @@ TestAspect.shrinks(0)
 
@@ -248,8 +248,8 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           gens.breaker.fixed(512),
         )
 
-        val innerTests = inner.runTests.map(_.label("inner")).debug("inner")
-        val outerTests = outer.runTests.map(_.label("outer")).debug("outer")
+        val innerTests = inner.runTests.map(_.label("inner"))
+        val outerTests = outer.runTests.map(_.label("outer"))
 
         val nestedTests = {
           val expectedNested = Nested.Multi(
@@ -262,7 +262,6 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           outer.partsToNested.map { collected =>
             zio.test.assert(collected)(Assertion.equalTo(expectedNested)).label("nestedTests")
           }
-            .debug("nestedTests")
         }
 
         (innerTests <*> outerTests <*> nestedTests).map { case (i, o, n) =>
@@ -308,8 +307,8 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           gens.breaker.fixed(512),
         )
 
-        val innerTests = inner.runTests.map(_.label("inner")).debug("inner")
-        val outerTests = outer.runTests.map(_.label("outer")).debug("outer")
+        val innerTests = inner.runTests.map(_.label("inner"))
+        val outerTests = outer.runTests.map(_.label("outer"))
 
         val nestedTests = {
           val expectedNested = Nested.Multi(
@@ -322,7 +321,6 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           outer.partsToNested.map { collected =>
             zio.test.assert(collected)(Assertion.equalTo(expectedNested)).label("nestedTests")
           }
-            .debug("nestedTests")
         }
 
         (innerTests <*> outerTests <*> nestedTests).map { case (i, o, n) =>
@@ -364,8 +362,8 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           gens.breaker.fixed(512),
         )
 
-        val innerTests = inner.runTests.map(_.label("inner")).debug("inner")
-        val outerTests = outer.runTests.map(_.label("outer")).debug("outer")
+        val innerTests = inner.runTests.map(_.label("inner"))
+        val outerTests = outer.runTests.map(_.label("outer"))
 
         val nestedTests = {
           val expectedNested = Nested.Multi(
@@ -379,7 +377,6 @@ object MultipartMixedSpec extends ZIOHttpSpec {
           outer.partsToNested.map { collected =>
             zio.test.assert(collected)(Assertion.equalTo(expectedNested)).label("nestedTests")
           }
-            .debug("nestedTests")
         }
 
         (innerTests <*> outerTests <*> nestedTests).map { case (i, o, n) =>

--- a/zio-http/jvm/src/test/scala/zio/http/RequestStreamingServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RequestStreamingServerSpec.scala
@@ -78,16 +78,14 @@ object RequestStreamingServerSpec extends HttpRunnableSpec {
           val host       = req.headers.get(Header.Host).get
           val newRequest =
             req.copy(url = req.url.path("/2").host(host.hostAddress).port(host.port.getOrElse(80)))
-          ZIO.debug(s"#1: got response, forwarding") *>
-            ZIO.serviceWithZIO[Client] { client =>
-              client.request(newRequest)
-            }
+          ZIO.serviceWithZIO[Client] { client =>
+            client.request(newRequest)
+          }
         },
         Method.POST / "2" -> handler { (req: Request) =>
-          ZIO.debug("#2: got response, collecting") *>
-            req.body.asChunk.map { body =>
-              Response.text(body.length.toString)
-            }
+          req.body.asChunk.map { body =>
+            Response.text(body.length.toString)
+          }
         },
       ).sandbox
       val sizes = Chunk(0, 8192, 1024 * 1024)

--- a/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
@@ -27,7 +27,7 @@ import zio.http.netty.client.NettyClientDriver
 object SSLSpec extends ZIOHttpSpec {
 
   val sslConfig = SSLConfig.fromResource("server.crt", "server.key")
-  val config    = Server.Config.default.port(8073).ssl(sslConfig)
+  val config    = Server.Config.default.port(8073).ssl(sslConfig).logWarningOnFatalError(false)
 
   val clientSSL1 = ClientSSLConfig.FromCertResource("server.crt")
   val clientSSL2 = ClientSSLConfig.FromCertResource("ss2.crt.pem")

--- a/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/StaticFileServerSpec.scala
@@ -66,7 +66,7 @@ object StaticFileServerSpec extends HttpRunnableSpec {
           assertZIO(res)(equalTo("foo\nbar"))
         },
         test("should have content-type") {
-          val res = fileOk.run().debug("fileOk").map(_.header(Header.ContentType))
+          val res = fileOk.run().map(_.header(Header.ContentType))
           assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.text.plain, charset = Some(Charsets.Utf8)))))
         },
         test("should respond with empty if file not found") {
@@ -121,7 +121,7 @@ object StaticFileServerSpec extends HttpRunnableSpec {
           assertZIO(res)(isSome(equalTo(Header.ContentType(MediaType.text.plain, charset = Some(Charsets.Utf8)))))
         },
         test("should respond with empty if not found") {
-          val res = resourceNotFound.run().debug("not found").map(_.status)
+          val res = resourceNotFound.run().map(_.status)
           assertZIO(res)(equalTo(Status.NotFound))
         },
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/ZIOHttpSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ZIOHttpSpec.scala
@@ -5,5 +5,5 @@ import zio.test._
 
 trait ZIOHttpSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectPoly] =
-    Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+    Chunk(TestAspect.timeout(60.seconds), TestAspect.timed, TestAspect.silentLogging, TestAspect.silent)
 }

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -42,7 +42,7 @@ object RoundtripSpec extends ZIOHttpSpec {
     ZLayer.make[Server & Client & Scope](
       Server.customized,
       ZLayer.succeed(Server.Config.default.onAnyOpenPort.enableRequestStreaming),
-      Client.customized.map(env => ZEnvironment(env.get @@ ZClientAspect.debug)),
+      Client.customized.map(env => ZEnvironment(env.get)),
       ClientDriver.shared,
       // NettyDriver.customized,
       ZLayer.succeed(NettyConfig.defaultWithFastShutdown),

--- a/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/AuthSpec.scala
@@ -119,11 +119,11 @@ object AuthSpec extends ZIOHttpSpec with HttpAppTestExtensions {
         val app          = secureRoutes
         for {
           s1     <- app.runZIO(Request.get(URL(Path.root / "a")).copy(headers = successBasicHeader))
-          s1Body <- s1.body.asString.debug("s1Body")
+          s1Body <- s1.body.asString
           s2     <- app.runZIO(Request.get(URL(Path.root / "b" / "1")).copy(headers = successBasicHeader))
-          s2Body <- s2.body.asString.debug("s2Body")
+          s2Body <- s2.body.asString
           s3     <- app.runZIO(Request.get(URL(Path.root / "c" / "name")).copy(headers = successBasicHeader))
-          s3Body <- s3.body.asString.debug("s3Body")
+          s3Body <- s3.body.asString
           resultStatus = s1.status == Status.Ok && s2.status == Status.Ok && s3.status == Status.Ok
           resultBody   = s1Body == "user" && s2Body == "for id: 1: user" && s3Body == "for name: name: user"
         } yield assertTrue(resultStatus, resultBody)

--- a/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/WebSpec.scala
@@ -249,8 +249,7 @@ object WebSpec extends ZIOHttpSpec with HttpAppTestExtensions { self =>
 
           for {
             url      <- ZIO.fromEither(URL.decode(url))
-            response <- app.runZIO(Request.get(url = url)).debug("response")
-            _        <- ZIO.debug(response.headerOrFail(Header.Location))
+            response <- app.runZIO(Request.get(url = url))
           } yield assertTrue(
             extractStatus(response) == status,
             response.header(Header.Location) == location.map(l => Header.Location(URL.decode(l).toOption.get)),

--- a/zio-http/jvm/src/test/scala/zio/http/internal/package.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/package.scala
@@ -25,7 +25,7 @@ import zio.http.netty.client.NettyClientDriver
 package object internal {
 
   val testServerConfig: ZLayer[Any, Nothing, Server.Config] =
-    ZLayer.succeed(Server.Config.default.onAnyOpenPort)
+    ZLayer.succeed(Server.Config.default.onAnyOpenPort.logWarningOnFatalError(false))
 
   val testNettyServerConfig: ZLayer[Any, Nothing, NettyConfig] =
     ZLayer.succeed(

--- a/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/client/NettyConnectionPoolSpec.scala
@@ -195,7 +195,7 @@ object NettyConnectionPoolSpec extends HttpRunnableSpec {
     }.provideSome[Client & Scope](
       ZLayer(appKeepAliveEnabled.unit),
       DynamicServer.live,
-      ZLayer.succeed(Server.Config.default.idleTimeout(500.millis).onAnyOpenPort),
+      ZLayer.succeed(Server.Config.default.idleTimeout(500.millis).onAnyOpenPort.logWarningOnFatalError(false)),
       testNettyServerConfig,
       Server.customized,
     ) @@ withLiveClock
@@ -211,7 +211,7 @@ object NettyConnectionPoolSpec extends HttpRunnableSpec {
   }.provideSome[Scope](
     ZLayer(appKeepAliveEnabled.unit),
     DynamicServer.live,
-    ZLayer.succeed(Server.Config.default.idleTimeout(500.millis).onAnyOpenPort),
+    ZLayer.succeed(Server.Config.default.idleTimeout(500.millis).onAnyOpenPort.logWarningOnFatalError(false)),
     testNettyServerConfig,
     Server.customized,
     Client.live,


### PR DESCRIPTION
Currently the test suites print _A LOT_ of stuff which is confusing and makes it difficult to track down errors. WIth this PR we reduce that verbosity by removing a lot of unnecessary `debug` / `println` statements, and by using the `silent` and `silentLogging` test aspects.

Note that I can't seem to manage to get rid of all of them, netty seems to be printing some warnings under the hood which I can't figure out a way to disable, e.g., 

```
WARNING: events[0]=[85, -1] had no channel!
July 26, 2024 12:38:21 PM io.netty.channel.kqueue.KQueueEventLoop processReady
WARNING: events[1]=[124, -1] had no channel!
July 26, 2024 12:38:21 PM io.netty.channel.kqueue.KQueueEventLoop processReady
WARNING: events[0]=[81, -1] had no channel!
July 26, 2024 12:38:21 PM io.netty.channel.kqueue.KQueueEventLoop processReady
WARNING: events[1]=[83, -1] had no channel!
July 26, 2024 12:38:21 PM io.netty.channel.kqueue.KQueueEventLoop processReady
WARNING: events[0]=[85, -1] had no channel!
```

If anyone has an idea on how to disable those as well that would be great!