### PR TITLE
[RFC] feat: scoped requests

### DIFF
--- a/zio-http-testkit/src/main/scala/zio/http/TestServer.scala
+++ b/zio-http-testkit/src/main/scala/zio/http/TestServer.scala
@@ -111,6 +111,19 @@ final case class TestServer(driver: Driver, bindPort: Int) extends Server {
         ),
       )
 
+  override def installScoped[R](routes: Routes[R with Scope, Response])(implicit
+    trace: zio.Trace,
+    tag: EnvironmentTag[R],
+  ): URIO[R, Unit] =
+    ZIO
+      .environment[R]
+      .flatMap(
+        driver.addAppScoped(
+          routes,
+          _,
+        ),
+      )
+
   override def port: UIO[Int] = ZIO.succeed(bindPort)
 }
 

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -24,13 +24,14 @@ import java.util.concurrent.atomic.AtomicReference // scalafix:ok;
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 package object server {
-  private[server] type RoutesRef = AtomicReference[(Routes[Any, Response], Runtime[Any])]
+  private[server] type RoutesRef =
+    AtomicReference[(Either[Routes[Any, Response], Routes[Scope, Response]], Runtime[Any])]
 
   private[server] object AppRef {
     val empty: UIO[RoutesRef] = {
       implicit val trace: Trace = Trace.empty
       // Environment will be populated when we `install` the app
-      ZIO.runtime[Any].map(rt => new AtomicReference((Routes.empty, rt.mapEnvironment(_ => ZEnvironment.empty))))
+      ZIO.runtime[Any].map(rt => new AtomicReference((Left(Routes.empty), rt.mapEnvironment(_ => ZEnvironment.empty))))
     }
   }
 

--- a/zio-http/shared/src/main/scala/zio/http/Driver.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Driver.scala
@@ -27,6 +27,7 @@ trait Driver {
   def start(implicit trace: Trace): RIO[Scope, StartResult]
 
   def addApp[R](newRoutes: Routes[R, Response], env: ZEnvironment[R])(implicit trace: Trace): UIO[Unit]
+  def addAppScoped[R](newRoutes: Routes[R with Scope, Response], env: ZEnvironment[R])(implicit trace: Trace): UIO[Unit]
 
   def createClientDriver()(implicit trace: Trace): ZIO[Scope, Throwable, ClientDriver]
 }


### PR DESCRIPTION
/fixes #3197
/claim #3197

**RFC** Adds support for per-request Scopes at server level. 

Adds the ability to run a server that provides a scope for each request. This is to not add any overhead or overly complicate the existing path that does not provide request-bound scopes.

I have not added tests or similar yet as I need some feedback on the idea of this as a solution first.
(Edit: also only implemented with the Netty driver for the above reason)