### PR TITLE
Update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,21 +2,21 @@ import sbt.*
 
 object Dependencies {
   val JwtCoreVersion                = "10.0.1"
-  val NettyVersion                  = "4.1.109.Final"
+  val NettyVersion                  = "4.1.112.Final"
   val NettyIncubatorVersion         = "0.0.25.Final"
   val ScalaCompactCollectionVersion = "2.12.0"
-  val ZioVersion                    = "2.1.1"
+  val ZioVersion                    = "2.1.7"
   val ZioCliVersion                 = "0.5.0"
-  val ZioJsonVersion                = "0.6.2"
-  val ZioSchemaVersion              = "1.2.1"
+  val ZioJsonVersion                = "0.7.1"
+  val ZioSchemaVersion              = "1.3.0"
   val SttpVersion                   = "3.3.18"
   val ZioConfigVersion              = "4.0.2"
 
   val `jwt-core`                 = "com.github.jwt-scala"   %% "jwt-core"                % JwtCoreVersion
   val `scala-compact-collection` = "org.scala-lang.modules" %% "scala-collection-compat" % ScalaCompactCollectionVersion
 
-  val scalafmt = "org.scalameta" %% "scalafmt-dynamic" % "3.8.1"
-  val scalametaParsers = "org.scalameta" %% "parsers" % "4.9.4"
+  val scalafmt         = "org.scalameta" %% "scalafmt-dynamic" % "3.8.1"
+  val scalametaParsers = "org.scalameta" %% "parsers"          % "4.9.9"
 
   val netty =
     Seq(

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSpec.scala
@@ -421,7 +421,7 @@ object ServerSpec extends HttpRunnableSpec {
           val res = Handler.text("äöü").sandbox.toRoutes.deploy.contentLength.run()
           assertZIO(res)(isSome(equalTo(Header.ContentLength(6L))))
         } +
-          test("already set") {
+          test("provided content-length is overwritten by actual length") {
             val res =
               Handler
                 .text("1234567890")
@@ -431,7 +431,7 @@ object ServerSpec extends HttpRunnableSpec {
                 .deploy
                 .contentLength
                 .run()
-            assertZIO(res)(isSome(equalTo(Header.ContentLength(4L))))
+            assertZIO(res)(isSome(equalTo(Header.ContentLength(10L))))
           }
       },
     ),

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -31,7 +31,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
   implicit val imageMetadataSchema: Schema[ImageMetadata]               =
     DeriveSchema.gen[ImageMetadata]
 
-  final case class WithTransientField(name: String, @transientField age: Int)
+  final case class WithTransientField(name: String, @transientField age: Int = 42)
   implicit val withTransientFieldSchema: Schema[WithTransientField] =
     DeriveSchema.gen[WithTransientField]
 


### PR DESCRIPTION
Since Netty v4.1.112, if the provided content-length header doesn't match the actual content length, the server seems to go a bit haywire (responds successfully and then drops the connection). To avoid this issue, we ignore the user-provided content length for cases where we know the size of the response.