### PR TITLE
fix OpenAPI not deserializing lowercase value of 'in' field in security schemes

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
@@ -1307,6 +1307,23 @@ object OpenAPI {
       sealed trait In extends Product with Serializable
 
       object In {
+        implicit val schema: Schema[In] =
+          Schema[String]
+            .transformOrFail(
+              s =>
+                s.toLowerCase match {
+                  case "query"  => Right(Query)
+                  case "header" => Right(Header)
+                  case "cookie" => Right(Cookie)
+                  case value    => Left(s"Invalid ApiKey.In $s")
+                },
+              {
+                case Query  => Right("query")
+                case Header => Right("header")
+                case Cookie => Right("cookie")
+              },
+            )
+
         case object Query extends In
 
         case object Header extends In

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -51,7 +51,7 @@ object OpenAPISpec extends ZIOSpecDefault {
                        |        {
                        |        "type" : "apiKey",
                        |        "name" : "Authorization",
-                       |        "in" : "Header"
+                       |        "in" : "header"
                        |      }
                        |    }
                        |  },


### PR DESCRIPTION
Resolves #3104 