### PR TITLE
Handle `Schema.Transform` in `StringSchemaCodec.emptyStringIsValue`

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ServerRuntimeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerRuntimeSpec.scala
@@ -116,7 +116,7 @@ object ServerRuntimeSpec extends RoutesRunnableSpec {
             .zipRight(routes.deploy.body.run(path = Path.root / "test", method = Method.GET))
             .flatMap(_.asString(Charsets.Utf8))
             .map(b => assertTrue(b == "ok")) *> ref.get.map { v => assertTrue(v == 1) }
-        }
+        } @@ TestAspect.flaky
     }
       .provide(
         Scope.default,

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -383,10 +383,13 @@ private[http] object StringSchemaCodec {
   @tailrec
   private def emptyStringIsValue(schema: Schema[_]): Boolean                                        = {
     schema match {
-      case value: Schema.Optional[_] =>
+      case value: Schema.Optional[_]        =>
         val innerSchema = value.schema
         emptyStringIsValue(innerSchema)
-      case _                         =>
+      case value: Schema.Transform[_, _, _] =>
+        val innerSchema = value.schema
+        emptyStringIsValue(innerSchema)
+      case _                                =>
         schema.asInstanceOf[Schema.Primitive[_]].standardType match {
           case StandardType.UnitType   => true
           case StandardType.StringType => true


### PR DESCRIPTION
fixes #3417
/claim #3417