### PR TITLE
Efficient query optional encoding (#2942)

### DIFF
--- a/docs/reference/endpoint.md
+++ b/docs/reference/endpoint.md
@@ -25,7 +25,7 @@ object Book {
 
 val endpoint =
   Endpoint(RoutePattern.GET / "books")
-    .query(QueryCodec.queryTo[String]("q") examples (("example1", "scala"), ("example2", "zio")))
+    .query(HttpCodec.query[String]("q") examples (("example1", "scala"), ("example2", "zio")))
     .out[List[Book]]
 ```
 
@@ -109,7 +109,7 @@ import zio.http.codec._
 ```scala mdoc:compile-only
 val endpoint: Endpoint[Unit, String, ZNothing, ZNothing, AuthType.None] =
   Endpoint(RoutePattern.GET / "books")
-    .query(QueryCodec.queryTo[String]("q"))
+    .query(HttpCodec.query[String]("q"))
 ```
 
 QueryCodecs are composable, so we can combine multiple query parameters:
@@ -117,7 +117,7 @@ QueryCodecs are composable, so we can combine multiple query parameters:
 ```scala mdoc:compile-only
 val endpoint: Endpoint[Unit, (String, Int), ZNothing, ZNothing, AuthType.None] =
   Endpoint(RoutePattern.GET / "books")
-    .query(QueryCodec.queryTo[String]("q") ++ QueryCodec.queryTo[Int]("limit"))
+    .query(HttpCodec.query[String]("q") ++ HttpCodec.query[Int]("limit"))
 ```
 
 Or we can use the `query` method multiple times:
@@ -125,8 +125,8 @@ Or we can use the `query` method multiple times:
 ```scala mdoc:compile-only
 val endpoint: Endpoint[Unit, (String, Int), ZNothing, ZNothing, AuthType.None] =
   Endpoint(RoutePattern.GET / "books")
-    .query(QueryCodec.queryTo[String]("q"))
-    .query(QueryCodec.queryTo[Int]("limit"))
+    .query(HttpCodec.query[String]("q"))
+    .query(HttpCodec.query[Int]("limit"))
 ```
 
 Please note that as we add more properties to the endpoint, the input and output types of the endpoint change accordingly. For example, in the following example, we have an endpoint with a path parameter of type `String` and two query parameters of type `String` and `Int`. So the input type of the endpoint is `(String, String, Int)`:
@@ -134,8 +134,8 @@ Please note that as we add more properties to the endpoint, the input and output
 ```scala mdoc:compile-only
 val endpoint: Endpoint[String, (String, String, Int), ZNothing, ZNothing, AuthType.None] =
   Endpoint(RoutePattern.GET / "books" / PathCodec.string("genre"))
-    .query(QueryCodec.queryTo[String]("q"))
-    .query(QueryCodec.queryTo[Int]("limit"))
+    .query(HttpCodec.query[String]("q"))
+    .query(HttpCodec.query[Int]("limit"))
 ```
 
 When we implement the endpoint, the handler function should take the input type of a tuple that the first element is the "genre" path parameter, and the second and third elements are the query parameters "q" and "limit" respectively.
@@ -215,7 +215,7 @@ object Book {
 
 val endpoint: Endpoint[Unit, String, ZNothing, List[Book], AuthType.None] =
   Endpoint(RoutePattern.GET / "books")
-    .query(QueryCodec.query("q"))
+    .query(HttpCodec.query[String]("q"))
     .out[List[Book]]
 ```
 
@@ -369,8 +369,8 @@ case class BookQuery(query: String, genre: String, title: String)
 
 val endpoint: Endpoint[String, (String, String, String), ZNothing, ZNothing, AuthType.None] =
   Endpoint(RoutePattern.POST / "books" / PathCodec.string("genre"))
-    .query(QueryCodec.query("q"))
-    .query(QueryCodec.query("title"))
+    .query(HttpCodec.query[String]("q"))
+    .query(HttpCodec.query[String]("title"))
 
 val mappedEndpoint: Endpoint[String, BookQuery, ZNothing, ZNothing, AuthType.None] =
   endpoint.transformIn[BookQuery] { case (genre, q, title) => BookQuery(q, genre, title) } { i =>
@@ -390,7 +390,7 @@ Every property of an `Endpoint` API can be annotated with documentation, may be 
 val endpoint =
   Endpoint((RoutePattern.GET / "books") ?? Doc.p("Route for querying books"))
     .query(
-      QueryCodec.queryTo[String]("q").examples(("example1", "scala"), ("example2", "zio")) ?? Doc.p(
+      HttpCodec.query[String]("q").examples(("example1", "scala"), ("example2", "zio")) ?? Doc.p(
         "Query parameter for searching books",
       ),
     )

--- a/docs/reference/http-codec.md
+++ b/docs/reference/http-codec.md
@@ -145,19 +145,19 @@ There are also predefined codecs for all the HTTP methods, e.g. `HttpCodec.conne
 
 ### QueryCodec
 
-The `QueryCodec[A]` is a codec for the query parameters of the HTTP message with type `A`. To be able to encode and decode query parameters, ZIO HTTP provides a wide range of query codecs. If we are dealing with a single query parameter we can use `HttpCodec.query`, `HttpCodec.queryBool`, `HttpCodec.queryInt`, and `HttpCodec.queryTo`:
+The `QueryCodec[A]` is a codec for the query parameters of the HTTP message with type `A`. To be able to encode and decode query parameters, ZIO HTTP provides a wide range of query codecs. If we are dealing with a single query parameter we can use `HttpCodec.query`, `HttpCodec.query[Boolean]`, `HttpCodec.query[Boolean]`, and `HttpCodec.queryTo`:
 
 ```scala mdoc:compile-only
 import zio.http._
 import zio.http.codec._
 import java.util.UUID
 
-val nameQueryCodec  : QueryCodec[String]         = HttpCodec.query("name")       // e.g. ?name=John
-val ageQueryCodec   : QueryCodec[Int]            = HttpCodec.queryInt("age")     // e.g. ?age=30 
-val activeQueryCodec: QueryCodec[Boolean]        = HttpCodec.queryBool("active") // e.g. ?active=true
+val nameQueryCodec  : QueryCodec[String]         = HttpCodec.query[String]("name")       // e.g. ?name=John
+val ageQueryCodec   : QueryCodec[Int]            = HttpCodec.query[Int]("age")     // e.g. ?age=30 
+val activeQueryCodec: QueryCodec[Boolean]        = HttpCodec.query[Boolean]("active") // e.g. ?active=true
 
 // e.g. ?uuid=43abea9e-0b0e-11ef-8d07-e755ec5cd767
-val uuidQueryCodec  : QueryCodec[UUID]           = HttpCodec.queryTo[UUID]("uuid") 
+val uuidQueryCodec  : QueryCodec[UUID]           = HttpCodec.query[UUID]("uuid") 
 ```
 
 We can combine multiple query codecs with `++`:
@@ -171,11 +171,11 @@ import zio.http._
 import zio.http.codec._
 import java.util.UUID
 
-val queryAllCodec    : QueryCodec[Chunk[String]] = HttpCodec.queryAll("q")      // e.g. ?q=one&q=two&q=three
-val queryAllIntCodec : QueryCodec[Chunk[Int]]    = HttpCodec.queryAllInt("id")  // e.g. ?ids=1&ids=2&ids=3
+val queryAllCodec    : QueryCodec[Chunk[String]] = HttpCodec.query[Chunk[String]]("q")      // e.g. ?q=one&q=two&q=three
+val queryAllIntCodec : QueryCodec[Chunk[Int]]    = HttpCodec.query[Chunk[Int]]("id")  // e.g. ?ids=1&ids=2&ids=3
 
 // e.g. ?uuid=43abea9e-0b0e-11ef-8d07-e755ec5cd767&uuid=43abea9e-0b0e-11ef-8d07-e755ec5cd768
-val queryAllUUIDCodec: QueryCodec[Chunk[UUID]]   = HttpCodec.queryAllTo[UUID]("uuid") 
+val queryAllUUIDCodec: QueryCodec[Chunk[UUID]]   = HttpCodec.query[Chunk[UUID]]("uuid") 
 ```
 
 ### StatusCodec
@@ -203,7 +203,7 @@ By combining two codecs using the `++` operator, we can create a new codec that 
 import zio.http.codec._
 
 // e.g. ?name=John&age=30
-val queryCodec: QueryCodec[(String, Int)]  = HttpCodec.query("name") ++ HttpCodec.queryInt("age")
+val queryCodec: QueryCodec[(String, Int)]  = HttpCodec.query[String]("name") ++ HttpCodec.query[Int]("age")
 ```
 
 ### Combining Codecs Alternatively
@@ -213,7 +213,7 @@ There is also a `|` operator that allows us to create a codec that can decode ei
 ```scala mdoc:silent
 import zio.http.codec._
 
-val eitherQueryCodec: QueryCodec[String] = HttpCodec.query("q") | HttpCodec.query("query")
+val eitherQueryCodec: QueryCodec[String] = HttpCodec.query[String]("q") | HttpCodec.query[String]("query")
 ```
 
 Assume we have a request
@@ -244,7 +244,7 @@ import zio._
 import zio.http._
 import zio.http.codec._
 
-val optionalQueryCodec: QueryCodec[Option[String]] = HttpCodec.query("q").optional
+val optionalQueryCodec: QueryCodec[Option[String]] = HttpCodec.query[String]("q").optional
 
 val request = Request(url = URL.root.copy(queryParams = QueryParams("query" -> "foo")))
 val result: Task[Option[String]] = optionalQueryCodec.decodeRequest(request)

--- a/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/EndpointBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/EndpointBenchmark.scala
@@ -11,7 +11,7 @@ import zio.{Scope => _, _}
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.QueryCodec
+import zio.http.codec.HttpCodec
 import zio.http.endpoint.Endpoint
 
 import cats.effect.unsafe.implicits.global
@@ -91,7 +91,7 @@ class EndpointBenchmark {
   // API DSL
   val usersPosts =
     Endpoint(Method.GET / "users" / int("userId") / "posts" / int("limit"))
-      .query(QueryCodec.query("query"))
+      .query(HttpCodec.query[String]("query"))
       .out[ExampleData]
 
   val handledUsersPosts =

--- a/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
+++ b/zio-http-cli/src/main/scala/zio/http/endpoint/cli/CliEndpoint.scala
@@ -1,6 +1,7 @@
 package zio.http.endpoint.cli
 
 import zio.http._
+import zio.http.codec.HttpCodec.Query.QueryType
 import zio.http.codec._
 import zio.http.endpoint._
 
@@ -127,8 +128,20 @@ private[cli] object CliEndpoint {
       case HttpCodec.Path(pathCodec, _) =>
         CliEndpoint(url = HttpOptions.Path(pathCodec) :: List())
 
-      case HttpCodec.Query(name, codec, _, _) =>
-        CliEndpoint(url = HttpOptions.Query(name, codec) :: List())
+      case HttpCodec.Query(queryType, _) =>
+        queryType match {
+          case QueryType.Primitive(name, codec)     =>
+            CliEndpoint(url = HttpOptions.Query(name, codec) :: List())
+          case record @ QueryType.Record(_)         =>
+            val queryOptions = record.fieldAndCodecs.map { case (field, codec) =>
+              HttpOptions.Query(field.name, codec)
+            }
+            CliEndpoint(url = queryOptions.toList)
+          case QueryType.Collection(_, elements, _) =>
+            val queryOptions =
+              HttpOptions.Query(elements.name, elements.codec)
+            CliEndpoint(url = queryOptions :: List())
+        }
 
       case HttpCodec.Status(_, _) => CliEndpoint.empty
 

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
@@ -6,7 +6,6 @@ import zio.test._
 import zio.schema.Schema
 
 import zio.http._
-import zio.http.codec.HttpCodec.Query.QueryParamHint
 import zio.http.codec._
 import zio.http.codec.internal.TextBinaryCodec
 import zio.http.endpoint._
@@ -106,7 +105,7 @@ object EndpointGen {
       val schema = schema0.asInstanceOf[Schema[Any]]
       val codec  = BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
       CliRepr(
-        HttpCodec.Query(name, codec, QueryParamHint.Any),
+        HttpCodec.Query(HttpCodec.Query.QueryType.Primitive(name, codec)),
         CliEndpoint(url = HttpOptions.Query(name, codec) :: Nil),
       )
     }

--- a/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
+++ b/zio-http-example/src/main/scala/example/CombinerTypesExample.scala
@@ -5,8 +5,8 @@ import zio.http.codec._
 
 object CombinerTypesExample extends App {
 
-  val foo = query("foo")
-  val bar = query("bar")
+  val foo = HttpCodec.query[String]("foo")
+  val bar = HttpCodec.query[String]("bar")
 
   val combine1L1R: HttpCodec[HttpCodecType.Query, (String, String)]                 = foo & bar
   val combine1L2R: HttpCodec[HttpCodecType.Query, (String, String, String)]         = foo & (bar & bar)

--- a/zio-http-example/src/main/scala/example/EndpointExamples.scala
+++ b/zio-http-example/src/main/scala/example/EndpointExamples.scala
@@ -4,13 +4,12 @@ import zio._
 
 import zio.http.Header.Authorization
 import zio.http._
-import zio.http.codec.{HttpCodec, PathCodec}
+import zio.http.codec.PathCodec.path
+import zio.http.codec._
+import zio.http.endpoint._
 import zio.http.endpoint.openapi.{OpenAPIGen, SwaggerUI}
-import zio.http.endpoint.{Endpoint, EndpointExecutor, EndpointLocator}
 
 object EndpointExamples extends ZIOAppDefault {
-  import HttpCodec.query
-  import PathCodec._
 
   // MiddlewareSpec can be added at the service level as well
   val getUser =
@@ -21,7 +20,7 @@ object EndpointExamples extends ZIOAppDefault {
 
   val getUserPosts =
     Endpoint(Method.GET / "users" / int("userId") / "posts" / int("postId"))
-      .query(query("name"))
+      .query(HttpCodec.query[String]("name"))
       .out[List[String]]
 
   val getUserPostsRoute =

--- a/zio-http-example/src/main/scala/example/endpoint/BooksEndpointExample.scala
+++ b/zio-http-example/src/main/scala/example/endpoint/BooksEndpointExample.scala
@@ -36,7 +36,7 @@ object BooksEndpointExample extends ZIOAppDefault {
   val endpoint =
     Endpoint((RoutePattern.GET / "books") ?? Doc.p("Route for querying books"))
       .query(
-        QueryCodec.queryTo[String]("q").examples(("example1", "scala"), ("example2", "zio")) ?? Doc.p(
+        HttpCodec.query[String]("q").examples(("example1", "scala"), ("example2", "zio")) ?? Doc.p(
           "Query parameter for searching books",
         ),
       )

--- a/zio-http-example/src/main/scala/example/endpoint/CliExamples.scala
+++ b/zio-http-example/src/main/scala/example/endpoint/CliExamples.scala
@@ -36,8 +36,6 @@ object Post {
 }
 
 trait TestCliEndpoints {
-  import HttpCodec._
-  import zio.http.codec.PathCodec._
 
   val getUser =
     Endpoint(Method.GET / "users" / int("userId") ?? Doc.p("The unique identifier of the user"))
@@ -51,7 +49,7 @@ trait TestCliEndpoints {
         "posts" / int("postId") ?? Doc.p("The unique identifier of the post"),
     )
       .query(
-        query("user-name") ?? Doc.p(
+        HttpCodec.query[String]("user-name") ?? Doc.p(
           "The user's name",
         ),
       )

--- a/zio-http-example/src/main/scala/example/endpoint/style/DeclarativeProgrammingExample.scala
+++ b/zio-http-example/src/main/scala/example/endpoint/style/DeclarativeProgrammingExample.scala
@@ -5,7 +5,7 @@ import zio._
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.QueryCodec
+import zio.http.codec._
 import zio.http.endpoint.{AuthType, Endpoint}
 
 object DeclarativeProgrammingExample extends ZIOAppDefault {
@@ -32,7 +32,7 @@ object DeclarativeProgrammingExample extends ZIOAppDefault {
 
   val endpoint: Endpoint[Unit, String, NotFoundError, Book, AuthType.None] =
     Endpoint(RoutePattern.GET / "books")
-      .query(QueryCodec.query("id"))
+      .query(HttpCodec.query[String]("id"))
       .out[Book]
       .outError[NotFoundError](Status.NotFound)
 

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -376,7 +376,7 @@ object CodeGen {
           val (imports, _) = renderQueryCode(Code.QueryParamCode(name, underlying))
           (Code.Import.FromBase(s"components.$newtypeName") :: imports) -> (newtypeName + ".Type")
       }
-      imports -> s""".query(QueryCodec.queryTo[$tpe]("$name"))"""
+      imports -> s""".query(HttpCodec.query[$tpe]("$name"))"""
   }
 
   def renderInCode(inCode: Code.InCode): String = {

--- a/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
@@ -11,7 +11,7 @@ object Species {
   import test.components.Age
   val list_by_species =
     Endpoint(Method.GET / "api" / "v1" / "zoo" / "list" / string("species").transform(Species.wrap)(Species.unwrap))
-      .query(QueryCodec.queryTo[Age.Type]("max-age"))
+      .query(HttpCodec.query[Age.Type]("max-age"))
       .in[Unit]
       .out[Chunk[Animal]](status = Status.Ok)
 

--- a/zio-http-gen/src/test/resources/EndpointForZooSpeciesUnAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooSpeciesUnAliasedSegment.scala
@@ -8,7 +8,7 @@ object Species {
   import zio.http.endpoint._
   import zio.http.codec._
   val list_by_species = Endpoint(Method.GET / "api" / "v1" / "zoo" / "list" / string("species"))
-    .query(QueryCodec.queryTo[Int]("max-age"))
+    .query(HttpCodec.query[Int]("max-age"))
     .in[Unit]
     .out[Chunk[Animal]](status = Status.Ok)
 

--- a/zio-http-gen/src/test/resources/EndpointWithQueryParams.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithQueryParams.scala
@@ -7,8 +7,8 @@ object Users {
   import zio.http.endpoint._
   import zio.http.codec._
   val get = Endpoint(Method.GET / "api" / "v1" / "users")
-    .query(QueryCodec.queryTo[Int]("limit"))
-    .query(QueryCodec.queryTo[String]("name"))
+    .query(HttpCodec.query[Int]("limit"))
+    .query(HttpCodec.query[String]("name"))
     .in[Unit]
 
 }

--- a/zio-http-gen/src/test/resources/EndpointsWithOverlappingPath.scala
+++ b/zio-http-gen/src/test/resources/EndpointsWithOverlappingPath.scala
@@ -7,7 +7,7 @@ object Pets {
   import zio.http.endpoint._
   import zio.http.codec._
   val listPets = Endpoint(Method.GET / "pets")
-    .query(QueryCodec.queryTo[Int]("limit"))
+    .query(HttpCodec.query[Int]("limit"))
     .in[Unit]
     .out[Pets](status = Status.Ok)
 

--- a/zio-http-gen/src/test/scala/zio/http/gen/grpc/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/grpc/EndpointGenSpec.scala
@@ -2,18 +2,11 @@ package zio.http.gen.grpc
 
 import java.nio.file._
 
-import scala.jdk.CollectionConverters._
-
 import zio._
 import zio.test._
 
 import zio.http._
-import zio.http.codec.HeaderCodec
-import zio.http.codec.HttpCodec.{query, queryInt}
-import zio.http.endpoint._
-import zio.http.gen.model._
 import zio.http.gen.scala.Code
-import zio.http.gen.scala.Code.Collection.Opt
 
 object EndpointGenSpec extends ZIOSpecDefault {
 

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -6,8 +6,7 @@ import zio._
 import zio.test._
 
 import zio.http._
-import zio.http.codec.HeaderCodec
-import zio.http.codec.HttpCodec.{query, queryInt}
+import zio.http.codec._
 import zio.http.endpoint._
 import zio.http.endpoint.openapi.JsonSchema.SchemaStyle.{Compact, Inline}
 import zio.http.endpoint.openapi.{OpenAPI, OpenAPIGen}
@@ -332,8 +331,8 @@ object EndpointGenSpec extends ZIOSpecDefault {
           val endpoint = Endpoint(Method.GET / "api" / "v1" / "users")
             .header(HeaderCodec.accept)
             .header(HeaderCodec.contentType)
-            .query(queryInt("limit"))
-            .query(query("name"))
+            .query(HttpCodec.query[Int]("limit"))
+            .query(HttpCodec.query[String]("name"))
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
           val scala    = EndpointGen.fromOpenAPI(openAPI)
           val expected = Code.File(
@@ -372,8 +371,8 @@ object EndpointGenSpec extends ZIOSpecDefault {
           val endpoint = Endpoint(Method.GET / "api" / "v1" / "users" / int("userId"))
             .header(HeaderCodec.accept)
             .header(HeaderCodec.contentType)
-            .query(queryInt("limit"))
-            .query(query("name"))
+            .query(HttpCodec.query[Int]("limit"))
+            .query(HttpCodec.query[String]("name"))
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
           val scala    = EndpointGen.fromOpenAPI(openAPI)
           val expected = Code.File(
@@ -481,8 +480,8 @@ object EndpointGenSpec extends ZIOSpecDefault {
         test("request body and empty response with path parameter and query parameters") {
           val endpoint = Endpoint(Method.POST / "api" / "v1" / "users" / int("userId"))
             .in[User]
-            .query(queryInt("limit"))
-            .query(query("name"))
+            .query(HttpCodec.query[Int]("limit"))
+            .query(HttpCodec.query[String]("name"))
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
           val scala    = EndpointGen.fromOpenAPI(openAPI)
           val expected = Code.File(
@@ -523,8 +522,8 @@ object EndpointGenSpec extends ZIOSpecDefault {
         test("request body and empty response with path parameter and query parameters and headers") {
           val endpoint = Endpoint(Method.POST / "api" / "v1" / "users" / int("userId"))
             .in[User]
-            .query(queryInt("limit"))
-            .query(query("name"))
+            .query(HttpCodec.query[Int]("limit"))
+            .query(HttpCodec.query[String]("name"))
             .header(HeaderCodec.accept)
             .header(HeaderCodec.contentType)
           val openAPI  = OpenAPIGen.fromEndpoints(endpoint)

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -103,8 +103,8 @@ object CodeGenSpec extends ZIOSpecDefault {
       },
       test("Endpoint with query parameters") {
         val endpoint = Endpoint(Method.GET / "api" / "v1" / "users")
-          .query(QueryCodec.queryInt("limit"))
-          .query(QueryCodec.query("name"))
+          .query(HttpCodec.query[Int]("limit"))
+          .query(HttpCodec.query[String]("name"))
         val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
         val code     = EndpointGen.fromOpenAPI(openAPI)
 

--- a/zio-http/jvm/src/test/scala/zio/http/codec/HttpCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/HttpCodecSpec.scala
@@ -38,14 +38,14 @@ object HttpCodecSpec extends ZIOHttpSpec {
   val emptyJson = Body.fromString("{}")
 
   val isAge                           = "isAge"
-  val codecBool                       = QueryCodec.queryBool(isAge)
+  val codecBool                       = HttpCodec.query[Boolean](isAge)
   def makeRequest(paramValue: String) = Request.get(googleUrl.setQueryParams(QueryParams(isAge -> paramValue)))
 
   def spec = suite("HttpCodecSpec")(
     suite("fallback") {
       test("query fallback") {
-        val codec1 = QueryCodec.query("skip")
-        val codec2 = QueryCodec.query("limit")
+        val codec1 = HttpCodec.query[String]("skip")
+        val codec2 = HttpCodec.query[String]("limit")
 
         val fallback = codec1 | codec2
 
@@ -73,11 +73,11 @@ object HttpCodecSpec extends ZIOHttpSpec {
         } +
         test("composite fallback") {
 
-          val codec1 = QueryCodec.query("skip") ++ HeaderCodec.headerCodec(
+          val codec1 = HttpCodec.query[String]("skip") ++ HeaderCodec.headerCodec(
             "Authentication",
             TextCodec.string,
           )
-          val codec2 = QueryCodec.query("limit") ++ HeaderCodec.headerCodec(
+          val codec2 = HttpCodec.query[String]("limit") ++ HeaderCodec.headerCodec(
             "X-Token-ID",
             TextCodec.string,
           )
@@ -111,7 +111,7 @@ object HttpCodecSpec extends ZIOHttpSpec {
     } +
       suite("optional") {
         test("fallback for missing values") {
-          val codec = QueryCodec.query("name").transformOrFail[String](_ => Left("fail"))(Right(_))
+          val codec = HttpCodec.query[String]("name").transformOrFail[String](_ => Left("fail"))(Right(_))
 
           val request = Request.get(url = URL.root)
 
@@ -122,7 +122,7 @@ object HttpCodecSpec extends ZIOHttpSpec {
           } yield assertTrue(result.isEmpty)
         } +
           test("no fallback for decoding errors") {
-            val codec = QueryCodec.query("key").transformOrFail[String](_ => Left("fail"))(Right(_))
+            val codec = HttpCodec.query[String]("key").transformOrFail[String](_ => Left("fail"))(Right(_))
 
             val request = Request.get(url = URL.root.copy(queryParams = QueryParams("key" -> "value")))
 

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
@@ -109,7 +109,7 @@ object AuthSpec extends ZIOSpecDefault {
       test("Auth from query parameter") {
         val endpoint = Endpoint(Method.GET / "test")
           .out[String](MediaType.text.`plain`)
-          .auth(AuthType.Custom(HttpCodec.query("token")))
+          .auth(AuthType.Custom(HttpCodec.query[String]("token")))
         val routes   =
           Routes(
             endpoint.implementHandler(handler((_: Unit) => withContext((ctx: AuthContext) => ctx.value))),
@@ -190,7 +190,7 @@ object AuthSpec extends ZIOSpecDefault {
         test("Auth from query parameter with context and endpoint client") {
           val endpoint = Endpoint(Method.GET / "test" / "query")
             .out[String](MediaType.text.`plain`)
-            .auth(AuthType.Custom(HttpCodec.query("token")))
+            .auth(AuthType.Custom(HttpCodec.query[String]("token")))
           val routes   =
             Routes(
               endpoint.implementHandler(handler((_: Unit) => withContext((ctx: AuthContext) => ctx.value))),

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/BadRequestSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/BadRequestSpec.scala
@@ -15,7 +15,7 @@ object BadRequestSpec extends ZIOSpecDefault {
     suite("BadRequestSpec")(
       test("should return html rendered error message by default for html accept header") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
         val request      =
@@ -25,8 +25,8 @@ object BadRequestSpec extends ZIOSpecDefault {
             body(
               h1("Codec Error"),
               p("There was an error en-/decoding the request/response"),
-              p("SchemaTransformationFailure", idAttr                                      := "name"),
-              p("Expected single value for query parameter age, but got 2 instead", idAttr := "message"),
+              p("InvalidQueryParamCount", idAttr                                         := "name"),
+              p("Invalid query parameter count for age: expected 1 but found 2.", idAttr := "message"),
             ),
           )
         for {
@@ -36,14 +36,14 @@ object BadRequestSpec extends ZIOSpecDefault {
       },
       test("should return json rendered error message by default for json accept header") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
         val request      =
           Request(method = Method.GET, url = url"/test?age=1&age=2")
             .addHeader(Header.Accept(MediaType.application.json))
         val expectedBody =
-          """{"name":"SchemaTransformationFailure","message":"Expected single value for query parameter age, but got 2 instead"}"""
+          """{"name":"InvalidQueryParamCount","message":"Invalid query parameter count for age: expected 1 but found 2."}"""
         for {
           response <- route.toRoutes.runZIO(request)
           body     <- response.body.asString
@@ -51,14 +51,14 @@ object BadRequestSpec extends ZIOSpecDefault {
       },
       test("should return json rendered error message by default as fallback for unsupported accept header") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
         val request      =
           Request(method = Method.GET, url = url"/test?age=1&age=2")
             .addHeader(Header.Accept(MediaType.application.`atf`))
         val expectedBody =
-          """{"name":"SchemaTransformationFailure","message":"Expected single value for query parameter age, but got 2 instead"}"""
+          """{"name":"InvalidQueryParamCount","message":"Invalid query parameter count for age: expected 1 but found 2."}"""
         for {
           response <- route.toRoutes.runZIO(request)
           body     <- response.body.asString
@@ -66,7 +66,7 @@ object BadRequestSpec extends ZIOSpecDefault {
       },
       test("should return empty body after calling Endpoint#emptyErrorResponse") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
           .emptyErrorResponse
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
@@ -81,14 +81,14 @@ object BadRequestSpec extends ZIOSpecDefault {
       },
       test("should return custom error message") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
         val request      =
           Request(method = Method.GET, url = url"/test?age=1&age=2")
             .addHeader(Header.Accept(MediaType.application.json))
         val expectedBody =
-          """{"name":"SchemaTransformationFailure","message":"Expected single value for query parameter age, but got 2 instead"}"""
+          """{"name":"InvalidQueryParamCount","message":"Invalid query parameter count for age: expected 1 but found 2."}"""
         for {
           response <- route.toRoutes.runZIO(request)
           body     <- response.body.asString
@@ -96,7 +96,7 @@ object BadRequestSpec extends ZIOSpecDefault {
       },
       test("should use custom error codec over default error codec") {
         val endpoint     = Endpoint(Method.GET / "test")
-          .query(QueryCodec.queryInt("age"))
+          .query(HttpCodec.query[Int]("age"))
           .out[Unit]
           .outCodecError(default)
         val route        = endpoint.implementHandler(handler((_: Int) => ()))
@@ -104,7 +104,7 @@ object BadRequestSpec extends ZIOSpecDefault {
           Request(method = Method.GET, url = url"/test?age=1&age=2")
             .addHeader(Header.Accept(MediaType.application.json))
         val expectedBody =
-          """{"name2":"SchemaTransformationFailure","message2":"Expected single value for query parameter age, but got 2 instead"}"""
+          """{"name2":"InvalidQueryParamCount","message2":"Invalid query parameter count for age: expected 1 but found 2."}"""
         for {
           response <- route.toRoutes.runZIO(request)
           body     <- response.body.asString

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/ExamplesSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/ExamplesSpec.scala
@@ -16,24 +16,10 @@
 
 package zio.http.endpoint
 
-import java.time.Instant
-
-import zio._
 import zio.test._
 
-import zio.stream.ZStream
-
-import zio.schema.annotation.validate
-import zio.schema.validation.Validation
-import zio.schema.{DeriveSchema, Schema}
-
-import zio.http.Header.ContentType
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt}
-import zio.http.codec._
-import zio.http.endpoint._
-import zio.http.forms.Fixtures.formField
 
 object ExamplesSpec extends ZIOHttpSpec {
   def spec = suite("ExamplesSpec")(

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/NotFoundSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/NotFoundSpec.scala
@@ -16,24 +16,12 @@
 
 package zio.http.endpoint
 
-import java.time.Instant
-
 import zio._
 import zio.test._
 
-import zio.stream.ZStream
-
-import zio.schema.annotation.validate
-import zio.schema.validation.Validation
-import zio.schema.{DeriveSchema, Schema}
-
-import zio.http.Header.ContentType
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.{query, queryInt}
 import zio.http.codec._
-import zio.http.endpoint._
-import zio.http.forms.Fixtures.formField
 
 object NotFoundSpec extends ZIOHttpSpec {
   def spec = suite("NotFoundSpec")(
@@ -49,7 +37,7 @@ object NotFoundSpec extends ZIOHttpSpec {
                 }
               },
             Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-              .query(query("name"))
+              .query(HttpCodec.query[String]("name"))
               .out[String]
               .implementHandler {
                 Handler.fromFunction { case (userId, postId, name) =>
@@ -74,7 +62,7 @@ object NotFoundSpec extends ZIOHttpSpec {
                 }
               },
             Endpoint(GET / "users" / int("userId") / "posts" / int("postId"))
-              .query(query("name"))
+              .query(HttpCodec.query[String]("name"))
               .out[String]
               .implementHandler {
                 Handler.fromFunction { case (userId, postId, name) =>

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -158,7 +158,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
   private val queryParamEndpoint =
     Endpoint(GET / "withQuery")
       .in[SimpleInputBody]
-      .query(QueryCodec.query("query"))
+      .query(HttpCodec.query[String]("query"))
       .out[SimpleOutputBody]
       .outError[NotFoundError](Status.NotFound)
 
@@ -863,7 +863,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                 HttpCodec
                   .content[SimpleInputBody] ?? Doc.p("simple input"),
             )
-            .query(QueryCodec.query("query"))
+            .query(HttpCodec.query[String]("query"))
             .outCodec(
               HttpCodec
                 .content[SimpleOutputBody] ?? Doc.p("simple output") |
@@ -2440,7 +2440,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
           Endpoint(RoutePattern.POST / "post")
             .in[Int]("foo")
             .in[Boolean]("bar")
-            .query(QueryCodec.query("q"))
+            .query(HttpCodec.query[String]("q"))
             .out[Unit]
 
         SwaggerUI.routes("docs/openapi", OpenAPIGen.fromEndpoints(endpoint))

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/SwaggerUISpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/SwaggerUISpec.scala
@@ -4,7 +4,8 @@ import zio._
 import zio.test._
 
 import zio.http._
-import zio.http.codec.HttpCodec.query
+import zio.http.codec.HttpCodec
+import zio.http.codec.HttpCodec.queryAll
 import zio.http.codec.PathCodec.path
 import zio.http.endpoint.Endpoint
 
@@ -19,7 +20,7 @@ object SwaggerUISpec extends ZIOSpecDefault {
 
         val getUserPosts =
           Endpoint(Method.GET / "users" / int("userId") / "posts" / int("postId"))
-            .query(query("name"))
+            .query(HttpCodec.query[String]("name"))
             .out[List[String]]
 
         val getUserPostsRoute =

--- a/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
@@ -123,16 +123,21 @@ object QueryParams {
      * takes advantage of LinkedHashMap implementation for O(1) lookup and
      * avoids conversion to Chunk.
      */
-    override def getAll(key: String): Chunk[String] = Option(underlying.get(key))
-      .map(_.asScala)
-      .map(Chunk.fromIterable)
-      .getOrElse(Chunk.empty)
+    override def getAll(key: String): Chunk[String] =
+      if (underlying.containsKey(key)) Chunk.fromIterable(underlying.get(key).asScala)
+      else Chunk.empty
 
     override def hasQueryParam(name: CharSequence): Boolean =
       underlying.containsKey(name.toString)
 
     override def updateQueryParams(f: QueryParams => QueryParams): QueryParams =
       f(self)
+
+    override private[http] def unsafeQueryParam(key: String): String =
+      underlying.get(key).get(0)
+
+    override def valueCount(name: CharSequence): Int =
+      if (underlying.containsKey(name)) underlying.get(name.toString).size() else 0
   }
 
   private def javaMapAsLinkedHashMap(

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -161,8 +161,8 @@ object Response {
       case Left(failure: Throwable) => fromThrowable(failure)
       case Left(failure: Cause[_])  => fromCause(failure)
       case _                        =>
-        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint.take(10000))
-        else error(Status.InternalServerError, cause.prettyPrint.take(10000))
+        if (cause.isInterruptedOnly) error(Status.RequestTimeout, cause.prettyPrint)
+        else error(Status.InternalServerError, cause.prettyPrint)
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -23,7 +23,7 @@ import zio.stream.ZPipeline
 import zio.schema.codec._
 import zio.schema.{DeriveSchema, Schema}
 
-import zio.http.codec.{BinaryCodecWithSchema, HttpContentCodec}
+import zio.http.codec._
 
 /**
  * Server-Sent Event (SSE) as defined by

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -24,11 +24,13 @@ import zio._
 import zio.stream.ZStream
 
 import zio.schema.Schema
+import zio.schema.annotation._
 
 import zio.http.Header.Accept.MediaTypeWithQFactor
 import zio.http._
+import zio.http.codec.HttpCodec.Query.QueryType
 import zio.http.codec.HttpCodec.{Annotated, Metadata}
-import zio.http.codec.internal.EncoderDecoder
+import zio.http.codec.internal._
 
 /**
  * A [[zio.http.codec.HttpCodec]] represents a codec for a part of an HTTP
@@ -275,7 +277,7 @@ sealed trait HttpCodec[-AtomTypes, Value] {
   /**
    * Returns a new codec, where the value produced by this one is optional.
    */
-  final def optional: HttpCodec[AtomTypes, Option[Value]] =
+  def optional: HttpCodec[AtomTypes, Option[Value]] =
     Annotated(
       if (self eq HttpCodec.Halt) HttpCodec.empty.asInstanceOf[HttpCodec[AtomTypes, Option[Value]]]
       else {
@@ -581,32 +583,140 @@ object HttpCodec extends ContentCodecs with HeaderCodecs with MethodCodecs with 
 
     def index(index: Int): ContentStream[A] = copy(index = index)
   }
-  private[http] final case class Query[A](
-    name: String,
-    codec: BinaryCodecWithSchema[A],
-    hint: Query.QueryParamHint,
+  private[http] final case class Query[A, Out](
+    queryType: Query.QueryType[A],
     index: Int = 0,
-  ) extends Atom[HttpCodecType.Query, Chunk[A]] {
+  ) extends Atom[HttpCodecType.Query, Out] {
     self =>
-    def erase: Query[Any] = self.asInstanceOf[Query[Any]]
+    def erase: Query[Any, Any] = self.asInstanceOf[Query[Any, Any]]
 
     def tag: AtomTag = AtomTag.Query
 
-    def index(index: Int): Query[A] = copy(index = index)
+    def index(index: Int): Query[A, Out] = copy(index = index)
+
+    def isOptional: Boolean =
+      queryType match {
+        case QueryType.Primitive(_, BinaryCodecWithSchema(_, schema)) if schema.isInstanceOf[Schema.Optional[_]] =>
+          true
+        case QueryType.Record(recordSchema)                                                                      =>
+          recordSchema match {
+            case s if s.isInstanceOf[Schema.Optional[_]]                      => true
+            case record: Schema.Record[_] if record.fields.forall(_.optional) => true
+            case _                                                            => false
+          }
+        case _ => false
+      }
+
+    /**
+     * Returns a new codec, where the value produced by this one is optional.
+     */
+    override def optional: HttpCodec[HttpCodecType.Query, Option[Out]] =
+      queryType match {
+        case QueryType.Primitive(name, codec) if codec.schema.isInstanceOf[Schema.Optional[_]] =>
+          throw new IllegalArgumentException(
+            s"Cannot make an optional query parameter optional. Name: $name schema: ${codec.schema}",
+          )
+        case QueryType.Primitive(name, codec)                                                  =>
+          val optionalSchema = codec.schema.optional
+          copy(queryType =
+            QueryType.Primitive(name, BinaryCodecWithSchema(TextBinaryCodec.fromSchema(optionalSchema), optionalSchema)),
+          )
+        case QueryType.Record(recordSchema) if recordSchema.isInstanceOf[Schema.Optional[_]]   =>
+          throw new IllegalArgumentException(s"Cannot make an optional query parameter optional")
+        case QueryType.Record(recordSchema)                                                    =>
+          val optionalSchema = recordSchema.optional
+          copy(queryType = QueryType.Record(optionalSchema))
+        case queryType @ QueryType.Collection(_, _, false)                                     =>
+          copy(queryType = QueryType.Collection(queryType.colSchema, queryType.elements, optional = true))
+        case queryType @ QueryType.Collection(_, _, true)                                      =>
+          throw new IllegalArgumentException(s"Cannot make an optional query parameter optional: $queryType")
+
+      }
+
   }
 
   private[http] object Query {
+    sealed trait QueryType[A]
+    object QueryType {
+      case class Primitive[A](name: String, codec: BinaryCodecWithSchema[A]) extends QueryType[A]
+      case class Collection[A](colSchema: Schema.Collection[_, _], elements: QueryType.Primitive[A], optional: Boolean)
+          extends QueryType[A] {
+        def toCollection(values: Chunk[Any]): A =
+          colSchema match {
+            case Schema.Sequence(_, fromChunk, _, _, _) =>
+              fromChunk.asInstanceOf[Chunk[Any] => Any](values).asInstanceOf[A]
+            case Schema.Set(_, _)                       =>
+              values.toSet.asInstanceOf[A]
+            case _                                      =>
+              throw new IllegalArgumentException(
+                s"Unsupported collection schema for query object field of type: $colSchema",
+              )
+          }
+      }
+      case class Record[A](recordSchema: Schema[A]) extends QueryType[A] {
+        private var namesAndCodecs: Chunk[(Schema.Field[_, _], BinaryCodecWithSchema[Any])]       = _
+        private[http] def fieldAndCodecs: Chunk[(Schema.Field[_, _], BinaryCodecWithSchema[Any])] =
+          if (namesAndCodecs == null) {
+            namesAndCodecs = recordSchema match {
+              case record: Schema.Record[A]                =>
+                record.fields.map { field =>
+                  validateSchema(field.name, field.schema)
+                  val codec = binaryCodecForField(field.schema)
+                  (unlazy(field.asInstanceOf[Schema.Field[Any, Any]]), codec)
+                }
+              case s if s.isInstanceOf[Schema.Optional[_]] =>
+                val record = s.asInstanceOf[Schema.Optional[A]].schema.asInstanceOf[Schema.Record[A]]
+                record.fields.map { field =>
+                  validateSchema(field.name, field.schema)
+                  val codec = binaryCodecForField(field.schema)
+                  (field, codec)
+                }
+              case s => throw new IllegalArgumentException(s"Unsupported schema for query object field of type: $s")
+            }
+            namesAndCodecs
+          } else {
+            namesAndCodecs
+          }
+      }
 
-    // Hint on how many query parameters codec expects
-    sealed trait QueryParamHint
-    object QueryParamHint {
-      case object One extends QueryParamHint
+      private def unlazy(field: Schema.Field[Any, Any]): Schema.Field[Any, Any] = field.schema match {
+        case Schema.Lazy(schema) =>
+          Schema.Field(
+            field.name,
+            schema(),
+            field.annotations,
+            field.validation,
+            field.get,
+            field.set,
+          )
+        case _                   => field
+      }
 
-      case object Many extends QueryParamHint
+      private def binaryCodecForField[A](schema: Schema[A]): BinaryCodecWithSchema[Any] = (schema match {
+        case schema @ Schema.Primitive(_, _)     => BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+        case Schema.Transform(_, _, _, _, _)     => BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+        case Schema.Optional(_, _)               => BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+        case e: Schema.Enum[_] if isSimple(e)    => BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema)
+        case l @ Schema.Lazy(_)                  => binaryCodecForField(l.schema)
+        case Schema.Set(schema, _)               => binaryCodecForField(schema)
+        case Schema.Sequence(schema, _, _, _, _) => binaryCodecForField(schema)
+        case schema => throw new IllegalArgumentException(s"Unsupported schema for query object field of type: $schema")
+      }).asInstanceOf[BinaryCodecWithSchema[Any]]
 
-      case object Zero extends QueryParamHint
+      def isSimple(schema: Schema.Enum[_]): Boolean =
+        schema.annotations.exists(_.isInstanceOf[simpleEnum])
 
-      case object Any extends QueryParamHint
+      @tailrec
+      private def validateSchema[A](name: String, schema: Schema[A]): Unit = schema match {
+        case _: Schema.Primitive[A]               => ()
+        case Schema.Transform(schema, _, _, _, _) => validateSchema(name, schema)
+        case Schema.Optional(schema, _)           => validateSchema(name, schema)
+        case Schema.Lazy(schema)                  => validateSchema(name, schema())
+        case Schema.Set(schema, _)                => validateSchema(name, schema)
+        case Schema.Sequence(schema, _, _, _, _)  => validateSchema(name, schema)
+        case s => throw new IllegalArgumentException(s"Unsupported schema for query object field of type: $s")
+      }
+
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -51,6 +51,9 @@ object HttpCodecError {
   final case class MissingQueryParam(queryParamName: String)                                   extends HttpCodecError {
     def message = s"Missing query parameter $queryParamName"
   }
+  final case class MissingQueryParams(queryParamNames: Chunk[String])                          extends HttpCodecError {
+    def message = s"Missing query parameters ${queryParamNames.mkString(", ")}"
+  }
   final case class MalformedQueryParam(queryParamName: String, cause: DecodeError)             extends HttpCodecError {
     def message = s"Malformed query parameter $queryParamName could not be decoded: $cause"
   }
@@ -66,6 +69,9 @@ object HttpCodecError {
         errors.map(err => err.message).mkString("\n"),
         errors,
       )
+  }
+  final case class InvalidQueryParamCount(name: String, expected: Int, actual: Int)            extends HttpCodecError {
+    def message = s"Invalid query parameter count for $name: expected $expected but found $actual."
   }
   final case class CustomError(name: String, message: String)                                  extends HttpCodecError
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -16,38 +16,123 @@
 
 package zio.http.codec
 import zio.Chunk
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.schema.Schema
+import zio.schema.annotation.simpleEnum
 
-import zio.http.codec.HttpCodec.Query.QueryParamHint
 import zio.http.codec.internal.TextBinaryCodec
 
 private[codec] trait QueryCodecs {
 
-  def query(name: String): QueryCodec[String] = singleValueCodec(name, Schema[String])
+  def query[A](name: String)(implicit schema: Schema[A]): QueryCodec[A] =
+    schema match {
+      case s @ Schema.Primitive(_, _)                                                    =>
+        HttpCodec.Query(
+          HttpCodec.Query.QueryType
+            .Primitive(name, BinaryCodecWithSchema.fromBinaryCodec(TextBinaryCodec.fromSchema(s))(s)),
+        )
+      case c @ Schema.Sequence(elementSchema, _, _, _, _)                                =>
+        if (supportedElementSchema(elementSchema.asInstanceOf[Schema[Any]])) {
+          HttpCodec.Query(
+            HttpCodec.Query.QueryType.Collection(
+              c,
+              HttpCodec.Query.QueryType.Primitive(
+                name,
+                BinaryCodecWithSchema(TextBinaryCodec.fromSchema(elementSchema), elementSchema),
+              ),
+              optional = false,
+            ),
+          )
+        } else {
+          throw new IllegalArgumentException("Only primitive types can be elements of sequences")
+        }
+      case c @ Schema.Set(elementSchema, _)                                              =>
+        if (supportedElementSchema(elementSchema.asInstanceOf[Schema[Any]])) {
+          HttpCodec.Query(
+            HttpCodec.Query.QueryType.Collection(
+              c,
+              HttpCodec.Query.QueryType.Primitive(
+                name,
+                BinaryCodecWithSchema(TextBinaryCodec.fromSchema(elementSchema), elementSchema),
+              ),
+              optional = false,
+            ),
+          )
+        } else {
+          throw new IllegalArgumentException("Only primitive types can be elements of sets")
+        }
+      case Schema.Optional(Schema.Primitive(_, _), _)                                    =>
+        HttpCodec.Query(
+          HttpCodec.Query.QueryType
+            .Primitive(name, BinaryCodecWithSchema.fromBinaryCodec(TextBinaryCodec.fromSchema(schema))(schema)),
+        )
+      case Schema.Optional(c @ Schema.Sequence(elementSchema, _, _, _, _), _)            =>
+        if (supportedElementSchema(elementSchema.asInstanceOf[Schema[Any]])) {
+          HttpCodec.Query(
+            HttpCodec.Query.QueryType.Collection(
+              c,
+              HttpCodec.Query.QueryType.Primitive(
+                name,
+                BinaryCodecWithSchema(TextBinaryCodec.fromSchema(elementSchema), elementSchema),
+              ),
+              optional = true,
+            ),
+          )
+        } else {
+          throw new IllegalArgumentException("Only primitive types can be elements of sequences")
+        }
+      case Schema.Optional(inner, _) if inner.isInstanceOf[Schema.Set[_]]                =>
+        val elementSchema = inner.asInstanceOf[Schema.Set[Any]].elementSchema
+        if (supportedElementSchema(elementSchema)) {
+          HttpCodec.Query(
+            HttpCodec.Query.QueryType.Collection(
+              inner.asInstanceOf[Schema.Set[_]],
+              HttpCodec.Query.QueryType.Primitive(
+                name,
+                BinaryCodecWithSchema(TextBinaryCodec.fromSchema(inner), inner),
+              ),
+              optional = true,
+            ),
+          )
+        } else {
+          throw new IllegalArgumentException("Only primitive types can be elements of sets")
+        }
+      case enum0: Schema.Enum[_] if enum0.annotations.exists(_.isInstanceOf[simpleEnum]) =>
+        HttpCodec.Query(
+          HttpCodec.Query.QueryType
+            .Primitive(name, BinaryCodecWithSchema.fromBinaryCodec(TextBinaryCodec.fromSchema(schema))(schema)),
+        )
+      case record: Schema.Record[A] if record.fields.size == 1                           =>
+        val field = record.fields.head
+        if (supportedElementSchema(field.schema.asInstanceOf[Schema[Any]])) {
+          HttpCodec.Query(
+            HttpCodec.Query.QueryType.Primitive(
+              name,
+              BinaryCodecWithSchema(TextBinaryCodec.fromSchema(record), record),
+            ),
+          )
+        } else {
+          throw new IllegalArgumentException("Only primitive types can be elements of records")
+        }
+      case other                                                                         =>
+        throw new IllegalArgumentException(
+          s"Only primitive types, sequences, sets, optional, enums and records with a single field can be used to infer query codecs, but got $other",
+        )
+    }
 
-  def queryBool(name: String): QueryCodec[Boolean] = singleValueCodec(name, Schema[Boolean])
+  private def supportedElementSchema(elementSchema: Schema[Any]) =
+    elementSchema.isInstanceOf[Schema.Primitive[_]] ||
+      elementSchema.isInstanceOf[Schema.Enum[_]] && elementSchema.annotations.exists(_.isInstanceOf[simpleEnum]) ||
+      elementSchema.isInstanceOf[Schema.Record[_]] && elementSchema.asInstanceOf[Schema.Record[_]].fields.size == 1
 
-  def queryInt(name: String): QueryCodec[Int] = singleValueCodec(name, Schema[Int])
+  def queryAll[A](implicit schema: Schema[A]): QueryCodec[A] =
+    schema match {
+      case _: Schema.Primitive[A]   =>
+        throw new IllegalArgumentException("Use query[A](name: String) for primitive types")
+      case record: Schema.Record[A] => HttpCodec.Query(HttpCodec.Query.QueryType.Record(record))
+      case Schema.Optional(_, _)    => HttpCodec.Query(HttpCodec.Query.QueryType.Record(schema))
+      case _ => throw new IllegalArgumentException("Only case classes can be used to infer query codecs")
+    }
 
-  def queryTo[A](name: String)(implicit codec: Schema[A]): QueryCodec[A] = singleValueCodec(name, codec)
-
-  def queryAll(name: String): QueryCodec[Chunk[String]] = multiValueCodec(name, Schema[String])
-
-  def queryAllBool(name: String): QueryCodec[Chunk[Boolean]] = multiValueCodec(name, Schema[Boolean])
-
-  def queryAllInt(name: String): QueryCodec[Chunk[Int]] = multiValueCodec(name, Schema[Int])
-
-  def queryAllTo[A](name: String)(implicit codec: Schema[A]): QueryCodec[Chunk[A]] = multiValueCodec(name, codec)
-
-  private def singleValueCodec[A](name: String, schema: Schema[A]): QueryCodec[A] =
-    HttpCodec
-      .Query(name, BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema), QueryParamHint.One)
-      .transformOrFail {
-        case chunk if chunk.size == 1 => Right(chunk.head)
-        case chunk => Left(s"Expected single value for query parameter $name, but got ${chunk.size} instead")
-      }(s => Right(Chunk(s)))
-
-  private def multiValueCodec[A](name: String, schema: Schema[A]): QueryCodec[Chunk[A]] =
-    HttpCodec.Query(name, BinaryCodecWithSchema(TextBinaryCodec.fromSchema(schema), schema), QueryParamHint.Many)
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/AtomizedCodecs.scala
@@ -25,7 +25,7 @@ import zio.http.codec._
 private[http] final case class AtomizedCodecs(
   method: Chunk[SimpleCodec[zio.http.Method, _]],
   path: Chunk[PathCodec[_]],
-  query: Chunk[Query[_]],
+  query: Chunk[Query[_, _]],
   header: Chunk[Header[_]],
   content: Chunk[BodyCodec[_]],
   status: Chunk[SimpleCodec[zio.http.Status, _]],
@@ -33,7 +33,7 @@ private[http] final case class AtomizedCodecs(
   def append(atom: Atom[_, _]): AtomizedCodecs = atom match {
     case path0: Path[_]            => self.copy(path = path :+ path0.pathCodec)
     case method0: Method[_]        => self.copy(method = method :+ method0.codec)
-    case query0: Query[_]          => self.copy(query = query :+ query0)
+    case query0: Query[_, _]       => self.copy(query = query :+ query0)
     case header0: Header[_]        => self.copy(header = header :+ header0)
     case content0: Content[_]      =>
       self.copy(content = content :+ BodyCodec.Single(content0.codec, content0.name))

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -16,17 +16,19 @@
 
 package zio.http.codec.internal
 
+import scala.annotation.nowarn
 import scala.util.Try
 
 import zio._
 
 import zio.stream.ZStream
 
-import zio.schema.codec.BinaryCodec
+import zio.schema.codec.{BinaryCodec, DecodeError}
+import zio.schema.{Schema, StandardType}
 
-import zio.http.Header.Accept.MediaTypeWithQFactor
+import zio.http.Header.Accept.{MediaTypeWithQFactor, render}
 import zio.http._
-import zio.http.codec.HttpCodec.Query
+import zio.http.codec.HttpCodec.Query.QueryType
 import zio.http.codec._
 
 private[codec] trait EncoderDecoder[-AtomTypes, Value] { self =>
@@ -40,7 +42,6 @@ private[codec] trait EncoderDecoder[-AtomTypes, Value] { self =>
 
 }
 private[codec] object EncoderDecoder {
-  private val emptyStringChunk = Chunk("")
 
   def apply[AtomTypes, Value](
     httpCodec: HttpCodec[AtomTypes, Value],
@@ -282,31 +283,152 @@ private[codec] object EncoderDecoder {
       while (i < queries.length) {
         val query = queries(i).erase
 
-        val params = queryParams.queryParamsOrElse(query.name, Nil)
+        val isOptional = query.isOptional
 
-        if (params.isEmpty)
-          throw HttpCodecError.MissingQueryParam(query.name)
-        else if (
-          params == emptyStringChunk
-          && (query.hint == Query.QueryParamHint.Any || query.hint == Query.QueryParamHint.Many)
-        ) {
-          inputs(i) = Chunk.empty
-        } else {
-          val parsedParams     = params.map { p =>
-            val decoded = query.codec.codec.decode(Chunk.fromArray(p.getBytes(Charsets.Utf8)))
-            decoded match {
-              case Left(error)  => throw HttpCodecError.MalformedQueryParam(query.name, error)
-              case Right(value) => value
+        query.queryType match {
+          case QueryType.Primitive(name, BinaryCodecWithSchema(codec, schema))                                   =>
+            val count    = queryParams.valueCount(name)
+            val hasParam = queryParams.hasQueryParam(name)
+            if (!hasParam && isOptional) inputs(i) = None
+            else if (!hasParam) throw HttpCodecError.MissingQueryParam(name)
+            else if (count != 1) throw HttpCodecError.InvalidQueryParamCount(name, 1, count)
+            else {
+              val decoded          = codec.decode(
+                Chunk.fromArray(queryParams.unsafeQueryParam(name).getBytes(Charsets.Utf8)),
+              ) match {
+                case Left(error)  => throw HttpCodecError.MalformedQueryParam(name, error)
+                case Right(value) => value
+              }
+              val validationErrors = schema.validate(decoded)(schema)
+              if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
+              inputs(i) =
+                if (isOptional && decoded == None && emptyStringIsValue(schema.asInstanceOf[Schema.Optional[_]].schema))
+                  Some("")
+                else decoded
             }
-          }
-          val validationErrors = parsedParams.flatMap(p => query.codec.schema.validate(p)(query.codec.schema))
-          if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
-          inputs(i) = parsedParams
+          case c @ QueryType.Collection(_, QueryType.Primitive(name, BinaryCodecWithSchema(codec, _)), optional) =>
+            if (!queryParams.hasQueryParam(name)) {
+              if (!optional) inputs(i) = c.toCollection(Chunk.empty)
+              else inputs(i) = None
+            } else {
+              val values           = queryParams.queryParams(name)
+              val decoded          = c.toCollection {
+                values.map { value =>
+                  codec.decode(Chunk.fromArray(value.getBytes(Charsets.Utf8))) match {
+                    case Left(error)  => throw HttpCodecError.MalformedQueryParam(name, error)
+                    case Right(value) => value
+                  }
+                }
+              }
+              val erasedSchema     = c.colSchema.asInstanceOf[Schema[Any]]
+              val validationErrors = erasedSchema.validate(decoded)(erasedSchema)
+              if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
+              inputs(i) =
+                if (optional) Some(decoded)
+                else decoded
+            }
+          case query @ QueryType.Record(recordSchema)                                                            =>
+            val hasAllParams = query.fieldAndCodecs.forall { case (field, _) =>
+              queryParams.hasQueryParam(field.name) || field.optional || field.defaultValue.isDefined
+            }
+            if (!hasAllParams && recordSchema.isInstanceOf[Schema.Optional[_]]) inputs(i) = None
+            else if (!hasAllParams && isOptional) {
+              inputs(i) = recordSchema.defaultValue match {
+                case Left(err)    =>
+                  throw new IllegalStateException(s"Cannot compute default value for $recordSchema. Error was: $err")
+                case Right(value) => value
+              }
+            } else if (!hasAllParams) throw HttpCodecError.MissingQueryParams {
+              query.fieldAndCodecs.collect {
+                case (field, _)
+                    if !(queryParams.hasQueryParam(field.name) || field.optional || field.defaultValue.isDefined) =>
+                  field.name
+              }
+            }
+            else {
+              val decoded = query.fieldAndCodecs.map {
+                case (field, codec) if field.schema.isInstanceOf[Schema.Collection[_, _]] =>
+                  if (!queryParams.hasQueryParam(field.name) && field.defaultValue.nonEmpty) field.defaultValue.get
+                  else {
+                    val values            = queryParams.queryParams(field.name)
+                    val decoded           = values.map { value =>
+                      codec.codec.decode(Chunk.fromArray(value.getBytes(Charsets.Utf8))) match {
+                        case Left(error)  => throw HttpCodecError.MalformedQueryParam(field.name, error)
+                        case Right(value) => value
+                      }
+                    }
+                    val decodedCollection =
+                      field.schema match {
+                        case s @ Schema.Sequence(_, fromChunk, _, _, _) =>
+                          val collection       = fromChunk.asInstanceOf[Chunk[Any] => Any](decoded)
+                          val erasedSchema     = s.asInstanceOf[Schema[Any]]
+                          val validationErrors = erasedSchema.validate(collection)(erasedSchema)
+                          if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
+                          collection
+                        case s @ Schema.Set(_, _)                       =>
+                          val collection       = decoded.toSet[Any]
+                          val erasedSchema     = s.asInstanceOf[Schema.Set[Any]]
+                          val validationErrors = erasedSchema.validate(collection)(erasedSchema)
+                          if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
+                          collection
+                        case _ => throw new IllegalStateException("Only Sequence and Set are supported.")
+                      }
+                    decodedCollection
+                  }
+                case (field, codec)                                                       =>
+                  val value            = queryParams.queryParamOrElse(field.name, null)
+                  val decoded          = {
+                    if (value == null) field.defaultValue.get
+                    else {
+                      codec.codec.decode(Chunk.fromArray(value.getBytes(Charsets.Utf8))) match {
+                        case Left(error)  => throw HttpCodecError.MalformedQueryParam(field.name, error)
+                        case Right(value) => value
+                      }
+                    }
+                  }
+                  val validationErrors = codec.schema.validate(decoded)(codec.schema)
+                  if (validationErrors.nonEmpty) throw HttpCodecError.InvalidEntity.wrap(validationErrors)
+                  decoded
+              }
+              if (recordSchema.isInstanceOf[Schema.Optional[_]]) {
+                val schema      = recordSchema.asInstanceOf[Schema.Optional[_]].schema.asInstanceOf[Schema.Record[Any]]
+                val constructed = schema.construct(decoded)(Unsafe.unsafe)
+                constructed match {
+                  case Left(value)  =>
+                    throw HttpCodecError.MalformedQueryParam(s"${schema.id}", DecodeError.ReadError(Cause.empty, value))
+                  case Right(value) =>
+                    schema.validate(value)(schema) match {
+                      case errors if errors.nonEmpty => throw HttpCodecError.InvalidEntity.wrap(errors)
+                      case _                         => inputs(i) = Some(value)
+                    }
+                }
+              } else {
+                val schema      = recordSchema.asInstanceOf[Schema.Record[Any]]
+                val constructed = schema.construct(decoded)(Unsafe.unsafe)
+                constructed match {
+                  case Left(value)  =>
+                    throw HttpCodecError.MalformedQueryParam(s"${schema.id}", DecodeError.ReadError(Cause.empty, value))
+                  case Right(value) =>
+                    schema.validate(value)(schema) match {
+                      case errors if errors.nonEmpty => throw HttpCodecError.InvalidEntity.wrap(errors)
+                      case _                         => inputs(i) = value
+                    }
+                }
+              }
+            }
         }
-
         i = i + 1
       }
     }
+
+    private def emptyStringIsValue(schema: Schema[_]): Boolean =
+      schema.asInstanceOf[Schema.Primitive[_]].standardType match {
+        case StandardType.UnitType   => true
+        case StandardType.StringType => true
+        case StandardType.BinaryType => true
+        case StandardType.CharType   => true
+        case _                       => false
+      }
 
     private def decodeStatus(status: Status, inputs: Array[Any]): Unit = {
       var i = 0
@@ -491,16 +613,96 @@ private[codec] object EncoderDecoder {
         val query = flattened.query(i).erase
         val input = inputs(i)
 
-        val inputCoerced = input.asInstanceOf[Chunk[Any]]
-
-        if (inputCoerced.isEmpty)
-          queryParams.addQueryParams(query.name, Chunk.empty[String])
-        else
-          inputCoerced.foreach { in =>
-            val value = query.codec.codec.encode(in).asString
-            queryParams = queryParams.addQueryParam(query.name, value)
-          }
-
+        query.queryType match {
+          case QueryType.Primitive(name, codec)                                                        =>
+            val schema = codec.schema
+            if (schema.isInstanceOf[Schema.Primitive[_]]) {
+              if (schema.asInstanceOf[Schema.Primitive[_]].standardType.isInstanceOf[StandardType.UnitType.type]) {
+                queryParams = queryParams.addQueryParams(name, Chunk.empty[String])
+              } else {
+                val encoded = codec.codec.asInstanceOf[BinaryCodec[Any]].encode(input).asString
+                queryParams = queryParams.addQueryParams(name, Chunk(encoded))
+              }
+            } else if (schema.isInstanceOf[Schema.Optional[_]]) {
+              val encoded = codec.codec.asInstanceOf[BinaryCodec[Any]].encode(input).asString
+              if (encoded.nonEmpty) queryParams = queryParams.addQueryParams(name, Chunk(encoded))
+            } else {
+              throw new IllegalStateException(
+                "Only primitive schema is supported for query parameters of type Primitive",
+              )
+            }
+          case QueryType.Collection(_, QueryType.Primitive(name, codec), optional)                     =>
+            var in: Any = input
+            if (optional) {
+              in = input.asInstanceOf[Option[Any]].getOrElse(Chunk.empty)
+            }
+            val values  = input.asInstanceOf[Iterable[Any]]
+            if (values.nonEmpty) {
+              queryParams = queryParams.addQueryParams(
+                name,
+                Chunk.fromIterable(
+                  values.map { value =>
+                    codec.codec.asInstanceOf[BinaryCodec[Any]].encode(value).asString
+                  },
+                ),
+              )
+            }
+          case query @ QueryType.Record(recordSchema) if recordSchema.isInstanceOf[Schema.Optional[_]] =>
+            input match {
+              case None        =>
+                ()
+              case Some(value) =>
+                val innerSchema = recordSchema.asInstanceOf[Schema.Optional[_]].schema.asInstanceOf[Schema.Record[Any]]
+                val fieldValues = innerSchema.deconstruct(value)(Unsafe.unsafe)
+                var j           = 0
+                while (j < fieldValues.size) {
+                  val (field, codec) = query.fieldAndCodecs(j)
+                  val name           = field.name
+                  val value          = fieldValues(j) match {
+                    case Some(value) => value
+                    case None        => field.defaultValue
+                  }
+                  value match {
+                    case values: Iterable[_] =>
+                      queryParams = queryParams.addQueryParams(
+                        name,
+                        Chunk.fromIterable(values.map { v =>
+                          codec.codec.asInstanceOf[BinaryCodec[Any]].encode(v).asString
+                        }),
+                      )
+                    case _                   =>
+                      val encoded = codec.codec.asInstanceOf[BinaryCodec[Any]].encode(value).asString
+                      queryParams = queryParams.addQueryParam(name, encoded)
+                  }
+                  j = j + 1
+                }
+            }
+          case query @ QueryType.Record(recordSchema)                                                  =>
+            val innerSchema = recordSchema.asInstanceOf[Schema.Record[Any]]
+            val fieldValues = innerSchema.deconstruct(input)(Unsafe.unsafe)
+            var j           = 0
+            while (j < fieldValues.size) {
+              val (field, codec) = query.fieldAndCodecs(j)
+              val name           = field.name
+              val value          = fieldValues(j) match {
+                case Some(value) => value
+                case None        => field.defaultValue
+              }
+              value match {
+                case values if values.isInstanceOf[Iterable[_]] =>
+                  queryParams = queryParams.addQueryParams(
+                    name,
+                    Chunk.fromIterable(values.asInstanceOf[Iterable[Any]].map { v =>
+                      codec.codec.asInstanceOf[BinaryCodec[Any]].encode(v).asString
+                    }),
+                  )
+                case _                                          =>
+                  val encoded = codec.codec.asInstanceOf[BinaryCodec[Any]].encode(value).asString
+                  queryParams = queryParams.addQueryParam(name, encoded)
+              }
+              j = j + 1
+            }
+        }
         i = i + 1
       }
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -5,9 +5,9 @@ import java.util.UUID
 import scala.collection.immutable.ListMap
 import scala.collection.{immutable, mutable}
 
+import zio._
 import zio.json.EncoderOps
 import zio.json.ast.Json
-import zio.{Chunk, schema}
 
 import zio.schema.Schema.Record
 import zio.schema.codec.JsonCodec
@@ -96,7 +96,7 @@ object OpenAPIGen {
   final case class AtomizedMetaCodecs(
     method: Chunk[MetaCodec[SimpleCodec[Method, _]]],
     path: Chunk[MetaCodec[SegmentCodec[_]]],
-    query: Chunk[MetaCodec[HttpCodec.Query[_]]],
+    query: Chunk[MetaCodec[HttpCodec.Query[_, _]]],
     header: Chunk[MetaCodec[HttpCodec.Header[_]]],
     content: Chunk[MetaCodec[HttpCodec.Atom[HttpCodecType.Content, _]]],
     status: Chunk[MetaCodec[HttpCodec.Status[_]]],
@@ -108,8 +108,8 @@ object OpenAPIGen {
         )
       case MetaCodec(_: SegmentCodec[_], _)                   =>
         copy(path = path :+ metaCodec.asInstanceOf[MetaCodec[SegmentCodec[_]]])
-      case MetaCodec(_: HttpCodec.Query[_], _)                =>
-        copy(query = query :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Query[_]]])
+      case MetaCodec(_: HttpCodec.Query[_, _], _)             =>
+        copy(query = query :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Query[_, _]]])
       case MetaCodec(_: HttpCodec.Header[_], _)               =>
         copy(header = header :+ metaCodec.asInstanceOf[MetaCodec[HttpCodec.Header[_]]])
       case MetaCodec(_: HttpCodec.Status[_], _)               =>
@@ -610,25 +610,57 @@ object OpenAPIGen {
       queryParams ++ pathParams ++ headerParams
 
     def queryParams: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]] = {
-      inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(name, codec, _, _), _) =>
-        OpenAPI.ReferenceOr.Or(
-          OpenAPI.Parameter.queryParameter(
-            name = name,
-            description = mc.docsOpt,
-            // TODO: For single field case classes we need to use the schema of the field
-            schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromZSchema(codec.schema))),
-            deprecated = mc.deprecated,
-            style = OpenAPI.Parameter.Style.Form,
-            explode = false,
-            allowReserved = false,
-            examples = mc.examples.map { case (name, value) =>
-              name -> OpenAPI.ReferenceOr.Or(OpenAPI.Example(value = Json.Str(value.toString)))
-            },
-            required = mc.required,
-          ),
-        )
+      inAtoms.query.collect {
+        case mc @ MetaCodec(HttpCodec.Query(HttpCodec.Query.QueryType.Primitive(name, codec), _), _)  =>
+          OpenAPI.ReferenceOr.Or(
+            OpenAPI.Parameter.queryParameter(
+              name = name,
+              description = mc.docsOpt,
+              schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromZSchema(codec.schema))),
+              deprecated = mc.deprecated,
+              style = OpenAPI.Parameter.Style.Form,
+              explode = false,
+              allowReserved = false,
+              examples = mc.examples.map { case (name, value) =>
+                name -> OpenAPI.ReferenceOr.Or(OpenAPI.Example(value = Json.Str(value.toString)))
+              },
+              required = mc.required,
+            ),
+          ) :: Nil
+        case mc @ MetaCodec(HttpCodec.Query(record @ HttpCodec.Query.QueryType.Record(schema), _), _) =>
+          val recordSchema = (schema match {
+            case schema if schema.isInstanceOf[Schema.Optional[_]] => schema.asInstanceOf[Schema.Optional[_]].schema
+            case _                                                 => schema
+          }).asInstanceOf[Schema.Record[Any]]
+          val examples     = mc.examples.map { case (exName, ex) =>
+            exName -> recordSchema.deconstruct(ex)(Unsafe.unsafe)
+          }
+          record.fieldAndCodecs.zipWithIndex.map { case ((field, codec), index) =>
+            OpenAPI.ReferenceOr.Or(
+              OpenAPI.Parameter.queryParameter(
+                name = field.name,
+                description = mc.docsOpt,
+                schema = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromZSchema(codec.schema))),
+                deprecated = mc.deprecated,
+                style = OpenAPI.Parameter.Style.Form,
+                explode = false,
+                allowReserved = false,
+                examples = examples.map { case (exName, values) =>
+                  val fieldValue = values(index)
+                    .orElse(field.defaultValue)
+                    .getOrElse(
+                      throw new Exception(s"No value or default value found for field ${exName}_${field.name}"),
+                    )
+                  s"${exName}_${field.name}" -> OpenAPI.ReferenceOr.Or(
+                    OpenAPI.Example(value = Json.Str(codec.codec.encode(fieldValue).asString)),
+                  )
+                },
+                required = mc.required,
+              ),
+            )
+          }
       }
-    }.toSet
+    }.flatten.toSet
 
     def pathParams: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]] =
       inAtoms.path.collect {

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryChecks.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryChecks.scala
@@ -20,4 +20,7 @@ trait QueryChecks[+A] { self: QueryOps[A] with A =>
 
   def hasQueryParam(name: CharSequence): Boolean =
     queryParameters.seq.exists(_.getKey == name)
+
+  def valueCount(name: CharSequence): Int =
+    queryParameters.seq.count(_.getKey == name)
 }

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryGetters.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryGetters.scala
@@ -104,4 +104,7 @@ trait QueryGetters[+A] { self: QueryOps[A] =>
   def queryParamToOrElse[T](key: String, default: => T)(implicit codec: TextCodec[T]): T =
     queryParamTo[T](key).getOrElse(default)
 
+  private[http] def unsafeQueryParam(key: String): String =
+    queryParams(key).head
+
 }

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
@@ -40,7 +40,7 @@ object HttpGenSpec extends ZIOSpecDefault {
       assertTrue(rendered == expected)
     },
     test("Path with query parameters") {
-      val endpoint     = Endpoint(Method.GET / "api" / "foo").query[Int](QueryCodec.queryInt("userId"))
+      val endpoint     = Endpoint(Method.GET / "api" / "foo").query[Int](HttpCodec.query[Int]("userId"))
       val httpEndpoint = HttpGen.fromEndpoint(endpoint)
       val rendered     = httpEndpoint.render
       val expected     =
@@ -51,7 +51,7 @@ object HttpGenSpec extends ZIOSpecDefault {
       assertTrue(rendered == expected)
     },
     test("Path with path and query parameters") {
-      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("pageId")).query[Int](QueryCodec.queryInt("userId"))
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("pageId")).query[Int](HttpCodec.query[Int]("userId"))
       val httpEndpoint = HttpGen.fromEndpoint(endpoint)
       val rendered     = httpEndpoint.render
       val expected     =
@@ -63,7 +63,7 @@ object HttpGenSpec extends ZIOSpecDefault {
       assertTrue(rendered == expected)
     },
     test("Path with path and query parameter with the same name") {
-      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId")).query[Int](QueryCodec.queryInt("userId"))
+      val endpoint     = Endpoint(Method.GET / "api" / "foo" / int("userId")).query[Int](HttpCodec.query[Int]("userId"))
       val httpEndpoint = HttpGen.fromEndpoint(endpoint)
       val rendered     = httpEndpoint.render
       val expected     =


### PR DESCRIPTION
More efficient optional query param encoding and query codes based on case class support

fixes #2942
fixes #2992
/claim #2942
/claim #2992