### PR TITLE
Use HashMap for literals look up (#2960)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,44 @@ jobs:
           name: Jmh_Main_ProbeContentTypeBenchmark
           path: Main_ProbeContentTypeBenchmark.txt
 
+  Jmh_RoutesBenchmark:
+    name: Jmh RoutesBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.14]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: coursier/setup-action@v1
+        with:
+          apps: sbt
+
+      - uses: actions/checkout@v4
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")' project/plugins.sbt
+          cat > Main_RoutesBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 RoutesBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_RoutesBenchmark.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Jmh_Main_RoutesBenchmark
+          path: Main_RoutesBenchmark.txt
+
   Jmh_SchemeDecodeBenchmark:
     name: Jmh SchemeDecodeBenchmark
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -752,7 +790,7 @@ jobs:
 
   Jmh_cache:
     name: Cache Jmh benchmarks
-    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
+    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_RoutesBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
@@ -823,6 +861,13 @@ jobs:
 
       - name: Format_Main_ProbeContentTypeBenchmark
         run: cat Main_ProbeContentTypeBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Jmh_Main_RoutesBenchmark
+
+      - name: Format_Main_RoutesBenchmark
+        run: cat Main_RoutesBenchmark.txt >> Main_benchmarks.txt
 
       - uses: actions/download-artifact@v4
         with:

--- a/profiling/build.sbt
+++ b/profiling/build.sbt
@@ -1,7 +1,7 @@
 name         := "zio-http"
 version      := "1.0.0"
 scalaVersion := "2.13.6"
-lazy val zhttp = ProjectRef(file("/zio-http/zio-http-src"), "zioHttp")
+lazy val zioHttp = ProjectRef(file("/zio-http/zio-http-src"), "zioHttp")
 lazy val root  = (project in file("."))
   .settings(
     name                             := "helloExample",
@@ -14,4 +14,4 @@ lazy val root  = (project in file("."))
         oldStrategy(x)
     },
   )
-  .dependsOn(zhttp)
+  .dependsOn(zioHttp)

--- a/profiling/project/build.properties
+++ b/profiling/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.8.3
+sbt.version = 1.10.7

--- a/profiling/project/plugins.sbt
+++ b/profiling/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.eed3si9n"  % "sbt-assembly" % "1.1.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("com.eed3si9n"  % "sbt-assembly" % "1.2.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")

--- a/zio-http-benchmarks/src/main/scala/zio/http/benchmark/RoutesBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zio/http/benchmark/RoutesBenchmark.scala
@@ -1,0 +1,77 @@
+package zio.http.benchmark
+
+import java.util.concurrent.TimeUnit
+
+import scala.util.Random
+
+import zio.{Runtime, Unsafe, ZIO}
+
+import zio.http.endpoint.Endpoint
+import zio.http.{Handler, Method, Request, Routes}
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class RoutesBenchmark {
+
+  val REPEAT_N = 1000
+
+  val paths = ('a' to 'z').inits.map(_.mkString).toList.reverse.tail
+
+  val routes = Routes.fromIterable(paths.map(p => Endpoint(Method.GET / p).out[Unit].implementHandler(Handler.unit)))
+
+  val requests = paths.map(p => Request.get(p))
+
+  def request: Request  = requests(Random.nextInt(requests.size))
+  val smallDataRequests = Array.fill(REPEAT_N)(request)
+
+  def unsafeRun[E, A](zio: ZIO[Any, E, A]): Unit = Unsafe.unsafe { implicit unsafe =>
+    Runtime.default.unsafe
+      .run(zio.unit)
+      .getOrThrowFiberFailure()
+  }
+
+  val paths2 = ('b' to 'z').inits.map(_.mkString).toList.reverse.tail
+
+  val routes2 = Routes.fromIterable(paths2.map(p => Endpoint(Method.GET / p).out[Unit].implementHandler(Handler.unit)))
+
+  val requests2 = requests ++ paths2.map(p => Request.get(p))
+
+  def request2: Request = requests2(Random.nextInt(requests2.size))
+
+  val smallDataRequests2 = Array.fill(REPEAT_N)(request2)
+
+  val routes3 = Routes(
+    Endpoint(Method.GET / "api").out[Unit].implementHandler(Handler.unit),
+    Endpoint(Method.GET / "ui").out[Unit].implementHandler(Handler.unit),
+  )
+
+  val requests3 = Array.fill(REPEAT_N)(List(Request.get("api"), Request.get("ui"))(Random.nextInt(2)))
+
+  @Benchmark
+  def benchmarkSmallDataZioApi(): Unit =
+    for (r <- smallDataRequests) routes.isDefinedAt(r)
+
+  @Benchmark
+  def benchmarkSmallDataZioApi2(): Unit =
+    for (r <- smallDataRequests2) routes2.isDefinedAt(r)
+
+  @Benchmark
+  def notFound1(): Unit =
+    for (_ <- 1 to REPEAT_N) {
+      routes.isDefinedAt(Request.get("not-found"))
+    }
+
+  @Benchmark
+  def notFound2(): Unit =
+    for (_ <- 1 to REPEAT_N) {
+      routes2.isDefinedAt(Request.get("not-found"))
+    }
+
+  @Benchmark
+  def benchmarkSmallDataZioApi3(): Unit =
+    for (r <- requests3) routes3.isDefinedAt(r)
+
+}

--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -230,9 +230,10 @@ object RoutePatternSpec extends ZIOHttpSpec {
         var tree: Tree[Int] = RoutePattern.Tree.empty
 
         val pattern1 = Method.GET / "users" / "123"
-        val pattern2 = Method.GET / "users" / trailing
+        val pattern2 = Method.GET / "users" / trailing / "123"
 
         tree = tree.add(pattern2, 2)
+        println(tree.get(Method.GET, Path("/users/bla/123")))
         tree = tree.add(pattern1, 1)
 
         assertTrue(tree.get(Method.GET, Path("/users/123")).contains(1))


### PR DESCRIPTION
A state machine can not improve literal path matching, since it is only fast for misses, but we need the best performance for hits. This is best done with hash maps. 

This PR adds a benchmark for literal path matching and replaces the current `ListMap` with `HashMap`. This leads to a significant performance increase, as can be seen below

```
Run on MacBook Pro M1 Max
Old implementation:
[info] Benchmark                                   Mode  Cnt   Score    Error  Units
[info] RoutesBenchmark.benchmarkSmallDataZioApi   thrpt    3  45.794 ± 16.348  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi2  thrpt    3  63.488 ± 10.817  ops/s
[info] RoutesBenchmark.notFound1                  thrpt    3  60.807 ± 13.060  ops/s
[info] RoutesBenchmark.notFound2                  thrpt    3  60.809 ± 13.525  ops/s

HashMap instead of ListMap:
[info] Benchmark                                   Mode  Cnt   Score    Error  Units
[info] RoutesBenchmark.benchmarkSmallDataZioApi   thrpt    3  67.768 ±  9.438  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi2  thrpt    3  78.646 ± 15.662  ops/s
[info] RoutesBenchmark.notFound1                  thrpt    3  79.978 ±  3.829  ops/s
[info] RoutesBenchmark.notFound2                  thrpt    3  87.911 ±  9.178  ops/s
```

closes #2960
/claim #2960