### PR TITLE
Try to fix the logger name used to log the "Duplicate routes detected"

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Routes.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Routes.scala
@@ -281,11 +281,12 @@ final case class Routes[-Env, +Err](routes: Chunk[zio.http.Route[Env, Err]]) { s
           Handler
             .fromZIO(
               if (message != null)
-                Exit.succeed {
+                ZIO.suspendSucceed {
                   val msg = message
                   message = null
-                  msg
-                }.tap(ZIO.logWarning(_)).as(h)
+
+                  ZIO.logWarning(msg).as(h)
+                }
               else Exit.succeed(h),
             )
             .flatten


### PR DESCRIPTION
Right now, the logger I see in my project is `zio-slf4j-logger` while I'd expect something like `zio.http.<whatever>`