### PR TITLE
Fix: Multipart Boundary Generation to Comply with RFC 2046

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
@@ -59,6 +59,18 @@ object BoundarySpec extends ZIOHttpSpec {
         boundary4.isEmpty,
       )
     },
+    suite("randomUUID")(
+      test("generated boundary is RFC 2046 compliant") {
+        for {
+          boundary <- Boundary.randomUUID
+          _        <- ZIO.logInfo(s"Generated boundary: ${boundary.id}")
+        } yield assertTrue(
+          boundary.id.matches("^[a-zA-Z0-9-]+$"),
+          boundary.id.startsWith("----"),
+          boundary.id.endsWith("----"),
+        )
+      },
+    ),
   )
 
   val spec = suite("BoundarySpec")(

--- a/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/BoundarySpec.scala
@@ -63,7 +63,6 @@ object BoundarySpec extends ZIOHttpSpec {
       test("generated boundary is RFC 2046 compliant") {
         for {
           boundary <- Boundary.randomUUID
-          _        <- ZIO.logInfo(s"Generated boundary: ${boundary.id}")
         } yield assertTrue(
           boundary.id.matches("^[a-zA-Z0-9-]+$"),
           boundary.id.startsWith("----"),

--- a/zio-http/shared/src/main/scala/zio/http/Boundary.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Boundary.scala
@@ -75,6 +75,6 @@ object Boundary {
 
   def randomUUID(implicit trace: Trace): zio.UIO[Boundary] =
     zio.Random.nextUUID.map { id =>
-      Boundary(s"----${id.toString.replaceAll("[^a-zA-Z0-9]", "-")}----")
+      Boundary(s"----${id.toString}----")
     }
 }

--- a/zio-http/shared/src/main/scala/zio/http/Boundary.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Boundary.scala
@@ -75,6 +75,6 @@ object Boundary {
 
   def randomUUID(implicit trace: Trace): zio.UIO[Boundary] =
     zio.Random.nextUUID.map { id =>
-      Boundary(s"(((${id.toString()})))")
+      Boundary(s"----${id.toString.replaceAll("[^a-zA-Z0-9]", "-")}----")
     }
 }


### PR DESCRIPTION
This PR addresses issue #3117, where multipart form boundaries generated by `Boundary.randomUUID` were not compliant with RFC 2046. The previous boundary format included invalid characters like parentheses `(((random-uuid)))` which caused server-side parsing errors and resulted in `400 Bad Request` responses.

### Changes
- Updated the `Boundary.randomUUID` method to generate RFC 2046-compliant boundaries by sanitizing the UUID. Any non-alphanumeric characters are replaced with hyphens (`-`), and the boundary is prefixed and suffixed with `----` to ensure a valid format.
- Added tests in `BoundarySpec.scala` to ensure the generated boundaries are valid and compliant with the standard.

fixes #3117
/claim #3117 