### PR TITLE
just fail instead of throwing if a relative url is provided

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClient.scala
@@ -736,7 +736,7 @@ object ZClient extends ZClientPlatformSpecific {
             } yield response
           }
         case Location.Relative           =>
-          ZIO.fail(throw new IllegalArgumentException("Absolute URL is required"))
+          ZIO.fail(new IllegalArgumentException("Absolute URL is required"))
       }
   }
 


### PR DESCRIPTION
Ran into an unexpected fiber death when `URL.decode` succeeded with a relative URL and that was passed to `ZClient.request`