### PR TITLE
Cache parsing of content-type header

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -2557,7 +2557,7 @@ object Header {
     def parse(s: String): Either[String, ContentType] = {
       // Guard against malicious registering of invalid content types
       if (cache.size >= CacheMaxSize) cache.clear()
-      cache.computeIfAbsent(s.toLowerCase, parseFn)
+      cache.computeIfAbsent(s, parseFn)
     }
 
     def render(contentType: ContentType): String = codec.encode(contentType).toOption.get

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -20,6 +20,7 @@ import java.net.URI
 import java.nio.charset.{Charset, UnsupportedCharsetException}
 import java.time.ZonedDateTime
 import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -2543,12 +2544,21 @@ object Header {
   }
 
   object ContentType extends HeaderType {
+    private final val CacheInitialSize = 256
+    private final val CacheMaxSize     = 8192
+
+    private val cache: ConcurrentHashMap[String, Either[String, ContentType]] =
+      new ConcurrentHashMap[String, Either[String, ContentType]](CacheInitialSize)
 
     override type HeaderValue = ContentType
 
     override def name: String = "content-type"
 
-    def parse(s: String): Either[String, ContentType] = codec.decode(s)
+    def parse(s: String): Either[String, ContentType] = {
+      // Guard against malicious registering of invalid content types
+      if (cache.size >= CacheMaxSize) cache.clear()
+      cache.computeIfAbsent(s.toLowerCase, parseFn)
+    }
 
     def render(contentType: ContentType): String = codec.encode(contentType).toOption.get
 
@@ -2607,6 +2617,9 @@ object Header {
         ),
       )
     }
+
+    private val parseFn: java.util.function.Function[String, Either[String, ContentType]] =
+      codec.decode(_)
 
     private[Header] sealed trait Parameter {
       self =>

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -2544,7 +2544,7 @@ object Header {
   }
 
   object ContentType extends HeaderType {
-    private final val CacheInitialSize = 256
+    private final val CacheInitialSize = 64
     private final val CacheMaxSize     = 8192
 
     private val cache: ConcurrentHashMap[String, Either[String, ContentType]] =


### PR DESCRIPTION
#2969 unknowingly introduced a ~10% regression in performance for simple requests when the content-type header is present. This regression was introduced because parsing of the content-type header is a fairly expensive (~1us to parse `application/json` based on some basic benchmarking), and to make things worse, it is executed within Netty's event loop which should not be performing CPU-intensive work.

On one hand, we could simply revert the PR or parse the content-type header only when needed, but I doubt this is the first time someone will accidentally do this. In order to guard against such usages in the future, this PR adds a cache infront of the content-type header parser. Since this can be potentially, we guard against this by clearing the cache if it grows too big. This size (8192 entries) should never be reached for standard usages