### PR TITLE
refactor:  `HttpContentCodec` for Improved Caching

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/grpc/GRPC.scala
@@ -11,7 +11,7 @@ import zio.http.codec.{BinaryCodecWithSchema, HttpContentCodec}
 object GRPC {
 
   implicit def fromSchema[A](implicit schema: Schema[A]): HttpContentCodec[A] =
-    HttpContentCodec(
+    HttpContentCodec.default(
       ListMap(
         MediaType.parseCustomMediaType("application/grpc").get ->
           BinaryCodecWithSchema(ProtobufCodec.protobufCodec[A], schema),

--- a/zio-http/shared/src/main/scala/zio/http/template/Dom.scala
+++ b/zio-http/shared/src/main/scala/zio/http/template/Dom.scala
@@ -90,7 +90,7 @@ object Dom {
     Schema[String].transform(Dom.raw, _.encode.toString)
 
   implicit val htmlCodec: HttpContentCodec[Dom] = {
-    HttpContentCodec(
+    HttpContentCodec.default(
       ListMap(
         MediaType.text.`html` ->
           BinaryCodecWithSchema.fromBinaryCodec(zio.http.codec.internal.TextBinaryCodec.fromSchema(Schema[Dom])),


### PR DESCRIPTION
### Changes Done:
1. Made `HttpContentCodec` a sealed trait with `Default` and `Filtered` subtypes.
2. The `lookupCache` has been optimized to avoid unnecessary recomputation
3. Refactored the `only` method to utilize the `Filtered` subtype to ensure that the original codecs cache is utilized effectively to reduce overhead.

fixes #3029 
/claim #3029 