### PR TITLE
Avoid secondary super type-checking on `UnsafeBytes`

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyBody.scala
@@ -65,8 +65,7 @@ object NettyBody extends BodyEncoding {
   private[zio] final case class AsciiStringBody(
     asciiString: AsciiString,
     override val contentType: Option[Body.ContentType] = None,
-  ) extends Body
-      with UnsafeBytes {
+  ) extends UnsafeBytes {
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(asciiString.array())
 

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -445,7 +445,7 @@ object Body {
   def fromSocketApp(app: WebSocketApp[Any]): WebsocketBody =
     WebsocketBody(app)
 
-  private[zio] trait UnsafeBytes extends Body { self =>
+  private[zio] abstract class UnsafeBytes extends Body { self =>
     private[zio] def unsafeAsArray(implicit unsafe: Unsafe): Array[Byte]
 
     final override def materialize(implicit trace: Trace): UIO[Body] = Exit.succeed(self)
@@ -455,7 +455,7 @@ object Body {
    * Helper to create empty Body
    */
 
-  private[zio] case object EmptyBody extends Body with UnsafeBytes {
+  private[zio] case object EmptyBody extends UnsafeBytes {
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = zioEmptyArray
 
@@ -500,8 +500,7 @@ object Body {
   private[zio] final case class ChunkBody(
     data: Chunk[Byte],
     override val contentType: Option[Body.ContentType] = None,
-  ) extends Body
-      with UnsafeBytes { self =>
+  ) extends UnsafeBytes { self =>
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = ZIO.succeed(data.toArray)
 
@@ -526,8 +525,7 @@ object Body {
   private[zio] final case class ArrayBody(
     data: Array[Byte],
     override val contentType: Option[Body.ContentType] = None,
-  ) extends Body
-      with UnsafeBytes { self =>
+  ) extends UnsafeBytes { self =>
 
     override def asArray(implicit trace: Trace): Task[Array[Byte]] = Exit.succeed(data)
 


### PR DESCRIPTION
There are a few places in zio-http where we pattern-match / use `isInstanceOf[UnsafeBytes]` on a `Body`.

There is a [bug in the JVM](https://bugs.openjdk.org/browse/JDK-8331341) (fixed in JDK23+) that affects type-checking on secondary supers causing them to be slow / not scaling well under contention. To prevent this issue, we make `UnsafeBytes` an abstract class and make any concrete implementations of it extend it directly (since it also extends `Body`)