### PR TITLE
Improve `From#toQueryParams` performance (#3289)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,6 +444,44 @@ jobs:
           name: Jmh_Main_EndpointBenchmark
           path: Main_EndpointBenchmark.txt
 
+  Jmh_FormToQueryBenchmark:
+    name: Jmh FormToQueryBenchmark
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [2.13.16]
+        java: [zulu@8]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: coursier/setup-action@v1
+        with:
+          apps: sbt
+
+      - uses: actions/checkout@v4
+        with:
+          path: zio-http
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Benchmark_Main
+        id: Benchmark_Main
+        env:
+          GITHUB_TOKEN: ${{secrets.ACTIONS_PAT}}
+        run: |
+          cd zio-http
+          sed -i -e '$aaddSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")' project/plugins.sbt
+          cat > Main_FormToQueryBenchmark.txt
+          sbt -no-colors -v "zioHttpBenchmarks/jmh:run -i 3 -wi 3 -f1 -t1 FormToQueryBenchmark" | grep -e "thrpt" -e "avgt" >> ../Main_FormToQueryBenchmark.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Jmh_Main_FormToQueryBenchmark
+          path: Main_FormToQueryBenchmark.txt
+
   Jmh_HttpCollectEval:
     name: Jmh HttpCollectEval
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -864,7 +902,7 @@ jobs:
 
   Jmh_cache:
     name: Cache Jmh benchmarks
-    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_MethodLookupBenchmark, Jmh_ProbeContentTypeBenchmark, Jmh_RoundtripBenchmark, Jmh_RoutesBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
+    needs: [Jmh_CachedDateHeaderBenchmark, Jmh_ClientBenchmark, Jmh_CookieDecodeBenchmark, Jmh_EndpointBenchmark, Jmh_FormToQueryBenchmark, Jmh_HttpCollectEval, Jmh_HttpCombineEval, Jmh_HttpNestedFlatMapEval, Jmh_HttpRouteTextPerf, Jmh_MethodLookupBenchmark, Jmh_ProbeContentTypeBenchmark, Jmh_RoundtripBenchmark, Jmh_RoutesBenchmark, Jmh_SchemeDecodeBenchmark, Jmh_ServerInboundHandlerBenchmark, Jmh_UtilBenchmark]
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     strategy:
       matrix:
@@ -900,6 +938,13 @@ jobs:
 
       - name: Format_Main_EndpointBenchmark
         run: cat Main_EndpointBenchmark.txt >> Main_benchmarks.txt
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Jmh_Main_FormToQueryBenchmark
+
+      - name: Format_Main_FormToQueryBenchmark
+        run: cat Main_FormToQueryBenchmark.txt >> Main_benchmarks.txt
 
       - uses: actions/download-artifact@v4
         with:

--- a/zio-http-benchmarks/src/main/scala/benchmark/FormToQueryBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/benchmark/FormToQueryBenchmark.scala
@@ -1,12 +1,14 @@
 package benchmark
 
-import org.openjdk.jmh.annotations._
-import zio._
-import zio.http._
-
 import java.net.http.{HttpClient, HttpRequest, HttpResponse}
 import java.net.{ConnectException, URI}
 import java.util.concurrent.TimeUnit
+
+import zio._
+
+import zio.http._
+
+import org.openjdk.jmh.annotations._
 
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -14,19 +16,22 @@ import java.util.concurrent.TimeUnit
 class FormToQueryBenchmark {
 
   val forms: List[Form] = List.fill(1000)(
-    Form.fromQueryParams(QueryParams.apply(Map(
-        "from" -> Chunk("2021-01-01T00:00:00Z"),
-        "to" -> Chunk("2021-01-02T00:00:00Z"),
-        "limit" -> Chunk("100"),
-        "offset" -> Chunk("0"),
-        "sort" -> Chunk("asc"),
-        "filter" -> Chunk("true")
-    ))
+    Form.fromQueryParams(
+      QueryParams.apply(
+        Map(
+          "from"   -> Chunk("2021-01-01T00:00:00Z"),
+          "to"     -> Chunk("2021-01-02T00:00:00Z"),
+          "limit"  -> Chunk("100"),
+          "offset" -> Chunk("0"),
+          "sort"   -> Chunk("asc"),
+          "filter" -> Chunk("true"),
+        ),
+      ),
+    ),
   )
-    )
 
-    @Benchmark
-    def fromToQueryBenchmark(): Unit = {
-      forms.foreach(_.toQueryParams)
-    }
+  @Benchmark
+  def fromToQueryBenchmark(): Unit = {
+    forms.foreach(_.toQueryParams)
+  }
 }

--- a/zio-http-benchmarks/src/main/scala/benchmark/FormToQueryBenchmark.scala
+++ b/zio-http-benchmarks/src/main/scala/benchmark/FormToQueryBenchmark.scala
@@ -1,0 +1,32 @@
+package benchmark
+
+import org.openjdk.jmh.annotations._
+import zio._
+import zio.http._
+
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.net.{ConnectException, URI}
+import java.util.concurrent.TimeUnit
+
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class FormToQueryBenchmark {
+
+  val forms: List[Form] = List.fill(1000)(
+    Form.fromQueryParams(QueryParams.apply(Map(
+        "from" -> Chunk("2021-01-01T00:00:00Z"),
+        "to" -> Chunk("2021-01-02T00:00:00Z"),
+        "limit" -> Chunk("100"),
+        "offset" -> Chunk("0"),
+        "sort" -> Chunk("asc"),
+        "filter" -> Chunk("true")
+    ))
+  )
+    )
+
+    @Benchmark
+    def fromToQueryBenchmark(): Unit = {
+      forms.foreach(_.toQueryParams)
+    }
+}

--- a/zio-http/shared/src/main/scala/zio/http/Form.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Form.scala
@@ -160,11 +160,10 @@ final case class Form(formData: Chunk[FormField]) {
   }
 
   def toQueryParams: QueryParams =
-    formData.foldLeft(QueryParams.empty) {
-      case (acc, FormField.Text(k, v, _, _)) => acc.addQueryParam(k, v)
-      case (acc, FormField.Simple(k, v))     => acc.addQueryParam(k, v)
-      case (acc, _)                          => acc
-    }
+    QueryParams(formData.collect {
+      case FormField.Text(k, v, _, _) => (k, Chunk(v))
+      case FormField.Simple(k, v)     => (k, Chunk(v))
+    }: _*)
 
   /**
    * Encodes the form using URL encoding, using the default charset.

--- a/zio-http/shared/src/main/scala/zio/http/Form.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Form.scala
@@ -161,8 +161,8 @@ final case class Form(formData: Chunk[FormField]) {
 
   def toQueryParams: QueryParams =
     QueryParams(formData.collect {
-      case FormField.Text(k, v, _, _) => (k, Chunk(v))
-      case FormField.Simple(k, v)     => (k, Chunk(v))
+      case t: FormField.Text   => (t.name, Chunk(t.value))
+      case s: FormField.Simple => (s.name, Chunk(s.value))
     }: _*)
 
   /**


### PR DESCRIPTION
fixes #3289 
/claim #3289

Old:
```
[info] Benchmark                                   Mode  Cnt     Score     Error  Units
[info] FormToQueryBenchmark.fromToQueryBenchmark  thrpt    3  1402.546 ± 455.149  ops/s
```

```
New:
[info] Benchmark                                   Mode  Cnt     Score      Error  Units
[info] FormToQueryBenchmark.fromToQueryBenchmark  thrpt    3  5090.872 ± 1630.801  ops/s
```
