### PR TITLE
Fix `QueryModifier.addQueryParam` to not duplicate old values (#3420)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/RequestSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RequestSpec.scala
@@ -144,6 +144,18 @@ object RequestSpec extends ZIOHttpSpec {
         } yield assertTrue(body.isComplete, body.isInstanceOf[Body.ErrorBody], bytes == Left(err))
       },
     ),
+    suiteAll("query")(
+      test("add multiple query parmas") {
+        val request        = Request
+          .get("https://example.com")
+          .addQueryParam("a", 1)
+          .addQueryParam("b", 2)
+          .addQueryParam("c", 3)
+          .addQueryParam("d", 4)
+        val expectedParams = QueryParams("a" -> "1", "b" -> "2", "c" -> "3", "d" -> "4")
+        assertTrue(request.url.queryParams == expectedParams)
+      },
+    ),
   )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/internal/QueryModifier.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/QueryModifier.scala
@@ -55,10 +55,10 @@ trait QueryModifier[+A] { self: QueryOps[A] with A =>
     )
 
   def addQueryParam[T](key: String, value: T)(implicit schema: Schema[T]): A =
-    self ++ StringSchemaCodec.queryFromSchema(schema, ErrorConstructor.query, key).encode(value, queryParameters)
+    updateQueryParams(StringSchemaCodec.queryFromSchema(schema, ErrorConstructor.query, key).encode(value, _))
 
   def addQueryParam[T](value: T)(implicit schema: Schema[T]): A =
-    self ++ StringSchemaCodec.queryFromSchema(schema, ErrorConstructor.query, null).encode(value, queryParameters)
+    updateQueryParams(StringSchemaCodec.queryFromSchema(schema, ErrorConstructor.query, null).encode(value, _))
 
   /**
    * Removes the specified key from the query parameters.


### PR DESCRIPTION
fixes #3420
/claim #3420