### PR TITLE
fix: Authorization Header 400 Bad Request

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -3,9 +3,9 @@ package zio.http.endpoint
 import zio._
 import zio.test._
 
+import zio.http.Method._
 import zio.http._
 import zio.http.codec._
-import zio.http.Method._
 
 object AuthorizationHeaderSpec extends ZIOSpecDefault {
 

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -1,0 +1,32 @@
+package zio.http.endpoint
+
+import zio._
+import zio.test._
+
+import zio.http._
+import zio.http.codec._
+import zio.http.Method._
+
+object AuthorizationHeaderSpec extends ZIOSpecDefault {
+
+  override def spec = suite("AuthorizationHeaderSpec")(
+    test("should respond with 401 Unauthorized when required authorization header is missing") {
+      // Define an endpoint that requires the Authorization header
+      val endpoint =
+        Endpoint(GET / "test")
+          .header(HeaderCodec.authorization)
+          .out[Unit]
+
+      // Implement the endpoint
+      val route = endpoint.implement(_ => ZIO.unit)
+
+      // Create a request to /test with no Authorization header
+      val request = Request.get(URL(Path.root / "test"))
+
+      // Run the request through the routes and check the response
+      for {
+        response <- Routes(route).runZIO(request)
+      } yield assertTrue(response.status == Status.Unauthorized)
+    }
+  )
+}

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -27,6 +27,6 @@ object AuthorizationHeaderSpec extends ZIOSpecDefault {
       for {
         response <- Routes(route).runZIO(request)
       } yield assertTrue(response.status == Status.Unauthorized)
-    }
+    },
   )
 }

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -3,9 +3,9 @@ package zio.http.endpoint
 import zio._
 import zio.test._
 
+import zio.http.Method._
 import zio.http._
 import zio.http.codec._
-import zio.http.Method._
 
 object AuthorizationHeaderSpec extends ZIOSpecDefault {
   override def spec =

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -5,6 +5,7 @@ import zio.test._
 
 import zio.http._
 import zio.http.codec._
+import zio.http.Method._
 
 object AuthorizationHeaderSpec extends ZIOSpecDefault {
   override def spec =

--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/AuthorizationHeaderSpec.scala
@@ -3,30 +3,22 @@ package zio.http.endpoint
 import zio._
 import zio.test._
 
-import zio.http.Method._
 import zio.http._
 import zio.http.codec._
 
 object AuthorizationHeaderSpec extends ZIOSpecDefault {
-
-  override def spec = suite("AuthorizationHeaderSpec")(
-    test("should respond with 401 Unauthorized when required authorization header is missing") {
-      // Define an endpoint that requires the Authorization header
-      val endpoint =
-        Endpoint(GET / "test")
+  override def spec =
+    suite("AuthorizationHeaderSpec")(
+      test("should respond with 401 Unauthorized when required authorization header is missing") {
+        val endpoint = Endpoint(Method.GET / "test")
           .header(HeaderCodec.authorization)
           .out[Unit]
-
-      // Implement the endpoint
-      val route = endpoint.implement(_ => ZIO.unit)
-
-      // Create a request to /test with no Authorization header
-      val request = Request.get(URL(Path.root / "test"))
-
-      // Run the request through the routes and check the response
-      for {
-        response <- Routes(route).runZIO(request)
-      } yield assertTrue(response.status == Status.Unauthorized)
-    },
-  )
+        val route    = endpoint.implement(_ => ZIO.unit)
+        val request  =
+          Request(method = Method.GET, url = url"/test")
+        for {
+          response <- route.toRoutes.runZIO(request)
+        } yield assertTrue(Status.Unauthorized == response.status)
+      },
+    )
 }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -384,6 +384,12 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
               case Some(HttpCodecError.CustomError("SchemaTransformationFailure", message))
                   if maybeUnauthedResponse.isDefined && message.endsWith(" auth required") =>
                 maybeUnauthedResponse.get
+              case Some(HttpCodecError.MissingHeader("authorization")) =>
+                Handler.succeed(Response.unauthorized)
+              case Some(HttpCodecError.MissingHeaders(headerNames)) if headerNames.contains("authorization") =>
+                Handler.succeed(Response.unauthorized)
+              case Some(HttpCodecError.DecodingErrorHeader("authorization", _)) =>
+                Handler.succeed(Response.unauthorized)
               case Some(_) =>
                 Handler.fromFunctionZIO { (request: zio.http.Request) =>
                   val error    = cause.defects.head.asInstanceOf[HttpCodecError]

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -384,13 +384,13 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
               case Some(HttpCodecError.CustomError("SchemaTransformationFailure", message))
                   if maybeUnauthedResponse.isDefined && message.endsWith(" auth required") =>
                 maybeUnauthedResponse.get
-              case Some(HttpCodecError.MissingHeader("authorization")) =>
+              case Some(HttpCodecError.MissingHeader("authorization"))                                       =>
                 Handler.succeed(Response.unauthorized)
               case Some(HttpCodecError.MissingHeaders(headerNames)) if headerNames.contains("authorization") =>
                 Handler.succeed(Response.unauthorized)
-              case Some(HttpCodecError.DecodingErrorHeader("authorization", _)) =>
+              case Some(HttpCodecError.DecodingErrorHeader("authorization", _))                              =>
                 Handler.succeed(Response.unauthorized)
-              case Some(_) =>
+              case Some(_)                                                                                   =>
                 Handler.fromFunctionZIO { (request: zio.http.Request) =>
                   val error    = cause.defects.head.asInstanceOf[HttpCodecError]
                   val response = {
@@ -405,7 +405,7 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
                   }
                   ZIO.succeed(response)
                 }
-              case None    =>
+              case None                                                                                      =>
                 Handler.failCause(cause)
             }
           }


### PR DESCRIPTION
###  Fixed: Wrong Error Code for Missing Authorization Header

Before, if the `Authorization` header was missing, the app returned a **400 Bad Request**.  
That just means something went wrong, but it didn’t clearly say the user wasn't logged in.

Now, the app checks if the `Authorization` header is missing or invalid.  
If it is, it returns **401 Unauthorized**, which correctly tells the user they need to log in.

####  Improvements

- [x] If the `Authorization` header is missing, the response is now **401 Unauthorized**
- [x] If multiple headers are missing, including `Authorization`, the response is still **401 Unauthorized**
- [x] If the `Authorization` header is present but invalid (decoding error), the response is **401 Unauthorized**

#### Compliance

This fix follows [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235), which says:

> The 401 (Unauthorized) status code indicates that the request has not been applied because it lackz valid authentication credentials for the resourrce.

#### 🧪 Tests

To confirm nothing else broke, I ran:

`sbt "zioHttpJVM / Test / testOnly endpoint"`

All tests passed ✅

It only changes how `Authorization` header issues are handled. Everything else stays the same.

/claim #3235 