### PR TITLE
Fix Issue #3441

### DIFF
--- a/zio-http-testkit/src/test/scala/zio/http/CaseClassOptionalSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/CaseClassOptionalSpec.scala
@@ -1,25 +1,27 @@
 package zio.http
 
+import zio.json._
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
 import zio.{&, Scope, ZIO, ZLayer, ZNothing}
+
+import zio.schema.annotation.optionalField
+import zio.schema.{DeriveSchema, Schema}
+
 import zio.http.endpoint.{AuthType, Endpoint}
 import zio.http.netty.NettyConfig
 import zio.http.netty.server.NettyDriver
-import zio.schema.annotation.optionalField
-import zio.schema.{DeriveSchema, Schema}
-import zio.json._
-import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
 
 object CaseClassOptionalSpec extends ZIOSpecDefault {
   final case class Params(
-                          @optionalField
-                          test1: Option[String],
-                          @optionalField
-                          test2: Option[String],
-                          @optionalField
-                          test3: Option[Int]
-                        )
-  implicit val params: Schema[Params] = DeriveSchema.gen[Params]
-  implicit val jsonCodec: JsonCodec[Params] = DeriveJsonCodec.gen[Params]
+    @optionalField
+    test1: Option[String],
+    @optionalField
+    test2: Option[String],
+    @optionalField
+    test3: Option[Int],
+  )
+  implicit val params: Schema[Params]                                   = DeriveSchema.gen[Params]
+  implicit val jsonCodec: JsonCodec[Params]                             = DeriveJsonCodec.gen[Params]
   val endpoint: Endpoint[Unit, Params, ZNothing, Params, AuthType.None] =
     Endpoint(RoutePattern.GET / "api").query[Params].out[Params]
 
@@ -50,7 +52,4 @@ object CaseClassOptionalSpec extends ZIOSpecDefault {
       ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
     )
 
-
 }
-
-

--- a/zio-http-testkit/src/test/scala/zio/http/CaseClassOptionalSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/CaseClassOptionalSpec.scala
@@ -1,0 +1,56 @@
+package zio.http
+
+import zio.{&, Scope, ZIO, ZLayer, ZNothing}
+import zio.http.endpoint.{AuthType, Endpoint}
+import zio.http.netty.NettyConfig
+import zio.http.netty.server.NettyDriver
+import zio.schema.annotation.optionalField
+import zio.schema.{DeriveSchema, Schema}
+import zio.json._
+import zio.test.{Spec, TestEnvironment, ZIOSpecDefault, assertTrue}
+
+object CaseClassOptionalSpec extends ZIOSpecDefault {
+  final case class Params(
+                          @optionalField
+                          test1: Option[String],
+                          @optionalField
+                          test2: Option[String],
+                          @optionalField
+                          test3: Option[Int]
+                        )
+  implicit val params: Schema[Params] = DeriveSchema.gen[Params]
+  implicit val jsonCodec: JsonCodec[Params] = DeriveJsonCodec.gen[Params]
+  val endpoint: Endpoint[Unit, Params, ZNothing, Params, AuthType.None] =
+    Endpoint(RoutePattern.GET / "api").query[Params].out[Params]
+
+  val api = endpoint.implement(params => {
+    ZIO.succeed(params)
+  })
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    test("GET with optional query param") {
+      for {
+        client <- ZIO.service[Client]
+        port   <- ZIO.serviceWithZIO[Server](_.port)
+        _      <- TestServer.addRoutes(api.toRoutes)
+        url     = URL.root.port(port) / "api?test1=a"
+        request = Request
+          .get(url)
+          .addHeader(Header.Accept(MediaType.application.json))
+        result <- client.request(request)
+        output <- result.body.asString
+        decoded = output.fromJson[Params]
+      } yield assertTrue(decoded == Right(Params(test1 = Some("a"), test2 = None, test3 = None)))
+    }.provideShared(
+      Scope.default,
+      ZLayer.succeed(Server.Config.default.onAnyOpenPort),
+      TestServer.layer,
+      Client.default,
+      NettyDriver.customized,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+
+}
+
+

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -152,7 +152,7 @@ private[http] trait StringSchemaCodec[A, Target] {
           val count0  = count(target, field.fieldName)
           if (count0 > 1) throw error.invalidCount(field.fieldName, 1, count0)
           val value   = {
-            if (contains(target,field.fieldName))
+            if (contains(target, field.fieldName))
               unsafeGet(target, field.fieldName)
             else
               null

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -151,7 +151,12 @@ private[http] trait StringSchemaCodec[A, Target] {
         case (field, codec)                                                       =>
           val count0  = count(target, field.fieldName)
           if (count0 > 1) throw error.invalidCount(field.fieldName, 1, count0)
-          val value   = unsafeGet(target, field.fieldName)
+          val value   = {
+            if (contains(target,field.fieldName))
+              unsafeGet(target, field.fieldName)
+            else
+              null
+          }
           val decoded = {
             if (value == null || (value == "" && !emptyStringIsValue(codec.schema) && codec.isOptional))
               codec.defaultValue

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
@@ -1,22 +1,25 @@
 package zio.http.endpoint.http
 
 import java.net.URI
+
 import zio.test._
+
 import zio.schema._
+import zio.schema.annotation.{fieldDefaultValue, optionalField}
+
 import zio.http._
 import zio.http.codec._
 import zio.http.endpoint._
-import zio.schema.annotation.{fieldDefaultValue, optionalField}
 
 object HttpGenSpec extends ZIOSpecDefault {
   final case class QueryParams(
-                          @optionalField
-                          test1: Option[String],
-                          @optionalField
-                          test2: Option[String],
-                          @optionalField
-                          test3: Option[Int]
-                        )
+    @optionalField
+    test1: Option[String],
+    @optionalField
+    test2: Option[String],
+    @optionalField
+    test3: Option[Int],
+  )
   object QueryParams {
     implicit val schema: Schema[QueryParams] = DeriveSchema.gen[QueryParams]
   }
@@ -62,7 +65,6 @@ object HttpGenSpec extends ZIOSpecDefault {
           |GET /api/foo?userId={{userId}}""".stripMargin
       assertTrue(rendered == expected)
     },
-
     test("Path with optional query parameters using a case class") {
       val endpoint     = Endpoint(Method.GET / "api" / "foo").query[QueryParams]
       val httpEndpoint = HttpGen.fromEndpoint(endpoint)


### PR DESCRIPTION
When an Endpoints implements function with options will only be called when all options are present. Tested with a case class, optional parameters. Validated with tests.