### PR TITLE
ContentType based on MediaType in HttpContentCodec (#3023)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/grpc/GRPCSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/grpc/GRPCSpec.scala
@@ -21,7 +21,7 @@ object GRPCSpec extends ZIOSpecDefault {
     suite("GRPC imports")(
       test("correct mediatype") {
 
-        assertTrue(!codec.lookup(MediaType.parseCustomMediaType("application/grpc").get).isEmpty)
+        assertTrue(codec.lookup(MediaType.parseCustomMediaType("application/grpc").get).isDefined)
 
       },
       test("encode and decode") {

--- a/zio-http/shared/src/main/scala/zio/http/codec/internal/BodyCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/internal/BodyCodec.scala
@@ -117,10 +117,10 @@ private[http] object BodyCodec {
         .lookup(field.contentType)
         .toRight(HttpCodecError.CustomError("UnsupportedMediaType", s"MediaType: ${field.contentType}"))
       codec0 match {
-        case Left(error)                                                       => ZIO.fail(error)
-        case Right(BinaryCodecWithSchema(_, schema)) if schema == Schema[Unit] =>
+        case Left(error)                                                            => ZIO.fail(error)
+        case Right((_, BinaryCodecWithSchema(_, schema))) if schema == Schema[Unit] =>
           ZIO.unit.asInstanceOf[IO[Throwable, A]]
-        case Right(bc @ BinaryCodecWithSchema(codec, schema))                  =>
+        case Right((_, bc @ BinaryCodecWithSchema(codec, schema)))                  =>
           field.asChunk.flatMap { chunk => ZIO.fromEither(bc.codec(config).decode(chunk)) }.flatMap(validateZIO(schema))
       }
     }
@@ -128,10 +128,10 @@ private[http] object BodyCodec {
     override def decodeFromBody(body: Body, config: CodecConfig)(implicit trace: Trace): IO[Throwable, A] = {
       val codec0 = codecForBody(codec, body)
       codec0 match {
-        case Left(error)                                                       => ZIO.fail(error)
-        case Right(BinaryCodecWithSchema(_, schema)) if schema == Schema[Unit] =>
+        case Left(error)                                                            => ZIO.fail(error)
+        case Right((_, BinaryCodecWithSchema(_, schema))) if schema == Schema[Unit] =>
           ZIO.unit.asInstanceOf[IO[Throwable, A]]
-        case Right(bc @ BinaryCodecWithSchema(_, schema))                      =>
+        case Right((_, bc @ BinaryCodecWithSchema(_, schema)))                      =>
           body.asChunk.flatMap { chunk => ZIO.fromEither(bc.codec(config).decode(chunk)) }.flatMap(validateZIO(schema))
       }
     }
@@ -178,7 +178,7 @@ private[http] object BodyCodec {
         codec
           .lookup(field.contentType)
           .toRight(HttpCodecError.CustomError("UnsupportedMediaType", s"MediaType: ${field.contentType}"))
-          .map { bc =>
+          .map { case (_, bc) =>
             (field.asStream >>> bc.codec(config).streamDecoder >>> validateStream(bc.schema)).orDie
           }
       }
@@ -187,7 +187,7 @@ private[http] object BodyCodec {
       trace: Trace,
     ): IO[Throwable, ZStream[Any, Nothing, E]] =
       ZIO.fromEither {
-        codecForBody(codec, body).map { case bc @ BinaryCodecWithSchema(_, schema) =>
+        codecForBody(codec, body).map { case (_, bc @ BinaryCodecWithSchema(_, schema)) =>
           (body.asStream >>> bc.codec(config).streamDecoder >>> validateStream(schema)).orDie
         }
       }


### PR DESCRIPTION
The ContentType is currently set the the media type of the accept header. That is not right. We need to select the first matching media type of the `HttpContentCodec`. Accept might be `*/*` but we want to return `application/json`, if found in the `HttpContentCodec`

fixes #3023
/claim #3023