### PR TITLE
fix: uuid PathCodec is broken in snapshot versions

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -116,7 +116,7 @@ object PathCodecSpec extends ZIOHttpSpec {
           )
         },
       ),
-      suite("UUID segment decoding")(
+      suite("UUID segment")(
         test("UUID segment decoding") {
           val codec = PathCodec.empty / "api" / PathCodec.uuid("entityId")
           val uuid  = UUID.randomUUID()

--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -127,10 +127,6 @@ object PathCodecSpec extends ZIOHttpSpec {
           val codec = SegmentCodec.uuid("entityId")
           val uuid  = UUID.randomUUID().toString()
           val path  = Chunk("api", uuid)
-
-          println(s"Testing UUID segment matches with path: $path and UUID: $uuid")
-          println(s"Segment codec: $codec")
-          println(s"Matching result: ${codec.matches(path, 1)}")
           assertTrue(codec.matches(path, 1) == 1)
         },
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -127,6 +127,10 @@ object PathCodecSpec extends ZIOHttpSpec {
           val codec = SegmentCodec.uuid("entityId")
           val uuid  = UUID.randomUUID().toString()
           val path  = Chunk("api", uuid)
+
+          println(s"Testing UUID segment matches with path: $path and UUID: $uuid")
+          println(s"Segment codec: $codec")
+          println(s"Matching result: ${codec.matches(path, 1)}")
           assertTrue(codec.matches(path, 1) == 1)
         },
       ),

--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -116,6 +116,20 @@ object PathCodecSpec extends ZIOHttpSpec {
           )
         },
       ),
+      suite("UUID segment decoding")(
+        test("UUID segment decoding") {
+          val codec = PathCodec.empty / "api" / PathCodec.uuid("entityId")
+          val uuid  = UUID.randomUUID()
+          val path  = Path(s"/api/$uuid")
+          assertTrue(codec.decode(path) == Right(uuid))
+        },
+        test("UUID segment matches") {
+          val codec = SegmentCodec.uuid("entityId")
+          val uuid  = UUID.randomUUID().toString()
+          val path  = Chunk("api", uuid)
+          assertTrue(codec.matches(path, 1) == 1)
+        },
+      ),
       suite("decoding with sub-segment codecs")(
         test("int") {
           val codec = PathCodec.empty /

--- a/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -439,9 +439,12 @@ object SegmentCodec          {
     def matches(segments: Chunk[String], index: Int): Int = {
       if (index < 0 || index >= segments.length) -1
       else {
-        val lastIndex = inSegmentUntil(segments(index), 0)
-        if (lastIndex == -1 || lastIndex + 1 != segments(index).length) -1
-        else 1
+        try {
+          java.util.UUID.fromString(segments(index))
+          1 // Valid UUID
+        } catch {
+          case _: IllegalArgumentException => -1 // Not a valid UUID
+        }
       }
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -438,13 +438,15 @@ object SegmentCodec          {
 
     def matches(segments: Chunk[String], index: Int): Int = {
       if (index < 0 || index >= segments.length) -1
+      else if (isValidUUID(segments(index))) 1
+      else -1
+    }
+
+    private def isValidUUID(segment: String): Boolean = {
+      if (segment.length != 36) false
       else {
-        try {
-          java.util.UUID.fromString(segments(index))
-          1 // Valid UUID
-        } catch {
-          case _: IllegalArgumentException => -1 // Not a valid UUID
-        }
+        val uuidPattern = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        segment.matches(uuidPattern)
       }
     }
 


### PR DESCRIPTION
/claim #3005
fixes #3005 


The issue stemmed from the recent changes to the UUID `SegmentCodec` implementation. Specifically, the matches method was modified to use the inSegmentUntil method which introduced an error in the way UUID segments were validated causing valid UUID segments to be mismatched.

I have simplified the `matches` method by using `java.util.UUID.fromString` directly to validate UUID strings. This approach ensures that the entire segment is validated as a proper UUID and handles segment boundaries correctly. This change ensures that only valid UUID strings will match, resolving the issue and restoring the correct behavior and the endpoint now correctly matches UUID segments.

