### PR TITLE
Various optimizations

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyRuntime.scala
@@ -75,8 +75,11 @@ private[zio] final class NettyRuntime(zioRuntime: Runtime[Any]) {
   private def closeListener(fiber: Fiber.Runtime[_, _])(implicit
     unsafe: Unsafe,
     trace: Trace,
-  ): GenericFutureListener[Future[_ >: Void]] =
-    (_: Future[_ >: Void]) => unsafeRunSync(ZIO.fiberIdWith(fiber.interruptAsFork))
+  ): GenericFutureListener[Future[_ >: Void]] = { _ =>
+    if (fiber.isAlive())
+      fiber.tellInterrupt(Cause.interrupt(FiberId.None, StackTrace(FiberId.None, Chunk.single(trace))))
+    else ()
+  }
 
 }
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -48,6 +48,7 @@ private[zio] final case class NettyDriver(
           .channelFactory(channelFactory)
           .childHandler(channelInitializer)
           .option[Integer](ChannelOption.SO_BACKLOG, serverConfig.soBacklog)
+          .childOption[JBoolean](ChannelOption.AUTO_READ, false)
           .childOption[JBoolean](ChannelOption.TCP_NODELAY, serverConfig.tcpNoDelay)
           .bind(serverConfig.address)
       }

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -181,8 +181,7 @@ private[zio] final case class ServerInboundHandler(
     runtime: NettyRuntime,
     response: Response,
     request: Request,
-  ): Task[Option[Task[Unit]]] = {
-    // Simplify the logic by enabling automatic reading of the channel
+  ): Task[Option[Task[Unit]]] =
     response.body match {
       case WebsocketBody(socketApp) if response.status == Status.SwitchingProtocols =>
         ctx.channel().config().setAutoRead(true)
@@ -209,7 +208,6 @@ private[zio] final case class ServerInboundHandler(
           }
         }.ensuring(ZIO.succeed(ctx.read()))
     }
-  }
 
   private def attemptImmediateWrite(
     ctx: ChannelHandlerContext,

--- a/zio-http/jvm/src/test/scala/zio/http/security/ExceptionSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/security/ExceptionSpec.scala
@@ -88,5 +88,5 @@ object ExceptionSpec extends ZIOSpecDefault {
     ),
     ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
     Client.default,
-  ) @@ TestAspect.sequential
+  ) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 }


### PR DESCRIPTION
This PR contains a few optimizations and fixes that I spotted over time while working on other issues.

Server:
1. Disable auto-read and manually read from the channel. This is mostly important for requests where the response is an effect, since Netty will be poll-reading the channel while we're processing the request in ZIO's threadpool
2. Increment/decrement the request count whenever the ServerInboundHandler is added/removed. The addition is done when a connection to a client is established, whereas the removal is done when the connection is closed. This reduces contention on the LongAdder for persisted connections
3. Place the `HttpServerExpectContinueHandler` and `HttpServerKeepAliveHandler` handlers _before_ the `HttpObjectAggregator` (this is documented in the javadoc of these handlers)
4. Use `fiber.tellInterrupt` in `NettyRuntime#closeFuture` to avoid blocking Netty's event-loop awaiting for the interruption of the effect

Client:
1. Use the Promise's unsafe API to avoid spinning up a fiber in the CloseFutureListener
2. Fail the promise with a new `PrematureChannelClosureException` each time so that the stack traces are properly filled