### PR TITLE
Fix uuid SegmentCodec matches

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -135,8 +135,8 @@ object RoutePatternSpec extends ZIOHttpSpec {
         val p1 = Path(s"/users/some_value/abc/$id/hello")
         val p2 = Path(s"/users/some_value/$id/hello")
         assertTrue(
-          routePattern1.decode(Method.GET, p1).is(_.right) == ("some_value", id),
-          routePattern2.decode(Method.GET, p2).is(_.right) == ("some_value", id),
+          routePattern1.decode(Method.GET, p1) == Right(("some_value", id)),
+          routePattern2.decode(Method.GET, p2) == Right(("some_value", id)),
           tree.get(Method.GET, p1).contains(1),
           tree.get(Method.GET, p2).contains(2),
         )

--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -16,13 +16,15 @@
 
 package zio.http
 
+import java.util.UUID
+
 import scala.collection.Seq
+
 import zio.Chunk
 import zio.test._
+
 import zio.http.internal.HttpGen
 import zio.http.{int => _, uuid => _, _}
-
-import java.util.UUID
 
 object RoutePatternSpec extends ZIOHttpSpec {
   import zio.http.Method

--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -139,13 +139,13 @@ object PathCodecSpec extends ZIOHttpSpec {
           val p  = s"/abc/foo/${id}__13/bar/42"
           assertTrue(codec.decode(Path(p)) == Right(("abc", id, 13, 42)))
         },
-        test("uuid with string") {
+        test("uuid after string") {
           val codec = PathCodec.empty / "foo" / "bar" / string("baz") / "xyz" / uuid(
             "id",
           ) / "abc"
           val id    = UUID.randomUUID()
           val p     = s"/foo/bar/some_value/xyz/$id/abc"
-          assertTrue(codec.decode(Path(p)).is(_.right) == ("some_value", id))
+          assertTrue(codec.decode(Path(p)) == Right(("some_value", id)))
         },
         test("string before literal") {
           val codec = PathCodec.empty /

--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -139,6 +139,14 @@ object PathCodecSpec extends ZIOHttpSpec {
           val p  = s"/abc/foo/${id}__13/bar/42"
           assertTrue(codec.decode(Path(p)) == Right(("abc", id, 13, 42)))
         },
+        test("uuid with string") {
+          val codec = PathCodec.empty / "foo" / "bar" / string("baz") / "xyz" / uuid(
+            "id",
+          ) / "abc"
+          val id    = UUID.randomUUID()
+          val p     = s"/foo/bar/some_value/xyz/$id/abc"
+          assertTrue(codec.decode(Path(p)).is(_.right) == ("some_value", id))
+        },
         test("string before literal") {
           val codec = PathCodec.empty /
             string("foo") /

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -429,7 +429,7 @@ sealed trait PathCodec[A] { self =>
         val t = value.regionMatches(true, idx, "true", 0, 4)
         if (t) idx + 4 else if (value.regionMatches(true, idx, "false", 0, 5)) idx + 5 else -1
       case UUIDOpt          =>
-        val until = SegmentCodec.UUID.isUUIDUntil(value, idx)
+        val until = SegmentCodec.UUID.inUUIDUntil(value, idx)
         if (until == -1) -1 else idx + until
       case MatchAny(values) =>
         var end      = -1

--- a/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/SegmentCodec.scala
@@ -440,23 +440,24 @@ object SegmentCodec          {
       if (index < 0 || index >= segments.length) -1
       else {
         val lastIndex = inSegmentUntil(segments(index), 0)
-        if (lastIndex == -1 || lastIndex + 1 != segments(index).length) -1
+        if (lastIndex == -1 || lastIndex != segments(index).length) -1
         else 1
       }
     }
 
     override def inSegmentUntil(segment: String, from: Int): Int =
-      UUID.isUUIDUntil(segment, from)
+      UUID.inUUIDUntil(segment, from)
   }
 
   private[http] object UUID {
-    def isUUIDUntil(segment: String, from: Int): Int = {
+    def inUUIDUntil(segment: String, from: Int): Int = {
       var i       = from
       var defined = true
       var group   = 0
       var count   = 0
       if (segment.length + from < 36) return -1
-      while (i < 36 && defined) {
+      val until   = from + 36
+      while (i < until && defined) {
         val char = segment.charAt(i)
         if ((char >= 48 && char <= 57) || (char >= 65 && char <= 70) || (char >= 97 && char <= 102))
           count += 1
@@ -475,7 +476,7 @@ object SegmentCodec          {
         }
         i += 1
       }
-      if (defined && from + 36 == i) i else -1
+      if (defined && until == i) i else -1
     }
 
   }

--- a/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
@@ -96,8 +96,8 @@ object SegmentCodecSpec extends ZIOSpecDefault {
     suite("matches")(
       test("uuid successful matches") {
         val codec = SegmentCodec.uuid("entityId")
-        val uuid  = UUID.randomUUID().toString()
-        val path  = Chunk("api", uuid)
+        val uuid  = new UUID(101, 304)
+        val path  = Chunk("api", uuid.toString())
         assertTrue(codec.matches(path, 1) == 1)
       },
     ),

--- a/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
@@ -1,6 +1,7 @@
 package zio.http.codec
 
 import java.util.UUID
+
 import scala.util._
 
 import zio._

--- a/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/codec/SegmentCodecSpec.scala
@@ -1,5 +1,6 @@
 package zio.http.codec
 
+import java.util.UUID
 import scala.util._
 
 import zio._
@@ -91,5 +92,13 @@ object SegmentCodecSpec extends ZIOSpecDefault {
         uuidLongInt.failed.toOption.map(_.getMessage).contains(expectedErrorMsg),
       )
     },
+    suite("matches")(
+      test("uuid successful matches") {
+        val codec = SegmentCodec.uuid("entityId")
+        val uuid  = UUID.randomUUID().toString()
+        val path  = Chunk("api", uuid)
+        assertTrue(codec.matches(path, 1) == 1)
+      },
+    ),
   )
 }


### PR DESCRIPTION
fixes #3005
/claim #3005

Fix `SegmentCodec.UUID.isUUIDUntil` which doesn't respect `from` offset when iterating over segment.

Actually issue with routing only happens if uuid segment was after string segment and `indexOfNextCodec` was called. (`indexOfNextCodec` is called only in case of string sgement appears in segments). So I added this test case.