### PR TITLE
Issue 3165: Fix Forwarded Header rendering

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/headers/ForwardedSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/headers/ForwardedSpec.scala
@@ -19,7 +19,7 @@ package zio.http.headers
 import zio.Scope
 import zio.test._
 
-import zio.http.{Header, ZIOHttpSpec}
+import zio.http.{Header, Headers, Request, ZIOHttpSpec}
 
 object ForwardedSpec extends ZIOHttpSpec {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("Forwarded suite")(
@@ -58,5 +58,22 @@ object ForwardedSpec extends ZIOHttpSpec {
       )
       assertTrue(Header.Forwarded.parse(headerValue) == Right(header))
     },
+    test("render Forwarded produces a valid raw header value") {
+      val gen = for {
+        by    <- Gen.option(Gen.const("by.host"))
+        forv  <- Gen.listOf(
+          Gen.elements("127.0.0.1", "localhost", "0.0.0.0"),
+        )
+        host  <- Gen.option(Gen.const("host.com"))
+        proto <- Gen.option(Gen.const("http"))
+      } yield (by, forv, host, proto)
+
+      check(gen) { case (by, forv, host, proto) =>
+        val expected = Header.Forwarded(by = by, forValues = forv, host = host, proto = proto)
+        val raw      = Header.Forwarded.render(expected)
+        val actual   = Header.Forwarded.parse(raw)
+        assertTrue(actual.is(_.right) == expected)
+      }
+    } @@ TestAspect.shrinks(0),
   )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -2856,8 +2856,13 @@ object Header {
       Right(Forwarded(by, forValue, host, proto))
     }
 
-    def render(forwarded: Forwarded): String =
-      s"${forwarded.by}; ${forwarded.forValues.map(v => s"for=$v").mkString(",")}; ${forwarded.host}; ${forwarded.proto}"
+    def render(forwarded: Forwarded): String = {
+      def formatDirective(directive: Option[String]) = directive.map(_ + ";").getOrElse("")
+
+      val forValues = if (forwarded.forValues.nonEmpty) forwarded.forValues.map(v => s"for=$v").mkString(",") + ";" else ""
+
+      s"${formatDirective(forwarded.by.map("by=" + _))}${forValues}${formatDirective(forwarded.host.map("host=" + _))}${formatDirective(forwarded.proto.map("proto=" + _))}"
+    }
   }
 
   /** From header value. */


### PR DESCRIPTION
This set of change address the issue described in https://github.com/zio/zio-http/issues/3165.

For instance the header, 'Header.Forwarded(forValues = List("127.0.0.1"))', previously rendered incorrectly as 'None; for=127.0.0.1; None; None'.

It now properly renders as 'for=127.0.0.1;'.

It includes an additional test spec that uses a property check to verify all permutations optional directives.