### PR TITLE
Fix `ClassCastException: class zio.schema.Schema$Lazy cannot be cast to class zio.schema.Schema$Record` 

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -678,7 +678,10 @@ object OpenAPIGen {
             // There should be no enums with cases that are not records with a nominal id
             // TODO: not true. Since one could build a schema with a enum with a case that is a primitive
             val typeId   =
-              case_.schema
+              (case_.schema match {
+                case lzy: Schema.Lazy[_] => lzy.schema
+                case _                   => case_.schema
+              })
                 .asInstanceOf[Schema.Record[_]]
                 .id
                 .asInstanceOf[TypeId.Nominal]


### PR DESCRIPTION
TODO:
- [ ] Write a test reproducing the error

```scala
Exception in thread "zio-fiber-62,59,0" java.lang.NoClassDefFoundError: Could not initialize class my.company.app.main.MainApi$
    	at my.company.app.tests.utils$.$anonfun$2$$anonfun$2$$anonfun$1$$anonfun$1$$anonfun$2$$anonfun$2$$anonfun$2(utils.scala:46)
    	at zio.ZIO.map$$anonfun$1$$anonfun$1(ZIO.scala:973)
    	at zio.UnsafeVersionSpecific.implicitFunctionIsFunction$$anonfun$1(UnsafeVersionSpecific.scala:27)
    	at zio.Unsafe$.unsafe(Unsafe.scala:37)
    	at zio.ZIOCompanionVersionSpecific.succeed$$anonfun$1(ZIOCompanionVersionSpecific.scala:195)
    	at my.company.app.tests.utils.myLayer.serverLayer(utils.scala:46)
    	at my.company.app.tests.utils.myLayer.serverLayer(utils.scala:47)
    	at my.company.app.tests.apis.MySpec.spec(TestSourceApiIntegrationSpec.scala:62)
    	Suppressed: java.lang.ExceptionInInitializerError: Exception java.lang.ClassCastException: class zio.schema.Schema$Lazy cannot be cast to class zio.schema.Schema$Record (zio.schema.Schema$Lazy and zio.schema.Schema$Record are in unnamed module of loader sbt.internal.LayeredClassLoader @1c25c65d) [in thread "ZScheduler-Worker-7"]
    		at zio.http.endpoint.openapi.OpenAPIGen$.$anonfun$27(OpenAPIGen.scala:681)
    		at zio.Chunk.mapChunk(Chunk.scala:1055)
    		at zio.ChunkLike.map(ChunkLike.scala:121)
    		at zio.ChunkLike.map$(ChunkLike.scala:39)
    		at zio.Chunk.map(Chunk.scala:42)
    		at zio.http.endpoint.openapi.OpenAPIGen$.zio$http$endpoint$openapi$OpenAPIGen$$$_$genDiscriminator$1(OpenAPIGen.scala:685)
    		at zio.http.endpoint.openapi.OpenAPIGen$$anon$7.applyOrElse(OpenAPIGen.scala:735)
    		at zio.http.endpoint.openapi.OpenAPIGen$$anon$7.applyOrElse(OpenAPIGen.scala:727)
    		at zio.Chunk$Arr.collectChunk(Chunk.scala:1749)
    		at zio.Chunk.collectChunk(Chunk.scala:1036)
    		at zio.ChunkLike.collect(ChunkLike.scala:55)
    		at zio.ChunkLike.collect$(ChunkLike.scala:39)
    		at zio.Chunk.collect(Chunk.scala:42)
    		at zio.http.endpoint.openapi.OpenAPIGen$.componentSchemas$1(OpenAPIGen.scala:787)
    		at zio.http.endpoint.openapi.OpenAPIGen$.components$1(OpenAPIGen.scala:696)
    		at zio.http.endpoint.openapi.OpenAPIGen$.gen(OpenAPIGen.scala:802)
    		at zio.http.endpoint.openapi.OpenAPIGen$.fromEndpoints$$anonfun$3(OpenAPIGen.scala:485)
    		at scala.collection.immutable.List.map(List.scala:250)
    		at scala.collection.immutable.List.map(List.scala:79)
    		at zio.http.endpoint.openapi.OpenAPIGen$.fromEndpoints(OpenAPIGen.scala:485)
    		at zio.http.endpoint.openapi.OpenAPIGen$.fromEndpoints(OpenAPIGen.scala:491)
    		at my.company.app.api.Endpoints$.openAPI(Endpoints.scala:23)
    		at my.company.app.main.MainApi$.<clinit>(MainApi.scala:35)
    		at my.company.app.tests.utils$.$anonfun$2$$anonfun$2$$anonfun$1$$anonfun$1$$anonfun$2$$anonfun$1(utils.scala:44)
    		at zio.ZIO$.blocking$$anonfun$1(ZIO.scala:2877)
    		at zio.FiberRef$unsafe$$anon$2.getWith$$anonfun$1(FiberRef.scala:474)
```