### PR TITLE
Optimizations for request execution happy path

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -172,16 +172,15 @@ object RoutePattern                                                       {
         tree.add(p, v)
       }
 
-    def get(method: Method, path: Path): Chunk[A] = {
-      val wildcards = roots.get(Method.ANY) match {
-        case None        => Chunk.empty
-        case Some(value) => value.get(path)
-      }
+    private val wildcardsTree = roots.getOrElse(Method.ANY, null)
 
-      (roots.get(method) match {
-        case None        => Chunk.empty
-        case Some(value) => value.get(path)
-      }) ++ wildcards
+    def get(method: Method, path: Path): Chunk[A] = {
+      val forMethod = roots.getOrElse(method, null) match {
+        case null  => Chunk.empty
+        case value => value.get(path)
+      }
+      if (wildcardsTree eq null) forMethod
+      else forMethod ++ wildcardsTree.get(path)
     }
 
     def map[B](f: A => B): Tree[B] =

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -245,20 +245,25 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
    */
   def toHandler(implicit ev: Err <:< Response): Handler[Env, Nothing, Request, Response] = {
     implicit val trace: Trace = Trace.empty
+    val tree                  = self.tree
     Handler
       .fromFunctionHandler[Request] { req =>
         val chunk = tree.get(req.method, req.path)
-
-        if (chunk.length == 0) Handler.notFound
-        else if (chunk.length == 1) chunk(0)
-        else {
-          // TODO: Support precomputed fallback among all chunk elements:
-          chunk.tail.foldLeft(chunk.head) { (acc, h) =>
-            acc.catchAll { response =>
-              if (response.status == Status.NotFound) h
-              else Handler.fail(response)
+        chunk.length match {
+          case 0 => Handler.notFound
+          case 1 => chunk(0)
+          case n => // TODO: Support precomputed fallback among all chunk elements
+            var acc = chunk(0)
+            var i   = 1
+            while (i < n) {
+              val h = chunk(i)
+              acc = acc.catchAll { response =>
+                if (response.status == Status.NotFound) h
+                else Handler.fail(response)
+              }
+              i += 1
             }
-          }
+            acc
         }
       }
       .merge


### PR DESCRIPTION
Main changes:
1. Convert `Routes` to `Handler` in `ServerInboundHandler` to avoid allocations & method invocations each time we call `Routes#apply`.
2. Store the wildcards tree in `RoutePattern` in a val to avoid doing that on each invocation to `RoutePattern#get`
3. Use `Map#getOrElse(key, null)` in a couple of places
4. Extract `tree` outside of the `Function1` in `toHandler` to avoid checking the class `var` on each request
5. Use `null` as the default for `Set[Int]` in `PathCodec#get`. This avoids the boxing of the Int on each iteration.

Note on (5): We could also use `BitSet` here, but since almost always `skipLiteralsFor` will be empty / null, it's better to avoid the method invocation and just do a null check