### PR TITLE
Fix for optional query string parameters

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/QueryParamsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/QueryParamsSpec.scala
@@ -325,6 +325,8 @@ object QueryParamsSpec extends ZIOHttpSpec {
             single.queryOrElse[Int](typed, default) == 1,
             queryParams.queryOrElse[Int](invalidTyped, default) == default,
             queryParams.queryOrElse[Int](unknown, default) == default,
+            single.query[Option[Int]](typed) == Right(Some(1)),
+            single.query[Option[Int]]("notGiven") == Right(None),
             queryParams.query[Chunk[Int]](typed) == Right(Chunk(1, 2)),
             queryParams.query[Chunk[Int]](invalidTyped).isLeft,
             queryParams.query[Chunk[Int]](unknown) == Right(Chunk.empty),

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/QueryParameterSpec.scala
@@ -105,13 +105,37 @@ object QueryParameterSpec extends ZIOHttpSpec {
         testRoutes(s"/users/$userId?details=$details", s"path(users, $userId, Some($details))")
       }
     },
-    test("multiple optional query parameters") {
+    test("multiple optional query parameters using optional operator") {
       check(Gen.int, Gen.alphaNumericString, Gen.alphaNumericString) { (userId, key, value) =>
         val testRoutes = testEndpoint(
           Routes(
             Endpoint(GET / "users" / int("userId"))
               .query(HttpCodec.query[String]("key").optional)
               .query(HttpCodec.query[String]("value").optional)
+              .out[String]
+              .implementHandler {
+                Handler.fromFunction { case (userId, key, value) =>
+                  s"path(users, $userId, $key, $value)"
+                }
+              },
+          ),
+        ) _
+        testRoutes(s"/users/$userId", s"path(users, $userId, None, None)") &&
+        testRoutes(s"/users/$userId?key=&value=", s"path(users, $userId, Some(), Some())") &&
+        testRoutes(s"/users/$userId?key=&value=$value", s"path(users, $userId, Some(), ${Some(value)})") &&
+        testRoutes(
+          s"/users/$userId?key=$key&value=$value",
+          s"path(users, $userId, ${Some(key)}, ${Some(value)})",
+        )
+      }
+    },
+    test("multiple optional query parameters by parsing query parameters as Option[T]") {
+      check(Gen.int, Gen.alphaNumericString, Gen.alphaNumericString) { (userId, key, value) =>
+        val testRoutes = testEndpoint(
+          Routes(
+            Endpoint(GET / "users" / int("userId"))
+              .query(HttpCodec.query[Option[String]]("key"))
+              .query(HttpCodec.query[Option[String]]("value"))
               .out[String]
               .implementHandler {
                 Handler.fromFunction { case (userId, key, value) =>

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -538,7 +538,7 @@ private[http] object StringSchemaCodec {
       case s @ Schema.Optional(schema, _)                              =>
         schema match {
           case _: Schema.Collection[_, _] | _: Schema.Primitive[_] =>
-            stringSchemaCodec(recordSchema(schema, name))
+            stringSchemaCodec(recordSchema(schema.asInstanceOf[Schema[Any]], name))
           case s if s.isInstanceOf[Schema.Record[_]] => stringSchemaCodec(schema.asInstanceOf[Schema[Any]])
           case _                                     => throw new IllegalArgumentException(s"Unsupported schema $s")
         }

--- a/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/StringSchemaCodec.scala
@@ -538,7 +538,7 @@ private[http] object StringSchemaCodec {
       case s @ Schema.Optional(schema, _)                              =>
         schema match {
           case _: Schema.Collection[_, _] | _: Schema.Primitive[_] =>
-            stringSchemaCodec(recordSchema(s.asInstanceOf[Schema[Any]], name))
+            stringSchemaCodec(recordSchema(schema, name))
           case s if s.isInstanceOf[Schema.Record[_]] => stringSchemaCodec(schema.asInstanceOf[Schema[Any]])
           case _                                     => throw new IllegalArgumentException(s"Unsupported schema $s")
         }


### PR DESCRIPTION
Hi all,
Took a closer look at issue #3448 and I think I found the problem.
I've added two simple examples to to decode an optional query string parameter to `QueryParamsSpec`.
Hope this is useful!!