### PR TITLE
Handler factory method for functions returning Either

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -854,6 +854,11 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   def fromFunctionHandler[In]: FromFunctionHandler[In] = new FromFunctionHandler[In](())
 
   /**
+   * Creates a Handler from an pure function from A to Either[E,B]
+   */
+  def fromFunctionEither[In]: FromFunctionEither[In] = new FromFunctionEither[In](())
+
+  /**
    * Creates a Handler from an pure function from A to HExit[R,E,B]
    */
   def fromFunctionExit[In]: FromFunctionExit[In] = new FromFunctionExit[In](())
@@ -1219,6 +1224,18 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
       new Handler[R, Err, In, Out] {
         override def apply(in: In): ZIO[R, Err, Out] =
           f(in)(in)
+      }
+  }
+
+  final class FromFunctionEither[In](val self: Unit) extends AnyVal {
+    def apply[R, Err, Out](f: In => Either[Err, Out]): Handler[Any, Err, In, Out] =
+      new Handler[Any, Err, In, Out] {
+        override def apply(in: In): ZIO[Any, Err, Out] =
+          try {
+            Exit.fromEither(f(in))
+          } catch {
+            case error: Throwable => Exit.die(error)
+          }
       }
   }
 


### PR DESCRIPTION
I found it useful to have this factory method for functions doing pure computation and returning `Either`.

Also wondering if it makes sense to have analogous method in the `fromResponseXXX` family:
```scala
def fromResponseEither[Err](response: Either[Err, Response]): Handler[Any, Err, Any, Response]
```