### PR TITLE
Endpoint gen additional types

### DIFF
--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/Config.scala
@@ -33,6 +33,7 @@ final case class Config(
   commonFieldsOnSuperType: Boolean,
   generateSafeTypeAliases: Boolean,
   fieldNamesNormalization: NormalizeFields,
+  stringFormatTypes: Map[String, String],
 )
 object Config {
 
@@ -73,11 +74,15 @@ object Config {
       enableAutomatic = false,
       manualOverrides = Map.empty,
     ),
+    stringFormatTypes = Map.empty,
   )
 
   def config: zio.Config[Config] = (
     zio.Config.boolean("common-fields-on-super-type").withDefault(Config.default.commonFieldsOnSuperType) ++
       zio.Config.boolean("generate-safe-type-aliases").withDefault(Config.default.generateSafeTypeAliases) ++
-      NormalizeFields.config.nested("fields-normalization")
+      NormalizeFields.config.nested("fields-normalization") ++ zio.Config.table(
+        "string-format-types",
+        zio.Config.string,
+      )
   ).to[Config]
 }

--- a/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/openapi/EndpointGen.scala
@@ -685,6 +685,14 @@ final case class EndpointGen(config: Config) {
         Code.PathSegmentCode(name = name, segmentType = Code.CodecType.Long)
       case JsonSchema.String(Some(JsonSchema.StringFormat.UUID), _, _, _)        =>
         Code.PathSegmentCode(name = name, segmentType = Code.CodecType.UUID)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Date), _, _, _)        =>
+        Code.PathSegmentCode(name = name, segmentType = Code.CodecType.LocalDate)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.DateTime), _, _, _)    =>
+        Code.PathSegmentCode(name = name, segmentType = Code.CodecType.Instant)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Time), _, _, _)        =>
+        Code.PathSegmentCode(name = name, segmentType = Code.CodecType.LocalTime)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Duration), _, _, _)    =>
+        Code.PathSegmentCode(name = name, segmentType = Code.CodecType.Duration)
       case JsonSchema.String(_, _, _, _)                                         =>
         Code.PathSegmentCode(name = name, segmentType = Code.CodecType.String)
       case JsonSchema.Boolean                                                    =>
@@ -719,6 +727,14 @@ final case class EndpointGen(config: Config) {
         Code.QueryParamCode(name = name, queryType = Code.CodecType.Long)
       case JsonSchema.Integer(JsonSchema.IntegerFormat.Timestamp, _, _, _, _, _) =>
         Code.QueryParamCode(name = name, queryType = Code.CodecType.Long)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Date), _, _, _)        =>
+        Code.QueryParamCode(name = name, queryType = Code.CodecType.LocalDate)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.DateTime), _, _, _)    =>
+        Code.QueryParamCode(name = name, queryType = Code.CodecType.Instant)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Duration), _, _, _)    =>
+        Code.QueryParamCode(name = name, queryType = Code.CodecType.Duration)
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Time), _, _, _)        =>
+        Code.QueryParamCode(name = name, queryType = Code.CodecType.LocalTime)
       case JsonSchema.String(Some(JsonSchema.StringFormat.UUID), _, _, _)        =>
         Code.QueryParamCode(name = name, queryType = Code.CodecType.UUID)
       case JsonSchema.String(_, _, _, _)                                         =>
@@ -1237,9 +1253,19 @@ final case class EndpointGen(config: Config) {
         val annotations  = addNumericValidations[Long](exclusiveMin, exclusiveMax)
         Some(Code.Field(name, Code.Primitive.ScalaLong, annotations, config.fieldNamesNormalization))
 
+      case JsonSchema.String(Some(format), _, _, _) if config.stringFormatTypes.contains(format.value)                =>
+        Some(Code.Field(name, Code.TypeRef(config.stringFormatTypes(format.value)), config.fieldNamesNormalization))
       case JsonSchema.String(Some(JsonSchema.StringFormat.UUID), _, maxLength, minLength)                             =>
         val annotations = addStringValidations(minLength, maxLength)
         Some(Code.Field(name, Code.Primitive.ScalaUUID, annotations, config.fieldNamesNormalization))
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Date), _, _, _)                                             =>
+        Some(Code.Field(name, Code.Primitive.ScalaLocalDate, config.fieldNamesNormalization))
+      case JsonSchema.String(Some(JsonSchema.StringFormat.DateTime), _, _, _)                                         =>
+        Some(Code.Field(name, Code.Primitive.ScalaInstant, config.fieldNamesNormalization))
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Time), _, _, _)                                             =>
+        Some(Code.Field(name, Code.Primitive.ScalaTime, config.fieldNamesNormalization))
+      case JsonSchema.String(Some(JsonSchema.StringFormat.Duration), _, _, _)                                         =>
+        Some(Code.Field(name, Code.Primitive.ScalaDuration, config.fieldNamesNormalization))
       case JsonSchema.String(_, _, maxLength, minLength)                                                              =>
         val annotations = addStringValidations(minLength, maxLength)
         Some(Code.Field(name, Code.Primitive.ScalaString, annotations, config.fieldNamesNormalization))

--- a/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
+++ b/zio-http-gen/src/main/scala/zio/http/gen/scala/Code.scala
@@ -217,17 +217,21 @@ object Code {
   sealed trait Primitive extends ScalaType
 
   object Primitive {
-    case object ScalaInt     extends Primitive
-    case object ScalaLong    extends Primitive
-    case object ScalaDouble  extends Primitive
-    case object ScalaFloat   extends Primitive
-    case object ScalaChar    extends Primitive
-    case object ScalaByte    extends Primitive
-    case object ScalaShort   extends Primitive
-    case object ScalaBoolean extends Primitive
-    case object ScalaUnit    extends Primitive
-    case object ScalaUUID    extends Primitive
-    case object ScalaString  extends Primitive
+    case object ScalaInt       extends Primitive
+    case object ScalaLong      extends Primitive
+    case object ScalaDouble    extends Primitive
+    case object ScalaFloat     extends Primitive
+    case object ScalaChar      extends Primitive
+    case object ScalaByte      extends Primitive
+    case object ScalaShort     extends Primitive
+    case object ScalaBoolean   extends Primitive
+    case object ScalaUnit      extends Primitive
+    case object ScalaUUID      extends Primitive
+    case object ScalaLocalDate extends Primitive
+    case object ScalaInstant   extends Primitive
+    case object ScalaTime      extends Primitive
+    case object ScalaDuration  extends Primitive
+    case object ScalaString    extends Primitive
   }
 
   final case class EndpointCode(
@@ -253,6 +257,10 @@ object Code {
     case object Long                                               extends CodecType
     case object String                                             extends CodecType
     case object UUID                                               extends CodecType
+    case object LocalDate                                          extends CodecType
+    case object LocalTime                                          extends CodecType
+    case object Duration                                           extends CodecType
+    case object Instant                                            extends CodecType
     case class Aliased(underlying: CodecType, newtypeName: String) extends CodecType
   }
   final case class QueryParamCode(name: String, queryType: CodecType)

--- a/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyInlineMinMaxLength.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyInlineMinMaxLength.scala
@@ -14,6 +14,10 @@ object Entries {
   object POST {
     import zio.schema.annotation.validate
     import zio.schema.validation.Validation
+    import java.util.UUID
+    import java.time.Instant
+    import java.time.LocalTime
+    import java.time.LocalDate
 
     case class RequestBody(
       id: Int,
@@ -23,8 +27,12 @@ object Entries {
       implicit val codec: Schema[RequestBody] = DeriveSchema.gen[RequestBody]
     }
     case class ResponseBody(
-      id: Int,
       @validate[String](Validation.maxLength(255) && Validation.minLength(1)) name: String,
+      uuid: Option[UUID],
+      deadline: Option[Instant],
+      id: Int,
+      time: Option[LocalTime],
+      day: LocalDate,
     )
     object ResponseBody {
       implicit val codec: Schema[ResponseBody] = DeriveSchema.gen[ResponseBody]

--- a/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyInlineMinMaxLength.scala
+++ b/zio-http-gen/src/test/resources/EndpointWithRequestResponseBodyInlineMinMaxLength.scala
@@ -1,0 +1,33 @@
+package test.api.v1
+
+import test.component._
+import zio.schema._
+
+object Entries {
+  import zio.http._
+  import zio.http.endpoint._
+  import zio.http.codec._
+  val post = Endpoint(Method.POST / "api" / "v1" / "entries")
+    .in[POST.RequestBody]
+    .out[POST.ResponseBody](status = Status.Ok)
+
+  object POST {
+    import zio.schema.annotation.validate
+    import zio.schema.validation.Validation
+
+    case class RequestBody(
+      id: Int,
+      @validate[String](Validation.maxLength(255) && Validation.minLength(1)) name: String,
+    )
+    object RequestBody  {
+      implicit val codec: Schema[RequestBody] = DeriveSchema.gen[RequestBody]
+    }
+    case class ResponseBody(
+      id: Int,
+      @validate[String](Validation.maxLength(255) && Validation.minLength(1)) name: String,
+    )
+    object ResponseBody {
+      implicit val codec: Schema[ResponseBody] = DeriveSchema.gen[ResponseBody]
+    }
+  }
+}

--- a/zio-http-gen/src/test/resources/ValidatedData.scala
+++ b/zio-http-gen/src/test/resources/ValidatedData.scala
@@ -5,7 +5,7 @@ import zio.schema.annotation.validate
 import zio.schema.validation.Validation
 
 case class ValidatedData(
-  @validate[String](Validation.minLength(10)) name: String,
+  @validate[String](Validation.maxLength(10)) name: String,
   @validate[Int](Validation.greaterThan(0) && Validation.lessThan(100)) age: Int,
 )
 object ValidatedData {

--- a/zio-http-gen/src/test/resources/inline_schema_minmaxlength.json
+++ b/zio-http-gen/src/test/resources/inline_schema_minmaxlength.json
@@ -1,0 +1,82 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "",
+    "version" : ""
+  },
+  "paths" : {
+    "/api/v1/entries" : {
+      "post" : {
+        "requestBody" :
+        {
+          "content" : {
+            "application/json" : {
+              "schema" :
+              {
+                "type" :
+                "object",
+                "properties" : {
+                  "id" : {
+                    "type" :
+                    "integer",
+                    "format" : "int32"
+                  },
+                  "name" : {
+                    "type" :
+                    "string",
+                    "minLength" : 1,
+                    "maxLength" : 255
+                  }
+                },
+                "additionalProperties" :
+                true,
+                "required" : [
+                  "id",
+                  "name"
+                ]
+              }
+
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" :
+          {
+            "description" : "",
+            "content" : {
+              "application/json" : {
+                "schema" :
+                {
+                  "type" :
+                  "object",
+                  "properties" : {
+                    "id" : {
+                      "type" :
+                      "integer",
+                      "format" : "int32"
+                    },
+                    "name" : {
+                      "type" :
+                      "string",
+                      "minLength" : 1,
+                      "maxLength" : 255
+                    }
+                  },
+                  "additionalProperties" :
+                  true,
+                  "required" : [
+                    "id",
+                    "name"
+                  ]
+                }
+
+              }
+            }
+          }
+        },
+        "deprecated" : false
+      }
+    }
+  }
+}

--- a/zio-http-gen/src/test/resources/inline_schema_minmaxlength.json
+++ b/zio-http-gen/src/test/resources/inline_schema_minmaxlength.json
@@ -61,13 +61,32 @@
                       "string",
                       "minLength" : 1,
                       "maxLength" : 255
+                    },
+                    "day" : {
+                      "type" :
+                      "string",
+                      "format": "date"
+                    },
+                    "deadline": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "time": {
+                      "type": "string",
+                      "format": "time"
+                    },
+                    "uuid" : {
+                      "type" :
+                      "string",
+                      "format" : "uuid"
                     }
                   },
                   "additionalProperties" :
                   true,
                   "required" : [
                     "id",
-                    "name"
+                    "name",
+                    "day"
                   ]
                 }
 

--- a/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
+++ b/zio-http-gen/src/test/scala/zio/http/gen/scala/CodeGenSpec.scala
@@ -198,6 +198,16 @@ object CodeGenSpec extends ZIOSpecDefault {
           }
         }
       } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3
+      test("OpenAPI spec with inline schema request and response body with minLength and maxLength") {
+        val openAPIString = stringFromResource("/inline_schema_minmaxlength.json")
+
+        openApiFromJsonString(openAPIString) { openAPI =>
+          codeGenFromOpenAPI(openAPI) { testDir =>
+            fileShouldBe(testDir, "api/v1/Entries.scala", "/EndpointWithRequestResponseBodyInlineMinMaxLength.scala")
+          }
+        }
+      } @@ TestAspect.exceptScala3, // for some reason, the temp dir is empty in Scala 3
+
       test("OpenAPI spec with inline schema request and response body, with nested object schema") {
         val openAPIString = stringFromResource("/inline_schema_nested.json")
 

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -293,8 +293,8 @@ object JsonSchema {
         JsonSchema.String(
           schema.format.map(StringFormat.fromString),
           schema.pattern.map(Pattern.apply),
-          schema.minLength,
           schema.maxLength,
+          schema.minLength,
         )
       case schema if schema.schemaType.contains(TypeOrTypes.Type("boolean"))                             =>
         JsonSchema.Boolean


### PR DESCRIPTION
Added more handling for the code generation from OpenAPI schema. Strings with specified format are generated as:
* `date` -> `java.time.LocalDate`
* `time` -> `java.time.LocalTime`
* `date-time` -> `java.time.Instant`
* `duration` -> `java.time.Duration`

Also added the possibility to override the generated types in configuration.