### PR TITLE
Use empty body for `Unit` payload in Endpoint (#3258)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/RoundtripSpec.scala
@@ -176,6 +176,11 @@ object RoundtripSpec extends ZIOHttpSpec {
           Post(20, "title", "body", 10),
         )
       },
+      test("simple get without payload") {
+        val healthCheckAPI     = Endpoint(GET / "health-check").out[Unit]
+        val healthCheckHandler = healthCheckAPI.implementAs(())
+        testEndpoint(healthCheckAPI, Routes(healthCheckHandler), (), ())
+      },
       test("simple get with query params from case class") {
         val endpoint = Endpoint(GET / "query")
           .query(HttpCodec.queryAll[Params])


### PR DESCRIPTION
With the zio-schema master state, Unit payload would fail without this change.
fixes #3258
/claim #3258 