### PR TITLE
Allow nesting `Routes` with unhandled errors (#2934)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RoutesSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutesSpec.scala
@@ -80,10 +80,10 @@ object RoutesSpec extends ZIOHttpSpec {
       val routes = literal("to") / Routes(
         Method.GET / "other"             -> handler(ZIO.fail(IdFormatError)),
         Method.GET / "do" / string("id") -> handler { (id: String, _: Request) => Response.text(s"GET /to/do/${id}") },
-      ).handleError { case IdFormatError =>
+      )
+      routes.handleError { case IdFormatError =>
         Response.badRequest
       }
-      routes
         .run(
           path = Path.root / "to" / "do" / "123",
         )

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -273,7 +273,7 @@ sealed trait Route[-Env, +Err] { self =>
    */
   def location: Trace
 
-  def nest(prefix: PathCodec[Unit])(implicit ev: Err <:< Response): Route[Env, Err] =
+  def nest(prefix: PathCodec[Unit]): Route[Env, Err] =
     self match {
       case Provided(route, env)                     => Provided(route.nest(prefix), env)
       case Augmented(route, aspect)                 => Augmented(route.nest(prefix), aspect)

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -117,7 +117,7 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
   def mapError[Err1](fxn: Err => Err1): Routes[Env, Err1] =
     new Routes(routes.map(_.mapError(fxn)))
 
-  def nest(prefix: PathCodec[Unit])(implicit trace: Trace, ev: Err <:< Response): Routes[Env, Err] =
+  def nest(prefix: PathCodec[Unit])(implicit trace: Trace): Routes[Env, Err] =
     new Routes(self.routes.map(_.nest(prefix)))
 
   /**

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -51,9 +51,9 @@ sealed trait PathCodec[A] { self =>
   final def /[B](that: PathCodec[B])(implicit combiner: Combiner[A, B]): PathCodec[combiner.Out] =
     self ++ that
 
-  final def /[Env](routes: Routes[Env, Response])(implicit
+  final def /[Env, Err](routes: Routes[Env, Err])(implicit
     ev: PathCodec[A] <:< PathCodec[Unit],
-  ): Routes[Env, Response] =
+  ): Routes[Env, Err] =
     routes.nest(ev(self))
 
   final def annotate(metaData: MetaData[A]): PathCodec[A] = {


### PR DESCRIPTION
fixes #2934
/claim #2934