### PR TITLE
[gen] newtype aliases

### DIFF
--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/EndpointGen.scala
@@ -3,7 +3,7 @@ package zio.http.endpoint.cli
 import zio.ZNothing
 import zio.test._
 
-import zio.schema.{Schema, StandardType}
+import zio.schema.Schema
 
 import zio.http._
 import zio.http.codec.HttpCodec.Query.QueryParamHint

--- a/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
@@ -43,6 +43,7 @@ object EndpointGen {
     }
     val obj       = Code.Object(
       name = name.capitalize,
+      extensions = Nil,
       schema = false,
       endpoints = endpoints.toMap,
       objects = Nil,

--- a/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/grpc/EndpointGen.scala
@@ -2,7 +2,6 @@ package zio.http.gen.grpc
 
 import zio.http.Method
 import zio.http.gen.scala.Code
-import zio.http.gen.scala.Code.ScalaType
 
 object EndpointGen {
 
@@ -44,7 +43,7 @@ object EndpointGen {
     val obj       = Code.Object(
       name = name.capitalize,
       extensions = Nil,
-      schema = false,
+      schema = None,
       endpoints = endpoints.toMap,
       objects = Nil,
       caseClasses = Nil,

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
@@ -1,15 +1,21 @@
 package zio.http.gen.openapi
 
-final case class Config(commonFieldsOnSuperType: Boolean)
+final case class Config(
+  commonFieldsOnSuperType: Boolean,
+  generateSafeTypeAliases: Boolean, // in the future we can consider enum instead of boolean for different aliased types
+)
 object Config {
 
   val default: Config = Config(
     commonFieldsOnSuperType = false,
+    generateSafeTypeAliases = false,
   )
 
-  lazy val config: zio.Config[Config] =
-    zio.Config
-      .boolean("common-fields-on-super-type")
-      .withDefault(Config.default.commonFieldsOnSuperType)
-      .map(Config.apply)
+  lazy val config: zio.Config[Config] = {
+    val c =
+      zio.Config.boolean("common-fields-on-super-type").withDefault(Config.default.commonFieldsOnSuperType) ++
+        zio.Config.boolean("generate-safe-type-aliases").withDefault(Config.default.generateSafeTypeAliases)
+
+    c.map { case (a, b) => Config(a, b) }
+  }
 }

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
@@ -1,8 +1,25 @@
 package zio.http.gen.openapi
 
 final case class Config(
-  commonFieldsOnSuperType: Boolean,
-  generateSafeTypeAliases: Boolean, // in the future we can consider enum instead of boolean for different aliased types
+  commonFieldsOnSuperType: Boolean /*
+   * oneOf expressions in openapi result in sealed traits in generated scala code.
+   * if this flag is set to true, and all oneOf's "sub types" are defined in terms of
+   * an allOf expression, and all share same object(s) included in the allOf expression,
+   * then the common fields from that shared object(s) will result in abstract fields
+   * defined on the sealed trait.
+   */,
+  generateSafeTypeAliases: Boolean, /*
+   * Referencing primitives, and giving them a name makes the openapi spec more readable.
+   * By default, the generated scala code will resolve the referenced name,
+   * and replace it with the primitive type.
+   * By setting this flag to true, the generator will create components with zio.prelude Newtype
+   * definitions wrapping over the aliased primitive type.
+   *
+   * Note: only aliased primitives are supported for now.
+   *
+   * TODO: in the future we can consider an enum instead of boolean for different aliased types.
+   *       e.g: scala 3 opaque types, neotype, prelude's newtype, etc'…
+   */
 )
 object Config {
 

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -348,7 +348,7 @@ final case class EndpointGen(config: Config) {
             Code.Object(
               name = className,
               extensions = Nil,
-              schema = false,
+              schema = None,
               endpoints = endpoints.toMap,
               objects = anonymousTypes.values.toList,
               caseClasses = Nil,
@@ -411,7 +411,7 @@ final case class EndpointGen(config: Config) {
                         Code.Object(
                           name = method.toString,
                           extensions = Nil,
-                          schema = false,
+                          schema = None,
                           endpoints = Map.empty,
                           objects = code.objects,
                           caseClasses = code.caseClasses,
@@ -450,7 +450,7 @@ final case class EndpointGen(config: Config) {
                         val obj  = Code.Object(
                           name = method.toString,
                           extensions = Nil,
-                          schema = false,
+                          schema = None,
                           endpoints = Map.empty,
                           objects = code.objects,
                           caseClasses = code.caseClasses,
@@ -498,7 +498,7 @@ final case class EndpointGen(config: Config) {
                         val obj  = Code.Object(
                           name = method.toString,
                           extensions = Nil,
-                          schema = false,
+                          schema = None,
                           endpoints = Map.empty,
                           objects = code.objects,
                           caseClasses = code.caseClasses,
@@ -626,10 +626,10 @@ final case class EndpointGen(config: Config) {
     }
 
   def schemaToType(openAPI: OpenAPI, name: String, schema: JsonSchema): Option[(List[Code.Import], String)] =
-    Option.when(schema.isPrimitive) {
+    if (schema.isPrimitive) {
       val field = schemaToField(schema, openAPI, name, Chunk.empty).get // .get is safe, always defined for primitives
-      CodeGen.render("")(field.fieldType)
-    }
+      Some(CodeGen.render("")(field.fieldType))
+    } else None
 
   @tailrec
   private def schemaToPathCodec(schema: JsonSchema, openAPI: OpenAPI, name: String): Code.PathSegmentCode = {

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -1,7 +1,5 @@
 package zio.http.gen.scala
 
-import java.nio.file.Path
-
 import scala.meta.Term
 import scala.meta.prettyprinters.XtensionSyntax
 
@@ -64,21 +62,19 @@ object Code {
 
   object Object {
 
-    def apply(
+    def withDefaultSchemaDerivation(
       name: String,
       extensions: List[String],
-      schema: Boolean,
       endpoints: Map[Field, EndpointCode],
       objects: List[Object],
       caseClasses: List[CaseClass],
       enums: List[Enum],
     ): Object =
-      Object(name, extensions, if (schema) Some("DeriveSchema.gen") else None, endpoints, objects, caseClasses, enums)
+      Object(name, extensions, Some("DeriveSchema.gen"), endpoints, objects, caseClasses, enums)
 
-    def schemaCompanion(str: String): Object = Object(
+    def schemaCompanion(str: String): Object = withDefaultSchemaDerivation(
       name = str,
       extensions = Nil,
-      schema = true,
       endpoints = Map.empty,
       objects = Nil,
       caseClasses = Nil,
@@ -86,10 +82,10 @@ object Code {
     )
 
     def apply(name: String, endpoints: Map[Field, EndpointCode]): Object =
-      Object(
+      new Object(
         name = name,
         extensions = Nil,
-        schema = false,
+        schema = None,
         endpoints = endpoints,
         objects = Nil,
         caseClasses = Nil,

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -94,17 +94,9 @@ object CodeGen {
           sb += '\n'
           sb ++= epc
         }
+        sb += '\n'
         sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
-        schema.foreach { deriveWith =>
-          sb += '\n'
-          sb ++= " implicit val codec: Schema["
-          sb ++= name
-          sb ++= "] = "
-          sb ++= deriveWith
-          sb += '['
-          sb ++= name
-          sb += ']'
-        }
+        schema.foreach(_.codecLineWithStringBuilder(name, sb))
         sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
         objectsContent.foreach { obj =>
           sb += '\n'

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -382,7 +382,7 @@ object CodeGen {
         case Code.CodecType.Literal => throw new Exception("Literal query params are not supported")
         case Code.CodecType.Aliased(underlying, newtypeName) =>
           val (imports, _) = renderQueryCode(Code.QueryParamCode(name, underlying))
-          (Code.Import.FromBase(s"components.$newtypeName") :: imports) -> newtypeName
+          (Code.Import.FromBase(s"components.$newtypeName") :: imports) -> (newtypeName + ".Type")
       }
       imports -> s""".query(QueryCodec.queryTo[$tpe]("$name"))"""
   }

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -63,7 +63,7 @@ object CodeGen {
     case Code.Import.FromBase(path) =>
       Nil -> s"import $basePackage.$path"
 
-    case Code.Object(name, schema, endpoints, objects, caseClasses, enums) =>
+    case Code.Object(name, extensions, schema, endpoints, objects, caseClasses, enums) =>
       val baseImports                      = if (endpoints.nonEmpty) EndpointImports else Nil
       val (epImports, epContent)           = endpoints.toList.map { case (k, v) =>
         val (kImports, kContent) = render(basePackage)(k)
@@ -75,15 +75,55 @@ object CodeGen {
       val (enumImports, enumContent)       = enums.map(render(basePackage)).unzip
       val allImports                       =
         (baseImports ++ epImports.flatten ++ objectsImports.flatten ++ ccImports.flatten ++ enumImports.flatten).distinct
-      val content                          =
-        s"object $name {\n" +
-          allImports.map(render(basePackage)(_)._2).mkString("", "\n", "\n") +
-          epContent.mkString("\n") +
-          (if (schema) s"\n\n implicit val codec: Schema[$name] = DeriveSchema.gen[$name]" else "") +
-          "\n" + objectsContent.mkString("\n") +
-          "\n" + ccContent.mkString("\n") +
-          "\n" + enumContent.mkString("\n") +
-          "\n}"
+      val content                          = {
+        val sb   = new StringBuilder()
+        sb ++= "object "
+        sb ++= name
+        var prex = " extends "
+        extensions.foreach { ext =>
+          sb ++= prex
+          prex = " with "
+          sb ++= ext
+        }
+        sb += '{'
+        allImports.map(render(basePackage)(_)._2).foreach { imp =>
+          sb += '\n'
+          sb ++= imp
+        }
+        epContent.foreach { epc =>
+          sb += '\n'
+          sb ++= epc
+        }
+        sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
+        schema.foreach { deriveWith =>
+          sb += '\n'
+          sb ++= " implicit val codec: Schema["
+          sb ++= name
+          sb ++= "] = "
+          sb ++= deriveWith
+          sb += '['
+          sb ++= name
+          sb += ']'
+        }
+        sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
+        objectsContent.foreach { obj =>
+          sb += '\n'
+          sb ++= obj
+        }
+        sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
+        ccContent.foreach { cc =>
+          sb += '\n'
+          sb ++= cc
+        }
+        sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
+        enumContent.foreach { en =>
+          sb += '\n'
+          sb ++= en
+        }
+        sb += '\n' // redundant: may be dropped  - but altering all test examples is needed, so it'll match
+        sb ++= "\n}"
+        sb.result()
+      }
       Nil -> content
 
     case Code.CaseClass(name, fields, companionObject, mixins) =>
@@ -200,9 +240,10 @@ object CodeGen {
 
     case Code.EndpointCode(method, pathPatternCode, queryParamsCode, headersCode, inCode, outCodes, errorsCode) =>
       val (queryImports, queryContent) = queryParamsCode.map(renderQueryCode).unzip
-      val allImports                   = queryImports.flatten.toList.distinct
+      val (segments, pathImports)      = pathPatternCode.segments.map(renderSegment).unzip
+      val allImports                   = (pathImports ++ queryImports).flatten.distinct
       val content                      =
-        s"""Endpoint(Method.$method / ${pathPatternCode.segments.map(renderSegment).mkString(" / ")})
+        s"""Endpoint(Method.$method / ${segments.mkString(" / ")})
            |  ${queryContent.mkString("\n")}
            |  ${headersCode.headers.map(renderHeader).mkString("\n")}
            |  ${renderInCode(inCode)}
@@ -218,17 +259,29 @@ object CodeGen {
       throw new Exception(s"Unknown ScalaType: $scalaType")
   }
 
-  def renderSegment(segment: Code.PathSegmentCode): String = segment match {
-    case Code.PathSegmentCode(name, segmentType) =>
-      segmentType match {
-        case Code.CodecType.Boolean => s"""bool("$name")"""
-        case Code.CodecType.Int     => s"""int("$name")"""
-        case Code.CodecType.Long    => s"""long("$name")"""
-        case Code.CodecType.String  => s"""string("$name")"""
-        case Code.CodecType.UUID    => s"""uuid("$name")"""
-        case Code.CodecType.Literal => s""""$name""""
-      }
+  def renderSegmentType(name: String, segmentType: Code.CodecType): (String, List[Code.Import]) =
+    segmentType match {
+      case Code.CodecType.Boolean                          => s"""bool("$name")"""   -> Nil
+      case Code.CodecType.Int                              => s"""int("$name")"""    -> Nil
+      case Code.CodecType.Long                             => s"""long("$name")"""   -> Nil
+      case Code.CodecType.String                           => s"""string("$name")""" -> Nil
+      case Code.CodecType.UUID                             => s"""uuid("$name")"""   -> Nil
+      case Code.CodecType.Literal                          => s""""$name""""         -> Nil
+      case Code.CodecType.Aliased(underlying, newtypeName) =>
+        val sb              = new StringBuilder()
+        val (code, imports) = renderSegmentType(name, underlying)
+        sb ++= code
+        sb ++= ".transform("
+        sb ++= newtypeName
+        sb ++= ".wrap)("
+        sb ++= newtypeName
+        sb ++= ".unwrap)"
+        sb.result() -> (Code.Import.FromBase("components." + newtypeName) :: imports)
+    }
 
+  def renderSegment(segment: Code.PathSegmentCode): (String, List[Code.Import]) = segment match {
+    case Code.PathSegmentCode(name, segmentType) =>
+      renderSegmentType(name, segmentType)
   }
 
   // currently, we do not support schemas
@@ -327,6 +380,9 @@ object CodeGen {
         case Code.CodecType.String  => Nil                                 -> "String"
         case Code.CodecType.UUID    => List(Code.Import("java.util.UUID")) -> "UUID"
         case Code.CodecType.Literal => throw new Exception("Literal query params are not supported")
+        case Code.CodecType.Aliased(underlying, newtypeName) =>
+          val (imports, _) = renderQueryCode(Code.QueryParamCode(name, underlying))
+          (Code.Import.FromBase(s"components.$newtypeName") :: imports) -> newtypeName
       }
       imports -> s""".query(QueryCodec.queryTo[$tpe]("$name"))"""
   }

--- a/zio-http-gen/src/test/resources/ComponentAliasAge.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasAge.scala
@@ -1,9 +1,10 @@
 package test.component
 
 import zio.prelude.Newtype
+import zio.schema.Schema
 
 object Age extends Newtype[Int] {
 
-  implicit val codec: Schema[Age] = derive[Age]
+  implicit val schema: Schema[Age.Type] = Schema.primitive[Int].transform(wrap, unwrap)
 
 }

--- a/zio-http-gen/src/test/resources/ComponentAliasAge.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasAge.scala
@@ -1,0 +1,9 @@
+package test.component
+
+import zio.prelude.Newtype
+
+object Age extends Newtype[Int] {
+
+  implicit val codec: Schema[Age] = derive[Age]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentAliasId.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasId.scala
@@ -1,9 +1,10 @@
 package test.component
 
 import zio.prelude.Newtype
+import zio.schema.Schema
 
 object Id extends Newtype[Int] {
 
-  implicit val codec: Schema[Id] = derive[Id]
+  implicit val schema: Schema[Id.Type] = Schema.primitive[Int].transform(wrap, unwrap)
 
 }

--- a/zio-http-gen/src/test/resources/ComponentAliasId.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasId.scala
@@ -1,0 +1,9 @@
+package test.component
+
+import zio.prelude.Newtype
+
+object Id extends Newtype[Int] {
+
+  implicit val codec: Schema[Id] = derive[Id]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentAliasName.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasName.scala
@@ -1,9 +1,10 @@
 package test.component
 
 import zio.prelude.Newtype
+import zio.schema.Schema
 
 object Name extends Newtype[String] {
 
-  implicit val codec: Schema[Name] = derive[Name]
+  implicit val schema: Schema[Name.Type] = Schema.primitive[String].transform(wrap, unwrap)
 
 }

--- a/zio-http-gen/src/test/resources/ComponentAliasName.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasName.scala
@@ -1,0 +1,9 @@
+package test.component
+
+import zio.prelude.Newtype
+
+object Name extends Newtype[String] {
+
+  implicit val codec: Schema[Name] = derive[Name]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentAliasSpecies.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasSpecies.scala
@@ -1,0 +1,9 @@
+package test.component
+
+import zio.prelude.Newtype
+
+object Species extends Newtype[String] {
+
+  implicit val codec: Schema[Species] = derive[Species]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentAliasSpecies.scala
+++ b/zio-http-gen/src/test/resources/ComponentAliasSpecies.scala
@@ -1,9 +1,10 @@
 package test.component
 
 import zio.prelude.Newtype
+import zio.schema.Schema
 
 object Species extends Newtype[String] {
 
-  implicit val codec: Schema[Species] = derive[Species]
+  implicit val schema: Schema[Species.Type] = Schema.primitive[String].transform(wrap, unwrap)
 
 }

--- a/zio-http-gen/src/test/resources/ComponentAnimalWithAliases.scala
+++ b/zio-http-gen/src/test/resources/ComponentAnimalWithAliases.scala
@@ -1,12 +1,14 @@
 package test.component
 
 import zio.schema._
+import zio.Chunk
 
 case class Animal(
-  id: Id.Type,
-  name: Name.Type,
   species: Species.Type,
+  name: Name.Type,
+  relatives: Chunk[Species.Type],
   age: Age.Type,
+  id: Id.Type,
 )
 object Animal {
 

--- a/zio-http-gen/src/test/resources/ComponentAnimalWithAliases.scala
+++ b/zio-http-gen/src/test/resources/ComponentAnimalWithAliases.scala
@@ -1,0 +1,15 @@
+package test.component
+
+import zio.schema._
+
+case class Animal(
+  id: Id.Type,
+  name: Name.Type,
+  species: Species.Type,
+  age: Age.Type,
+)
+object Animal {
+
+  implicit val codec: Schema[Animal] = DeriveSchema.gen[Animal]
+
+}

--- a/zio-http-gen/src/test/resources/ComponentAnimalWithoutAliases.scala
+++ b/zio-http-gen/src/test/resources/ComponentAnimalWithoutAliases.scala
@@ -1,12 +1,14 @@
 package test.component
 
 import zio.schema._
+import zio.Chunk
 
 case class Animal(
-  id: Int,
-  name: String,
   species: String,
+  name: String,
+  relatives: Chunk[String],
   age: Int,
+  id: Int,
 )
 object Animal {
 

--- a/zio-http-gen/src/test/resources/ComponentAnimalWithoutAliases.scala
+++ b/zio-http-gen/src/test/resources/ComponentAnimalWithoutAliases.scala
@@ -1,0 +1,15 @@
+package test.component
+
+import zio.schema._
+
+case class Animal(
+  id: Int,
+  name: String,
+  species: String,
+  age: Int,
+)
+object Animal {
+
+  implicit val codec: Schema[Animal] = DeriveSchema.gen[Animal]
+
+}

--- a/zio-http-gen/src/test/resources/EndpointForZooAnimalAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooAnimalAliasedSegment.scala
@@ -1,0 +1,14 @@
+package test.api.v1.zoo.info
+
+import test.component._
+
+object Id {
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  import test.components.Id
+  val get_animal_info = Endpoint(Method.GET / "api" / "v1" / "zoo" / "info" / int("id").transform(Id.wrap)(Id.unwrap))
+    .in[Unit]
+    .out[Animal](status = Status.Ok)
+
+}

--- a/zio-http-gen/src/test/resources/EndpointForZooAnimalUnAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooAnimalUnAliasedSegment.scala
@@ -1,0 +1,13 @@
+package test.api.v1.zoo.info
+
+import test.component._
+
+object Id {
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  val get_animal_info = Endpoint(Method.GET / "api" / "v1" / "zoo" / "info" / int("id"))
+    .in[Unit]
+    .out[Animal](status = Status.Ok)
+
+}

--- a/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
@@ -1,0 +1,16 @@
+package test.api.v1.zoo.list
+
+import test.component._
+import zio.Chunk
+
+object Species {
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  import test.components.Species
+  val list_by_species =
+    Endpoint(Method.GET / "api" / "v1" / "zoo" / "list" / string("species").transform(Species.wrap)(Species.unwrap))
+      .in[Unit]
+      .out[Chunk[Animal]](status = Status.Ok)
+
+}

--- a/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooSpeciesAliasedSegment.scala
@@ -8,8 +8,10 @@ object Species {
   import zio.http.endpoint._
   import zio.http.codec._
   import test.components.Species
+  import test.components.Age
   val list_by_species =
     Endpoint(Method.GET / "api" / "v1" / "zoo" / "list" / string("species").transform(Species.wrap)(Species.unwrap))
+      .query(QueryCodec.queryTo[Age.Type]("max-age"))
       .in[Unit]
       .out[Chunk[Animal]](status = Status.Ok)
 

--- a/zio-http-gen/src/test/resources/EndpointForZooSpeciesUnAliasedSegment.scala
+++ b/zio-http-gen/src/test/resources/EndpointForZooSpeciesUnAliasedSegment.scala
@@ -1,0 +1,15 @@
+package test.api.v1.zoo.list
+
+import test.component._
+import zio.Chunk
+
+object Species {
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  val list_by_species = Endpoint(Method.GET / "api" / "v1" / "zoo" / "list" / string("species"))
+    .query(QueryCodec.queryTo[Int]("max-age"))
+    .in[Unit]
+    .out[Chunk[Animal]](status = Status.Ok)
+
+}

--- a/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
+++ b/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
@@ -34,9 +34,13 @@ paths:
           schema:
             $ref: '#/components/schemas/Species'
           required: true
+        - in: query
+          name: max-age
+          schema:
+            $ref: '#/components/schemas/Age'
       tags:
         - Animals_API
-      description: List all animals of a certain species
+      description: List all animals of a certain species, possibly filtering results up to a certain age
       responses:
         "200":
           content:

--- a/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
+++ b/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
@@ -1,0 +1,78 @@
+info:
+  title: Animals Service
+  version: 0.0.1
+servers:
+  - url: http://127.0.0.1:5000/
+tags:
+  - name: Animals_API
+paths:
+  /api/v1/zoo/info/{id}:
+    get:
+      operationId: get_animal_info
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/Id'
+          required: true
+      tags:
+        - Animals_API
+      description: Get info by animal id
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Animal'
+          description: OK
+  /api/v1/zoo/list/{species}:
+    get:
+      operationId: list_by_species
+      parameters:
+        - in: path
+          name: species
+          schema:
+            $ref: '#/components/schemas/Species'
+          required: true
+      tags:
+        - Animals_API
+      description: List all animals of a certain species
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Animal'
+          description: OK
+openapi: 3.0.3
+components:
+  schemas:
+    Animal:
+      type: object
+      required:
+        - id
+        - name
+        - species
+        - age
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        name:
+          $ref: '#/components/schemas/Name'
+        species:
+          $ref: '#/components/schemas/Species'
+        age:
+          $ref: '#/components/schemas/Age'
+    Age:
+      type: integer
+      format: int32
+      minimum: 0
+    Id:
+      type: integer
+      format: int32
+    Name:
+      type: string
+    Species:
+      type: string

--- a/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
+++ b/zio-http-gen/src/test/resources/inline_schema_alias_primitives.yaml
@@ -60,6 +60,7 @@ components:
         - name
         - species
         - age
+        - relatives
       properties:
         id:
           $ref: '#/components/schemas/Id'
@@ -69,6 +70,10 @@ components:
           $ref: '#/components/schemas/Species'
         age:
           $ref: '#/components/schemas/Age'
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/Species'
     Age:
       type: integer
       format: int32

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -2,8 +2,6 @@ package zio.http.gen.openapi
 
 import java.nio.file._
 
-import scala.util.Try
-
 import zio._
 import zio.test._
 
@@ -918,7 +916,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
               Code.Object(
                 "Users",
                 extensions = Nil,
-                schema = false,
+                schema = None,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
                     Method.POST,
@@ -936,7 +934,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                   Code.Object(
                     "POST",
                     extensions = Nil,
-                    schema = false,
+                    schema = None,
                     endpoints = Map.empty,
                     objects = Nil,
                     caseClasses = List(
@@ -976,7 +974,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
               Code.Object(
                 "Users",
                 extensions = Nil,
-                schema = false,
+                schema = None,
                 endpoints = Map(
                   Code.Field("get") -> Code.EndpointCode(
                     Method.GET,
@@ -994,7 +992,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                   Code.Object(
                     "GET",
                     extensions = Nil,
-                    schema = false,
+                    schema = None,
                     endpoints = Map.empty,
                     objects = Nil,
                     caseClasses = List(
@@ -1034,7 +1032,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
               Code.Object(
                 "Users",
                 extensions = Nil,
-                schema = false,
+                schema = None,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
                     Method.POST,
@@ -1052,7 +1050,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                   Code.Object(
                     "POST",
                     extensions = Nil,
-                    schema = false,
+                    schema = None,
                     endpoints = Map.empty,
                     objects = Nil,
                     caseClasses = List(
@@ -1098,7 +1096,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
               Code.Object(
                 "Users",
                 extensions = Nil,
-                schema = false,
+                schema = None,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
                     Method.POST,
@@ -1175,7 +1173,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
               Code.Object(
                 "Foo",
                 extensions = Nil,
-                schema = false,
+                schema = None,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
                     Method.POST,
@@ -1289,7 +1287,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                   Code.Object(
                     extensions = Nil,
                     name = "Bar",
-                    schema = true,
+                    schema = Some("DeriveSchema.gen"),
                     endpoints = Map(
                     ),
                     objects = Nil,

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -1287,7 +1287,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                   Code.Object(
                     extensions = Nil,
                     name = "Bar",
-                    schema = Some("DeriveSchema.gen"),
+                    schema = Some(Code.Object.SchemaCode.DeriveSchemaGen),
                     endpoints = Map(
                     ),
                     objects = Nil,

--- a/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/openapi/EndpointGenSpec.scala
@@ -917,6 +917,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
             objects = List(
               Code.Object(
                 "Users",
+                extensions = Nil,
                 schema = false,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
@@ -934,6 +935,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                 objects = List(
                   Code.Object(
                     "POST",
+                    extensions = Nil,
                     schema = false,
                     endpoints = Map.empty,
                     objects = Nil,
@@ -973,6 +975,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
             objects = List(
               Code.Object(
                 "Users",
+                extensions = Nil,
                 schema = false,
                 endpoints = Map(
                   Code.Field("get") -> Code.EndpointCode(
@@ -990,6 +993,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                 objects = List(
                   Code.Object(
                     "GET",
+                    extensions = Nil,
                     schema = false,
                     endpoints = Map.empty,
                     objects = Nil,
@@ -1029,6 +1033,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
             objects = List(
               Code.Object(
                 "Users",
+                extensions = Nil,
                 schema = false,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
@@ -1046,6 +1051,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                 objects = List(
                   Code.Object(
                     "POST",
+                    extensions = Nil,
                     schema = false,
                     endpoints = Map.empty,
                     objects = Nil,
@@ -1091,6 +1097,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
             objects = List(
               Code.Object(
                 "Users",
+                extensions = Nil,
                 schema = false,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
@@ -1167,6 +1174,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
             objects = List(
               Code.Object(
                 "Foo",
+                extensions = Nil,
                 schema = false,
                 endpoints = Map(
                   Code.Field("post") -> Code.EndpointCode(
@@ -1279,6 +1287,7 @@ object EndpointGenSpec extends ZIOSpecDefault {
                 ),
                 companionObject = Some(
                   Code.Object(
+                    extensions = Nil,
                     name = "Bar",
                     schema = true,
                     endpoints = Map(

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -949,5 +949,5 @@ object CodeGenSpec extends ZIOSpecDefault {
         )
 
       },
-    ) @@ java11OrNewer @@ flaky @@ blocking // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer /*@@ flaky*/ @@ blocking // Downloading scalafmt on CI is flaky
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -949,5 +949,5 @@ object CodeGenSpec extends ZIOSpecDefault {
         )
 
       },
-    ) @@ java11OrNewer /*@@ flaky*/ @@ blocking // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer @@ flaky @@ blocking // Downloading scalafmt on CI is flaky
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -330,7 +330,8 @@ object CodeGenSpec extends ZIOSpecDefault {
         openAPIString.fromYaml match {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
-            val code = EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true))
+            val code =
+              EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false))
 
             val tempDir = Files.createTempDirectory("codegen")
             val testDir = tempDir.resolve("test")
@@ -376,7 +377,8 @@ object CodeGenSpec extends ZIOSpecDefault {
         openAPIString.fromYaml match {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
-            val code = EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true))
+            val code =
+              EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false))
 
             val tempDir = Files.createTempDirectory("codegen")
             val testDir = tempDir.resolve("test")
@@ -446,7 +448,9 @@ object CodeGenSpec extends ZIOSpecDefault {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
             assert {
-              Try(EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true)))
+              Try(
+                EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false)),
+              )
             }(isFailure)
         }
       } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3
@@ -472,7 +476,9 @@ object CodeGenSpec extends ZIOSpecDefault {
         openAPIString.fromYaml match {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
-            val t = Try(EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true)))
+            val t = Try(
+              EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false)),
+            )
             assert(t)(isSuccess) && {
               val tempDir = Files.createTempDirectory("codegen")
               val testDir = tempDir.resolve("test")
@@ -519,7 +525,9 @@ object CodeGenSpec extends ZIOSpecDefault {
         openAPIString.fromYaml match {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
-            val t = Try(EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true)))
+            val t = Try(
+              EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false)),
+            )
             assert(t)(isSuccess) && {
               val tempDir = Files.createTempDirectory("codegen")
               val testDir = tempDir.resolve("test")
@@ -550,7 +558,7 @@ object CodeGenSpec extends ZIOSpecDefault {
             }
         }
       } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3
-      test("OpenAPI spec with inline schema response body with type aliases") {
+      test("OpenAPI spec with inline schema response body with newtype type aliases") {
 
         import zio.json.yaml.DecoderYamlOps
         implicit val decoder: JsonDecoder[OpenAPI] = JsonCodec.jsonDecoder(OpenAPI.schema)
@@ -570,7 +578,8 @@ object CodeGenSpec extends ZIOSpecDefault {
         openAPIString.fromYaml match {
           case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
           case Right(oapi) =>
-            val t = Try(EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true)))
+            val t =
+              Try(EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = true)))
             assert(t)(isSuccess) && {
               val tempDir = Files.createTempDirectory("codegen")
               val testDir = tempDir.resolve("test")
@@ -616,6 +625,58 @@ object CodeGenSpec extends ZIOSpecDefault {
                 testDir,
                 "component/Species.scala",
                 "/ComponentAliasSpecies.scala",
+              )
+            }
+        }
+      } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3
+      test("OpenAPI spec with inline schema response body with bare type aliases") {
+
+        import zio.json.yaml.DecoderYamlOps
+        implicit val decoder: JsonDecoder[OpenAPI] = JsonCodec.jsonDecoder(OpenAPI.schema)
+
+        val openAPIString =
+          Files
+            .readAllLines(
+              Paths.get(
+                getClass
+                  .getResource("/inline_schema_alias_primitives.yaml")
+                  .toURI,
+              ),
+            )
+            .asScala
+            .mkString("\n")
+
+        openAPIString.fromYaml match {
+          case Left(error) => TestResult(TestArrow.make(_ => TestTrace.fail(ErrorMessage.text(error))))
+          case Right(oapi) =>
+            val t = Try(
+              EndpointGen.fromOpenAPI(oapi, Config(commonFieldsOnSuperType = true, generateSafeTypeAliases = false)),
+            )
+            assert(t)(isSuccess) && {
+              val tempDir = Files.createTempDirectory("codegen")
+              val testDir = tempDir.resolve("test")
+
+              CodeGen.writeFiles(t.get, testDir, "test", Some(scalaFmtPath))
+
+              allFilesShouldBe(
+                testDir.toFile,
+                List(
+                  "api/v1/zoo/info/Id.scala",
+                  "api/v1/zoo/list/Species.scala",
+                  "component/Animal.scala",
+                ),
+              ) && fileShouldBe(
+                testDir,
+                "api/v1/zoo/info/Id.scala",
+                "/EndpointForZooAnimalAliasedSegment.scala",
+              ) && fileShouldBe(
+                testDir,
+                "api/v1/zoo/list/Species.scala",
+                "/EndpointForZooSpeciesAliasedSegment.scala",
+              ) && fileShouldBe(
+                testDir,
+                "component/Animal.scala",
+                "/ComponentAnimalWithoutAliases.scala",
               )
             }
         }
@@ -888,5 +949,5 @@ object CodeGenSpec extends ZIOSpecDefault {
         )
 
       },
-    ) @@ java11OrNewer @@ flaky @@ blocking // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer /* @@ flaky*/ @@ blocking // Downloading scalafmt on CI is flaky
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -668,11 +668,11 @@ object CodeGenSpec extends ZIOSpecDefault {
               ) && fileShouldBe(
                 testDir,
                 "api/v1/zoo/info/Id.scala",
-                "/EndpointForZooAnimalAliasedSegment.scala",
+                "/EndpointForZooAnimalUnAliasedSegment.scala",
               ) && fileShouldBe(
                 testDir,
                 "api/v1/zoo/list/Species.scala",
-                "/EndpointForZooSpeciesAliasedSegment.scala",
+                "/EndpointForZooSpeciesUnAliasedSegment.scala",
               ) && fileShouldBe(
                 testDir,
                 "component/Animal.scala",
@@ -949,5 +949,5 @@ object CodeGenSpec extends ZIOSpecDefault {
         )
 
       },
-    ) @@ java11OrNewer /* @@ flaky*/ @@ blocking // Downloading scalafmt on CI is flaky
+    ) @@ java11OrNewer @@ flaky @@ blocking // Downloading scalafmt on CI is flaky
 }

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -29,15 +29,12 @@ import zio.schema.annotation.validate
 import zio.schema.validation.Validation
 import zio.schema.{DeriveSchema, Schema}
 
-import zio.http.Header.Authorization
 import zio.http.Method._
 import zio.http._
-import zio.http.codec.HttpCodec.authorization
 import zio.http.codec.HttpContentCodec.protobuf
 import zio.http.codec._
 import zio.http.endpoint.EndpointSpec.ImageMetadata
 import zio.http.netty.NettyConfig
-import zio.http.netty.server.NettyDriver
 
 object RoundtripSpec extends ZIOHttpSpec {
   val testLayer: ZLayer[Any, Throwable, Server & Client & Scope] =

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -16,12 +16,11 @@
 
 package zio.http
 
-import java.io.{FileInputStream, IOException}
+import java.io.FileInputStream
 import java.nio.charset._
 import java.nio.file._
 
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.stream.ZStream
 

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -25,9 +25,7 @@ import zio._
 import zio.stream.ZStream
 
 import zio.schema.Schema
-import zio.schema.codec.BinaryCodec
 
-import zio.http.codec.internal.TextBinaryCodec
 import zio.http.internal.HeaderOps
 import zio.http.template.Html
 

--- a/zio-http/shared/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClient.scala
@@ -18,7 +18,6 @@ package zio.http
 
 import java.net.{InetSocketAddress, URI}
 
-import zio.ConfigProvider.Flat.util
 import zio._
 
 import zio.http.URL.Location

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodec.scala
@@ -17,7 +17,6 @@
 package zio.http.codec
 
 import scala.annotation.tailrec
-import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 import zio._
@@ -25,13 +24,11 @@ import zio._
 import zio.stream.ZStream
 
 import zio.schema.Schema
-import zio.schema.annotation.validate
-import zio.schema.validation.Validation
 
 import zio.http.Header.Accept.MediaTypeWithQFactor
 import zio.http._
 import zio.http.codec.HttpCodec.{Annotated, Metadata}
-import zio.http.codec.internal.{AtomizedCodecs, EncoderDecoder}
+import zio.http.codec.internal.EncoderDecoder
 
 /**
  * A [[zio.http.codec.HttpCodec]] represents a codec for a part of an HTTP

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpCodecError.scala
@@ -18,7 +18,6 @@ package zio.http.codec
 
 import scala.util.control.NoStackTrace
 
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{Cause, Chunk}
 
 import zio.schema.codec.DecodeError

--- a/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/QueryCodecs.scala
@@ -16,7 +16,6 @@
 
 package zio.http.codec
 import zio.Chunk
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.schema.Schema
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/EncoderDecoder.scala
@@ -22,7 +22,6 @@ import zio._
 
 import zio.stream.ZStream
 
-import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
 
 import zio.http.Header.Accept.MediaTypeWithQFactor

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/internal/EndpointClient.scala
@@ -17,7 +17,6 @@
 package zio.http.endpoint.internal
 
 import zio._
-import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.http._
 import zio.http.codec._


### PR DESCRIPTION
 basic implementation.
Aliased types is only supported for primitives in this PR.

fixes #2962 
/claim #2962

TODO:
- [x] make it configurable
- [x] when opt-out, replace alias with original primitive name
- [x] add more tests to cover most common scenarios:
  * [x] collections of aliased newtypes
  * [x] collections of un-aliased primitives
  * [x] path aliased newtype params
  * [x] path un-aliased primitive params 
  * [x] query aliased newtype params
  * [x] query un-aliased primitive params 
- [x] documentation