### PR TITLE
Use an unbounded queue in `AsyncBody#asStream`

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
@@ -19,14 +19,13 @@ package zio.http.netty
 import java.nio.charset.Charset
 
 import zio._
-import zio.internal.OneShot
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import zio.stream.ZStream
+import zio.stream.{Take, ZChannel, ZStream}
 
 import zio.http.Body.UnsafeBytes
 import zio.http.internal.BodyEncoding
-import zio.http.{Body, Boundary, Header, MediaType}
+import zio.http.{Body, Header}
 
 import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.util.AsciiString
@@ -111,17 +110,15 @@ object NettyBody extends BodyEncoding {
         }
       }
 
-    override def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte] =
-      ZStream
-        .async[Any, Throwable, Byte](
-          emit =>
-            try {
-              unsafeAsync(new UnsafeAsync.Streaming(emit))
-            } catch {
-              case e: Throwable => emit(ZIO.fail(Option(e)))
-            },
-          bufferSize(4096),
-        )
+    override def asStream(implicit trace: Trace): ZStream[Any, Throwable, Byte] = {
+      asyncUnboundedStream[Any, Throwable, Byte](emit =>
+        try {
+          unsafeAsync(new UnsafeAsync.Streaming(emit))
+        } catch {
+          case e: Throwable => emit(ZIO.fail(Option(e)))
+        },
+      )
+    }
 
     // No need to create a large buffer when we know the response is small
     private[this] def bufferSize(maxSize: Int): Int = {
@@ -140,6 +137,43 @@ object NettyBody extends BodyEncoding {
     override def contentType(newContentType: Body.ContentType): Body = copy(contentType = Some(newContentType))
   }
 
+  /**
+   * Code ported from zio.stream to use an unbounded queue
+   */
+  private def asyncUnboundedStream[R, E, A](
+    register: ZStream.Emit[R, E, A, Unit] => Unit,
+  )(implicit trace: Trace): ZStream[R, E, A] =
+    ZStream.unwrapScoped[R](for {
+      queue   <- ZIO.acquireRelease(Queue.unbounded[Take[E, A]])(_.shutdown)
+      runtime <- ZIO.runtime[R]
+    } yield {
+      val rtm = runtime.unsafe
+      register { k =>
+        try {
+          rtm
+            .run(Take.fromPull(k).flatMap(queue.offer))(trace, Unsafe)
+            .getOrThrowFiberFailure()(Unsafe)
+          ()
+        } catch {
+          case FiberFailure(c) if c.isInterrupted =>
+        }
+      }
+
+      lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+        ZChannel.unwrap(
+          queue.take
+            .flatMap(_.done)
+            .fold(
+              maybeError =>
+                ZChannel.fromZIO(queue.shutdown) *>
+                  maybeError.fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.fail(_)),
+              a => ZChannel.write(a) *> loop,
+            ),
+        )
+
+      ZStream.fromChannel(loop)
+    })
+
   private[zio] trait UnsafeAsync {
     def apply(message: Chunk[Byte], isLast: Boolean): Unit
     def fail(cause: Throwable): Unit
@@ -153,7 +187,7 @@ object NettyBody extends BodyEncoding {
 
       def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
         assert(isLast)
-        callback(ZIO.succeed(message))
+        callback(Exit.succeed(message))
       }
 
       def fail(cause: Throwable): Unit =
@@ -162,7 +196,7 @@ object NettyBody extends BodyEncoding {
 
     final class Streaming(emit: ZStream.Emit[Any, Throwable, Byte, Unit])(implicit trace: Trace) extends UnsafeAsync {
       def apply(message: Chunk[Byte], isLast: Boolean): Unit = {
-        if (message.nonEmpty) emit(ZIO.succeed(message))
+        if (message.nonEmpty) emit(Exit.succeed(message))
         if (isLast) emit(FailNone)
       }
 


### PR DESCRIPTION
/fixes #2297
/claim #2297

As I mentioned in https://github.com/zio/zio-http/pull/2402#issuecomment-2315114560, the problem with this issue (as well as what #2402 was trying to resolve) is that in the case of an ultra-fast producer, the ZStream buffer queue becomes full, which ends up blocking Netty's event loop. Since Netty's event loop is... event-based, once a connection is is closed, reading from the channel will keep returning messages until all of them have been consumed.

The solution here is to use an unbounded queue to construct the `ZStream`. By using an unbounded queue, we no longer block Netty's event loop in cases that the buffer becomes full. This means that when the connection is interrupted we can shutdown the queue / ZStream via `callback.fail(cause)`.

PS: While it might sound dangerous not to have a backpressure mechanism on the ZStream, in reality the backpressure needs to be applied on Netty's side via Netty's config. Otherwise, even if the ZStream has backpressure, Netty's queues will still be filled and memory issues will arise. See https://github.com/zio/zio-http/pull/2402#issuecomment-2315114560 for more info