### PR TITLE
ZClient enhancements for URL and path

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/ZClient.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClient.scala
@@ -151,8 +151,10 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
 
   def path(path: String): ZClient[Env, ReqEnv, In, Err, Out] = self.path(Path(path))
 
-  def path(path: Path): ZClient[Env, ReqEnv, In, Err, Out] =
-    copy(url = url.copy(path = path))
+  def path(path: Path): ZClient[Env, ReqEnv, In, Err, Out] = updatePath(_ => path)
+
+  def updatePath(f: Path => Path): ZClient[Env, ReqEnv, In, Err, Out] =
+    copy(url = url.copy(path = f(url.path)))
 
   def patch(suffix: String)(implicit ev: Body <:< In, trace: Trace): ZIO[Env & ReqEnv, Err, Out] =
     request(Method.PATCH, suffix)(ev(Body.empty))
@@ -263,6 +265,8 @@ final case class ZClient[-Env, ReqEnv, -In, +Err, +Out](
   def uri(uri: URI): ZClient[Env, ReqEnv, In, Err, Out] = url(URL.fromURI(uri).getOrElse(URL.empty))
 
   def url(url: URL): ZClient[Env, ReqEnv, In, Err, Out] = copy(url = url)
+
+  def updateURL(f: URL => URL): ZClient[Env, ReqEnv, In, Err, Out] = copy(url = f(url))
 }
 
 object ZClient extends ZClientPlatformSpecific {


### PR DESCRIPTION
Hello!

With this PR, I would like to extend the ability to mutate the `URL` or just the `path` of `ZClient`, making usage more ergonomic and friendlier.

Usage examples

```scala
client.updatePath(_ / "my-service")
client.updateURL(_ => URL.decode(s"http://test.com/x").toOption.get)
client.updateURL(url => url.copy(path = url.path / "my-service"))
```

P.s.: I'm new to this codebase, so please be gentle. :)

Thank you, and have a lovely day!

\- Oto