### PR TITLE
Make QueryParams#unsafeQueryParam return null for missing key (#3441)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
@@ -133,8 +133,10 @@ object QueryParams {
     override def updateQueryParams(f: QueryParams => QueryParams): QueryParams =
       f(self)
 
-    override private[http] def unsafeQueryParam(key: String): String =
-      underlying.get(key).get(0)
+    override private[http] def unsafeQueryParam(key: String): String = {
+      val value = underlying.get(key)
+      if (value == null || value.isEmpty) null else value.get(0)
+    }
 
     override def valueCount(name: CharSequence): Int =
       if (underlying.containsKey(name)) underlying.get(name.toString).size() else 0

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -218,7 +218,7 @@ private[http] trait StringSchemaCodec[A, Target] {
             target0 = addAll(target0, values.map { v => (name, codec.encode(v)) })
           case _                   =>
             val encoded = codec.encode(value)
-            target0 = add(target0, name, encoded)
+            if (encoded != null) target0 = add(target0, name, encoded)
         }
       }
       target0


### PR DESCRIPTION
fixes #3441