### PR TITLE
Efficient query optional encoding (#2942)

### DIFF
--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -127,11 +127,8 @@ private[cli] object CliEndpoint {
       case HttpCodec.Path(pathCodec, _) =>
         CliEndpoint(url = HttpOptions.Path(pathCodec) :: List())
 
-      case HttpCodec.Query(name, textCodec, _, _) =>
-        textCodec.asInstanceOf[TextCodec[_]] match {
-          case TextCodec.Constant(value) => CliEndpoint(url = HttpOptions.QueryConstant(name, value) :: List())
-          case _                         => CliEndpoint(url = HttpOptions.Query(name, textCodec) :: List())
-        }
+      case HttpCodec.Query(name, codec, _, _) =>
+        CliEndpoint(url = HttpOptions.Query(name, codec) :: List())
 
       case HttpCodec.Status(_, _) => CliEndpoint.empty
 

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -262,7 +262,7 @@ private[cli] object HttpOptions {
 
   }
 
-  final case class Query(override val name: String, codec: BinaryCodecWithSchema[_], doc: Doc = Doc.empty)
+  final case class Query(override val name: String, codec: CodecBuilderWithSchema[_], doc: Doc = Doc.empty)
       extends URLOptions {
     self =>
 
@@ -291,7 +291,7 @@ private[cli] object HttpOptions {
 
   }
 
-  private[cli] def optionsFromSchema[A](codec: BinaryCodecWithSchema[A]): String => Options[A] =
+  private[cli] def optionsFromSchema[A](codec: CodecBuilderWithSchema[A]): String => Options[A] =
     codec.schema match {
       case Schema.Primitive(standardType, _) =>
         standardType match {

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/HttpOptions.scala
@@ -3,6 +3,7 @@ package zio.http.endpoint.cli
 import scala.language.implicitConversions
 import scala.util.Try
 
+import zio.Chunk
 import zio.cli._
 import zio.json.ast._
 
@@ -261,11 +262,12 @@ private[cli] object HttpOptions {
 
   }
 
-  final case class Query(override val name: String, textCodec: TextCodec[_], doc: Doc = Doc.empty) extends URLOptions {
+  final case class Query(override val name: String, codec: BinaryCodecWithSchema[_], doc: Doc = Doc.empty)
+      extends URLOptions {
     self =>
 
     override val tag             = "?" + name
-    lazy val options: Options[_] = optionsFromTextCodec(textCodec)(name)
+    lazy val options: Options[_] = optionsFromSchema(codec)(name)
 
     override def ??(doc: Doc): Query = self.copy(doc = self.doc + doc)
 
@@ -288,6 +290,76 @@ private[cli] object HttpOptions {
       request.map(_.addQueryParam(name, value))
 
   }
+
+  private[cli] def optionsFromSchema[A](codec: BinaryCodecWithSchema[A]): String => Options[A] =
+    codec.schema match {
+      case Schema.Primitive(standardType, _) =>
+        standardType match {
+          case StandardType.UnitType           =>
+            _ => Options.Empty
+          case StandardType.StringType         =>
+            Options.text
+          case StandardType.BoolType           =>
+            Options.boolean(_)
+          case StandardType.ByteType           =>
+            Options.integer(_).map(_.toByte)
+          case StandardType.ShortType          =>
+            Options.integer(_).map(_.toShort)
+          case StandardType.IntType            =>
+            Options.integer(_).map(_.toInt)
+          case StandardType.LongType           =>
+            Options.integer(_).map(_.toLong)
+          case StandardType.FloatType          =>
+            Options.decimal(_).map(_.toFloat)
+          case StandardType.DoubleType         =>
+            Options.decimal(_).map(_.toDouble)
+          case StandardType.BinaryType         =>
+            Options.text(_).map(_.getBytes).map(Chunk.fromArray)
+          case StandardType.CharType           =>
+            Options.text(_).map(_.charAt(0))
+          case StandardType.UUIDType           =>
+            Options.text(_).map(java.util.UUID.fromString)
+          case StandardType.CurrencyType       =>
+            Options.text(_).map(java.util.Currency.getInstance)
+          case StandardType.BigDecimalType     =>
+            Options.decimal(_).map(_.bigDecimal)
+          case StandardType.BigIntegerType     =>
+            Options.integer(_).map(_.bigInteger)
+          case StandardType.DayOfWeekType      =>
+            Options.integer(_).map(i => java.time.DayOfWeek.of(i.toInt))
+          case StandardType.MonthType          =>
+            Options.text(_).map(java.time.Month.valueOf)
+          case StandardType.MonthDayType       =>
+            Options.text(_).map(java.time.MonthDay.parse)
+          case StandardType.PeriodType         =>
+            Options.text(_).map(java.time.Period.parse)
+          case StandardType.YearType           =>
+            Options.integer(_).map(i => java.time.Year.of(i.toInt))
+          case StandardType.YearMonthType      =>
+            Options.text(_).map(java.time.YearMonth.parse)
+          case StandardType.ZoneIdType         =>
+            Options.text(_).map(java.time.ZoneId.of)
+          case StandardType.ZoneOffsetType     =>
+            Options.text(_).map(java.time.ZoneOffset.of)
+          case StandardType.DurationType       =>
+            Options.text(_).map(java.time.Duration.parse)
+          case StandardType.InstantType        =>
+            Options.instant(_)
+          case StandardType.LocalDateType      =>
+            Options.localDate(_)
+          case StandardType.LocalTimeType      =>
+            Options.localTime(_)
+          case StandardType.LocalDateTimeType  =>
+            Options.localDateTime(_)
+          case StandardType.OffsetTimeType     =>
+            Options.text(_).map(java.time.OffsetTime.parse)
+          case StandardType.OffsetDateTimeType =>
+            Options.text(_).map(java.time.OffsetDateTime.parse)
+          case StandardType.ZonedDateTimeType  =>
+            Options.text(_).map(java.time.ZonedDateTime.parse)
+        }
+      case schema                            => throw new NotImplementedError(s"Schema $schema not yet supported")
+    }
 
   private[cli] def optionsFromTextCodec[A](textCodec: TextCodec[A]): (String => Options[A]) =
     textCodec match {

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
@@ -47,7 +47,7 @@ object CommandGen {
       case _: HttpOptions.Constant => false
       case _                       => true
     }.map {
-      case HttpOptions.Path(pathCodec, _)        =>
+      case HttpOptions.Path(pathCodec, _)    =>
         pathCodec.segments.toList.flatMap { case segment =>
           getSegment(segment) match {
             case (_, "")           => Nil
@@ -55,12 +55,12 @@ object CommandGen {
             case (name, codec)     => s"${getName(name, "")} $codec" :: Nil
           }
         }
-      case HttpOptions.Query(name, textCodec, _) =>
-        getType(textCodec) match {
+      case HttpOptions.Query(name, codec, _) =>
+        getType(codec) match {
           case ""    => s"[${getName(name, "")}]" :: Nil
           case codec => s"${getName(name, "")} $codec" :: Nil
         }
-      case _                                     => Nil
+      case _                                 => Nil
     }.foldRight(List[String]())(_ ++ _)
 
     val headersOptions = cliEndpoint.headers.filter {
@@ -119,6 +119,45 @@ object CommandGen {
       case TextCodec.LongCodec    => "integer"
       case TextCodec.BooleanCodec => ""
       case _                      => ""
+    }
+
+  def getType[A](codec: BinaryCodecWithSchema[A]): String =
+    codec.schema match {
+      case Schema.Primitive(standardType, _) =>
+        standardType match {
+          case StandardType.UnitType           => ""
+          case StandardType.StringType         => "text"
+          case StandardType.BoolType           => "bool"
+          case StandardType.ByteType           => "integer"
+          case StandardType.ShortType          => "integer"
+          case StandardType.IntType            => "integer"
+          case StandardType.LongType           => "integer"
+          case StandardType.FloatType          => "decimal"
+          case StandardType.DoubleType         => "decimal"
+          case StandardType.BinaryType         => "binary"
+          case StandardType.CharType           => "text"
+          case StandardType.UUIDType           => "text"
+          case StandardType.CurrencyType       => "currency"
+          case StandardType.BigDecimalType     => "decimal"
+          case StandardType.BigIntegerType     => "integer"
+          case StandardType.DayOfWeekType      => "integer"
+          case StandardType.MonthType          => "text"
+          case StandardType.MonthDayType       => "text"
+          case StandardType.PeriodType         => "text"
+          case StandardType.YearType           => "integer"
+          case StandardType.YearMonthType      => "text"
+          case StandardType.ZoneIdType         => "text"
+          case StandardType.ZoneOffsetType     => "text"
+          case StandardType.DurationType       => "text"
+          case StandardType.InstantType        => "instant"
+          case StandardType.LocalDateType      => "date"
+          case StandardType.LocalTimeType      => "time"
+          case StandardType.LocalDateTimeType  => "datetime"
+          case StandardType.OffsetTimeType     => "time"
+          case StandardType.OffsetDateTimeType => "datetime"
+          case StandardType.ZonedDateTimeType  => "datetime"
+        }
+      case _                                 => ""
     }
 
   def getPrimitive(schema: Schema[_]): String =

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CommandGen.scala
@@ -121,7 +121,7 @@ object CommandGen {
       case _                      => ""
     }
 
-  def getType[A](codec: BinaryCodecWithSchema[A]): String =
+  def getType[A](codec: CodecBuilderWithSchema[A]): String =
     codec.schema match {
       case Schema.Primitive(standardType, _) =>
         standardType match {

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
@@ -104,7 +104,7 @@ object EndpointGen {
   lazy val anyQuery: Gen[Any, CliReprOf[Codec[_]]] =
     Gen.alphaNumericStringBounded(1, 30).zip(anyStandardType).map { case (name, schema0) =>
       val schema = schema0.asInstanceOf[Schema[Any]]
-      val codec  = BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+      val codec  = CodecBuilderWithSchema(TextBinaryCodec.codecBuilder, schema)
       CliRepr(
         HttpCodec.Query(name, codec, QueryParamHint.Any),
         CliEndpoint(url = HttpOptions.Query(name, codec) :: Nil),

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/OptionsGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/OptionsGen.scala
@@ -33,7 +33,7 @@ object OptionsGen {
       .optionsFromTextCodec(textCodec)(name)
       .map(value => textCodec.encode(value))
 
-  def encodeOptions[A](name: String, codec: BinaryCodecWithSchema[A]): Options[String] =
+  def encodeOptions[A](name: String, codec: CodecBuilderWithSchema[A]): Options[String] =
     HttpOptions
       .optionsFromSchema(codec)(name)
       .map(value => codec.codec.encode(value).asString)
@@ -86,7 +86,7 @@ object OptionsGen {
         .alphaNumericStringBounded(1, 30)
         .zip(anyStandardType.map { s =>
           val schema = s.asInstanceOf[Schema[Any]]
-          BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+          CodecBuilderWithSchema(TextBinaryCodec.codecBuilder, schema)
         })
         .map { case (name, codec) =>
           CliRepr(

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
@@ -16,8 +16,6 @@
 
 package zio.http.endpoint
 
-import java.time.Instant
-
 import zio._
 import zio.test._
 
@@ -296,9 +294,7 @@ object QueryParameterSpec extends ZIOHttpSpec {
             .query(queryAllInt("ints"))
             .out[String]
             .implementHandler {
-              Handler.fromFunction { case queryParams =>
-                s"path(users, $queryParams)"
-              }
+              Handler.fromFunction { queryParams => s"path(users, $queryParams)" }
             },
         ),
       ) _

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -25,6 +25,8 @@ import zio.test._
 
 import zio.stream.ZStream
 
+import zio.schema.annotation.validate
+import zio.schema.validation.Validation
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http.Header.Authorization
@@ -32,7 +34,7 @@ import zio.http.Method._
 import zio.http._
 import zio.http.codec.HttpCodec.authorization
 import zio.http.codec.HttpContentCodec.protobuf
-import zio.http.codec.{Doc, HeaderCodec, HttpCodec, HttpContentCodec, QueryCodec}
+import zio.http.codec._
 import zio.http.endpoint.EndpointSpec.ImageMetadata
 import zio.http.netty.NettyConfig
 import zio.http.netty.server.NettyDriver
@@ -61,6 +63,17 @@ object RoundtripSpec extends ZIOHttpSpec {
 
   object Post {
     implicit val schema: Schema[Post] = DeriveSchema.gen[Post]
+  }
+
+  case class Age(@validate(Validation.greaterThan(18)) ignoredFieldName: Int)
+  object Age {
+    implicit val schema: Schema[Age] = DeriveSchema.gen[Age]
+  }
+
+  final case class PostWithAge(id: Int, title: String, body: String, userId: Int, age: Age)
+
+  object PostWithAge {
+    implicit val schema: Schema[PostWithAge] = DeriveSchema.gen[PostWithAge]
   }
 
   def makeExecutor(client: Client, port: Int): EndpointExecutor[Unit] = {
@@ -209,31 +222,66 @@ object RoundtripSpec extends ZIOHttpSpec {
             .query(HttpCodec.queryInt("id"))
             .query(HttpCodec.query("name").optional)
             .query(HttpCodec.query("details").optional)
-            .out[Post]
+            .query(HttpCodec.queryTo[Age]("age").optional)
+            .out[PostWithAge]
 
         val handler =
           api.implementHandler {
-            Handler.fromFunction { case (id, userId, name, details) =>
-              Post(id, name.getOrElse("-"), details.getOrElse("-"), userId)
+            Handler.fromFunction { case (id, userId, name, details, age) =>
+              PostWithAge(id, name.getOrElse("-"), details.getOrElse("-"), userId, age.getOrElse(Age(20)))
             }
           }
 
         testEndpoint(
           api,
           Routes(handler),
-          (10, 20, None, Some("x")),
-          Post(10, "-", "x", 20),
+          (10, 20, None, Some("x"), None),
+          PostWithAge(10, "-", "x", 20, Age(20)),
         ) && testEndpoint(
           api,
           Routes(handler),
-          (10, 20, None, None),
-          Post(10, "-", "-", 20),
+          (10, 20, None, None, None),
+          PostWithAge(10, "-", "-", 20, Age(20)),
         ) &&
         testEndpoint(
           api,
           Routes(handler),
-          (10, 20, Some("x"), Some("y")),
-          Post(10, "x", "y", 20),
+          (10, 20, Some("x"), Some("y"), Some(Age(23))),
+          PostWithAge(10, "x", "y", 20, Age(23)),
+        )
+      },
+      test("simple get with query params that fails validation") {
+        val api =
+          Endpoint(GET / "users" / int("userId"))
+            .query(HttpCodec.queryInt("id"))
+            .query(HttpCodec.query("name").optional)
+            .query(HttpCodec.query("details").optional)
+            .query(HttpCodec.queryTo[Age]("age").optional)
+            .out[PostWithAge]
+
+        val handler =
+          api.implementHandler {
+            Handler.fromFunction { case (id, userId, name, details, age) =>
+              PostWithAge(id, name.getOrElse("-"), details.getOrElse("-"), userId, age.getOrElse(Age(0)))
+            }
+          }
+
+        testEndpoint(
+          api,
+          Routes(handler),
+          (10, 20, Some("x"), Some("y"), Some(Age(17))),
+          PostWithAge(10, "x", "y", 20, Age(17)),
+        ).catchAllCause(t =>
+          ZIO.succeed(
+            assertTrue(
+              t.dieOption.contains(
+                HttpCodecError.CustomError(
+                  name = "InvalidEntity",
+                  message = "A well-formed entity failed validation: 17 should be greater than 18",
+                ),
+              ),
+            ),
+          ),
         )
       },
       test("throwing error in handler") {

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -17,6 +17,7 @@
 package zio.http.endpoint
 
 import scala.annotation.nowarn
+import scala.util.chaining.scalaUtilChainingOps
 
 import zio._
 import zio.test.Assertion._

--- a/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
@@ -123,16 +123,21 @@ object QueryParams {
      * takes advantage of LinkedHashMap implementation for O(1) lookup and
      * avoids conversion to Chunk.
      */
-    override def getAll(key: String): Chunk[String] = Option(underlying.get(key))
-      .map(_.asScala)
-      .map(Chunk.fromIterable)
-      .getOrElse(Chunk.empty)
+    override def getAll(key: String): Chunk[String] =
+      if (underlying.containsKey(key)) Chunk.fromIterable(underlying.get(key).asScala)
+      else Chunk.empty
 
     override def hasQueryParam(name: CharSequence): Boolean =
       underlying.containsKey(name.toString)
 
     override def updateQueryParams(f: QueryParams => QueryParams): QueryParams =
       f(self)
+
+    override private[http] def unsafeQueryParam(key: String): String =
+      underlying.get(key).get(0)
+
+    override def valueCount(name: CharSequence): Int =
+      if (underlying.containsKey(name)) underlying.get(name.toString).size() else 0
   }
 
   private def javaMapAsLinkedHashMap(

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -163,8 +163,8 @@ object Response {
       case Left(failure: Throwable) => fromThrowable(failure)
       case Left(failure: Cause[_])  => fromCause(failure)
       case _                        =>
-        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint.take(10000))
-        else error(Status.InternalServerError, cause.prettyPrint.take(10000))
+        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint)
+        else error(Status.InternalServerError, cause.prettyPrint)
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -23,7 +23,7 @@ import zio.stream.ZPipeline
 import zio.schema.codec._
 import zio.schema.{DeriveSchema, Schema}
 
-import zio.http.codec.{BinaryCodecWithSchema, HttpContentCodec}
+import zio.http.codec._
 
 /**
  * Server-Sent Event (SSE) as defined by
@@ -47,7 +47,9 @@ final case class ServerSentEvent[T](
 
   def encode(implicit binaryCodec: BinaryCodec[T]): String = {
     val sb = new StringBuilder
-    sb.append("data: ").append(binaryCodec.encode(data).asString)
+    binaryCodec.encode(data).asString.linesIterator.foreach { line =>
+      sb.append("data: ").append(line).append('\n')
+    }
     eventType.foreach { et =>
       sb.append("event: ").append(et.linesIterator.mkString(" ")).append('\n')
     }

--- a/zio-http/shared/src/main/scala/zio/http/codec/CodecBuilderWithSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/CodecBuilderWithSchema.scala
@@ -1,0 +1,23 @@
+package zio.http.codec
+
+import zio.schema.Schema
+import zio.schema.codec.BinaryCodec
+
+trait CodecBuilder {
+  def build[A](schema: Schema[A]): BinaryCodec[A]
+}
+
+final case class CodecBuilderWithSchema[A](codecBuilder: CodecBuilder, schema: Schema[A]) {
+  private var codec0: BinaryCodec[A] = _
+  def codec: BinaryCodec[A]          = {
+    if (codec0 == null) codec0 = codecBuilder.build(schema)
+    codec0
+  }
+
+  def optional: CodecBuilderWithSchema[Option[A]] = copy(schema = schema.optional)
+}
+
+object CodecBuilderWithSchema {
+  def fromBinaryCodec[A](codecBuilder: CodecBuilder)(implicit schema: Schema[A]): CodecBuilderWithSchema[A] =
+    CodecBuilderWithSchema(codecBuilder, schema)
+}

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -25,6 +25,8 @@ import zio._
 import zio.stream.ZStream
 
 import zio.schema.Schema
+import zio.schema.annotation.validate
+import zio.schema.validation.Validation
 
 import zio.http.Header.Accept.MediaTypeWithQFactor
 import zio.http._
@@ -584,7 +586,7 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
   }
   private[http] final case class Query[A](
     name: String,
-    textCodec: TextCodec[A],
+    codec: BinaryCodecWithSchema[A],
     hint: Query.QueryParamHint,
     index: Int = 0,
   ) extends Atom[HttpCodecType.Query, Chunk[A]] {

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -68,6 +68,9 @@ object HttpCodecError {
         errors,
       )
   }
+  final case class InvalidQueryParamCount(name: String, expected: Int, actual: Int)            extends HttpCodecError {
+    def message = s"Invalid query parameter count for $name: expected $expected but found $actual."
+  }
   final case class CustomError(name: String, message: String)                                  extends HttpCodecError
 
   final case class UnsupportedContentType(contentType: String) extends HttpCodecError {

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
@@ -25,7 +25,7 @@ import zio.http.codec._
 private[http] final case class AtomizedCodecs(
   method: Chunk[SimpleCodec[zio.http.Method, _]],
   path: Chunk[PathCodec[_]],
-  query: Chunk[Query[_]],
+  query: Chunk[Query[_, _]],
   header: Chunk[Header[_]],
   content: Chunk[BodyCodec[_]],
   status: Chunk[SimpleCodec[zio.http.Status, _]],
@@ -33,7 +33,7 @@ private[http] final case class AtomizedCodecs(
   def append(atom: Atom[_, _]): AtomizedCodecs = atom match {
     case path0: Path[_]            => self.copy(path = path :+ path0.pathCodec)
     case method0: Method[_]        => self.copy(method = method :+ method0.codec)
-    case query0: Query[_]          => self.copy(query = query :+ query0)
+    case query0: Query[_, _]       => self.copy(query = query :+ query0)
     case header0: Header[_]        => self.copy(header = header :+ header0)
     case content0: Content[_]      =>
       self.copy(content = content :+ BodyCodec.Single(content0.codec, content0.name))

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -49,7 +49,10 @@ private[endpoint] final case class EndpointClient[P, I, E, O, M <: EndpointMiddl
       } else if (endpoint.error.matchesStatus(response.status)) {
         endpoint.error.decodeResponse(response).orDie.flip
       } else {
-        ZIO.die(new IllegalStateException(s"Status code: ${response.status} is not defined in the endpoint"))
+        val error = endpoint.codecError.decodeResponse(response)
+        error
+          .flatMap(codecError => ZIO.die(codecError))
+          .orElse(ZIO.die(new IllegalStateException(s"Status code: ${response.status} is not defined in the endpoint")))
       }
     }
   }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -96,7 +96,7 @@ object OpenAPIGen {
   final case class AtomizedMetaCodecs(
     method: Chunk[MetaCodec[SimpleCodec[Method, _]]],
     path: Chunk[MetaCodec[SegmentCodec[_]]],
-    query: Chunk[MetaCodec[HttpCodec.Query[_]]],
+    query: Chunk[MetaCodec[HttpCodec.Query[_, _]]],
     header: Chunk[MetaCodec[HttpCodec.Header[_]]],
     content: Chunk[MetaCodec[HttpCodec.Atom[HttpCodecType.Content, _]]],
     status: Chunk[MetaCodec[HttpCodec.Status[_]]],
@@ -108,8 +108,8 @@ object OpenAPIGen {
         )
       case MetaCodec(_: SegmentCodec[_], _)                   =>
         copy(path = path :+ metaCodec.asInstanceOf[MetaCodec[SegmentCodec[_]]])
-      case MetaCodec(_: HttpCodec.Query[_], _)                =>
-        copy(query = query :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Query[_]]])
+      case MetaCodec(_: HttpCodec.Query[_, _], _)             =>
+        copy(query = query :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Query[_, _]]])
       case MetaCodec(_: HttpCodec.Header[_], _)               =>
         copy(header = header :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Header[_]]])
       case MetaCodec(_: HttpCodec.Status[_], _)               =>

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -615,7 +615,8 @@ object OpenAPIGen {
           OpenAPI.Parameter.queryParameter(
             name = name,
             description = mc.docsOpt,
-            schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromTextCodec(codec))),
+            // TODO: For single field case classes we need to use the schema of the field
+            schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromZSchema(codec.schema))),
             deprecated = mc.deprecated,
             style = OpenAPI.Parameter.Style.Form,
             explode = false,

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryChecks.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryChecks.scala
@@ -16,8 +16,16 @@
 
 package zio.http.internal
 
+import scala.jdk.CollectionConverters._
+
 trait QueryChecks[+A] { self: QueryOps[A] with A =>
 
   def hasQueryParam(name: CharSequence): Boolean =
     queryParameters.seq.exists(_.getKey == name)
+
+  def hasQueryParamValues(name: CharSequence, value: Seq[String]): Boolean =
+    queryParameters.seq.exists(p => p.getKey == name && p.getValue.asScala == value)
+
+  def valueCount(name: CharSequence): Int =
+    queryParameters.seq.count(_.getKey == name)
 }

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryGetters.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryGetters.scala
@@ -104,4 +104,7 @@ trait QueryGetters[+A] { self: QueryOps[A] =>
   def queryParamToOrElse[T](key: String, default: => T)(implicit codec: TextCodec[T]): T =
     queryParamTo[T](key).getOrElse(default)
 
+  private[http] def unsafeQueryParam(key: String): String =
+    queryParams(key).head
+
 }


### PR DESCRIPTION
This PR is based on the changes in #2991.
It encodes the optionality of the query params by adjusting the type hint and the binary codec.
This has multiple benefits.
1. the codecs are not blowing up the http codec alternatives when calculated
2. the more accurate modeling of the types for the query codec (Unit vs single value vs chunk) safes unnecessary chunk allocation when en/decoding
3. the change to BinaryCodecWithSchema allows us, to offer an API that manipulates the schema and generating a new codec from the changes schema. We could use this to add option or validation calls to the codec, instead of forcing the user to use zio-schema annotations on the data type. This would also work with primitive types. There would be no need to wrap them in a case class to annotate the field with validations.

fixes #2942
/claim #2942