### PR TITLE
Fix ScalaJS Compilation by Removing JVM-specific java.util.Objects References in PathCodecPlatformSpecific

### DIFF
--- a/zio-http/js/src/main/scala/zio/http/codec/PathCodecPlatformSpecific.scala
+++ b/zio-http/js/src/main/scala/zio/http/codec/PathCodecPlatformSpecific.scala
@@ -1,11 +1,10 @@
 package zio.http.codec
 
-import java.util.Objects
-
 trait PathCodecPlatformSpecific {
   private[codec] def parseLong(s: CharSequence, beginIndex: Int, endIndex: Int, radix: Int): Long = {
-    Objects.requireNonNull(s)
-    Objects.checkFromToIndex(beginIndex, endIndex, s.length)
+    require(s != null, "CharSequence cannot be null")
+    checkFromToIndex(beginIndex, endIndex, s.length)
+
     if (radix < Character.MIN_RADIX)
       throw new NumberFormatException("radix " + radix + " less than Character.MIN_RADIX")
     if (radix > Character.MAX_RADIX)
@@ -42,8 +41,9 @@ trait PathCodecPlatformSpecific {
   }
 
   private[codec] def parseInt(s: CharSequence, beginIndex: Int, endIndex: Int, radix: Int): Int = {
-    Objects.requireNonNull(s)
-    Objects.checkFromToIndex(beginIndex, endIndex, s.length)
+    require(s != null, "CharSequence cannot be null")
+    checkFromToIndex(beginIndex, endIndex, s.length)
+
     if (radix < Character.MIN_RADIX)
       throw new NumberFormatException("radix " + radix + " less than Character.MIN_RADIX")
     if (radix > Character.MAX_RADIX)
@@ -88,4 +88,10 @@ trait PathCodecPlatformSpecific {
     "For input string: \"" + s + "\"" + (if (radix == 10) ""
                                          else " under radix " + radix),
   )
+
+  private def checkFromToIndex(from: Int, to: Int, length: Int): Unit = {
+    if (from < 0 || to > length || from > to) {
+      throw new IndexOutOfBoundsException(s"Range [$from, $to) out of bounds for length $length")
+    }
+  }
 }

--- a/zio-http/js/src/test/scala/zio/http/PathCodecPlatformSpecificSpec.scala
+++ b/zio-http/js/src/test/scala/zio/http/PathCodecPlatformSpecificSpec.scala
@@ -1,0 +1,35 @@
+package zio.http.codec
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+object PathCodecPlatformSpecificSpec extends ZIOSpecDefault {
+
+  def spec = suite("PathCodecJSPlatformSpecificSpec")(
+    test("parseInt should correctly parse a valid integer from a CharSequence") {
+      val charSequence = "12345"
+      val result       = new PathCodecPlatformSpecific {}.parseInt(charSequence, 0, charSequence.length, 10)
+      assert(result)(equalTo(12345))
+    },
+    test("parseInt should throw an error for an invalid radix") {
+      val charSequence = "12345"
+      val result       = ZIO.attempt {
+        new PathCodecPlatformSpecific {}.parseInt(charSequence, 0, charSequence.length, Character.MAX_RADIX + 1)
+      }.either
+      assertZIO(result)(isLeft(hasMessage(containsString("radix"))))
+    },
+    test("parseLong should correctly parse a valid long from a CharSequence") {
+      val charSequence = "123456789012345"
+      val result       = new PathCodecPlatformSpecific {}.parseLong(charSequence, 0, charSequence.length, 10)
+      assert(result)(equalTo(123456789012345L))
+    },
+    test("parseLong should throw an error for an invalid input") {
+      val charSequence = "invalid123"
+      val result       = ZIO.attempt {
+        new PathCodecPlatformSpecific {}.parseLong(charSequence, 0, charSequence.length, 10)
+      }.either
+      assertZIO(result)(isLeft(hasMessage(containsString("Error at index"))))
+    },
+  )
+}


### PR DESCRIPTION
The ScalaJS compilation fails due to references to JVM-specific methods in PathCodecPlatformSpecific.scala. This fix removes the dependency on java.util.Objects and replaces it with Scala-compatible checks to ensure compatibility with compilation in the ScalaJS

/claim #3142 
Closes #3142 