### PR TITLE
Sandbox routes later & don't pass handled responses into error handlers

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -245,6 +245,9 @@ sealed trait Route[-Env, +Err] { self =>
    * account the request that caused the error. This method can be used to
    * convert a route that does not handle its errors into one that does handle
    * its errors.
+   *
+   * If the underlying handler uses the error channel to send responses, this
+   * method will not pass the responses to the provided function.
    */
   final def handleErrorRequestCauseZIO[Env1 <: Env](
     f: (Request, Cause[Err]) => ZIO[Env1, Nothing, Response],

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -49,6 +49,9 @@ sealed trait Route[-Env, +Err] { self =>
    * Handles all typed errors in the route by converting them into responses.
    * This method can be used to convert a route that does not handle its errors
    * into one that does handle its errors.
+   *
+   * If the underlying handler uses the error channel to send responses, this
+   * method will not pass the responses to the provided function.
    */
   final def handleError(f: Err => Response)(implicit trace: Trace): Route[Env, Nothing] =
     self.handleErrorCauseZIO(c => ErrorResponseConfig.configRef.get.map(Response.fromCauseWith(c, _)(f)))
@@ -187,6 +190,9 @@ sealed trait Route[-Env, +Err] { self =>
    * taking into account the request that caused the error. This method can be
    * used to convert a route that does not handle its errors into one that does
    * handle its errors.
+   *
+   * If the underlying handler uses the error channel to send responses, this
+   * method will not pass the responses to the provided function.
    */
   final def handleErrorRequest(f: (Err, Request) => Response)(implicit trace: Trace): Route[Env, Nothing] =
     self.handleErrorRequestCauseZIO((request, cause) =>

--- a/zio-http/shared/src/main/scala/zio/http/Route.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Route.scala
@@ -211,7 +211,7 @@ sealed trait Route[-Env, +Err] { self =>
           routePattern,
           handler0.map { h =>
             Handler.fromFunctionHandler { (req: Request) =>
-              h.mapErrorCause(c => c.failureOrCause.fold(identity, f(req, _)))
+              h.mapErrorCause(_.failureOrCause.fold(identity, f(req, _)))
             }
           },
           location,


### PR DESCRIPTION
resolves #3134 
/claim #3134

Two changes in this pr:

1. We no longer pass Responses of handled routes into error handlers. This is a changes the behaviour of the api a little bit, but I would argue that the old behaviour was actually a bug. The type of the error was as a Cause[Nothing] in those cases, so you could never meaningfully work with it anyway.

2. Sandboxing is delayed until the time the handler is actually used now. We should still always have a sandboxed handler in the end, so I don't think application behaviour will change in a meaningful way.
But, this should resolve a couple of subtle issues for people that were using the handleErrorXXX function for error logging, as in certain setup this would cause errors to be wrapped before the error handler sees them.
For example
```scala
(Method.GET / "endpoint" -> handler { (_: Request) => ZIO.dieMessage("hmm...") }).handleErrorCause(c => {println(c); Response.ok})
``` 
used to be immediately sandbox the defect, resulting in a 500 Response getting printed instead of the actual defect.
Now the actual defect will be forwarded to the error handlers.