### PR TITLE
Allow applying aspects only to handlers with `Request` input (#3141)

### DIFF
--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -426,7 +426,7 @@ We notice in the response that first `basicAuth` handler aspect responded `HTTP/
 We can abort the requests by specific response using `HandlerAspect.fail` and `HandlerAspect.failWith` aspects, so the downstream handlers will not be executed:
 
 ```scala mdoc:invisible
-val myHandler = Handler.identity
+val myHandler = Handler.ok
 ```
 
 ```scala mdoc:compile-only

--- a/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
@@ -5,7 +5,7 @@ import zio._
 trait HandlerVersionSpecific {
   private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](private val self: Handler[Env, Err, In, Out]) {
     def apply[Env1, Ctx: Tag, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
-      in: Handler.IsRequest[In1],
+      ev0: Request <:< In,
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,

--- a/zio-http/shared/src/main/scala-2/zio/http/RouteCompanionVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/RouteCompanionVersionSpecific.scala
@@ -1,0 +1,12 @@
+package zio.http
+
+import zio.Tag
+
+trait RouteCompanionVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, Env0](private val self: Route[Env, Err]) {
+    def apply[Env1, Env2 <: Env, Ctx: Tag](aspect: HandlerAspect[Env1, Ctx])(implicit
+      ev: Env0 with Ctx <:< Env,
+    ): Route[Env0 with Env1, Err] = self.transform(_.@@[Env0](aspect))
+  }
+
+}

--- a/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
@@ -5,7 +5,7 @@ import zio.*
 trait HandlerVersionSpecific {
   private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](self: Handler[Env, Err, In, Out]) {
     transparent inline def apply[Env1, Ctx, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
-      in: Handler.IsRequest[In1],
+      ev0: Request <:< In,
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,

--- a/zio-http/shared/src/main/scala-3/zio/http/RouteCompanionVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/RouteCompanionVersionSpecific.scala
@@ -1,0 +1,10 @@
+package zio.http
+
+trait RouteCompanionVersionSpecific {
+  private[http] class ApplyContextAspect[-Env, +Err, Env0](private val self: Route[Env, Err]) {
+    transparent inline def apply[Env1, Env2 <: Env, Ctx](aspect: HandlerAspect[Env1, Ctx])(implicit
+      ev: Env0 with Ctx <:< Env,
+    ): Route[Env0 with Env1, Err] = self.transform(_.@@[Env0](aspect))
+  }
+
+}

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -35,7 +35,7 @@ import zio.http.template._
 sealed trait Handler[-R, +Err, -In, +Out] { self =>
 
   def @@[Env1 <: R, In1 <: In](aspect: HandlerAspect[Env1, Unit])(implicit
-    in: Handler.IsRequest[In1],
+    ev: Request <:< In,
     out: Out <:< Response,
     err: Err <:< Response,
   ): Handler[Env1, Response, Request, Response] = {
@@ -46,7 +46,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   }
 
   def @@[Env0, Ctx <: R, In1 <: In](aspect: HandlerAspect[Env0, Ctx])(implicit
-    in: Handler.IsRequest[In1],
+    ev: Request <:< In,
     out: Out <:< Response,
     err: Err <:< Response,
     trace: Trace,
@@ -981,7 +981,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
     fromResponse(Response.html(view))
 
   /**
-   * Creates a pass thru Handler instance
+   * Creates a pass through Handler instance
    */
   def identity[A]: Handler[Any, Nothing, A, A] =
     new Handler[Any, Nothing, A, A] {

--- a/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
@@ -104,6 +104,26 @@ final case class HandlerAspect[-Env, +CtxOut](
     }
 
   /**
+   * Applies middleware to the specified handler, which may ignore the context
+   * produced by this middleware.
+   */
+  override def apply[Env1 <: Env, Err](
+    routes: Route[Env1, Err],
+  ): Route[Env1, Err] =
+    routes.transform[Env1] { handler =>
+      if (self == HandlerAspect.identity) handler
+      else {
+        for {
+          tuple <- protocol.incomingHandler
+          (state, (request, ctxOut)) = tuple
+          either   <- Handler.fromZIO(handler(request)).either
+          response <- Handler.fromZIO(protocol.outgoingHandler((state, either.merge)))
+          response <- if (either.isLeft) Handler.fail(response) else Handler.succeed(response)
+        } yield response
+      }
+    }
+
+  /**
    * Applies middleware to the specified handler, which must process the context
    * produced by this middleware.
    */

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -30,6 +30,9 @@ trait Middleware[-UpperEnv] { self =>
 
   def apply[Env1 <: UpperEnv, Err](routes: Routes[Env1, Err]): Routes[Env1, Err]
 
+  def apply[Env1 <: UpperEnv, Err](route: Route[Env1, Err]): Route[Env1, Err] =
+    (route.toRoutes @@ self).routes.head
+
   def @@[UpperEnv1 <: UpperEnv](
     that: Middleware[UpperEnv1],
   ): Middleware[UpperEnv1] =

--- a/zio-http/shared/src/main/scala/zio/http/RequestHandlerInput.scala.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RequestHandlerInput.scala.scala
@@ -22,11 +22,24 @@ import zio.Zippable
 
 @implicitNotFound("""
 Your request handler is required to accept both parameters ${A}, as well as the incoming [[zio.http.Request]].
-This is true even if you wish to ignore some parameters or the request itself. Try to add missing parameters 
-until you no longer receive this error message. If all else fails, you can construct a handler manually using 
+This is true even if you wish to ignore some parameters or the request itself. Try to add missing parameters
+until you no longer receive this error message. If all else fails, you can construct a handler manually using
 the constructors in the companion object of [[zio.http.Handler]] using the precise types.""")
 final class RequestHandlerInput[A, I](val zippable: Zippable.Out[A, Request, I])
 object RequestHandlerInput {
   implicit def apply[A, I](implicit zippable: Zippable.Out[A, Request, I]): RequestHandlerInput[A, I] =
     new RequestHandlerInput(zippable)
+}
+
+@implicitNotFound("""
+Your request handler is required to accept both parameters ${A}, as well as the incoming [[zio.http.Request]].
+This is true even if you wish to ignore some parameters or the request itself. Try to add missing parameters
+until you no longer receive this error message. If all else fails, you can construct a handler manually using
+the constructors in the companion object of [[zio.http.Handler]] using the precise types.""")
+final class RequestHandlerInputWithContext[A, I, Ctx](val zippable: Zippable.Out[A, (Ctx, Request), I])
+object RequestHandlerInputWithContext {
+  implicit def apply[A, I, Ctx](implicit
+    zippable: Zippable.Out[A, (Ctx, Request), I],
+  ): RequestHandlerInputWithContext[A, I, Ctx] =
+    new RequestHandlerInputWithContext(zippable)
 }


### PR DESCRIPTION
The actual bug was, that the handler aspect could be applied to a handler that has a input different then request. There was a construct that should have prevented it, but it did not work.

To make it easier to add aspects to a single route, I added `@@` methods to `Route` too. And a test that shows, that it works with path parameters

fixes #3141
/claim #3141 