### PR TITLE
Expose additional server config

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -16,8 +16,8 @@
 
 package zio.http.netty.server
 
+import java.lang.{Boolean => JBoolean}
 import java.net.InetSocketAddress
-import java.util.concurrent.atomic.AtomicReference
 
 import zio._
 
@@ -29,6 +29,7 @@ import zio.http.{ClientDriver, Driver, Response, Routes, Server}
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel._
 import io.netty.util.ResourceLeakDetector
+
 private[zio] final case class NettyDriver(
   appRef: AppRef,
   channelFactory: ChannelFactory[ServerChannel],
@@ -41,12 +42,19 @@ private[zio] final case class NettyDriver(
 
   def start(implicit trace: Trace): RIO[Scope, StartResult] =
     for {
-      serverBootstrap <- ZIO.attempt(new ServerBootstrap().channelFactory(channelFactory).group(eventLoopGroup))
-      chf             <- ZIO.attempt(serverBootstrap.childHandler(channelInitializer).bind(serverConfig.address))
-      _               <- NettyFutureExecutor.scoped(chf)
-      _               <- ZIO.succeed(ResourceLeakDetector.setLevel(nettyConfig.leakDetectionLevel.toNetty))
-      channel         <- ZIO.attempt(chf.channel())
-      port            <- ZIO.attempt(channel.localAddress().asInstanceOf[InetSocketAddress].getPort)
+      chf     <- ZIO.attempt {
+        new ServerBootstrap()
+          .group(eventLoopGroup)
+          .channelFactory(channelFactory)
+          .childHandler(channelInitializer)
+          .option[Integer](ChannelOption.SO_BACKLOG, serverConfig.soBacklog)
+          .childOption[JBoolean](ChannelOption.TCP_NODELAY, serverConfig.tcpNoDelay)
+          .bind(serverConfig.address)
+      }
+      _       <- NettyFutureExecutor.scoped(chf)
+      _       <- ZIO.succeed(ResourceLeakDetector.setLevel(nettyConfig.leakDetectionLevel.toNetty))
+      channel <- ZIO.attempt(chf.channel())
+      port    <- ZIO.attempt(channel.localAddress().asInstanceOf[InetSocketAddress].getPort)
 
       _ <- Scope.addFinalizer(
         NettyFutureExecutor.executed(channel.close()).ignoreLogged,

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -252,7 +252,7 @@ object Server extends ServerPlatformSpecific {
 
     lazy val default: Config = Config(
       sslConfig = None,
-      address = new InetSocketAddress(InetAddress.getLocalHost, 8080),
+      address = new InetSocketAddress(InetAddress.getLoopbackAddress, 8080),
       acceptContinue = false,
       keepAlive = true,
       requestDecompression = Decompression.No,

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -148,7 +148,7 @@ object Server extends ServerPlatformSpecific {
     /**
      * Configure the server to listen on the provided port.
      */
-    def port(port: Int): Config = self.copy(address = new InetSocketAddress(address.getAddress, port))
+    def port(port: Int): Config = self.copy(address = new InetSocketAddress(port))
 
     /**
      * Configure the new server with netty's HttpContentCompressor to compress
@@ -233,7 +233,7 @@ object Server extends ServerPlatformSpecific {
           ) =>
         default.copy(
           sslConfig = sslConfig,
-          address = new InetSocketAddress(host.fold(InetAddress.getLoopbackAddress)(InetAddress.getByName), port),
+          address = new InetSocketAddress(host.getOrElse(Config.default.address.getHostName), port),
           acceptContinue = acceptContinue,
           keepAlive = keepAlive,
           requestDecompression = requestDecompression,
@@ -252,7 +252,7 @@ object Server extends ServerPlatformSpecific {
 
     lazy val default: Config = Config(
       sslConfig = None,
-      address = new InetSocketAddress(InetAddress.getLoopbackAddress, 8080),
+      address = new InetSocketAddress(8080),
       acceptContinue = false,
       keepAlive = true,
       requestDecompression = Decompression.No,


### PR DESCRIPTION
This PR:
1. Allows configuring the `SO_BACKLOG` server option which configures the maximum number of pending connections that can be queued and sets it to 100 as default
2. Allows configuring the `TCP_NODELAY` server option which disables Nagle's algorithm and sets it to true. AFAICT, this seems to be recommended for modern servers/systems
