### PR TITLE
Optimize netty integration and default config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,21 +1,20 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/java/.devcontainer/base.Dockerfile
 
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT="11"
+ARG VARIANT="17"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
 
 
 RUN curl -s "https://get.sdkman.io" | bash
 
 # Install Scala Lang
-ARG SBT_VERSION="1.7.1"
+ARG SBT_VERSION="1.10.1"
 RUN \
   curl -L "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar zxf - -C /usr/share  && \
   cd /usr/share/sbt/bin && \
-  rm sbt.bat sbtn-x86_64-apple-darwin sbtn-x86_64-pc-linux sbtn-x86_64-pc-win32.exe && \
   ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
-ARG SCALA_VERSION="3.1.3"
+ARG SCALA_VERSION="3.3.3"
 RUN \
   mkdir /setup-project && \
   cd /setup-project && \
@@ -23,5 +22,14 @@ RUN \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -rf /setup-project
+
+RUN \
+  mkdir /setup-wrk && \
+  sudo apt-get update -y && sudo apt-get install build-essential libssl-dev git -y && \
+  git clone https://github.com/wg/wrk.git wrk && \
+  cd wrk && \
+  make && \
+  cp wrk /usr/local/bin && \
+  rm -rf /setup-wrk
 
 CMD ["sbt"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
 ARG VARIANT="17"
-FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 
 RUN curl -s "https://get.sdkman.io" | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
 			// Update the VARIANT arg to pick a Java version: 11, 17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use the -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "11",
-			"SCALA_VERSION": "3.1.3"
+			"VARIANT": "17",
+			"SCALA_VERSION": "3.3.3"
 		}
 	},
 

--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,8 @@ lazy val zioHttpExample = (project in file("zio-http-example"))
   .settings(runSettings(Debug.Main))
   .settings(libraryDependencies ++= Seq(`jwt-core`, `zio-schema-json`))
   .settings(
+    run / fork := true,
+    run / javaOptions ++= Seq("-Xms4G", "-Xmx4G", "-XX:+UseG1GC"),
     libraryDependencies ++= Seq(
       `zio-config`,
       `zio-config-magnolia`,
@@ -404,7 +406,7 @@ lazy val docs = project
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     libraryDependencies ++= Seq(
       `jwt-core`,
-      "dev.zio" %% "zio-test"            % ZioVersion,
+      "dev.zio" %% "zio-test" % ZioVersion,
       `zio-config`,
       `zio-config-magnolia`,
       `zio-config-typesafe`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,15 +21,15 @@ object Dependencies {
 
   val netty =
     Seq(
-      "io.netty" % "netty-codec-http"              % NettyVersion,
-      "io.netty" % "netty-handler-proxy"           % NettyVersion,
-      "io.netty" % "netty-transport-native-epoll"  % NettyVersion,
-      "io.netty" % "netty-transport-native-epoll"  % NettyVersion % Runtime classifier "linux-x86_64",
-      "io.netty" % "netty-transport-native-epoll"  % NettyVersion % Runtime classifier "linux-aarch_64",
-      "io.netty" % "netty-transport-native-kqueue" % NettyVersion,
-      "io.netty" % "netty-transport-native-kqueue" % NettyVersion % Runtime classifier "osx-x86_64",
-      "io.netty" % "netty-transport-native-kqueue" % NettyVersion % Runtime classifier "osx-aarch_64",
-      "com.aayushatharva.brotli4j" % "brotli4j" % "1.16.0" % "provided",
+      "io.netty"                   % "netty-codec-http"              % NettyVersion,
+      "io.netty"                   % "netty-handler-proxy"           % NettyVersion,
+      "io.netty"                   % "netty-transport-native-epoll"  % NettyVersion,
+      "io.netty"                   % "netty-transport-native-epoll"  % NettyVersion classifier "linux-x86_64",
+      "io.netty"                   % "netty-transport-native-epoll"  % NettyVersion classifier "linux-aarch_64",
+      "io.netty"                   % "netty-transport-native-kqueue" % NettyVersion,
+      "io.netty"                   % "netty-transport-native-kqueue" % NettyVersion classifier "osx-x86_64",
+      "io.netty"                   % "netty-transport-native-kqueue" % NettyVersion classifier "osx-aarch_64",
+      "com.aayushatharva.brotli4j" % "brotli4j"                      % "1.16.0" % "provided",
     )
 
   val `netty-incubator` =

--- a/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/PlainTextBenchmarkServer.scala
@@ -36,11 +36,9 @@ object PlainTextBenchmarkServer extends ZIOAppDefault {
 
   private val config = Server.Config.default
     .port(8080)
-    .enableRequestStreaming
 
   private val nettyConfig = NettyConfig.default
     .leakDetection(LeakDetectionLevel.DISABLED)
-    .maxThreads(8)
 
   private val configLayer      = ZLayer.succeed(config)
   private val nettyConfigLayer = ZLayer.succeed(nettyConfig)

--- a/zio-http-example/src/main/scala/example/SimpleEffectBenchmarkServer.scala
+++ b/zio-http-example/src/main/scala/example/SimpleEffectBenchmarkServer.scala
@@ -33,11 +33,9 @@ object SimpleEffectBenchmarkServer extends ZIOAppDefault {
 
   private val config = Server.Config.default
     .port(8080)
-    .enableRequestStreaming
 
   private val nettyConfig = NettyConfig.default
     .leakDetection(LeakDetectionLevel.DISABLED)
-    .maxThreads(8)
 
   private val configLayer      = ZLayer.succeed(config)
   private val nettyConfigLayer = ZLayer.succeed(nettyConfig)

--- a/zio-http/jvm/src/main/scala/zio/http/netty/NettyConfig.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/NettyConfig.scala
@@ -78,7 +78,7 @@ object NettyConfig {
   val default: NettyConfig = NettyConfig(
     LeakDetectionLevel.SIMPLE,
     ChannelType.AUTO,
-    0,
+    java.lang.Runtime.getRuntime.availableProcessors(),
     // Defaults taken from io.netty.util.concurrent.AbstractEventExecutor
     Duration.fromSeconds(2),
     Duration.fromSeconds(15),

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -28,9 +28,6 @@ import zio.http.{ClientDriver, Driver, Response, Routes, Server}
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel._
-import io.netty.channel.epoll.EpollEventLoopGroup
-import io.netty.channel.kqueue.KQueueEventLoopGroup
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.util.ResourceLeakDetector
 
 private[zio] final case class NettyDriver(
@@ -38,28 +35,16 @@ private[zio] final case class NettyDriver(
   channelFactory: ChannelFactory[ServerChannel],
   channelInitializer: ChannelInitializer[Channel],
   serverInboundHandler: ServerInboundHandler,
-  eventLoopGroup: EventLoopGroup,
+  eventLoopGroups: ServerEventLoopGroups,
   serverConfig: Server.Config,
   nettyConfig: NettyConfig,
 ) extends Driver { self =>
 
   def start(implicit trace: Trace): RIO[Scope, StartResult] =
     for {
-      boss    <- {
-        // The boss group is responsible for accepting new connections.
-        // It's recommended to use a separate, single-threaded group for this purpose to avoid contention between
-        // accepting new connections and processing I/O.
-        val cfg = nettyConfig.maxThreads(1).copy(shutdownQuietPeriodDuration = 0.seconds)
-        eventLoopGroup match {
-          case _: EpollEventLoopGroup   => EventLoopGroups.epoll(cfg)
-          case _: KQueueEventLoopGroup  => EventLoopGroups.kqueue(cfg)
-          case _: IOUringEventLoopGroup => EventLoopGroups.uring(cfg)
-          case _                        => EventLoopGroups.nio(cfg)
-        }
-      }
       chf     <- ZIO.attempt {
         new ServerBootstrap()
-          .group(boss, eventLoopGroup)
+          .group(eventLoopGroups.boss, eventLoopGroups.worker)
           .channelFactory(channelFactory)
           .childHandler(channelInitializer)
           .option[Integer](ChannelOption.SO_BACKLOG, serverConfig.soBacklog)
@@ -99,7 +84,7 @@ private[zio] final case class NettyDriver(
       channelFactory <- ChannelFactories.Client.live.build
         .provideSomeEnvironment[Scope](_ ++ ZEnvironment[ChannelType.Config](nettyConfig))
       nettyRuntime   <- NettyRuntime.live.build
-    } yield NettyClientDriver(channelFactory.get, eventLoopGroup, nettyRuntime.get)
+    } yield NettyClientDriver(channelFactory.get, eventLoopGroups.worker, nettyRuntime.get)
 
   override def toString: String = s"NettyDriver($serverConfig)"
 }
@@ -112,7 +97,7 @@ object NettyDriver {
     RoutesRef
       & ChannelFactory[ServerChannel]
       & ChannelInitializer[Channel]
-      & EventLoopGroup
+      & ServerEventLoopGroups
       & Server.Config
       & NettyConfig
       & ServerInboundHandler,
@@ -123,7 +108,7 @@ object NettyDriver {
       app   <- ZIO.service[RoutesRef]
       cf    <- ZIO.service[ChannelFactory[ServerChannel]]
       cInit <- ZIO.service[ChannelInitializer[Channel]]
-      elg   <- ZIO.service[EventLoopGroup]
+      elg   <- ZIO.service[ServerEventLoopGroups]
       sc    <- ZIO.service[Server.Config]
       nsc   <- ZIO.service[NettyConfig]
       sih   <- ZIO.service[ServerInboundHandler]
@@ -132,14 +117,15 @@ object NettyDriver {
       channelFactory = cf,
       channelInitializer = cInit,
       serverInboundHandler = sih,
-      eventLoopGroup = elg,
+      eventLoopGroups = elg,
       serverConfig = sc,
       nettyConfig = nsc,
     )
 
-  val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] = {
+  val manual
+    : ZLayer[ServerEventLoopGroups & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] = {
     implicit val trace: Trace = Trace.empty
-    ZLayer.makeSome[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Driver](
+    ZLayer.makeSome[ServerEventLoopGroups & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Driver](
       ZLayer(AppRef.empty),
       ServerChannelInitializer.layer,
       ServerInboundHandler.live,
@@ -150,7 +136,7 @@ object NettyDriver {
   val customized: ZLayer[Server.Config & NettyConfig, Throwable, Driver] = {
     val serverChannelFactory: ZLayer[NettyConfig, Nothing, ChannelFactory[ServerChannel]] =
       ChannelFactories.Server.fromConfig
-    val eventLoopGroup: ZLayer[NettyConfig, Nothing, EventLoopGroup]                      = EventLoopGroups.live
+    val eventLoopGroup: ZLayer[NettyConfig, Nothing, ServerEventLoopGroups]               = ServerEventLoopGroups.live
 
     ZLayer.makeSome[Server.Config & NettyConfig, Driver](
       eventLoopGroup,

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -28,9 +28,8 @@ import zio.http.{ClientDriver, Driver, Response, Routes, Server}
 
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel._
-import io.netty.channel.epoll.{EpollChannelOption, EpollEventLoopGroup, EpollMode}
+import io.netty.channel.epoll.EpollEventLoopGroup
 import io.netty.channel.kqueue.KQueueEventLoopGroup
-import io.netty.channel.unix.UnixChannelOption
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup
 import io.netty.util.ResourceLeakDetector
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/NettyDriver.scala
@@ -59,14 +59,13 @@ private[zio] final case class NettyDriver(
         }
       }
       chf     <- ZIO.attempt {
-        val b = new ServerBootstrap()
+        new ServerBootstrap()
           .group(boss, eventLoopGroup)
           .channelFactory(channelFactory)
           .childHandler(channelInitializer)
           .option[Integer](ChannelOption.SO_BACKLOG, serverConfig.soBacklog)
           .childOption[JBoolean](ChannelOption.TCP_NODELAY, serverConfig.tcpNoDelay)
-
-        b.bind(serverConfig.address)
+          .bind(serverConfig.address)
       }
       _       <- NettyFutureExecutor.scoped(chf)
       _       <- ZIO.succeed(ResourceLeakDetector.setLevel(nettyConfig.leakDetectionLevel.toNetty))

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerEventLoopGroups.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerEventLoopGroups.scala
@@ -1,0 +1,30 @@
+package zio.http.netty.server
+
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import zio.http.netty.{EventLoopGroups, NettyConfig}
+
+import io.netty.channel.EventLoopGroup
+
+final case class ServerEventLoopGroups(
+  boss: EventLoopGroup,
+  worker: EventLoopGroup,
+)
+
+object ServerEventLoopGroups {
+  private implicit val trace: Trace = Trace.empty
+
+  private def groupLayer(cfg: EventLoopGroups.Config): ULayer[EventLoopGroup] =
+    (ZLayer.succeed(cfg) >>> EventLoopGroups.live).fresh
+
+  val live: ZLayer[NettyConfig, Nothing, ServerEventLoopGroups] = ZLayer.fromZIO {
+    ZIO.serviceWith[NettyConfig] { cfg =>
+      val boss   = groupLayer(cfg.bossGroup)
+      val worker = groupLayer(cfg)
+      boss.zipWithPar(worker) { (boss, worker) =>
+        ZEnvironment(ServerEventLoopGroups(boss.get, worker.get))
+      }
+    }
+  }.flatten
+}

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -152,10 +152,10 @@ private[zio] final case class ServerInboundHandler(
       // ctx.write and ctx.channel.write are different in netty. ctx.write will write to the next handler in the pipeline
       // whereas ctx.channel.write will write to the channel directly. If we're not on the event loop, it's better
       // to use ctx.channel.write
-      val ch = ctx.channel()
-      if (ch.eventLoop().inEventLoop()) {
+      if (ctx.executor().inEventLoop()) {
         ctx.writeAndFlush(djResponse, ctx.voidPromise())
       } else {
+        val ch = ctx.channel()
         ch.writeAndFlush(djResponse, ch.voidPromise())
       }
       true

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -37,6 +37,7 @@ package object server {
   val live: ZLayer[Server.Config, Throwable, Driver] =
     NettyDriver.live
 
-  val manual: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] =
+  val manual
+    : ZLayer[ServerEventLoopGroups & ChannelFactory[ServerChannel] & Server.Config & NettyConfig, Nothing, Driver] =
     NettyDriver.manual
 }

--- a/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerEventLoopGroupsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerEventLoopGroupsSpec.scala
@@ -1,0 +1,52 @@
+package zio.http.netty.server
+
+import zio._
+import zio.test.TestAspect.{sequential, withLiveClock}
+import zio.test.{Spec, TestEnvironment, assertTrue}
+
+import zio.http.ZIOHttpSpec
+import zio.http.netty.NettyConfig
+
+object ServerEventLoopGroupsSpec extends ZIOHttpSpec {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("ServerEventLoopGroups")(
+      test("group sizes are as configured") {
+        val nBoss   = 2
+        val nWorker = 5
+        val config  = ZLayer.succeed {
+          val c = NettyConfig.defaultWithFastShutdown
+          c.copy(nThreads = nWorker, bossGroup = c.bossGroup.copy(nThreads = nBoss))
+        }
+
+        ZIO.scoped {
+          ServerEventLoopGroups.live.build.map { env =>
+            val groups        = env.get[ServerEventLoopGroups]
+            var bossThreads   = 0
+            var workerThreads = 0
+            groups.boss.forEach(_ => bossThreads += 1)
+            groups.worker.forEach(_ => workerThreads += 1)
+            assertTrue(bossThreads == nBoss, workerThreads == nWorker)
+          }
+        }.provide(config)
+      },
+      test("finalizers are run in parallel") {
+        val configLayer = ZLayer.succeed {
+          val c = NettyConfig.default
+          c.copy(
+            shutdownQuietPeriodDuration = 500.millis,
+            bossGroup = c.bossGroup.copy(shutdownQuietPeriodDuration = 500.millis),
+          )
+        }
+
+        val st = Ref.unsafe.make(0L)(Unsafe)
+
+        (for {
+          _  <- ZIO.scoped(ServerEventLoopGroups.live.build <* Clock.nanoTime.flatMap(st.set))
+          et <- Clock.nanoTime
+          st <- st.get
+          d = Duration.fromNanos(et - st)
+        } yield assertTrue(d >= 500.millis, d < 700.millis)).provide(configLayer)
+      } @@ withLiveClock,
+    ) @@ sequential
+}

--- a/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerEventLoopGroupsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerEventLoopGroupsSpec.scala
@@ -45,8 +45,8 @@ object ServerEventLoopGroupsSpec extends ZIOHttpSpec {
           _  <- ZIO.scoped(ServerEventLoopGroups.live.build <* Clock.nanoTime.flatMap(st.set))
           et <- Clock.nanoTime
           st <- st.get
-          d = Duration.fromNanos(et - st)
-        } yield assertTrue(d >= 500.millis, d < 700.millis)).provide(configLayer)
+          d = Duration.fromNanos(et - st).toMillis
+        } yield assertTrue(d >= 500L, d < 700L)).provide(configLayer)
       } @@ withLiveClock,
     ) @@ sequential
 }


### PR DESCRIPTION
## Change to default Netty configuration

The main improvement in this PR is a change in the sizing of Netty's EvenLoopGroup. By default, Netty will size the EventLoopGroup at `nCPU * 2`, and will use this pool for 2 purposes:
1. Accepting new connections (boss)
2. Running the pipeline and IO (worker)

The sizing of this pool is extremely conservative and assumes that _some_ blocking IO might occur in Netty's worker threads. It also guards against cases where the underlying transport is blocking. However, since we're delegating all user-defined logic to ZIO's executor, and since the transports we're using are all non-blocking (Epoll, KQueue, NIO), a better configuration is to:
1. Use a separate EventLoopGroup with `nThreads=1` for the boss group. This way, we avoid delays in accepting new connections when the worker threads are busy serving existing connections
2. Size the worker EventLoopGroup with `nThreads=nCPU` since there's no blocking code running in the worker threads

With this change, we see a ~10% increase in throughput vs the default configuration

## Use `ctx.channel.write` instead of `ctx.write` in ServerInboundHandler

This part is not really well documented in Netty, but their main differences are
- `ctx.write` / `ctx.writeAndFlush` will walk through the pipeline from the current handler until the head of the pipeline when writing a response
- `ctx.channel.write` / `ctx.channel.writeAndFlush` will start at the end of the pipeline and walk through all the handlers in the pipeline when writing a response

In our case, short-cutting writes to the pipeline by starting at the current handler doesn't bring any benefit because the ServerInboundHandler is the last one in the pipeline. In addition, as [this video on Netty's best practises](https://youtu.be/WsMOJqAYW5M?si=piFsYwMvpKrfNY3v&t=1725) seems to suggest, when we're writing to the channel from a different thread it's better to use `ctx.channel.write`.

## Other changes

- removed the `runtime` scope from epoll / kqueue native transports. These are generally tiny (~20kb each) and I think it's better for users to have them available by default rather than having to install them manually and having to align netty versions
- updated the `./.devcontainer` files to install `wrk` and updated the Java / SBT versions in order to make it quicker to spin up a devcontainer for benchmarking purposes
- updated `build.sbt` to fork processes when using `sbt zioHttpExample/runMain example.xx` to avoid having issues with restarting servers
- added sensible java opts when running examples