### PR TITLE
Show documentation for path segments

### DIFF
--- a/zio-http-example/src/main/scala/example/EndpointExamples.scala
+++ b/zio-http-example/src/main/scala/example/EndpointExamples.scala
@@ -13,7 +13,7 @@ object EndpointExamples extends ZIOAppDefault {
 
   // MiddlewareSpec can be added at the service level as well
   val getUser =
-    Endpoint(Method.GET / "users" / int("userId")).out[Int]
+    Endpoint(Method.GET / "users" / int("userId") ?? md"id of the user").out[Int]
 
   val getUserRoute =
     getUser.implement { id => ZIO.succeed(id) }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -796,7 +796,7 @@ object OpenAPIGen {
           OpenAPI.ReferenceOr.Or(
             OpenAPI.Parameter.pathParameter(
               name = mc.name.getOrElse(throw new Exception("Path parameter must have a name")),
-              description = mc.docsOpt.flatMap(_.flattened.filterNot(_ == pathDoc).reduceOption(_ + _)),
+              description = mc.docsOpt,
               definition = Some(OpenAPI.ReferenceOr.Or(JsonSchema.fromSegmentCodec(codec))),
               deprecated = mc.deprecated,
               style = OpenAPI.Parameter.Style.Simple,

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -121,13 +121,13 @@ object OpenAPISpec extends ZIOSpecDefault {
       assertTrue(toJsonAst(json) == toJsonAst(expected))
     },
     test("PathCodec has documentation") {
-        val segment = PathCodec.long("id") ?? md"Id of the user"
-        val post = Endpoint(RoutePattern.POST / "user" / segment).in[String].out[String]
-        val parameter = OpenAPIGen.gen(post, SchemaStyle.Compact).paths.toList.head._2.post.get.parameters.head
-        @nowarn
-        val Or(p: Parameter) = parameter
-        assertTrue(p.name == "id")
-        assertTrue(p.description.get.toCommonMark == "Id of the user")
-    }
+      val segment          = PathCodec.long("id") ?? md"Id of the user"
+      val post             = Endpoint(RoutePattern.POST / "user" / segment).in[String].out[String]
+      val parameter        = OpenAPIGen.gen(post, SchemaStyle.Compact).paths.toList.head._2.post.get.parameters.head
+      @nowarn
+      val Or(p: Parameter) = parameter
+      assertTrue(p.name == "id")
+      assertTrue(p.description.get.toCommonMark == "Id of the user")
+    },
   )
 }


### PR DESCRIPTION
I'm not sure what was the reason to aggregate documentation from all segments to main endpoint and remove it from path segments. I left it there and now it looks like this. Is it ok? I can update it if it should work differently.
<img width="461" alt="image" src="https://github.com/user-attachments/assets/26c9a859-bdc3-47fe-8681-99ae2f54b4c4" />
