### PR TITLE
Improve error handling for `collect` and `ignore` methods

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBodyWriter.scala
@@ -126,7 +126,7 @@ object NettyBodyWriter {
       case ChunkBody(data, _)              =>
         writeArray(data.toArray, isLast = true)
         None
-      case EmptyBody                       =>
+      case EmptyBody | ErrorBody(_)        =>
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT)
         None
     }

--- a/zio-http/jvm/src/test/scala/zio/http/ResponseSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ResponseSpec.scala
@@ -20,6 +20,8 @@ import zio._
 import zio.test.Assertion._
 import zio.test._
 
+import zio.stream.ZStream
+
 object ResponseSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
   private val location: URL                     = URL.decode("www.google.com").toOption.get
@@ -99,6 +101,52 @@ object ResponseSpec extends ZIOHttpSpec {
         val ok   = Response.ok
         val http = ok.toHandler
         assertZIO(http.runZIO(()))(equalTo(ok))
+      },
+    ),
+    suite("ignore")(
+      test("consumes the stream") {
+        for {
+          flag <- Ref.make(false)
+          stream   = ZStream.succeed(1.toByte) ++ ZStream.fromZIO(flag.set(true).as(2.toByte))
+          response = Response(body = Body.fromStreamChunked(stream))
+          _ <- response.ignoreBody
+          v <- flag.get
+        } yield assertTrue(v)
+      },
+      test("ignores failures when consuming the stream") {
+        for {
+          flag1 <- Ref.make(false)
+          flag2 <- Ref.make(false)
+          stream   = ZStream.succeed(1.toByte) ++
+            ZStream.fromZIO(flag1.set(true).as(2.toByte)) ++
+            ZStream.fail(new Throwable("boom")) ++
+            ZStream.fromZIO(flag1.set(true).as(2.toByte))
+          response = Response(body = Body.fromStreamChunked(stream))
+          _  <- response.ignoreBody
+          v1 <- flag1.get
+          v2 <- flag2.get
+        } yield assertTrue(v1, !v2)
+      },
+    ),
+    suite("collect")(
+      test("materializes the stream") {
+        val stream   = ZStream.succeed(1.toByte) ++ ZStream.succeed(2.toByte)
+        val response = Response(body = Body.fromStreamChunked(stream))
+        for {
+          newResp <- response.collect
+          body = newResp.body
+          bytes <- body.asChunk
+        } yield assertTrue(body.isComplete, body.isInstanceOf[Body.UnsafeBytes], bytes == Chunk[Byte](1, 2))
+      },
+      test("failures are preserved") {
+        val err      = new Throwable("boom")
+        val stream   = ZStream.succeed(1.toByte) ++ ZStream.fail(err) ++ ZStream.succeed(2.toByte)
+        val response = Response(body = Body.fromStreamChunked(stream))
+        for {
+          newResp <- response.collect
+          body = newResp.body
+          bytes <- body.asChunk.either
+        } yield assertTrue(body.isComplete, body.isInstanceOf[Body.ErrorBody], bytes == Left(err))
       },
     ),
   )

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -182,8 +182,8 @@ trait Body { self =>
   /**
    * Materializes the body of the request into memory
    */
-  def materialize(implicit trace: Trace): Task[Body] =
-    asArray.map(Body.ArrayBody(_, self.contentType))
+  def materialize(implicit trace: Trace): UIO[Body] =
+    asArray.foldCause(Body.ErrorBody(_), Body.ArrayBody(_, self.contentType))
 
   /**
    * Returns the media type for this Body
@@ -448,14 +448,14 @@ object Body {
   private[zio] trait UnsafeBytes extends Body { self =>
     private[zio] def unsafeAsArray(implicit unsafe: Unsafe): Array[Byte]
 
-    final override def materialize(implicit trace: Trace): Task[Body] = Exit.succeed(self)
+    final override def materialize(implicit trace: Trace): UIO[Body] = Exit.succeed(self)
   }
 
   /**
    * Helper to create empty Body
    */
 
-  private[zio] object EmptyBody extends Body with UnsafeBytes {
+  private[zio] case object EmptyBody extends Body with UnsafeBytes {
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = zioEmptyArray
 
@@ -472,6 +472,27 @@ object Body {
 
     override def contentType(newContentType: Body.ContentType): Body = this
     override def contentType: Option[Body.ContentType]               = None
+
+    override def knownContentLength: Option[Long] = Some(0L)
+  }
+
+  private[zio] final case class ErrorBody(cause: Cause[Throwable]) extends Body {
+
+    override def asArray(implicit trace: Trace): Task[Array[Byte]] = Exit.failCause(cause)
+
+    override def asChunk(implicit trace: Trace): Task[Chunk[Byte]] = Exit.failCause(cause)
+
+    override def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte] = ZStream.failCause(cause)
+
+    override def isComplete: Boolean = true
+
+    override def isEmpty: Boolean = true
+
+    override def toString: String = "Body.failed"
+
+    override def contentType(newContentType: Body.ContentType): Body = this
+
+    override def contentType: Option[Body.ContentType] = None
 
     override def knownContentLength: Option[Long] = Some(0L)
   }

--- a/zio-http/shared/src/main/scala/zio/http/Request.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Request.scala
@@ -68,14 +68,17 @@ final case class Request(
   def addTrailingSlash: Request = self.copy(url = self.url.addTrailingSlash)
 
   /**
-   * Collects the potentially streaming body of the request into a single chunk.
+   * Collects the potentially streaming body of the response into a single
+   * chunk.
+   *
+   * Any errors that occur from the collection of the body will be caught and
+   * propagated to the Body
    */
-  def collect(implicit trace: Trace): ZIO[Any, Throwable, Request] =
-    if (self.body.isComplete) ZIO.succeed(self)
-    else
-      self.body.asChunk.map { bytes =>
-        self.copy(body = Body.fromChunk(bytes))
-      }
+  def collect(implicit trace: Trace): ZIO[Any, Nothing, Request] =
+    self.body.materialize.map { b =>
+      if (b eq self.body) self
+      else self.copy(body = b)
+    }
 
   def dropLeadingSlash: Request = updateURL(_.dropLeadingSlash)
 
@@ -84,9 +87,16 @@ final case class Request(
    */
   def dropTrailingSlash: Request = updateURL(_.dropTrailingSlash)
 
-  /** Consumes the streaming body fully and then drops it */
-  def ignoreBody(implicit trace: Trace): ZIO[Any, Throwable, Request] =
-    self.collect.map(_.copy(body = Body.empty))
+  /**
+   * Consumes the streaming body fully and then discards it while also ignoring
+   * any failures
+   */
+  def ignoreBody(implicit trace: Trace): ZIO[Any, Nothing, Request] = {
+    val out   = self.copy(body = Body.empty)
+    val body0 = self.body
+    if (body0.isComplete) Exit.succeed(out)
+    else body0.asStream.runDrain.ignore.as(out)
+  }
 
   def patch(p: Request.Patch): Request =
     self.copy(headers = self.headers ++ p.addHeaders, url = self.url.addQueryParams(p.addQueryParams))

--- a/zio-http/shared/src/main/scala/zio/http/Response.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Response.scala
@@ -50,16 +50,26 @@ final case class Response(
   /**
    * Collects the potentially streaming body of the response into a single
    * chunk.
+   *
+   * Any errors that occur from the collection of the body will be caught and
+   * propagated to the Body
    */
-  def collect(implicit trace: Trace): ZIO[Any, Throwable, Response] =
+  def collect(implicit trace: Trace): ZIO[Any, Nothing, Response] =
     self.body.materialize.map { b =>
       if (b eq self.body) self
       else self.copy(body = b)
     }
 
-  /** Consumes the streaming body fully and then drops it */
-  def ignoreBody(implicit trace: Trace): ZIO[Any, Throwable, Response] =
-    self.collect.map(_.copy(body = Body.empty))
+  /**
+   * Consumes the streaming body fully and then discards it while also ignoring
+   * any failures
+   */
+  def ignoreBody(implicit trace: Trace): ZIO[Any, Nothing, Response] = {
+    val out   = self.copy(body = Body.empty)
+    val body0 = self.body
+    if (body0.isComplete) Exit.succeed(out)
+    else body0.asStream.runDrain.ignore.as(out)
+  }
 
   def patch(p: Response.Patch)(implicit trace: Trace): Response = p.apply(self)
 

--- a/zio-http/shared/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClient.scala
@@ -419,15 +419,9 @@ object ZClient extends ZClientPlatformSpecific {
           sslConfig: Option[ClientSSLConfig],
           proxy: Option[Proxy],
         )(implicit trace: Trace): ZIO[Env, Err, Response] =
-          ZIO
-            .scoped[Env] {
-              self0.request(version, method, url, headers, body, sslConfig, proxy).flatMap { resp =>
-                resp.collect.foldCause(
-                  cause => resp.copy(body = Body.ErrorBody(cause)),
-                  ZIO.identityFn,
-                )
-              }
-            }
+          ZIO.scoped[Env] {
+            self0.request(version, method, url, headers, body, sslConfig, proxy).flatMap(_.collect)
+          }
 
         // This should never be possible to invoke unless the user unsafely casted the Driver environment
         override def socket[Env1 <: Env](version: Version, url: URL, headers: Headers, app: WebSocketApp[Env1])(implicit


### PR DESCRIPTION
One of the issues I realised too late with the `batched` API is that it doesn't account for a use-case where the server returns the headers of a response with a non-2xx status, and then closes the connection before the client has finished reading the body of the response.

In most of those cases, e.g., code `5xx` the client might not necessarily care about the body of the response since the status gives it all the information that it needs. In such cases, we should not be failing the request just because we failed to read the streaming body unless the user decides to read the body.

In short, this PR does the following:
1. Adds the `ErrorBody extends Body` case class where all the methods on it fail the effect
2. Changes `ignoreBody` and `collectBody` to have `Nothing` in the error channel. In the case of `collectBody`, we use `ErrorBody` as the body of the response, whereas `ignoreBody` simply swallows the error

This change also allows us to remove some of the implicit evidences on the `batched` methods since we no longer require the error to be a subtype of `Throwable`.