### PR TITLE
feat: Added auth for generated openapi documents

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -1,6 +1,5 @@
 package zio.http.endpoint.openapi
 
-import zio.http.Header.Authorization.{Basic, Bearer}
 import zio.json.ast.Json
 import zio.test._
 import zio.{Chunk, Scope, ZIO}
@@ -9,6 +8,7 @@ import zio.schema.annotation._
 import zio.schema.validation.Validation
 import zio.schema.{DeriveSchema, Schema}
 
+import zio.http.Header.Authorization.{Basic, Bearer}
 import zio.http.Method.{GET, POST}
 import zio.http._
 import zio.http.codec.PathCodec.{empty, string}

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -7,8 +7,6 @@ import scala.collection.immutable.ListMap
 import scala.collection.{immutable, mutable}
 
 import zio._
-import zio.http.Header.Authorization
-import zio.http.Header.Authorization.Basic
 import zio.json.EncoderOps
 import zio.json.ast.Json
 
@@ -16,15 +14,16 @@ import zio.schema.Schema.{Record, Transform}
 import zio.schema.codec.JsonCodec
 import zio.schema.{Schema, TypeId}
 
+import zio.http.Header.Authorization
+import zio.http.Header.Authorization.Basic
 import zio.http._
 import zio.http.codec.HttpCodec.Metadata
 import zio.http.codec._
 import zio.http.endpoint.AuthType.Bearer
 import zio.http.endpoint._
 import zio.http.endpoint.openapi.JsonSchema.SchemaStyle
-import zio.http.endpoint.openapi.OpenAPI.{Path, PathItem}
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme.{ApiKey, SecurityRequirement}
-import zio.http.endpoint.openapi.OpenAPI.{Key, Path, PathItem, ReferenceOr, SecurityScheme, securityRequirementSchema}
+import zio.http.endpoint.openapi.OpenAPI._
 
 object OpenAPIGen {
   private val PathWildcard = "pathWildcard"
@@ -814,7 +813,7 @@ object OpenAPIGen {
           ).filterNot(_._1 == OpenAPI.Key.fromString("noAuth").get).toSeq: _*,
       )
     }
-    def createApiKeySecurityScheme(name: String) =
+    def createApiKeySecurityScheme(name: String)                                                              =
       OpenAPI.Key.fromString(apiKeyAuth).get -> OpenAPI.ReferenceOr.Or(
         OpenAPI.SecurityScheme.ApiKey(description = None, name = name, in = in(name)),
       )

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -7,6 +7,8 @@ import scala.collection.immutable.ListMap
 import scala.collection.{immutable, mutable}
 
 import zio._
+import zio.http.Header.Authorization
+import zio.http.Header.Authorization.Basic
 import zio.json.EncoderOps
 import zio.json.ast.Json
 
@@ -17,12 +19,23 @@ import zio.schema.{Schema, TypeId}
 import zio.http._
 import zio.http.codec.HttpCodec.Metadata
 import zio.http.codec._
+import zio.http.endpoint.AuthType.Bearer
 import zio.http.endpoint._
 import zio.http.endpoint.openapi.JsonSchema.SchemaStyle
 import zio.http.endpoint.openapi.OpenAPI.{Path, PathItem}
+import zio.http.endpoint.openapi.OpenAPI.SecurityScheme.{ApiKey, SecurityRequirement}
+import zio.http.endpoint.openapi.OpenAPI.{Key, Path, PathItem, ReferenceOr, SecurityScheme, securityRequirementSchema}
 
 object OpenAPIGen {
   private val PathWildcard = "pathWildcard"
+
+  val apiKeyHeaderName     = "x-api-key" // opinionated names
+  val apiKeyQueryParamName = "api_key"
+  val apiKeyAuth           = "apiKeyAuth"
+  val basicAuth            = "basicAuth"
+  val bearerAuth           = "bearerAuth"
+  val digestAuth           = "digestAuth"
+  private val noAuth       = "noAuth"
 
   private[openapi] def groupMap[A, K, B](chunk: Chunk[A])(key: A => K)(f: A => B): immutable.Map[K, Chunk[B]] = {
     val m = mutable.Map.empty[K, mutable.Builder[B, Chunk[B]]]
@@ -591,7 +604,7 @@ object OpenAPIGen {
         requestBody = requestBody,
         responses = responses,
         callbacks = Map.empty,
-        security = Nil,
+        security = security(endpoint),
         servers = Nil,
       )
     }
@@ -628,6 +641,10 @@ object OpenAPIGen {
 
     def responses: OpenAPI.Responses =
       responsesForAlternatives(outs)
+
+    def security(endpoint: Endpoint[_, _, _, _, _]): List[SecurityRequirement] = {
+      extractSecurityRequirements(endpoint, queryParams ++ headerParams)
+    }
 
     def parameters: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]] =
       queryParams ++ pathParams ++ headerParams
@@ -780,6 +797,48 @@ object OpenAPIGen {
       }
     }
 
+    def collectSecurityScheme(endpoint: Endpoint[_, _, _, _, _], params: Set[ReferenceOr[OpenAPI.Parameter]]) = {
+      ListMap(
+        params.collect {
+          case OpenAPI.ReferenceOr.Or(param)
+              if param.name.equalsIgnoreCase(apiKeyHeaderName) || param.name.equalsIgnoreCase(apiKeyQueryParamName) =>
+            createApiKeySecurityScheme(param.name)
+        }.toSeq ++
+          Set(
+            endpoint.authType match {
+              case AuthType.Basic  => createHttpSecurityScheme(basicAuth, "basic")
+              case AuthType.Bearer => createHttpSecurityScheme(bearerAuth, "bearer")
+              case AuthType.Digest => createHttpSecurityScheme(digestAuth, "digest")
+              case _               => createHttpSecurityScheme()
+            },
+          ).filterNot(_._1 == OpenAPI.Key.fromString("noAuth").get).toSeq: _*,
+      )
+    }
+    def createApiKeySecurityScheme(name: String) =
+      OpenAPI.Key.fromString(apiKeyAuth).get -> OpenAPI.ReferenceOr.Or(
+        OpenAPI.SecurityScheme.ApiKey(description = None, name = name, in = in(name)),
+      )
+    def in(paramName: String): OpenAPI.SecurityScheme.ApiKey.In = {
+      if (paramName.equalsIgnoreCase(apiKeyHeaderName))
+        OpenAPI.SecurityScheme.ApiKey.In.Header
+      else if (paramName.equalsIgnoreCase(apiKeyQueryParamName))
+        OpenAPI.SecurityScheme.ApiKey.In.Query
+      else throw new IllegalArgumentException(s"Unknown apiKey param name: $paramName")
+    }
+    def createHttpSecurityScheme(
+      name: String = noAuth,
+      scheme: String = "",
+      description: Option[Doc] = None,
+    ): (OpenAPI.Key, OpenAPI.ReferenceOr[OpenAPI.SecurityScheme.Http]) = {
+      OpenAPI.Key.fromString(name).get -> OpenAPI.ReferenceOr.Or(
+        OpenAPI.SecurityScheme.Http(
+          scheme = scheme,
+          bearerFormat = None,
+          description = description,
+        ),
+      )
+    }
+
     def components = OpenAPI.Components(
       schemas = ListMap(componentSchemas.toSeq.sortBy(_._1.name): _*),
       responses = ListMap.empty,
@@ -787,7 +846,7 @@ object OpenAPIGen {
       examples = ListMap.empty,
       requestBodies = ListMap.empty,
       headers = ListMap.empty,
-      securitySchemes = ListMap.empty,
+      securitySchemes = collectSecurityScheme(endpoint, headerParams ++ queryParams),
       links = ListMap.empty,
       callbacks = ListMap.empty,
     )
@@ -1011,6 +1070,23 @@ object OpenAPIGen {
         ),
       )
     }
+
+  private def extractSecurityRequirements(
+    endpoint: Endpoint[_, _, _, _, _],
+    parameters: Set[OpenAPI.ReferenceOr[OpenAPI.Parameter]],
+  ): List[SecurityRequirement] = {
+    parameters.collect {
+      case OpenAPI.ReferenceOr.Or(param: OpenAPI.Parameter)
+          if param.name.equalsIgnoreCase(apiKeyHeaderName) || param.name.equalsIgnoreCase(apiKeyQueryParamName) =>
+        SecurityRequirement(Map(apiKeyAuth -> Nil))
+    }.toList ++
+      List(endpoint.authType match {
+        case AuthType.Basic  => SecurityRequirement(Map(basicAuth -> Nil))
+        case AuthType.Bearer => SecurityRequirement(Map(bearerAuth -> Nil))
+        case AuthType.Digest => SecurityRequirement(Map(digestAuth -> Nil))
+        case _               => SecurityRequirement(Map.empty)
+      }).filterNot(_.securitySchemes.isEmpty)
+  }
 
   private def headersFrom(codec: AtomizedMetaCodecs)                                           = {
     codec.header.map { case mc @ MetaCodec(codec, _) =>

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -23,7 +23,7 @@ import zio.http.endpoint.AuthType.Bearer
 import zio.http.endpoint._
 import zio.http.endpoint.openapi.JsonSchema.SchemaStyle
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme.{ApiKey, SecurityRequirement}
-import zio.http.endpoint.openapi.OpenAPI._
+import zio.http.endpoint.openapi.OpenAPI.{MediaType => OpenAPIMediaType, _}
 
 object OpenAPIGen {
   private val PathWildcard = "pathWildcard"
@@ -546,7 +546,7 @@ object OpenAPIGen {
     // there is no status for inputs. So we just take the first one (default)
     val ins = schemaByStatusAndMediaType(endpoint.input.alternatives.map(_._1), referenceType).values.headOption
 
-    def path: Map[Path, PathItem] = {
+    def path: Map[OpenAPI.Path, PathItem] = {
       val path           = buildPath(endpoint.input)
       val method0        = method(inAtoms.method)
       // Endpoint has only one doc. But open api has a summery and a description


### PR DESCRIPTION
The auth specified on an Endpoint is being reflected on the openapi components 

![image](https://github.com/user-attachments/assets/c2fd668f-2570-44b1-8794-bf20a072ae31)


Fixes #3183 
/claim #3183
