### PR TITLE
Make `JsonSchema.fromSerializableSchema` package private

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -253,7 +253,7 @@ object JsonSchema {
       .toOption
       .get
 
-  private def fromSerializableSchema(schema: SerializableJsonSchema): JsonSchema = {
+  private[openapi] def fromSerializableSchema(schema: SerializableJsonSchema): JsonSchema = {
     val additionalProperties = schema.additionalProperties match {
       case Some(BoolOrSchema.BooleanWrapper(bool))  => Left(bool)
       case Some(BoolOrSchema.SchemaWrapper(schema)) =>


### PR DESCRIPTION
While working with [OpenAI structured outputs](https://platform.openai.com/docs/guides/structured-outputs/), I need an uncommon requirement like omitting `format` field from the schema.

To overcome such technical constraint, I need an escape hatch between `JsonSchema` and `SerializableJsonSchema` for a workaround like the below:

```scala
package zio.http.endpoint.openapi

import zio.prelude.Newtype
import zio.schema.Schema

object OpenAIJsonSchema extends Newtype[JsonSchema] {

  given Schema[Type] =
    SerializableJsonSchema.schema.transform[Type](
      ss => wrap(JsonSchema.fromSerializableSchema(ss)), // `JsonSchema.fromSerializableSchema` is inaccessible
      s => {
        val ss = unwrap(s).toSerializableSchema
        println(s)
        println(unwrap(s).toJson)
        adjustForOpenAI(ss)
      }
    )

  def fromZSchema(s: Schema[?]): Type =
    wrap(JsonSchema.fromZSchema(s, JsonSchema.SchemaStyle.Inline))

  private def adjustForOpenAI(s: SerializableJsonSchema): SerializableJsonSchema =
    s.copy(
      format = None,
      properties = s.properties.map(_.view.mapValues(adjustForOpenAI).toMap),
      items = s.items.map(adjustForOpenAI),
      additionalProperties =
        Option.when(s.properties.nonEmpty) {
          BoolOrSchema.BooleanWrapper(false)
        }
    )
}
type OpenAIJsonSchema = OpenAIJsonSchema.Type
```