### PR TITLE
More efficient root path look up (#3302)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,44 @@ jobs:
           name: Jmh_Main_HttpRouteTextPerf
           path: Main_HttpRouteTextPerf.txt
 
+  Jmh_MethodLookupBenchmark:
+    name: Jmh MethodLookupBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.16]
+        java: [temurin@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: coursier/setup-action@v1
+        with:
+          apps: sbt
+
+      - uses: actions/checkout@v4
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")' project/plugins.sbt
+          cat > Main_MethodLookupBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 MethodLookupBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_MethodLookupBenchmark.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Jmh_Main_MethodLookupBenchmark
+          path: Main_MethodLookupBenchmark.txt
+
   Jmh_ProbeContentTypeBenchmark:
     name: Jmh ProbeContentTypeBenchmark
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -832,7 +870,7 @@ jobs:
 
   Jmh_cache:
     name: Cache Jmh benchmarks
-    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_ProbeContentTypeBenchmark, Jmh_RoundtripBenchmark, Jmh_RoutesBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
+    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_MethodLookupBenchmark, Jmh_ProbeContentTypeBenchmark, Jmh_RoundtripBenchmark, Jmh_RoutesBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
@@ -896,6 +934,13 @@ jobs:
 
       - name: Format_Main_HttpRouteTextPerf
         run: cat Main_HttpRouteTextPerf.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Jmh_Main_MethodLookupBenchmark
+
+      - name: Format_Main_MethodLookupBenchmark
+        run: cat Main_MethodLookupBenchmark.txt >> Main_benchmarks.txt
 
       - uses: actions/download-artifact@v4
         with:

--- a/zio-http-benchmarks/src/main/scala/zio/http/benchmark/MethodLookupBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zio/http/benchmark/MethodLookupBenchmark.scala
@@ -1,0 +1,59 @@
+package zio.http.benchmark
+
+import java.util.concurrent.TimeUnit
+
+import scala.util.Random
+
+import zio.http._
+import zio.http.endpoint.Endpoint
+
+import org.openjdk.jmh.annotations._
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class MethodLookupBenchmark {
+
+  val REPEAT_N = 1000
+
+  val paths   = ('a' to 'z').inits.map(_.mkString).toList.reverse.tail
+  val methods =
+    List(Method.GET, Method.POST, Method.PUT, Method.DELETE, Method.HEAD, Method.OPTIONS, Method.PATCH, Method.TRACE)
+  val routes  =
+    Routes.fromIterable(paths.flatMap(p => methods.map(m => Endpoint(m / p).out[Unit].implementHandler(Handler.unit))))
+
+  val requests = paths.flatMap(p => methods.map(m => Request(method = m, url = url"$p")))
+
+  def request: Request       = requests(Random.nextInt(requests.size))
+  val defaultMethodsRequests = Array.fill(REPEAT_N)(request)
+
+  @Benchmark
+  def defaultMethods(): Unit =
+    for (request <- defaultMethodsRequests) routes.isDefinedAt(request)
+
+  val methodsCustom = List(
+    Method.GET,
+    Method.POST,
+    Method.PUT,
+    Method.DELETE,
+    Method.HEAD,
+    Method.OPTIONS,
+    Method.PATCH,
+    Method.TRACE,
+    Method.CUSTOM("CUSTOM"),
+    Method.CUSTOM("CUSTOM2"),
+  )
+  val routesCustom  = Routes.fromIterable(
+    paths.flatMap(p => methodsCustom.map(m => Endpoint(m / p).out[Unit].implementHandler(Handler.unit))),
+  )
+
+  val requestsCustom = paths.flatMap(p => methodsCustom.map(m => Request(method = m, url = url"$p")))
+
+  def requestCustom: Request = requestsCustom(Random.nextInt(requestsCustom.size))
+  val customMethodsRequests  = Array.fill(REPEAT_N)(requestCustom)
+
+  @Benchmark
+  def customMethods(): Unit =
+    for (request <- customMethodsRequests) routesCustom.isDefinedAt(request)
+
+}

--- a/zio-http-benchmarks/src/main/scala/zio/http/benchmark/RoutesBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/zio/http/benchmark/RoutesBenchmark.scala
@@ -4,8 +4,6 @@ import java.util.concurrent.TimeUnit
 
 import scala.util.Random
 
-import zio.{Runtime, Unsafe, ZIO}
-
 import zio.http.endpoint.Endpoint
 import zio.http.{Handler, Method, Request, Routes}
 

--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -162,9 +162,33 @@ object RoutePattern                                                       {
   /**
    * A tree of route patterns, indexed by method and path.
    */
-  private[http] final case class Tree[+A](roots: ListMap[Method, SegmentSubtree[A]]) { self =>
+  private[http] final case class Tree[+A](
+    anyRoot: SegmentSubtree[A],
+    connectRoot: SegmentSubtree[A],
+    deleteRoot: SegmentSubtree[A],
+    getRoot: SegmentSubtree[A],
+    headRoot: SegmentSubtree[A],
+    optionsRoot: SegmentSubtree[A],
+    patchRoot: SegmentSubtree[A],
+    postRoot: SegmentSubtree[A],
+    putRoot: SegmentSubtree[A],
+    traceRoot: SegmentSubtree[A],
+    customRoots: Map[Method, SegmentSubtree[A]],
+  ) { self =>
     def ++[A1 >: A](that: Tree[A1]): Tree[A1] =
-      Tree(mergeMaps(self.roots, that.roots)(_ ++ _))
+      Tree(
+        if (self.anyRoot != null) self.anyRoot ++ that.anyRoot else that.anyRoot,
+        if (self.connectRoot != null) self.connectRoot ++ that.connectRoot else that.connectRoot,
+        if (self.deleteRoot != null) self.deleteRoot ++ that.deleteRoot else that.deleteRoot,
+        if (self.getRoot != null) self.getRoot ++ that.getRoot else that.getRoot,
+        if (self.headRoot != null) self.headRoot ++ that.headRoot else that.headRoot,
+        if (self.optionsRoot != null) self.optionsRoot ++ that.optionsRoot else that.optionsRoot,
+        if (self.patchRoot != null) self.patchRoot ++ that.patchRoot else that.patchRoot,
+        if (self.postRoot != null) self.postRoot ++ that.postRoot else that.postRoot,
+        if (self.putRoot != null) self.putRoot ++ that.putRoot else that.putRoot,
+        if (self.traceRoot != null) self.traceRoot ++ that.traceRoot else that.traceRoot,
+        mergeMaps(self.customRoots, that.customRoots)(_ ++ _),
+      )
 
     def add[A1 >: A](routePattern: RoutePattern[_], value: A1): Tree[A1] =
       self ++ Tree(routePattern, value)
@@ -174,35 +198,82 @@ object RoutePattern                                                       {
         tree.add(p, v)
       }
 
-    private val wildcardsTree = roots.getOrElse(Method.ANY, null)
-
     def get(method: Method, path: Path): Chunk[A] = {
-      val forMethod = roots.getOrElse(method, null) match {
-        case null  => Chunk.empty
-        case value => value.get(path)
+      val forMethod = {
+        method match {
+          case Method.GET if getRoot != null               => getRoot.get(path)
+          case Method.POST if postRoot != null             => postRoot.get(path)
+          case Method.PUT if putRoot != null               => putRoot.get(path)
+          case Method.DELETE if deleteRoot != null         => deleteRoot.get(path)
+          case Method.CONNECT if connectRoot != null       => connectRoot.get(path)
+          case Method.HEAD if headRoot != null             => headRoot.get(path)
+          case Method.OPTIONS if optionsRoot != null       => optionsRoot.get(path)
+          case Method.PATCH if patchRoot != null           => patchRoot.get(path)
+          case Method.TRACE if traceRoot != null           => traceRoot.get(path)
+          case Method.ANY if anyRoot != null               => anyRoot.get(path)
+          case m: Method.CUSTOM if customRoots.contains(m) => customRoots(m).get(path)
+          case _                                           => Chunk.empty
+        }
       }
-      if (wildcardsTree eq null) forMethod
-      else forMethod ++ wildcardsTree.get(path)
+
+      if (anyRoot eq null) forMethod
+      else {
+        forMethod ++ anyRoot.get(path)
+      }
     }
 
     def map[B](f: A => B): Tree[B] =
-      Tree(roots.map { case (k, v) =>
-        k -> v.map(f)
-      })
+      Tree(
+        if (anyRoot != null) anyRoot.map(f) else null,
+        if (connectRoot != null) connectRoot.map(f) else null,
+        if (deleteRoot != null) deleteRoot.map(f) else null,
+        if (getRoot != null) getRoot.map(f) else null,
+        if (headRoot != null) headRoot.map(f) else null,
+        if (optionsRoot != null) optionsRoot.map(f) else null,
+        if (patchRoot != null) patchRoot.map(f) else null,
+        if (postRoot != null) postRoot.map(f) else null,
+        if (putRoot != null) putRoot.map(f) else null,
+        if (traceRoot != null) traceRoot.map(f) else null,
+        customRoots.map { case (k, v) => k -> v.map(f) },
+      )
   }
-  private[http] object Tree                                                          {
+  private[http] object Tree {
     def apply[A](routePattern: RoutePattern[_], value: A): Tree[A] = {
       val segments = routePattern.pathCodec.segments
 
       val subtree = SegmentSubtree.single(segments, value)
 
-      Tree(ListMap(routePattern.method -> subtree))
+      routePattern.method match {
+        case Method.GET       => Tree.empty.copy(getRoot = subtree)
+        case Method.POST      => Tree.empty.copy(postRoot = subtree)
+        case Method.PUT       => Tree.empty.copy(putRoot = subtree)
+        case Method.DELETE    => Tree.empty.copy(deleteRoot = subtree)
+        case Method.CONNECT   => Tree.empty.copy(connectRoot = subtree)
+        case Method.HEAD      => Tree.empty.copy(headRoot = subtree)
+        case Method.OPTIONS   => Tree.empty.copy(optionsRoot = subtree)
+        case Method.PATCH     => Tree.empty.copy(patchRoot = subtree)
+        case Method.TRACE     => Tree.empty.copy(traceRoot = subtree)
+        case Method.ANY       => Tree.empty.copy(anyRoot = subtree)
+        case m: Method.CUSTOM => Tree.empty.copy(customRoots = ListMap(m -> subtree))
+      }
     }
 
-    val empty: Tree[Nothing] = Tree(ListMap.empty)
+    val empty: Tree[Nothing] = Tree(
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      Map.empty,
+    )
   }
 
-  private def mergeMaps[A, B](left: ListMap[A, B], right: ListMap[A, B])(f: (B, B) => B): ListMap[A, B] =
+  private def mergeMaps[A, B](left: Map[A, B], right: Map[A, B])(f: (B, B) => B): Map[A, B] =
     right.foldLeft(left) { case (acc, (k, v)) =>
       val old = acc.get(k)
 

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -770,19 +770,22 @@ object PathCodec {
   ) {
     self =>
     def ++[A1 >: A](that: SegmentSubtree[A1]): SegmentSubtree[A1] = {
-      val newLiterals          = mergeMaps(self.literals, that.literals)(_ ++ _)
-      val newOthers            = mergeMaps(self.others, that.others)(_ ++ _)
-      val newLiteralCollisions = mergeLiteralCollisions(
-        self.literalsWithCollisions ++ that.literalsWithCollisions,
-        newLiterals.keySet,
-        newOthers.keys,
-      )
-      SegmentSubtree(
-        Map(newLiterals.toList: _*),
-        ListMap(newOthers.toList: _*),
-        newLiteralCollisions,
-        self.value ++ that.value,
-      )
+      if (that eq null) self
+      else {
+        val newLiterals          = mergeMaps(self.literals, that.literals)(_ ++ _)
+        val newOthers            = mergeMaps(self.others, that.others)(_ ++ _)
+        val newLiteralCollisions = mergeLiteralCollisions(
+          self.literalsWithCollisions ++ that.literalsWithCollisions,
+          newLiterals.keySet,
+          newOthers.keys,
+        )
+        SegmentSubtree(
+          Map(newLiterals.toList: _*),
+          ListMap(newOthers.toList: _*),
+          newLiteralCollisions,
+          self.value ++ that.value,
+        )
+      }
     }
 
     def add[A1 >: A](segments: Iterable[SegmentCodec[_]], value: A1): SegmentSubtree[A1] =


### PR DESCRIPTION
**Reasoning**
Most http apps don't use custom http methods. In fact most probably only use GET, POST, PUT and DELETE.
Having an efficient lookup for the default methods, seems the most reasonable solution.

Current impl.
```
[info] Benchmark                              Mode  Cnt      Score       Error  Units
[info] MethodLookupBenchmark.customMethods   thrpt    3  17133.273 ± 13370.029  ops/s
[info] MethodLookupBenchmark.defaultMethods  thrpt    3  18215.269 ± 17379.965  ops/s
```

Map instead of ListMap
```
[info] Benchmark                              Mode  Cnt      Score      Error  Units
[info] MethodLookupBenchmark.customMethods   thrpt    3  22974.932 ± 1760.853  ops/s
[info] MethodLookupBenchmark.defaultMethods  thrpt    3  25215.348 ± 4809.175  ops/s
```

New filed per default HTTP method
```
[info] Benchmark                              Mode  Cnt      Score      Error  Units
[info] MethodLookupBenchmark.customMethods   thrpt    3  31862.950 ± 3407.335  ops/s
[info] MethodLookupBenchmark.defaultMethods  thrpt    3  32393.768 ±  765.915  ops/s

```

fixes #3302
/claim #3302