### PR TITLE
Simplify `Routes`/`RoutePattern` trees

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RoutePatternSpec.scala
@@ -17,28 +17,29 @@
 package zio.http
 
 import java.util.UUID
+import javax.swing.plaf.metal.MetalIconFactory.TreeLeafIcon
 
-import zio.Chunk
 import zio.test._
 
 import zio.http.codec.Doc
 import zio.http.{int => _, uuid => _}
 
 object RoutePatternSpec extends ZIOHttpSpec {
-  import zio.http.Method
   import zio.http.RoutePattern._
 
   def tree     =
     suite("tree")(
       test("wildcard route") {
-        var tree: RoutePattern.Tree[Int] = RoutePattern.Tree.empty
+        var tree: RoutePattern.Tree[Any] = RoutePattern.Tree.empty
 
         val routePattern = RoutePattern.any
 
-        tree = tree.add(routePattern, 42)
+        val handler = Handler.ok
+
+        tree = tree.add(routePattern, handler)
 
         def check(method: Method, path: Path): TestResult =
-          assertTrue(tree.get(method, path) == Chunk(42))
+          assertTrue(tree.get(method, path) == handler)
 
         check(Method.GET, Path("")) &&
         check(Method.GET, Path("/")) &&
@@ -50,77 +51,51 @@ object RoutePatternSpec extends ZIOHttpSpec {
       test("wildcard method") {
         val routePattern = Method.ANY / "users"
 
-        var tree: RoutePattern.Tree[Unit] = RoutePattern.Tree.empty
+        var tree: RoutePattern.Tree[Any] = RoutePattern.Tree.empty
 
-        tree = tree.add(routePattern, ())
+        val handler = Handler.ok
+
+        tree = tree.add(routePattern, handler)
 
         assertTrue(
-          tree
-            .get(
-              Method.CUSTOM("foo"),
-              Path("/users"),
-            )
-            .nonEmpty,
-        ) &&
-        assertTrue(
-          tree
-            .get(
-              Method.GET,
-              Path("/users"),
-            )
-            .nonEmpty,
-        ) &&
-        assertTrue(
-          tree
-            .get(
-              Method.PUT,
-              Path("/users"),
-            )
-            .nonEmpty,
-        ) &&
-        assertTrue(
-          tree
-            .get(
-              Method.POST,
-              Path("/users"),
-            )
-            .nonEmpty,
-        ) && assertTrue(
-          tree
-            .get(
-              Method.DELETE,
-              Path("/users"),
-            )
-            .nonEmpty,
+          tree.get(Method.CUSTOM("foo"), Path("/users")) == handler,
+          tree.get(Method.GET, Path("/users")) == handler,
+          tree.get(Method.PUT, Path("/users")) == handler,
+          tree.get(Method.POST, Path("/users")) == handler,
+          tree.get(Method.DELETE, Path("/users")) == handler,
         )
       },
       test("empty tree") {
-        val tree = RoutePattern.Tree.empty
+        val tree = RoutePattern.Tree.empty[Any]
 
-        assertTrue(tree.get(Method.GET, Path("/")).isEmpty)
+        assertTrue(tree.get(Method.GET, Path("/")) == null)
       },
       test("xyz GET /users") {
-        var tree: Tree[Unit] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern = Method.GET / "users"
 
-        tree = tree.add(pattern, ())
+        val handler = Handler.ok
+
+        tree = tree.add(pattern, handler)
 
         assertTrue(
-          tree.get(Method.GET, Path("/users")).nonEmpty,
-          tree.get(Method.POST, Path("/users")).isEmpty,
+          tree.get(Method.GET, Path("/users")) == handler,
+          tree.get(Method.POST, Path("/users")) == null,
         )
       },
       test("GET /users/{user-id}/posts/{post-id}") {
-        var tree: Tree[Unit] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern = Method.GET / "users" / int("user-id") / "posts" / string("post-id")
 
-        tree = tree.add(pattern, ())
+        val handler = Handler.ok
+
+        tree = tree.add(pattern, handler)
 
         assertTrue(
-          tree.get(Method.GET, Path("/users/1/posts/abc")).nonEmpty,
-          tree.get(Method.GET, Path("/users/abc/posts/1")).isEmpty,
+          tree.get(Method.GET, Path("/users/1/posts/abc")) == handler,
+          tree.get(Method.GET, Path("/users/abc/posts/1")) == null,
         )
       },
       test("GET /users/{string-param}/{user-id:uuid} issue 3005") {
@@ -128,128 +103,127 @@ object RoutePatternSpec extends ZIOHttpSpec {
         val routePattern2 = Method.GET / "users" / string("param") / uuid("id") / "hello"
 
         val id              = UUID.randomUUID()
-        var tree: Tree[Int] = RoutePattern.Tree.empty
-        tree = tree.add(routePattern1, 1)
-        tree = tree.add(routePattern2, 2)
+        var tree: Tree[Any] = RoutePattern.Tree.empty
+        val handler1        = Handler.ok
+        val handler2        = Handler.notFound
+        tree = tree.add(routePattern1, handler1)
+        tree = tree.add(routePattern2, handler2)
 
         val p1 = Path(s"/users/some_value/abc/$id/hello")
         val p2 = Path(s"/users/some_value/$id/hello")
         assertTrue(
           routePattern1.decode(Method.GET, p1) == Right(("some_value", id)),
           routePattern2.decode(Method.GET, p2) == Right(("some_value", id)),
-          tree.get(Method.GET, p1).contains(1),
-          tree.get(Method.GET, p2).contains(2),
+          tree.get(Method.GET, p1) == handler1,
+          tree.get(Method.GET, p2) == handler2,
         )
       },
       suite("collisions properly resolved")(
         test("simple collision between literal and text segment i3036") {
-          val routes: Chunk[RoutePattern[_]] =
-            Chunk(Method.GET / "users" / "param1" / "fixed", Method.GET / "users" / string("param") / "dynamic")
-
-          var tree: Tree[Int] = RoutePattern.Tree.empty
-          routes.zipWithIndexFrom(1).foreach { case (routePattern, idx) =>
-            tree = tree.add(routePattern, idx)
-          }
+          val tree: Tree[Any] = Tree
+            .empty[Any]
+            .addAll(
+              List(
+                (Method.GET / "users" / "param1" / "fixed", Handler.ok),
+                (Method.GET / "users" / string("param") / "dynamic", Handler.notFound),
+              ),
+            )
 
           assertTrue(
-            tree.get(Method.GET, Path("/users/param1/fixed")).contains(1),
-            tree.get(Method.GET, Path("/users/param1/dynamic")).contains(2),
+            tree.get(Method.GET, Path("/users/param1/fixed")) == Handler.ok,
+            tree.get(Method.GET, Path("/users/param1/dynamic")) == Handler.notFound,
           )
         },
         test("two collisions between literal and text segment") {
-          val routes: Chunk[RoutePattern[_]] = Chunk(
-            Method.GET / "users" / "param1" / "literal1" / "p1" / "tail1",
-            Method.GET / "users" / "param1" / "literal1" / string("p2") / "tail2",
-            Method.GET / "users" / string("param") / "literal1" / "p1" / "tail3",
-            Method.GET / "users" / string("param") / "literal1" / string("p2") / "tail4",
-          )
-
-          var tree: Tree[Int] = RoutePattern.Tree.empty
-          routes.zipWithIndexFrom(1).foreach { case (routePattern, idx) =>
-            tree = tree.add(routePattern, idx)
-          }
+          val tree: Tree[Any] = Tree
+            .empty[Any]
+            .addAll(
+              List(
+                (Method.GET / "users" / "param1" / "literal1" / "p1" / "tail1", Handler.ok),
+                (Method.GET / "users" / "param1" / "literal1" / string("p2") / "tail2", Handler.notFound),
+                (Method.GET / "users" / string("param") / "literal1" / "p1" / "tail3", Handler.badRequest),
+                (Method.GET / "users" / string("param") / "literal1" / string("p2") / "tail4", Handler.tooLarge),
+              ),
+            )
 
           assertTrue(
-            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail1")).contains(1),
-            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail2")).contains(2),
-            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail3")).contains(3),
-            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail4")).contains(4),
+            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail1")) == Handler.ok,
+            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail2")) == Handler.notFound,
+            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail3")) == Handler.badRequest,
+            tree.get(Method.GET, Path("/users/param1/literal1/p1/tail4")) == Handler.tooLarge,
           )
         },
         test("collision where distinguish is by literal and int segment") {
-          val routes: Chunk[RoutePattern[_]] = Chunk(
-            Method.GET / "users" / "param1" / int("id"),
-            Method.GET / "users" / string("param") / "dynamic",
-          )
-
-          var tree: Tree[Int] = RoutePattern.Tree.empty
-          routes.zipWithIndexFrom(1).foreach { case (routePattern, idx) =>
-            tree = tree.add(routePattern, idx)
-          }
+          val tree: Tree[Any] = Tree
+            .empty[Any]
+            .addAll(
+              List(
+                (Method.GET / "users" / "param1" / int("id"), Handler.ok),
+                (Method.GET / "users" / string("param") / "dynamic", Handler.notFound),
+              ),
+            )
 
           val r1 = tree.get(Method.GET, Path("/users/param1/155"))
           val r2 = tree.get(Method.GET, Path("/users/param1/dynamic"))
 
           assertTrue(
-            r1.contains(1),
-            r2.contains(2),
+            r1 == Handler.ok,
+            r2 == Handler.notFound,
           )
         },
         test("collision where distinguish is by two not literal segments") {
-          val uuid1                          = new UUID(10, 10)
-          val routes: Chunk[RoutePattern[_]] = Chunk(
-            Method.GET / "users" / "param1" / int("id"),
-            Method.GET / "users" / string("param") / uuid("dynamic"),
-          )
-
-          var tree: Tree[Int] = RoutePattern.Tree.empty
-          routes.zipWithIndexFrom(1).foreach { case (routePattern, idx) =>
-            tree = tree.add(routePattern, idx)
-          }
-
-          val r2 = tree.get(Method.GET, Path(s"/users/param1/$uuid1"))
-          val r1 = tree.get(Method.GET, Path("/users/param1/155"))
+          val uuid1           = new UUID(10, 10)
+          val tree: Tree[Any] = Tree
+            .empty[Any]
+            .addAll(
+              List(
+                (Method.GET / "users" / "param1" / int("id"), Handler.ok),
+                (Method.GET / "users" / string("param") / uuid("dynamic"), Handler.notFound),
+              ),
+            )
+          val r2              = tree.get(Method.GET, Path(s"/users/param1/$uuid1"))
+          val r1              = tree.get(Method.GET, Path("/users/param1/155"))
 
           assertTrue(
-            r1.contains(1),
-            r2.contains(2),
+            r1 == Handler.ok,
+            r2 == Handler.notFound,
           )
         },
       ),
-      test("on conflict, first one wins") {
-        var tree: Tree[Int] = RoutePattern.Tree.empty
+      test("on conflict, last one wins") {
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern1 = Method.GET / "users"
         val pattern2 = Method.GET / "users"
 
-        tree = tree.add(pattern1, 1)
-        tree = tree.add(pattern2, 2)
+        tree = tree.add(pattern1, Handler.ok)
+        tree = tree.add(pattern2, Handler.notFound)
 
-        assertTrue(tree.get(Method.GET, Path("/users")).contains(1))
+        assertTrue(tree.get(Method.GET, Path("/users")) == Handler.notFound)
       },
       test("on conflict, trailing loses") {
-        var tree: Tree[Int] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern1 = Method.GET / "users" / "123"
         val pattern2 = Method.GET / "users" / trailing / "123"
 
-        tree = tree.add(pattern2, 2)
-        tree = tree.add(pattern1, 1)
+        tree = tree.add(pattern2, Handler.ok)
+        tree = tree.add(pattern1, Handler.notFound)
 
-        assertTrue(tree.get(Method.GET, Path("/users/123")).contains(1))
+        tree.get(Method.GET, Path("/users/123"))(Request()).map(r => assertTrue(r.status == Status.NotFound))
       },
       test("more specific beats less specific") {
-        var tree: Tree[Int] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern1 = Method.ANY / "users"
         val pattern2 = Method.OPTIONS / "users"
         val pattern3 = Method.ANY / "users"
 
-        tree = tree.add(pattern1, 1)
-        tree = tree.add(pattern2, 2)
-        tree = tree.add(pattern3, 3)
+        tree = tree.add(pattern1, Handler.ok)
+        tree = tree.add(pattern2, Handler.notFound)
+        tree = tree.add(pattern3, Handler.badRequest)
 
-        assertTrue(tree.get(Method.OPTIONS, Path("/users")) == Chunk(2))
+        assertTrue(tree.get(Method.OPTIONS, Path("/users")) == Handler.notFound)
       },
       test("multiple routes") {
         var tree: Tree[Unit] = RoutePattern.Tree.empty
@@ -257,53 +231,51 @@ object RoutePatternSpec extends ZIOHttpSpec {
         val pattern1 = Method.GET / "users"
         val pattern2 = Method.GET / "users" / int("user-id") / "posts" / string("post-id")
 
-        tree = tree.add(pattern1, ())
-        tree = tree.add(pattern2, ())
+        tree = tree.add(pattern1, Handler.ok)
+        tree = tree.add(pattern2, Handler.notFound)
 
-        assertTrue(tree.get(Method.GET, Path("/users")).nonEmpty) &&
-        assertTrue(tree.get(Method.GET, Path("/users/1/posts/abc")).nonEmpty)
+        assertTrue(
+          tree.get(Method.GET, Path("/users")) == Handler.ok,
+          tree.get(Method.GET, Path("/users/1/posts/abc")) == Handler.notFound,
+        )
       },
       test("overlapping routes") {
-        var tree: Tree[Int] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern1 = Method.GET / "users" / int("user-id")
         val pattern2 = Method.GET / "users" / int("user-id") / "posts" / string("post-id")
 
-        tree = tree.add(pattern1, 1)
-        tree = tree.add(pattern2, 2)
+        tree = tree.add(pattern1, Handler.ok)
+        tree = tree.add(pattern2, Handler.notFound)
 
-        assertTrue(tree.get(Method.GET, Path("/users/1")).contains(1)) &&
-        assertTrue(tree.get(Method.GET, Path("/users/1/posts/abc")).contains(2))
+        assertTrue(
+          tree.get(Method.GET, Path("/users/1")) == Handler.ok,
+          tree.get(Method.GET, Path("/users/1/posts/abc")) == Handler.notFound,
+        )
       },
       test("get with prefix") {
-        var tree: Tree[Unit] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern = Method.GET / "users"
 
-        tree = tree.add(pattern, ())
+        tree = tree.add(pattern, Handler.ok)
 
         assertTrue(
-          tree.get(Method.GET, Path("/users/1")).isEmpty,
+          tree.get(Method.GET, Path("/users/1")) == null,
         )
       },
       test("trailing route pattern can handle all paths") {
-        var tree: Tree[Unit] = RoutePattern.Tree.empty
+        var tree: Tree[Any] = RoutePattern.Tree.empty
 
         val pattern = Method.GET / "users" / trailing
 
-        tree = tree.add(pattern, ())
+        tree = tree.add(pattern, Handler.ok)
 
         assertTrue(
-          tree.get(Method.GET, Path("/posts/")).isEmpty,
-        ) &&
-        assertTrue(
-          tree.get(Method.GET, Path("/users/1")).nonEmpty,
-        ) &&
-        assertTrue(
-          tree.get(Method.GET, Path("/users/1/posts/abc")).nonEmpty,
-        ) &&
-        assertTrue(
-          tree.get(Method.GET, Path("/users/1/posts/abc/def")).nonEmpty,
+          tree.get(Method.GET, Path("/posts/")) == null,
+          tree.get(Method.GET, Path("/users/1")) == Handler.ok,
+          tree.get(Method.GET, Path("/users/1/posts/abc")) == Handler.ok,
+          tree.get(Method.GET, Path("/users/1/posts/abc/def")) == Handler.ok,
         )
       },
     )
@@ -316,8 +288,6 @@ object RoutePatternSpec extends ZIOHttpSpec {
 
           assertTrue(
             variant1.decode(Method.GET, Path("/")) == variant2.decode(Method.GET, Path("/")),
-          ) &&
-          assertTrue(
             variant1.decode(Method.GET, Path("/users")) == variant2.decode(Method.GET, Path("/users")),
           )
         },
@@ -352,27 +322,27 @@ object RoutePatternSpec extends ZIOHttpSpec {
             val routePattern = Method.ANY / "users"
 
             assertTrue(
-              routePattern.decode(
-                Method.GET,
-                Path("/users"),
-              ) == Right(()),
-            ) &&
-            assertTrue(
-              routePattern.decode(
-                Method.PUT,
-                Path("/users"),
-              ) == Right(()),
-            ) &&
-            assertTrue(
-              routePattern.decode(
-                Method.POST,
-                Path("/users"),
-              ) == Right(()),
-            ) && assertTrue(
-              routePattern.decode(
-                Method.DELETE,
-                Path("/users"),
-              ) == Right(()),
+              {
+                routePattern.decode(
+                  Method.GET,
+                  Path("/users"),
+                ) == Right(())
+              }, {
+                routePattern.decode(
+                  Method.PUT,
+                  Path("/users"),
+                ) == Right(())
+              }, {
+                routePattern.decode(
+                  Method.POST,
+                  Path("/users"),
+                ) == Right(())
+              }, {
+                routePattern.decode(
+                  Method.DELETE,
+                  Path("/users"),
+                ) == Right(())
+              },
             )
           },
           test("* ...") {
@@ -474,8 +444,6 @@ object RoutePatternSpec extends ZIOHttpSpec {
   def rendering =
     suite("rendering")(
       test("GET /users") {
-        import zio.http.Method
-
         assertTrue((Method.GET / "users").render == "GET /users")
       },
       test("GET /users/{user-id}/posts/{post-id}") {

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -724,7 +724,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   /**
    * Creates a handler which always responds with a 400 status code.
    */
-  def badRequest: Handler[Any, Nothing, Any, Response] =
+  val badRequest: Handler[Any, Nothing, Any, Response] =
     error(Status.BadRequest)
 
   /**
@@ -1025,7 +1025,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   /**
    * Creates a handler that fails with a NotFound exception.
    */
-  def notFound: Handler[Any, Nothing, Request, Response] =
+  val notFound: Handler[Any, Nothing, Request, Response] =
     Handler
       .fromFunctionHandler[Request] { request =>
         error(Status.NotFound, request.url.path.encode)
@@ -1037,7 +1037,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   /**
    * Creates a handler which always responds with a 200 status code.
    */
-  def ok: Handler[Any, Nothing, Any, Response] =
+  val ok: Handler[Any, Nothing, Any, Response] =
     status(Status.Ok)
 
   /**
@@ -1104,7 +1104,7 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
   /**
    * Creates a handler which always responds with a 413 status code.
    */
-  def tooLarge: Handler[Any, Nothing, Any, Response] =
+  val tooLarge: Handler[Any, Nothing, Any, Response] =
     Handler.status(Status.RequestEntityTooLarge)
 
   val unit: Handler[Any, Nothing, Any, Unit] =

--- a/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
@@ -630,15 +630,15 @@ private[http] trait HandlerAspects extends zio.http.internal.HeaderModifier[Hand
    */
   def requestLogging(
     level: Status => LogLevel = (_: Status) => LogLevel.Info,
-    loggedRequestHeaders: Set[Header.HeaderType] = Set.empty,
-    loggedResponseHeaders: Set[Header.HeaderType] = Set.empty,
+    loggedRequestHeaders: Set[Header.HeaderTypeBase] = Set.empty,
+    loggedResponseHeaders: Set[Header.HeaderTypeBase] = Set.empty,
     logRequestBody: Boolean = false,
     logResponseBody: Boolean = false,
     requestCharset: Charset = StandardCharsets.UTF_8,
     responseCharset: Charset = StandardCharsets.UTF_8,
   )(implicit trace: Trace): HandlerAspect[Any, Unit] = {
-    val loggedRequestHeaderNames  = loggedRequestHeaders.map(_.name.toLowerCase)
-    val loggedResponseHeaderNames = loggedResponseHeaders.map(_.name.toLowerCase)
+    val loggedRequestHeaderNames  = loggedRequestHeaders.flatMap(_.names.map(_.toLowerCase))
+    val loggedResponseHeaderNames = loggedResponseHeaders.flatMap(_.names.map(_.toLowerCase))
 
     HandlerAspect.interceptHandlerStateful(Handler.fromFunctionZIO[Request] { request =>
       zio.Clock.instant.map(now => ((now, request), (request, ())))

--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -174,20 +174,20 @@ object RoutePattern                                                       {
   /**
    * A tree of route patterns, indexed by method and path.
    */
-  private[http] final case class Tree[+A](
-    anyRoot: SegmentSubtree[A],
-    connectRoot: SegmentSubtree[A],
-    deleteRoot: SegmentSubtree[A],
-    getRoot: SegmentSubtree[A],
-    headRoot: SegmentSubtree[A],
-    optionsRoot: SegmentSubtree[A],
-    patchRoot: SegmentSubtree[A],
-    postRoot: SegmentSubtree[A],
-    putRoot: SegmentSubtree[A],
-    traceRoot: SegmentSubtree[A],
-    customRoots: Map[Method, SegmentSubtree[A]],
+  private[http] final case class Tree[Env](
+    anyRoot: SegmentSubtree[Env],
+    connectRoot: SegmentSubtree[Env],
+    deleteRoot: SegmentSubtree[Env],
+    getRoot: SegmentSubtree[Env],
+    headRoot: SegmentSubtree[Env],
+    optionsRoot: SegmentSubtree[Env],
+    patchRoot: SegmentSubtree[Env],
+    postRoot: SegmentSubtree[Env],
+    putRoot: SegmentSubtree[Env],
+    traceRoot: SegmentSubtree[Env],
+    customRoots: Map[Method, SegmentSubtree[Env]],
   ) { self =>
-    def ++[A1 >: A](that: Tree[A1]): Tree[A1] =
+    def ++[Env1 >: Env](that: Tree[Env1]): Tree[Env1] =
       Tree(
         if (self.anyRoot != null) self.anyRoot ++ that.anyRoot else that.anyRoot,
         if (self.connectRoot != null) self.connectRoot ++ that.connectRoot else that.connectRoot,
@@ -199,19 +199,19 @@ object RoutePattern                                                       {
         if (self.postRoot != null) self.postRoot ++ that.postRoot else that.postRoot,
         if (self.putRoot != null) self.putRoot ++ that.putRoot else that.putRoot,
         if (self.traceRoot != null) self.traceRoot ++ that.traceRoot else that.traceRoot,
-        mergeMaps(self.customRoots, that.customRoots)(_ ++ _),
+        mergeMaps(self.customRoots.asInstanceOf[Map[Method, SegmentSubtree[Env1]]], that.customRoots),
       )
 
-    def add[A1 >: A](routePattern: RoutePattern[_], value: A1): Tree[A1] =
+    def add[Env1 >: Env](routePattern: RoutePattern[_], value: RequestHandler[Env1, Response]): Tree[Env1] =
       self ++ Tree(routePattern, value)
 
-    def addAll[A1 >: A](pathPatterns: Iterable[(RoutePattern[_], A1)]): Tree[A1] =
-      pathPatterns.foldLeft[Tree[A1]](self) { case (tree, (p, v)) =>
+    def addAll[Env1 >: Env](pathPatterns: Iterable[(RoutePattern[_], RequestHandler[Env1, Response])]): Tree[Env1] =
+      pathPatterns.foldLeft[Tree[Env1]](self.asInstanceOf[Tree[Env1]]) { case (tree, (p, v)) =>
         tree.add(p, v)
       }
 
-    def get(method: Method, path: Path): Chunk[A] = {
-      val forMethod = {
+    def get(method: Method, path: Path): RequestHandler[Env, Response] = {
+      val forMethod: RequestHandler[Env, Response] = {
         method match {
           case Method.GET if getRoot != null               => getRoot.get(path)
           case Method.POST if postRoot != null             => postRoot.get(path)
@@ -224,14 +224,14 @@ object RoutePattern                                                       {
           case Method.TRACE if traceRoot != null           => traceRoot.get(path)
           case Method.ANY if anyRoot != null               => anyRoot.get(path)
           case m: Method.CUSTOM if customRoots.contains(m) => customRoots(m).get(path)
-          case _                                           => Chunk.empty
+          case _                                           => null.asInstanceOf[RequestHandler[Env, Response]]
         }
       }
 
-      if (forMethod.isEmpty && anyRoot != null) anyRoot.get(path) else forMethod
+      if (forMethod == null && anyRoot != null) anyRoot.get(path) else forMethod
     }
 
-    def map[B](f: A => B): Tree[B] =
+    def map[Env1](f: RequestHandler[Env, Response] => RequestHandler[Env1, Response]): Tree[Env1] =
       Tree(
         if (anyRoot != null) anyRoot.map(f) else null,
         if (connectRoot != null) connectRoot.map(f) else null,
@@ -247,27 +247,31 @@ object RoutePattern                                                       {
       )
   }
   private[http] object Tree {
-    def apply[A](routePattern: RoutePattern[_], value: A): Tree[A] = {
+    def apply[Env](routePattern: RoutePattern[_], value: RequestHandler[Env, Response]): Tree[Env] = {
       val segments = routePattern.pathCodec.segments
 
       val subtree = SegmentSubtree.single(segments, value)
 
+      val empty = Tree.empty[Env]
+
       routePattern.method match {
-        case Method.GET       => Tree.empty.copy(getRoot = subtree)
-        case Method.POST      => Tree.empty.copy(postRoot = subtree)
-        case Method.PUT       => Tree.empty.copy(putRoot = subtree)
-        case Method.DELETE    => Tree.empty.copy(deleteRoot = subtree)
-        case Method.CONNECT   => Tree.empty.copy(connectRoot = subtree)
-        case Method.HEAD      => Tree.empty.copy(headRoot = subtree)
-        case Method.OPTIONS   => Tree.empty.copy(optionsRoot = subtree)
-        case Method.PATCH     => Tree.empty.copy(patchRoot = subtree)
-        case Method.TRACE     => Tree.empty.copy(traceRoot = subtree)
-        case Method.ANY       => Tree.empty.copy(anyRoot = subtree)
-        case m: Method.CUSTOM => Tree.empty.copy(customRoots = ListMap(m -> subtree))
+        case Method.GET       => empty.copy(getRoot = subtree)
+        case Method.POST      => empty.copy(postRoot = subtree)
+        case Method.PUT       => empty.copy(putRoot = subtree)
+        case Method.DELETE    => empty.copy(deleteRoot = subtree)
+        case Method.CONNECT   => empty.copy(connectRoot = subtree)
+        case Method.HEAD      => empty.copy(headRoot = subtree)
+        case Method.OPTIONS   => empty.copy(optionsRoot = subtree)
+        case Method.PATCH     => empty.copy(patchRoot = subtree)
+        case Method.TRACE     => empty.copy(traceRoot = subtree)
+        case Method.ANY       => empty.copy(anyRoot = subtree)
+        case m: Method.CUSTOM => empty.copy(customRoots = Map(m -> subtree))
       }
     }
 
-    val empty: Tree[Nothing] = Tree(
+    def empty[Env]: Tree[Env] = empty0.asInstanceOf[Tree[Env]]
+
+    private val empty0: Tree[Any] = Tree(
       null,
       null,
       null,
@@ -282,13 +286,16 @@ object RoutePattern                                                       {
     )
   }
 
-  private def mergeMaps[A, B](left: Map[A, B], right: Map[A, B])(f: (B, B) => B): Map[A, B] =
+  private def mergeMaps[B](
+    left: Map[Method, SegmentSubtree[B]],
+    right: Map[Method, SegmentSubtree[B]],
+  ): Map[Method, SegmentSubtree[B]] =
     right.foldLeft(left) { case (acc, (k, v)) =>
       val old = acc.get(k)
 
       old match {
         case None     => acc.updated(k, v)
-        case Some(v0) => acc.updated(k, f(v0, v))
+        case Some(v0) => acc.updated(k, v0 ++ v)
       }
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -172,7 +172,7 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
    * method and path of the specified request.
    */
   def isDefinedAt(request: Request)(implicit ev: Err <:< Response): Boolean =
-    tree(Trace.empty, ev).get(request.method, request.path).nonEmpty
+    tree(Trace.empty, ev).get(request.method, request.path) != null
 
   def provide[Env1 <: Env](env: Env1)(implicit tag: Tag[Env1]): Routes[Any, Err] =
     provideEnvironment(ZEnvironment(env))
@@ -261,15 +261,11 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
       _handler = {
         implicit val trace: Trace = Trace.empty
         val (unique, duplicates)  = uniqueRoutes
-        val tree                  = Routes(unique).tree
+        val tree                  = Routes(unique).tree[Env]
         val h                     = Handler
           .fromFunctionHandler[Request] { req =>
-            val chunk = tree.get(req.method, req.path)
-            chunk.length match {
-              case 0 => Handler.notFound
-              case 1 => chunk(0)
-              case _ => throw new IllegalStateException("Multiple routes found for the same path")
-            }
+            val handler = tree.get(req.method, req.path)
+            if (handler eq null) Handler.notFound else handler
           }
           .merge
           .asInstanceOf[Handler[Any, Nothing, Request, Response]]
@@ -310,11 +306,11 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
   /**
    * Accesses the underlying tree that provides fast dispatch to handlers.
    */
-  def tree(implicit trace: Trace, ev: Err <:< Response): Routes.Tree[Env] = {
+  def tree[Env1 <: Env](implicit trace: Trace, ev: Err <:< Response): Routes.Tree[Env1] = {
     if (_tree eq null) {
-      _tree = Routes.Tree.fromRoutes(routes.asInstanceOf[Chunk[Route[Env, Response]]])
+      _tree = Routes.Tree.fromRoutes(routes.asInstanceOf[Chunk[Route[Env1, Response]]])
     }
-    _tree.asInstanceOf[Routes.Tree[Env]]
+    _tree.asInstanceOf[Routes.Tree[Env1]]
   }
 
   private[http] def uniqueRoutes: (Chunk[Route[Env, Err]], Chunk[Route[Env, Err]]) = {
@@ -381,21 +377,29 @@ object Routes extends RoutesCompanionVersionSpecific {
   def serveResources(path: Path, resourcePrefix: String = "public")(implicit trace: Trace): Routes[Any, Nothing] =
     empty @@ Middleware.serveResources(path, resourcePrefix)
 
-  private[http] final case class Tree[-Env](tree: RoutePattern.Tree[RequestHandler[Env, Response]]) { self =>
+  private[http] final case class Tree[Env](tree: RoutePattern.Tree[Env]) { self =>
     final def ++[Env1 <: Env](that: Tree[Env1]): Tree[Env1] =
-      Tree(self.tree ++ that.tree)
+      Tree(self.tree.asInstanceOf[RoutePattern.Tree[Env1]] ++ that.tree)
 
     final def add[Env1 <: Env](route: Route[Env1, Response])(implicit trace: Trace): Tree[Env1] =
-      Tree(self.tree.addAll(route.routePattern.alternatives.map(alt => (alt, route.toHandler))))
+      Tree(
+        self.tree
+          .asInstanceOf[RoutePattern.Tree[Env1]]
+          .addAll(route.routePattern.alternatives.map(alt => (alt, route.toHandler))),
+      )
 
     final def addAll[Env1 <: Env](routes: Iterable[Route[Env1, Response]])(implicit trace: Trace): Tree[Env1] =
       // only change to flatMap when Scala 2.12 is dropped
-      Tree(self.tree.addAll(routes.map(r => r.routePattern.alternatives.map(alt => (alt, r.toHandler))).flatten))
+      Tree(
+        self.tree
+          .asInstanceOf[RoutePattern.Tree[Env1]]
+          .addAll(routes.map(r => r.routePattern.alternatives.map(alt => (alt, r.toHandler))).flatten),
+      )
 
-    final def get(method: Method, path: Path): Chunk[RequestHandler[Env, Response]] =
+    final def get(method: Method, path: Path): RequestHandler[Env, Response] =
       tree.get(method, path)
   }
-  private[http] object Tree                                                                         {
+  private[http] object Tree                                              {
     val empty: Tree[Any] = Tree(RoutePattern.Tree.empty)
 
     def fromRoutes[Env](routes: Chunk[zio.http.Route[Env, Response]])(implicit trace: Trace): Tree[Env] =

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -20,7 +20,7 @@ import java.net.{MalformedURLException, URI}
 
 import scala.util.control.NonFatal
 
-import zio.Config
+import zio.{Config, ZIO, durationInt}
 
 import zio.http.URL.{Fragment, Location}
 import zio.http.internal._


### PR DESCRIPTION
fixes #3408 
/claim #3408


**Benchmark Results**
```
Old:
[info] Benchmark                                   Mode  Cnt      Score       Error  Units
[info] RoutesBenchmark.benchmarkSmallDataZioApi   thrpt    3  32930.757 ± 20407.643  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi2  thrpt    3  42425.839 ±  7626.782  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi3  thrpt    3  51836.349 ±  2721.059  ops/s
[info] RoutesBenchmark.notFound1                  thrpt    3  22016.697 ±  2269.065  ops/s
[info] RoutesBenchmark.notFound2                  thrpt    3  19405.132 ±  2278.351  ops/s

[info] Benchmark                                            Mode  Cnt   Score    Error  Units
[info] RoundtripBenchmark.roundtripBenchmarkJavaClientAPI  thrpt    3  13.135 ± 10.142  ops/s

New:
[info] Benchmark                                   Mode  Cnt      Score      Error  Units
[info] RoutesBenchmark.benchmarkSmallDataZioApi   thrpt    3  39949.578 ±  612.926  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi2  thrpt    3  64732.621 ± 4345.785  ops/s
[info] RoutesBenchmark.benchmarkSmallDataZioApi3  thrpt    3  69094.709 ± 4062.645  ops/s
[info] RoutesBenchmark.notFound1                  thrpt    3  13494.307 ±  581.835  ops/s
[info] RoutesBenchmark.notFound2                  thrpt    3  21118.038 ±  423.684  ops/s

[info] Benchmark                                            Mode  Cnt   Score   Error  Units
[info] RoundtripBenchmark.roundtripBenchmarkJavaClientAPI  thrpt    3  16.851 ± 0.611  ops/s
```