### PR TITLE
Fix Possible Race Condition

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -147,9 +147,9 @@ private[netty] object NettyConnectionPool {
    *   true if the handler was successfully refreshed prior to the channel being
    *   closed and the channel is still open.
    *
-   *   true if the `timeout` is None and the channel is still open.
+   * true if the `timeout` is None and the channel is still open.
    *
-   *   false of the channel is closed.
+   * false of the channel is closed.
    */
   private def refreshIdleTimeoutHandler(
     channel: JChannel,


### PR DESCRIPTION
fixes #3268

Refactor 'refreshIdleTimeoutHandler' so that 'ChannelPipeline.replace' does not crash the fiber on unhandled exceptions.