### PR TITLE
Exclude `sourcecode` from scalameta parsers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -327,7 +327,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       scalafmt.cross(CrossVersion.for3Use2_13),
       scalametaParsers
         .cross(CrossVersion.for3Use2_13)
-        .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
+        .exclude("org.scala-lang.modules", "scala-collection-compat_2.13")
         .exclude("com.lihaoyi", "sourcecode_2.13"),
       `zio-json-yaml` % Test,
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -325,9 +325,10 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test-sbt`,
       `zio-config`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      (scalametaParsers % Test)
+      scalametaParsers
         .cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
+        .exclude("com.lihaoyi", "sourcecode_2.13"),
       `zio-json-yaml` % Test,
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -325,7 +325,7 @@ lazy val zioHttpGen = (project in file("zio-http-gen"))
       `zio-test-sbt`,
       `zio-config`,
       scalafmt.cross(CrossVersion.for3Use2_13),
-      scalametaParsers
+      (scalametaParsers % Test)
         .cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-lang.modules", "scala-collection-compat_2.13"),
       `zio-json-yaml` % Test,


### PR DESCRIPTION
Because it pulls in `sourcecode` for Scala 2.13 even on Scala 3, this just wasted a lot of my time trying to figure out why I was getting bizarre errors caused by Scala 3 not being able to run Scala 2 macros.
