### PR TITLE
fix OpenAPI doc for Endpoint not rendered

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -165,7 +165,7 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
       (GET / "static" / int("id") / uuid("uuid") ?? Doc.p("user id") / string("name")) ?? Doc.p("get path"),
     )
       .in[SimpleInputBody](Doc.p("input body"))
-      .out[SimpleOutputBody](Doc.p("output body"))
+      .out[SimpleOutputBody](mediaType = MediaType.application.json, Doc.p("output body"))
       .outError[NotFoundError](Status.NotFound, Doc.p("not found"))
 
   private val queryParamEndpoint =
@@ -269,21 +269,21 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
                              |        },
                              |        "responses" : {
                              |          "200" : {
+                             |            "description" : "output body\n\n",
                              |            "content" : {
                              |              "application/json" : {
                              |                "schema" : {
-                             |                  "$ref" : "#/components/schemas/SimpleOutputBody",
-                             |                  "description" : "output body\n\n"
+                             |                  "$ref" : "#/components/schemas/SimpleOutputBody"
                              |                }
                              |              }
                              |            }
                              |          },
                              |          "404" : {
+                             |            "description" : "not found\n\n",
                              |            "content" : {
                              |              "application/json" : {
                              |                "schema" : {
-                             |                  "$ref" : "#/components/schemas/NotFoundError",
-                             |                  "description" : "not found\n\n"
+                             |                  "$ref" : "#/components/schemas/NotFoundError"
                              |                }
                              |              }
                              |            }
@@ -1539,24 +1539,24 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |        "responses" : {
             |          "200" :
             |            {
+            |            "description" : "output body\n\n",
             |            "content" : {
             |              "application/json" : {
             |                "schema" :
             |                  {
-            |                  "$ref" : "#/components/schemas/SimpleOutputBody",
-            |                  "description" : "output body\n\n"
+            |                  "$ref" : "#/components/schemas/SimpleOutputBody"
             |                }
             |              }
             |            }
             |          },
             |          "404" :
             |            {
+            |            "description" : "not found\n\n",
             |            "content" : {
             |              "application/json" : {
             |                "schema" :
             |                  {
-            |                  "$ref" : "#/components/schemas/NotFoundError",
-            |                  "description" : "not found\n\n"
+            |                  "$ref" : "#/components/schemas/NotFoundError"
             |                }
             |              }
             |            }


### PR DESCRIPTION
As per [OpenAPI 3.0.3 spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md), `description` field for responses should be nested under status code (e.g. `responses.200`).
Components may have a `description` field, but it is not described for `schema` part by the official spec.

Also, eliminated merging of output documentation into `Endpoint` documentation when calling `.outX` family of endoint methods.

Resolves #3045 