### PR TITLE
remove unnecessary Server type tag in testkit

### DIFF
--- a/zio-http-testkit/src/main/scala/zio/http/TestServer.scala
+++ b/zio-http-testkit/src/main/scala/zio/http/TestServer.scala
@@ -139,7 +139,7 @@ object TestServer {
       } yield TestServer(driver, result.port)
     }
 
-  val default: ZLayer[Any, Nothing, Server with TestServer] = ZLayer.make[Server with TestServer][Nothing](
+  val default: ZLayer[Any, Nothing, TestServer] = ZLayer.make[TestServer][Nothing](
     TestServer.layer.orDie,
     ZLayer.succeed(Server.Config.default.onAnyOpenPort),
     NettyDriver.customized.orDie,


### PR DESCRIPTION
Current method signature breaks `ZIO#provideSome` macros

Since `TestServer` is also a `Server`, macros doesn't know which type to choose when providing [TestServer.default](https://github.com/zio/zio-http/blob/4ae6e4ea441c139063379a3327d4ea0e2311119b/zio-http-testkit/src/main/scala/zio/http/TestServer.scala#L142) and thus breaks. Here's the minimised example
https://scastie.scala-lang.org/AEVvkDVrQ4uYj1llM580og

Works fine with Scala 3 (not sure which is more correct)
https://scastie.scala-lang.org/PKBCoiqpQsuvUoSKqUoWTQ

Scala 3 behaviour seems more correct (if I use `provideSomeLayer`, it compiles fine in both Scala 2 and Scala 3). However, AFAIK this should not break binary compatibility, nor the existing code, so maybe it's worth quick fixing it here as well

I don't known how existing code base compiles with the existing type signature (and not sure if I want to). For me it worked when `test(...)` was within a `spec(...)` as in the `zio-http` repository, but broke when I moved to a separate variable.
