### PR TITLE
Add concept docs and update various outdated docs

### DIFF
--- a/docs/concepts/endpoint.md
+++ b/docs/concepts/endpoint.md
@@ -1,0 +1,56 @@
+# Endpoint API
+
+The Endpoint API is a declarative DSL for defining HTTP endpoints. It is a way to define a type safe API for your application.
+It comes with batteries included and supports out of the box JSON, protobuf, plain text and binary data serialization and deserialization. It also supports automatic validation via ZIO Schema, and automatic OpenAPI documentation generation.
+Endpoints can be used to implement not only servers but also clients.
+
+```scala mdoc:compile-only
+import zio._
+import zio.http._
+import zio.http.codec.PathCodec.path
+import zio.http.codec._
+import zio.http.endpoint._
+import zio.schema._
+import zio.schema.annotation._
+import zio.http.endpoint.openapi._
+import zio.http.template.Dom
+import zio.schema.validation.Validation
+
+final case class UserParams(city: String, @validate(Validation.greaterThan(17)) age: Int)
+
+object UserParams {
+  implicit val schema: Schema[UserParams] = DeriveSchema.gen[UserParams]
+}
+
+val endpoint =
+  // typed path parameter "user"
+  Endpoint(Method.GET / "hello" / string("user"))
+    // reads the two query parameters city and age from the request and validates the age
+    .query(HttpCodec.queryAll[UserParams])
+    // support for HTML templates included
+    .out[Dom]
+
+/* SERVER */
+
+// Generates OpenAPI documentation for the endpoint
+val openApi = OpenAPIGen.fromEndpoints("User API", "1.0.0", endpoint)
+
+// Routes for the endpoint and the Swagger UI
+val routes =
+  endpoint.implement { case (user, params) =>
+    ZIO.succeed(Dom.text(s"Hello $user, you are ${params.age} years old and live in ${params.city}"))
+  }.toRoutes ++ SwaggerUI.routes("intern" / "apidoc", openApi)
+
+/* CLIENT */
+
+val locator = EndpointLocator.fromURL(url"http://localhost:8080")
+
+def endpointExecutor(client: Client) = EndpointExecutor(client, locator)
+
+val clientApp: ZIO[Scope with Client, Nothing, Dom] = for {
+  client <- ZIO.service[Client]
+  dom   <- endpointExecutor(client)(endpoint("John", UserParams("New York", 25)))
+} yield dom
+```
+
+For more details on the Endpoint API, see the [documentation](./../reference/endpoint.md).

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -1,0 +1,14 @@
+# Middleware
+
+A middleware has the purpose of intercepting a request, a response or both. It helps in implementing cross-cutting concerns like access logging, authentication, etc.
+
+ZIO HTTP provides a lot out-of-the-box middlewares. For example for CORS or authentication.
+
+For more details how to use middlewares, see the [middleware documentation](./../reference/aop/middleware.md).
+
+## Handler Aspect
+
+A `HandlerAspect` is a special middleware, that can not only intercept requests and responses, but also compute values based on the request and inject it back into the request handler.
+This is useful for example for authentication, where the handler aspect can extract the user from the request or the database.
+
+For more details how to use handler aspects, see the [handler aspect documentation](./../reference/aop/handler_aspect.md).

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -1,0 +1,36 @@
+# Routing
+
+ZIO HTTP routing does some things differently than other (Scala) HTTP libraries.
+This document explains the differences and the reasons behind them.
+
+## Declarative routing
+
+ZIO HTTP uses a declarative routing DSL. This means that a data structures describe the routing logic.
+This is in contrast to other libraries that often use functions to describe routing logic. In the Scala world usually partial functions.
+
+The main advantage of a declarative routing is the ability to inspect the routes at runtime. This gives ZIO HTTP the ability to generate not only a lookup tree but also generate documentation.
+Partial functions are opaque and can't be inspected at runtime. A request must therefore in the worst case traverse all routes to find the correct one.
+A service with 1000 routes build on partial functions would need to check all 1000 routes just to generate a 404 response.
+ZIO HTTPs tree based lookup can immediately tell if a route is not present just by inspecting the first segment of the path.
+
+
+## Type-safe routing
+Path parameters are typed in ZIO HTTP. So a segment that is a variable must have a type. If a request does not match the type the route is not considered a match.
+ZIO HTTP will then reject the request automatically. The user defined handler will not be called.
+
+```scala mdoc:compile-only
+import zio.http._
+val routes = Routes(
+  Method.GET / "hello" / string("name") -> handler { (name: String, req: Request) =>
+    Response.text(s"Hello $name")
+  }
+)
+```
+
+For more details and code examples see the [routing pattern documentation](./../reference/routing/route_pattern.md).
+
+## Query Parameters are not part of the routing
+Query parameters are not part of the routing. They are part of the request handling.
+
+
+

--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -390,7 +390,8 @@ There are several built-in `HandlerAspect`s that can be used to implement authen
 
 1. **Basic Authentication**: The `basicAuth` and `basicAuthZIO` handler aspect can be used to implement basic authentication.
 2. **Bearer Authentication**: The `bearerAuth` and `bearerAuthZIO` handler aspect can be used to implement bearer authentication. We have to provide a function that validates the bearer token.
-3. **Custom Authentication**: The `customAuth`, `customAuthZIO`, `customAuthProviding`, and `customAuthProvidingZIO` handler aspects can be used to implement custom authentication. We have to provide a function that validates the request.
+3. **Custom Authentication**: The `customAuth` and `customAuthZIO` handler aspects can be used to implement custom authentication. We have to provide a function that validates the request.
+4. **Custom Authentication providing**: The `customAuthProviding` and `customAuthProvidingZIO` handler aspects allow us to provide a value to the handler based on the authentication result.
 
 ### Basic Authentication Example
 
@@ -398,6 +399,14 @@ There are several built-in `HandlerAspect`s that can be used to implement authen
 import utils._
 
 printSource("zio-http-example/src/main/scala/example/BasicAuth.scala")
+```
+
+### Custom Authentication Providing Example
+
+```scala mdoc:passthrough
+import utils._
+
+printSource("zio-http-example/src/main/scala/example/middleware/CustomAuthProviding.scala")
 ```
 
 To the example, start the server and fire a curl request with an incorrect user/password combination:
@@ -531,27 +540,6 @@ HandlerAspect.patch(request =>
 )
 ```
 
-## Beautify Errors Handler Aspect
-
-To make the error responses more user-friendly, we have a built-in handler aspect called `beautifyErrors`. This aspect beautifies the error responses based on the requested content type. If the client requests an HTML response, it returns a formatted HTML response, otherwise, it returns a plain text response:
-
-```scala
-val route = 
-  Method.GET / "internal-error" -> Handler.fromResponse(Response.forbidden) @@ HandlerAspect.beautifyErrors
-```
-
-If we deploy this route and send a GET request to the `/internal-error` route with the `Accept: text/html` header, we will get the following response body:
-
-```html
-<!DOCTYPE html><html><head><title>ZIO HTTP - Forbidden</title><style>
- body {
-   font-family: monospace;
-   font-size: 16px;
-   background-color: #edede0;
- }
-</style></head><body><div style="margin: auto; padding: 2em 4em; max-width: 80%"><h1>Forbidden</h1><div><div style="text-align: center"><div style="font-size: 20em">403</div><div>403</div></div></div></div></body></html>⏎
-```
-
 ## Debug Handler Aspect
 
 The `debug` handler aspect is a useful aspect for debugging requests and responses. It prints the response status code, request method and url, and the response time of each request to the console.
@@ -592,12 +580,4 @@ X-Environment: Dev
 content-length: 12
 
 Hello Bob
-```
-
-### Endpoint Middleware Example
-
-```scala mdoc:passthrough
-import utils._
-
-printSource("zio-http-example/src/main/scala/example/EndpointExamples.scala")
 ```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -9,7 +9,18 @@ const sidebars = {
       link: { type: "doc", id: "index" },
       items: [
         "installation",
+        // Concepts section
+        {
+            type: "category",
+            collapsed: true,
+            label: "Concepts",
+            items: [
+                "concepts/routing",
+                "concepts/middleware",
+                "concepts/endpoint",
+                ],
 
+        },
         // Reference section
         {
           type: "category",

--- a/zio-http-example/src/main/scala/example/BasicAuth.scala
+++ b/zio-http-example/src/main/scala/example/BasicAuth.scala
@@ -8,7 +8,7 @@ import zio.http.codec.PathCodec.string
 
 object BasicAuth extends ZIOAppDefault {
 
-  // Http app that requires a JWT claim
+  // Http app that requires basic auth
   val user: Routes[Any, Response] = Routes(
     Method.GET / "user" / string("name") / "greet" ->
       handler { (name: String, _: Request) =>
@@ -19,6 +19,5 @@ object BasicAuth extends ZIOAppDefault {
   // Add basic auth middleware
   val routes: Routes[Any, Response] = user @@ basicAuth("admin", "admin")
 
-  // Run it like any simple app
   val run = Server.serve(routes).provide(Server.default)
 }

--- a/zio-http-example/src/main/scala/example/middleware/CustomAuthProviding.scala
+++ b/zio-http-example/src/main/scala/example/middleware/CustomAuthProviding.scala
@@ -1,0 +1,41 @@
+package example.middleware
+
+import zio.Config.Secret
+import zio._
+
+import zio.http._
+import zio.http.codec.PathCodec.string
+
+object CustomAuthProviding extends ZIOAppDefault {
+
+  final case class AuthContext(value: String)
+
+  // Provides an AuthContext to the request handler
+  val provideContext: HandlerAspect[Any, AuthContext] = HandlerAspect.customAuthProviding[AuthContext] { r =>
+    {
+      r.headers.get(Header.Authorization).flatMap {
+        case Header.Authorization.Basic(uname, password) if Secret(uname.reverse) == password =>
+          Some(AuthContext(uname))
+        case _                                                                                =>
+          None
+      }
+
+    }
+  }
+
+  // Multiple routes that require an AuthContext via withContext
+  val secureRoutes: Routes[AuthContext, Response] = Routes(
+    Method.GET / "a" -> handler((_: Request) => withContext((ctx: AuthContext) => Response.text(ctx.value))),
+    Method.GET / "b" / int("id")      -> handler((id: Int, _: Request) =>
+      withContext((ctx: AuthContext) => Response.text(s"for id: $id: ${ctx.value}")),
+    ),
+    Method.GET / "c" / string("name") -> handler((name: String, _: Request) =>
+      withContext((ctx: AuthContext) => Response.text(s"for name: $name: ${ctx.value}")),
+    ),
+  )
+
+  val app: Routes[Any, Response] = secureRoutes @@ provideContext
+
+  val run = Server.serve(app).provide(Server.default)
+
+}


### PR DESCRIPTION
#2198 mentions

>  - Concepts
>    - Routing
>    - Request Handling
>    - Server
>    - Client
>    - Middleware
>    - Endpoint

I did not add Client, Server and Request Handling.
I tried to stick to the idea of http4k and only put high level information in this section. Just as little code as possible.
I don't see how to add something meaningful or useful to the docs, when I would try to add Server/Client, as they have already a very good detailed description. And I am not sure what is the idea behind Request Handling.

@jdegoes I am happy to add concept docs, if you tell me what the goal of them should be.