### PR TITLE
Curl logger

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ZClientAspectSpec.scala
@@ -22,6 +22,8 @@ import zio._
 import zio.test.TestAspect.withLiveClock
 import zio.test._
 
+import zio.stream.ZStream
+
 import zio.http.URL.Location
 import zio.http.netty.NettyConfig
 
@@ -29,10 +31,12 @@ object ZClientAspectSpec extends ZIOHttpSpec {
   def extractStatus(response: Response): Status = response.status
 
   val routes: Routes[Any, Response] =
-    Route.handled(Method.GET / "hello")(Handler.fromResponse(Response.text("hello"))).toRoutes ++
-      Route
-        .handled(Method.POST / "hello")(Handler.fromFunctionZIO[Request](_.body.asString.map(Response.text(_)).orDie))
-        .toRoutes
+    Routes(
+      Route.handled(Method.GET / "hello")(Handler.fromResponse(Response.text("hello"))),
+      Route.handled(Method.POST / "hello")(
+        Handler.fromFunctionZIO[Request](_.body.asString.map(Response.text(_)).orDie),
+      ),
+    )
 
   val redir: Routes[Any, Response] =
     Route.handled(Method.GET / "redirect")(Handler.fromResponse(Response.redirect(URL.empty / "hello"))).toRoutes
@@ -129,7 +133,7 @@ object ZClientAspectSpec extends ZIOHttpSpec {
             )
           }
         },
-        test("with POST request") {
+        test("with non-streaming POST request") {
 
           for {
             port       <- Server.installRoutes(routes)
@@ -148,6 +152,31 @@ object ZClientAspectSpec extends ZIOHttpSpec {
                  |  --request POST \\
                  |  --header 'user-agent:${Client.defaultUAHeader.renderedValue}' \\
                  |  --data 'world' \\
+                 |  'http://localhost:${port}/hello'
+                 |""".stripMargin,
+            extractStatus(response) == Status.Ok,
+          )
+        },
+        test("with streaming POST request") {
+
+          for {
+            port       <- Server.installRoutes(routes)
+            baseClient <- ZIO.service[Client]
+            client = baseClient
+              .url(
+                URL(Path.empty, Location.Absolute(Scheme.HTTP, "localhost", Some(port))),
+              )
+              .batched @@ ZClientAspect.curlLogger(logEffect = m => Console.printLine(m).orDie)
+            response <- client.request(
+              Request.post(URL.empty / "hello", Body.fromStreamChunked(ZStream.fromIterable("world".getBytes))),
+            )
+            output   <- TestConsole.output
+          } yield assertTrue(
+            output.mkString("") ==
+              s"""curl \\
+                 |  --verbose \\
+                 |  --request POST \\
+                 |  --header 'user-agent:${Client.defaultUAHeader.renderedValue}' \\
                  |  'http://localhost:${port}/hello'
                  |""".stripMargin,
             extractStatus(response) == Status.Ok,

--- a/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
@@ -577,14 +577,9 @@ object ZClientAspect {
             body: Body,
             sslConfig: Option[ClientSSLConfig],
             proxy: Option[Proxy],
-          )(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Response] = {
-
-            val r: ZIO[Env & ReqEnv, Err, Response] =
+          )(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Response] =
               logEffect(formatCurlCommand(version, method, url, headers, body, proxy)) *>
-                oldDriver
-                  .request(version, method, url, headers, body, sslConfig, proxy)
-            r
-          }
+                oldDriver.request(version, method, url, headers, body, sslConfig, proxy)
 
           override def socket[Env1 <: Env](version: Version, url: URL, headers: Headers, app: WebSocketApp[Env1])(
             implicit

--- a/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
@@ -498,7 +498,7 @@ object ZClientAspect {
    */
   final def curlLogger(
     verbose: Boolean = true,
-    logEffect: String => ZIO[Any, Nothing, Unit] = (m: String) => ZIO.log(m),
+    logEffect: String => UIO[Unit] = (m: String) => ZIO.log(m),
   )(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
     new ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] {
 

--- a/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ZClientAspect.scala
@@ -492,4 +492,109 @@ object ZClientAspect {
           },
         )
     }
+
+  /**
+   * Client aspect that logs details of web request as curl command
+   */
+  final def curlLogger(
+    verbose: Boolean = true,
+    logEffect: String => ZIO[Any, Nothing, Unit] = (m: String) => ZIO.log(m),
+  )(implicit trace: Trace): ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] =
+    new ZClientAspect[Nothing, Any, Nothing, Body, Nothing, Any, Nothing, Response] {
+
+      def formatCurlCommand(
+        version: Version,
+        method: Method,
+        url: URL,
+        headers: Headers,
+        body: Body,
+        proxy: Option[Proxy],
+      ): String = {
+        val versionOpt = version match {
+          case Version.Default  => Chunk.empty
+          case Version.Http_1_0 => Chunk("--http1.0")
+          case Version.Http_1_1 => Chunk("--http1.1")
+        }
+        val verboseOpt = if (verbose) Chunk("--verbose") else Chunk.empty
+        val requestOpt = method match {
+          case Method.GET          => Chunk("--request GET")
+          case Method.POST         => Chunk("--request POST")
+          case Method.PUT          => Chunk("--request PUT")
+          case Method.DELETE       => Chunk("--request DELETE")
+          case Method.PATCH        => Chunk("--request PATCH")
+          case Method.HEAD         => Chunk("--request HEAD")
+          case Method.OPTIONS      => Chunk("--request OPTIONS")
+          case Method.CONNECT      => Chunk("--request CONNECT")
+          case Method.TRACE        => Chunk("--request TRACE")
+          case Method.CUSTOM(name) => Chunk(s"--request $name")
+          case Method.ANY          => Chunk("--request GET")
+        }
+        val headerOpt  = Chunk.fromIterable(headers.map(h => s"--header '${h.headerName}:${h.renderedValue}'"))
+        val bodyOpt    = body match {
+          case Body.empty => Chunk.empty
+          case body       => {
+            Chunk(s"--data '${body.asString.map(_.replace("'", "'\\''"))}'")
+          }
+        }
+        val proxyOpt   = proxy match {
+          case Some(proxy) =>
+            Chunk(
+              s"--proxy '${proxy.url}'" +
+                proxy.credentials.map(c => s" --proxy-user  '${c.uname}:${c.upassword}'") +
+                proxy.headers.map(h => s" --proxy-header '${h.headerName}:${h.renderedValue}'").mkString(" "),
+            )
+          case None        => Chunk.empty
+        }
+        (
+          Chunk("curl") ++
+            verboseOpt ++
+            requestOpt ++
+            headerOpt ++
+            versionOpt ++
+            proxyOpt ++
+            bodyOpt ++
+            Chunk.single("'" + url.encode + "'")
+        ).mkString(" \\\n  ")
+      }
+
+      override def apply[
+        ReqEnv,
+        Env >: Nothing <: Any,
+        In >: Nothing <: Body,
+        Err >: Nothing <: Any,
+        Out >: Nothing <: Response,
+      ](
+        client: ZClient[Env, ReqEnv, In, Err, Out],
+      ): ZClient[Env, ReqEnv, In, Err, Out] = {
+        val oldDriver = client.driver
+
+        val newDriver = new ZClient.Driver[Env, ReqEnv, Err] {
+          override def request(
+            version: Version,
+            method: Method,
+            url: URL,
+            headers: Headers,
+            body: Body,
+            sslConfig: Option[ClientSSLConfig],
+            proxy: Option[Proxy],
+          )(implicit trace: Trace): ZIO[Env & ReqEnv, Err, Response] = {
+
+            val r: ZIO[Env & ReqEnv, Err, Response] =
+              logEffect(formatCurlCommand(version, method, url, headers, body, proxy)) *>
+                oldDriver
+                  .request(version, method, url, headers, body, sslConfig, proxy)
+            r
+          }
+
+          override def socket[Env1 <: Env](version: Version, url: URL, headers: Headers, app: WebSocketApp[Env1])(
+            implicit
+            trace: Trace,
+            ev: ReqEnv =:= Scope,
+          ): ZIO[Env1 & ReqEnv, Err, Response] =
+            client.driver.socket(version, url, headers, app)
+        }
+
+        client.transform(client.bodyEncoder, client.bodyDecoder, newDriver)
+      }
+    }
 }


### PR DESCRIPTION
Hi all!

Sorry for the delay...! Here are the fixes for the issues raised in the this pull request:
https://github.com/zio/zio-http/pull/3285

As mentioned by @guizmaii  it is really nice to have an explicit formatter method for the any `zio.http.Request`, so I added one.
I also fixed the issues discovered by @987Nabil :
Check if the body can be consumed using `body.isComplete` and the bug were an effect is returned instead of the result of the effect. A second test explicitly checks for this issue.

It might be a good idea to start reorganizing the client aspects into a dedicated package, but I'm pretty bad with code reorganizations. 😓

Hope this is useful!