### PR TITLE
Configurable EndpointAPI codecs (#2911)

### DIFF
--- a/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/EndpointBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala-2.13/zio/http/benchmarks/EndpointBenchmark.scala
@@ -11,7 +11,7 @@ import zio.{Scope => _, _}
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.HttpCodec
+import zio.http.codec.{CodecConfig, HttpCodec}
 import zio.http.endpoint.Endpoint
 
 import cats.effect.unsafe.implicits.global

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/OptionsGen.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/OptionsGen.scala
@@ -36,7 +36,7 @@ object OptionsGen {
   def encodeOptions[A](name: String, codec: BinaryCodecWithSchema[A]): Options[String] =
     HttpOptions
       .optionsFromSchema(codec)(name)
-      .map(value => codec.codec.encode(value).asString)
+      .map(value => codec.codec(CodecConfig.defaultConfig).encode(value).asString)
 
   lazy val anyBodyOption: Gen[Any, CliReprOf[Options[Retriever]]] =
     Gen

--- a/zio-http-example/src/main/scala/example/ServerSentEventAsJsonEndpoint.scala
+++ b/zio-http-example/src/main/scala/example/ServerSentEventAsJsonEndpoint.scala
@@ -9,7 +9,7 @@ import zio.stream.ZStream
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.HttpCodec
+import zio.http.codec.{CodecConfig, HttpCodec}
 import zio.http.endpoint._
 
 object ServerSentEventAsJsonEndpoint extends ZIOAppDefault {

--- a/zio-http-example/src/main/scala/example/ServerSentEventEndpoint.scala
+++ b/zio-http-example/src/main/scala/example/ServerSentEventEndpoint.scala
@@ -8,7 +8,7 @@ import zio._
 import zio.stream.ZStream
 
 import zio.http._
-import zio.http.codec.HttpCodec
+import zio.http.codec.{CodecConfig, HttpCodec}
 import zio.http.endpoint._
 
 object ServerSentEventEndpoint extends ZIOAppDefault {

--- a/zio-http-example/src/main/scala/example/endpoint/EndpointWithMultipleErrorsUsingEither.scala
+++ b/zio-http-example/src/main/scala/example/endpoint/EndpointWithMultipleErrorsUsingEither.scala
@@ -5,7 +5,7 @@ import zio._
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.{HeaderCodec, PathCodec}
+import zio.http.codec.{CodecConfig, HeaderCodec, PathCodec}
 import zio.http.endpoint.{AuthType, Endpoint}
 
 object EndpointWithMultipleErrorsUsingEither extends ZIOAppDefault {

--- a/zio-http-example/src/main/scala/example/endpoint/EndpointWithMultipleUnifiedErrors.scala
+++ b/zio-http-example/src/main/scala/example/endpoint/EndpointWithMultipleUnifiedErrors.scala
@@ -7,7 +7,7 @@ import zio._
 import zio.schema.{DeriveSchema, Schema}
 
 import zio.http._
-import zio.http.codec.{HeaderCodec, HttpCodec, PathCodec}
+import zio.http.codec.{CodecConfig, HeaderCodec, HttpCodec, PathCodec}
 import zio.http.endpoint.{AuthType, Endpoint}
 
 object EndpointWithMultipleUnifiedErrors extends ZIOAppDefault {

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthSpec.scala
@@ -5,7 +5,7 @@ import zio.test._
 import zio.{Scope, ZIO, durationInt}
 
 import zio.http._
-import zio.http.codec.HttpCodec
+import zio.http.codec.{CodecConfig, HttpCodec}
 import zio.http.internal.middlewares.AuthSpec.AuthContext
 
 object AuthSpec extends ZIOSpecDefault {

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -159,6 +159,9 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
   def isDefinedAt(request: Request)(implicit ev: Err <:< Response): Boolean =
     tree(Trace.empty, ev).get(request.method, request.path).nonEmpty
 
+  def provide[Env1 <: Env](env: Env1)(implicit tag: Tag[Env1]): Routes[Any, Err] =
+    provideEnvironment(ZEnvironment(env))
+
   /**
    * Provides the specified environment to the HTTP application, returning a new
    * HTTP application that has no environmental requirements.

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -106,10 +106,10 @@ object ServerSentEvent {
     }
 
   implicit def contentCodec[T](implicit
-    tCodec: BinaryCodec[T],
-    schema: Schema[T],
+    codecT: BinaryCodec[T],
+    schemaT: Schema[T],
   ): HttpContentCodec[ServerSentEvent[T]] = HttpContentCodec.from(
-    MediaType.text.`event-stream` -> BinaryCodecWithSchema.fromBinaryCodec(binaryCodec),
+    MediaType.text.`event-stream` -> BinaryCodecWithSchema(binaryCodec(codecT), schema(schemaT)),
   )
 
   implicit def defaultContentCodec[T](implicit

--- a/zio-http/shared/src/main/scala/zio/http/codec/BinaryCodecWithSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/BinaryCodecWithSchema.scala
@@ -1,11 +1,64 @@
 package zio.http.codec
 
+import zio._
+
 import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
 
-final case class BinaryCodecWithSchema[A](codec: BinaryCodec[A], schema: Schema[A])
+import zio.http.{HandlerAspect, Middleware}
+
+final case class BinaryCodecWithSchema[A](codecFn: CodecConfig => BinaryCodec[A], schema: Schema[A]) {
+  private var cached                             = Map.empty[CodecConfig, BinaryCodec[A]]
+  def codec(config: CodecConfig): BinaryCodec[A] =
+    cached.getOrElse(
+      config, {
+        val codec = codecFn(config)
+        cached += (config -> codec)
+        codec
+      },
+    )
+}
 
 object BinaryCodecWithSchema {
-  def fromBinaryCodec[A](codec: BinaryCodec[A])(implicit schema: Schema[A]): BinaryCodecWithSchema[A] =
+  def apply[A](codec: BinaryCodec[A], schema: Schema[A]): BinaryCodecWithSchema[A] =
+    BinaryCodecWithSchema(_ => codec, schema)
+
+  def fromBinaryCodec[A](codec: CodecConfig => BinaryCodec[A])(implicit
+    schema: Schema[A],
+  ): BinaryCodecWithSchema[A] =
     BinaryCodecWithSchema(codec, schema)
+
+  def fromBinaryCodec[A](codec: BinaryCodec[A])(implicit schema: Schema[A]): BinaryCodecWithSchema[A] =
+    BinaryCodecWithSchema(_ => codec, schema)
+}
+
+/**
+ * Configuration that is handed over when creating a binary codec
+ * @param ignoreEmptyCollections
+ *   if true, empty collections will be ignored when encoding. This is currently
+ *   only used for the JSON codec
+ */
+
+final case class CodecConfig(
+  ignoreEmptyCollections: Boolean = true,
+)
+
+object CodecConfig {
+  val defaultConfig: CodecConfig = CodecConfig()
+
+  def setConfig(config: CodecConfig): ZIO[Any, Nothing, Unit] =
+    ZIO.withFiberRuntime[Any, Nothing, Unit] { (state, _) =>
+      val existing = state.getFiberRef(codecRef)
+      if (existing != config) state.setFiberRef(codecRef, config)
+      Exit.unit
+    }
+
+  def configLayer(config: CodecConfig): ULayer[Unit] =
+    ZLayer(setConfig(config))
+
+  def withConfig(config: CodecConfig): HandlerAspect[Any, Unit] =
+    Middleware.runBefore(setConfig(config))
+
+  private[http] val codecRef: FiberRef[CodecConfig] =
+    FiberRef.unsafe.make(defaultConfig)(Unsafe)
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/EndpointExecutor.scala
@@ -20,7 +20,7 @@ import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.http._
-import zio.http.codec.{Alternator, Combiner}
+import zio.http.codec.{Alternator, CodecConfig, Combiner}
 import zio.http.endpoint.internal.EndpointClient
 
 /**
@@ -63,7 +63,7 @@ final case class EndpointExecutor[R, Auth](
     combiner: Combiner[I, invocation.endpoint.authType.ClientRequirement],
     ev: Auth <:< invocation.endpoint.authType.ClientRequirement,
     trace: Trace,
-  ): ZIO[Scope with R, E, B] = {
+  ): ZIO[R with Scope, E, B] = {
     getClient(invocation.endpoint).orDie.flatMap { endpointClient =>
       endpointClient.execute(
         client,

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -16,20 +16,31 @@ object HttpGen {
   private val PathWildcard = "pathWildcard"
 
   def fromEndpoints(
+    config: CodecConfig,
     endpoint1: Endpoint[_, _, _, _, _],
     endpoints: Endpoint[_, _, _, _, _]*,
   ): HttpFile = {
-    HttpFile((endpoint1 +: endpoints).map(fromEndpoint).toList)
+    HttpFile((endpoint1 +: endpoints).map(fromEndpoint(config, _)).toList)
   }
 
-  def fromEndpoint(endpoint: Endpoint[_, _, _, _, _]): HttpEndpoint = {
+  def fromEndpoints(
+    endpoint1: Endpoint[_, _, _, _, _],
+    endpoints: Endpoint[_, _, _, _, _]*,
+  ): HttpFile = {
+    HttpFile((endpoint1 +: endpoints).map(fromEndpoint(CodecConfig.defaultConfig, _)).toList)
+  }
+
+  def fromEndpoint(endpoint: Endpoint[_, _, _, _, _]): HttpEndpoint =
+    fromEndpoint(CodecConfig.defaultConfig, endpoint)
+
+  def fromEndpoint(config: CodecConfig, endpoint: Endpoint[_, _, _, _, _]): HttpEndpoint = {
     val atomizedInput = AtomizedMetaCodecs.flatten(endpoint.input)
     HttpEndpoint(
       OpenAPIGen.method(atomizedInput.method),
-      buildPath(endpoint.input),
+      buildPath(config, endpoint.input),
       headersVariables(atomizedInput).map(_.name),
       bodySchema(atomizedInput),
-      variables(atomizedInput),
+      variables(config, atomizedInput),
       doc(endpoint),
     )
   }
@@ -49,8 +60,8 @@ object HttpGen {
   private def doc(endpoint: Endpoint[_, _, _, _, _]) =
     if (endpoint.documentation == Doc.empty) None else Some(endpoint.documentation.toPlaintext(color = false))
 
-  def variables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] =
-    pathVariables(inAtoms) ++ queryVariables(inAtoms) ++ headersVariables(inAtoms) ++ bodyVariables(inAtoms)
+  def variables(config: CodecConfig, inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] =
+    pathVariables(inAtoms) ++ queryVariables(config, inAtoms) ++ headersVariables(inAtoms) ++ bodyVariables(inAtoms)
 
   def bodyVariables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
     val bodySchema0 = bodySchema(inAtoms)
@@ -121,12 +132,14 @@ object HttpGen {
       )
     }
 
-  def queryVariables(inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
+  def queryVariables(config: CodecConfig, inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
     inAtoms.query.collect {
       case mc @ MetaCodec(HttpCodec.Query(HttpCodec.Query.QueryType.Primitive(name, codec), _), _)  =>
         HttpVariable(
           name,
-          mc.examples.values.headOption.map((e: Any) => codec.codec.asInstanceOf[BinaryCodec[Any]].encode(e).asString),
+          mc.examples.values.headOption.map((e: Any) =>
+            codec.codec(config).asInstanceOf[BinaryCodec[Any]].encode(e).asString,
+          ),
         ) :: Nil
       case mc @ MetaCodec(HttpCodec.Query(record @ HttpCodec.Query.QueryType.Record(schema), _), _) =>
         val recordSchema = (schema match {
@@ -143,7 +156,7 @@ object HttpGen {
               val fieldValue = values(index)
                 .orElse(field.defaultValue)
                 .getOrElse(throw new Exception(s"No value or default value for field ${field.name}"))
-              codec.codec.encode(fieldValue).asString
+              codec.codec(config).encode(fieldValue).asString
             }),
           )
         }
@@ -160,7 +173,7 @@ object HttpGen {
     }
   }
 
-  def buildPath(in: HttpCodec[_, _]): String = {
+  def buildPath(config: CodecConfig, in: HttpCodec[_, _]): String = {
 
     def pathCodec(in1: HttpCodec[_, _]): Option[HttpCodec.Path[_]] = in1 match {
       case atom: HttpCodec.Atom[_, _]            =>
@@ -177,7 +190,7 @@ object HttpGen {
     }
 
     val atomizedInput = AtomizedMetaCodecs.flatten(in)
-    val queryNames    = queryVariables(atomizedInput).map(_.name)
+    val queryNames    = queryVariables(config, atomizedInput).map(_.name)
 
     val pathString = {
       val codec = pathCodec(in).getOrElse(throw new Exception("No path found.")).pathCodec

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -652,7 +652,9 @@ object OpenAPIGen {
                       throw new Exception(s"No value or default value found for field ${exName}_${field.name}"),
                     )
                   s"${exName}_${field.name}" -> OpenAPI.ReferenceOr.Or(
-                    OpenAPI.Example(value = Json.Str(codec.codec.encode(fieldValue).asString)),
+                    OpenAPI.Example(value =
+                      Json.Str(codec.codec(CodecConfig.defaultConfig).encode(fieldValue).asString),
+                    ),
                   )
                 },
                 required = mc.required,


### PR DESCRIPTION
This PR also contains the changes of #3026 to avoid conflicts later on.
fixes #2911
/claim #2911