### PR TITLE
Optimize `QueryParams#getAll`

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
@@ -126,6 +126,7 @@ object QueryParams {
     override def getAll(key: String): Chunk[String] = {
       val jList = underlying.get(key)
       if (jList eq null) Chunk.empty
+      else if (jList.size() == 1) Chunk.single(jList.get(0))
       else Chunk.fromJavaIterable(jList)
     }
 

--- a/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
+++ b/zio-http/shared/src/main/scala/zio/http/QueryParams.scala
@@ -123,9 +123,11 @@ object QueryParams {
      * takes advantage of LinkedHashMap implementation for O(1) lookup and
      * avoids conversion to Chunk.
      */
-    override def getAll(key: String): Chunk[String] =
-      if (underlying.containsKey(key)) Chunk.fromIterable(underlying.get(key).asScala)
-      else Chunk.empty
+    override def getAll(key: String): Chunk[String] = {
+      val jList = underlying.get(key)
+      if (jList eq null) Chunk.empty
+      else Chunk.fromJavaIterable(jList)
+    }
 
     override def hasQueryParam(name: CharSequence): Boolean =
       underlying.containsKey(name.toString)


### PR DESCRIPTION
Minor optimization I came across, avoids additional allocations and double-checking whether the map contains the specific key