### PR TITLE
fix OpenAPI code gen not quoting arbitrary header names

### DIFF
--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/CodeGen.scala
@@ -371,7 +371,7 @@ object CodeGen {
       case "www-authenticate"                 => "HeaderCodec.wwwAuthenticate"
       case "x-frame-options"                  => "HeaderCodec.xFrameOptions"
       case "x-requested-with"                 => "HeaderCodec.xRequestedWith"
-      case name                               => s"HeaderCodec.name[String]($name)"
+      case name                               => s"""HeaderCodec.name[String]("$name")"""
     }
     s""".header($headerSelector)"""
   }

--- a/zio-http-gen/src/test/resources/EndpointWithHeaders.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithHeaders.scala
@@ -9,6 +9,7 @@ object Users {
   val get = Endpoint(Method.GET / "api" / "v1" / "users")
     .header(HeaderCodec.accept)
     .header(HeaderCodec.contentType)
+    .header(HeaderCodec.name[String]("token"))
     .in[Unit]
 
 }

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -151,7 +151,10 @@ object CodeGenSpec extends ZIOSpecDefault {
       },
       test("Endpoint with headers") {
         val endpoint =
-          Endpoint(Method.GET / "api" / "v1" / "users").header(HeaderCodec.accept).header(HeaderCodec.contentType)
+          Endpoint(Method.GET / "api" / "v1" / "users")
+            .header(HeaderCodec.accept)
+            .header(HeaderCodec.contentType)
+            .header(HeaderCodec.name[String]("Token"))
         val openAPI  = OpenAPIGen.fromEndpoints(endpoint)
 
         codeGenFromOpenAPI(openAPI) { testDir =>


### PR DESCRIPTION
Arbitrary header names are now quoted.

Fixes #3102 