### PR TITLE
feat(ssl): add support and tests for ClientSSLCertConfig.FromClientCertContent

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
@@ -18,9 +18,11 @@ package zio.http
 
 import java.security.cert.X509Certificate
 
+import scala.io.Source
+
 import zio.ZLayer
 import zio.test.Assertion.equalTo
-import zio.test.{Gen, assertCompletes, assertNever, assertZIO}
+import zio.test._
 
 import zio.http.SSLConfig.HttpBehaviour
 import zio.http.netty.NettyConfig
@@ -28,20 +30,36 @@ import zio.http.netty.client.NettyClientDriver
 
 object DualSSLSpec extends ZIOHttpSpec {
 
-  val clientSSL1 = ClientSSLConfig.FromCertResource("server.crt")
-  val clientSSL2 = ClientSSLConfig.FromCertResource("ss2.crt.pem")
+  private def loadResourceAsString(path: String): String =
+    Source.fromInputStream(getClass.getClassLoader.getResourceAsStream(path)).mkString
 
-  val clientSSLWithClientCert = ClientSSLConfig.FromClientAndServerCert(
+  private val clientSSL1 = ClientSSLConfig.FromCertResource("server.crt")
+  private val clientSSL2 = ClientSSLConfig.FromCertResource("ss2.crt.pem")
+
+  private val clientSSLWithClientCert = ClientSSLConfig.FromClientAndServerCert(
     clientSSL1,
     ClientSSLCertConfig.FromClientCertResource("client.crt", "client.key"),
   )
 
-  val clientSSLWithClientCert2 = ClientSSLConfig.FromClientAndServerCert(
+  private val clientSSLWithClientCert2 = ClientSSLConfig.FromClientAndServerCert(
     clientSSL1,
     ClientSSLCertConfig.FromClientCertResource("client_other.crt", "client_other.key"),
   )
 
-  val sslConfigWithTrustedClient = SSLConfig.fromResource(
+  private lazy val envClientCertContent: String = loadResourceAsString("client.crt")
+  private lazy val envClientKeyContent: String  = loadResourceAsString("client.key")
+
+  private val clientSSLWithEnvCertFromResource = ClientSSLConfig.FromClientAndServerCert(
+    clientSSL1,
+    ClientSSLCertConfig.FromClientCertContent(envClientCertContent, envClientKeyContent),
+  )
+
+  private val clientSSLWithInvalidEnvCert = ClientSSLConfig.FromClientAndServerCert(
+    clientSSL1,
+    ClientSSLCertConfig.FromClientCertContent("INVALID_CERT", "INVALID_KEY"),
+  )
+
+  private val sslConfigWithTrustedClient = SSLConfig.fromResource(
     HttpBehaviour.Redirect,
     "server.crt",
     "server.key",
@@ -50,11 +68,11 @@ object DualSSLSpec extends ZIOHttpSpec {
     includeClientCert = true,
   )
 
-  val config = Server.Config.default.port(8073).ssl(sslConfigWithTrustedClient).logWarningOnFatalError(false)
+  private val config = Server.Config.default.port(8073).ssl(sslConfigWithTrustedClient).logWarningOnFatalError(false)
 
-  val payload = Gen.alphaNumericStringBounded(10000, 20000)
+  private val payload = Gen.alphaNumericStringBounded(10000, 20000)
 
-  val routes: Routes[Any, Response] = Routes(
+  private val routes: Routes[Any, Response] = Routes(
     Method.GET / "success" -> handler((req: Request) =>
       Response.text(
         req.remoteCertificate.map { _.asInstanceOf[X509Certificate].getSubjectX500Principal.getName() }.getOrElse(""),
@@ -62,67 +80,113 @@ object DualSSLSpec extends ZIOHttpSpec {
     ),
   ).sandbox
 
-  val httpUrl =
+  private val httpUrl =
     URL.decode("http://localhost:8073/success").toOption.get
 
-  val httpsUrl =
+  private val httpsUrl =
     URL.decode("https://localhost:8073/success").toOption.get
 
-  override def spec = suite("SSL")(
+  private val successWithClientCert: Spec[Client, Throwable]#ZSpec[Any, Throwable, TestSuccess] =
+    test("succeed when client has the server certificate and client certificate is configured") {
+      val actual =
+        Client.batched(Request.get(httpsUrl)).flatMap(r => r.body.asString.map(body => (r.status, body)))
+      assertZIO(actual)(equalTo((Status.Ok, "O=client1,ST=Some-State,C=AU")))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCert)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  // Unfortunately if the channel closes before we create the request, we can't extract the DecoderException
+  private val failWithoutClientCert: Spec[Client, Nothing]#ZSpec[Any, Throwable, TestSuccess] =
+    test("fail when client has the server certificate but no client certificate is configured") {
+      Client
+        .batched(Request.get(httpsUrl))
+        .fold(
+          { e =>
+            val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
+            val errorType      = e.getClass.getSimpleName
+            if (expectedErrors.contains(errorType)) assertCompletes
+            else assertNever(s"request failed with unexpected error type: $errorType")
+          },
+          _ => assertNever("expected request to fail"),
+        )
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val failWithWrongClientCert: Spec[Client, Nothing]#ZSpec[Any, Throwable, TestSuccess] =
+    test("fail when client has the server certificate but wrong client certificate is configured") {
+      Client
+        .batched(Request.get(httpsUrl))
+        .fold(
+          { e =>
+            val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
+            val errorType      = e.getClass.getSimpleName
+            if (expectedErrors.contains(errorType)) assertCompletes
+            else assertNever(s"request failed with unexpected error type: $errorType")
+          },
+          _ => assertNever("expected request to fail"),
+        )
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCert2)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val successWithClientEnvCert =
+    test("succeed when client cert and key are loaded from resource and passed as env stream") {
+      val actual =
+        Client.batched(Request.get(httpsUrl)).flatMap(r => r.body.asString.map(body => (r.status, body)))
+      assertZIO(actual)(equalTo((Status.Ok, "O=client1,ST=Some-State,C=AU")))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithEnvCertFromResource)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val failWithInvalidClientEnvCert =
+    test("fail when invalid client cert and key are passed from env string") {
+      Client
+        .batched(Request.get(httpsUrl))
+        .fold(
+          { e =>
+            val expectedErrors =
+              List("DecoderException", "PrematureChannelClosureException", "StacklessClosedChannelException")
+            val errorType      = e.getClass.getSimpleName
+            if (expectedErrors.contains(errorType)) assertCompletes
+            else assertNever(s"unexpected error: $errorType")
+          },
+          _ => assertNever("expected failure"),
+        )
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithInvalidEnvCert)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  override def spec: Spec[Any, Throwable] = suite("SSL")(
     Server
       .installRoutes(routes)
       .as(
         List(
-          test("succeed when client has the server certificate and client certificate is configured") {
-            val actual =
-              Client.batched(Request.get(httpsUrl)).flatMap(r => r.body.asString.map(body => (r.status, body)))
-            assertZIO(actual)(equalTo((Status.Ok, "O=client1,ST=Some-State,C=AU")))
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCert)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          // Unfortunately if the channel closes before we create the request, we can't extract the DecoderException
-          test("fail when client has the server certificate but no client certificate is configured") {
-            Client
-              .batched(Request.get(httpsUrl))
-              .fold(
-                { e =>
-                  val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
-                  val errorType      = e.getClass.getSimpleName
-                  if (expectedErrors.contains(errorType)) assertCompletes
-                  else assertNever(s"request failed with unexpected error type: $errorType")
-                },
-                _ => assertNever("expected request to fail"),
-              )
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          test("fail when client has the server certificate but wrong client certificate is configured") {
-            Client
-              .batched(Request.get(httpsUrl))
-              .fold(
-                { e =>
-                  val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
-                  val errorType      = e.getClass.getSimpleName
-                  if (expectedErrors.contains(errorType)) assertCompletes
-                  else assertNever(s"request failed with unexpected error type: $errorType")
-                },
-                _ => assertNever("expected request to fail"),
-              )
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCert2)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
+          successWithClientCert,
+          failWithoutClientCert,
+          failWithWrongClientCert,
+          successWithClientEnvCert,
+          failWithInvalidClientEnvCert,
         ),
       ),
   ).provideShared(

--- a/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/SSLSpec.scala
@@ -16,105 +16,146 @@
 
 package zio.http
 
+import scala.io.Source
+
+import zio._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.withLiveClock
 import zio.test.{Gen, assertCompletes, assertNever, assertZIO}
-import zio.{Scope, ZLayer}
 
 import zio.http.netty.NettyConfig
 import zio.http.netty.client.NettyClientDriver
 
 object SSLSpec extends ZIOHttpSpec {
 
-  val sslConfig = SSLConfig.fromResource("server.crt", "server.key")
-  val config    = Server.Config.default.port(8073).ssl(sslConfig).logWarningOnFatalError(false)
+  private def loadResourceAsString(path: String): String =
+    Source.fromInputStream(getClass.getClassLoader.getResourceAsStream(path)).mkString
 
-  val clientSSL1 = ClientSSLConfig.FromCertResource("server.crt")
-  val clientSSL2 = ClientSSLConfig.FromCertResource("ss2.crt.pem")
+  private val sslConfig = SSLConfig.fromResource("server.crt", "server.key")
+  private val config    = Server.Config.default.port(8073).ssl(sslConfig).logWarningOnFatalError(false)
 
-  val payload = Gen.alphaNumericStringBounded(10000, 20000)
+  private val clientSSL1 = ClientSSLConfig.FromCertResource("server.crt")
+  private val clientSSL2 = ClientSSLConfig.FromCertResource("ss2.crt.pem")
 
-  val routes: Routes[Any, Response] = Routes(
+  private val payload = Gen.alphaNumericStringBounded(10000, 20000)
+
+  private val routes: Routes[Any, Response] = Routes(
     Method.GET / "success" -> handler(Response.ok),
     Method.GET / "file"    -> Handler.fromResource("TestStatic/TestFile1.txt"),
   ).sandbox
 
-  val httpUrl =
+  private val httpUrl =
     URL.decode("http://localhost:8073/success").toOption.get
 
-  val httpsUrl =
+  private val httpsUrl =
     URL.decode("https://localhost:8073/success").toOption.get
 
-  val staticFileUrl =
+  private val staticFileUrl =
     URL.decode("https://localhost:8073/file").toOption.get
+
+  private lazy val clientCertFromResource: String = loadResourceAsString("client.crt")
+  private lazy val clientKeyFromResource: String  = loadResourceAsString("client.key")
+
+  private lazy val clientSSLWithEnvContent = ClientSSLConfig.FromClientAndServerCert(
+    clientSSL1,
+    ClientSSLCertConfig.FromClientCertContent(clientCertFromResource, clientKeyFromResource),
+  )
+
+  private val successWithClientCert =
+    test("succeed when client has the server certificate") {
+      val actual = Client.batched(Request.get(httpsUrl)).map(_.status)
+      assertZIO(actual)(equalTo(Status.Ok))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  // Unfortunately if the channel closes before we create the request, we can't extract the DecoderException
+  private val failWithoutClientCert =
+    test(
+      "fail with DecoderException or PrematureChannelClosureException when client doesn't have the server certificate",
+    ) {
+      Client
+        .batched(Request.get(httpsUrl))
+        .fold(
+          { e =>
+            val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
+            val errorType      = e.getClass.getSimpleName
+            if (expectedErrors.contains(errorType)) assertCompletes
+            else assertNever(s"request failed with unexpected error type: $errorType")
+          },
+          _ => assertNever("expected request to fail"),
+        )
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSL2)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val successWithDefaultClientCert =
+    test("succeed when client has default SSL") {
+      val actual = Client.batched(Request.get(httpsUrl)).map(_.status)
+      assertZIO(actual)(equalTo(Status.Ok))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val successOnHttpsRedirect =
+    test("Https Redirect when client makes http request") {
+      val actual = Client.batched(Request.get(httpUrl)).map(_.status)
+      assertZIO(actual)(equalTo(Status.PermanentRedirect))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
+
+  private val staticFiles =
+    test("static files") {
+      val actual = Client.batched(Request.get(staticFileUrl)).flatMap(_.body.asString)
+      assertZIO(actual)(equalTo("This file is added for testing Static File Server."))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    ) @@ withLiveClock
+
+  private val successWithClientEnvCert =
+    test("succeed when client uses cert/key passed as strings from env (simulated via resource)") {
+      val actual = Client.batched(Request.get(httpsUrl)).map(_.status)
+      assertZIO(actual)(equalTo(Status.Ok))
+    }.provide(
+      Client.customized,
+      ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithEnvContent)),
+      NettyClientDriver.live,
+      DnsResolver.default,
+      ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+    )
 
   override def spec = suite("SSL")(
     Server
       .installRoutes(routes)
       .as(
         List(
-          test("succeed when client has the server certificate") {
-            val actual = Client.batched(Request.get(httpsUrl)).map(_.status)
-            assertZIO(actual)(equalTo(Status.Ok))
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          // Unfortunately if the channel closes before we create the request, we can't extract the DecoderException
-          test(
-            "fail with DecoderException or PrematureChannelClosureException when client doesn't have the server certificate",
-          ) {
-            Client
-              .batched(Request.get(httpsUrl))
-              .fold(
-                { e =>
-                  val expectedErrors = List("DecoderException", "PrematureChannelClosureException")
-                  val errorType      = e.getClass.getSimpleName
-                  if (expectedErrors.contains(errorType)) assertCompletes
-                  else assertNever(s"request failed with unexpected error type: $errorType")
-                },
-                _ => assertNever("expected request to fail"),
-              )
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSL2)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          test("succeed when client has default SSL") {
-            val actual = Client.batched(Request.get(httpsUrl)).map(_.status)
-            assertZIO(actual)(equalTo(Status.Ok))
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          test("Https Redirect when client makes http request") {
-            val actual = Client.batched(Request.get(httpUrl)).map(_.status)
-            assertZIO(actual)(equalTo(Status.PermanentRedirect))
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(clientSSL1)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ),
-          test("static files") {
-            val actual = Client.batched(Request.get(staticFileUrl)).flatMap(_.body.asString)
-            assertZIO(actual)(equalTo("This file is added for testing Static File Server."))
-          }.provide(
-            Client.customized,
-            ZLayer.succeed(ZClient.Config.default.ssl(ClientSSLConfig.Default)),
-            NettyClientDriver.live,
-            DnsResolver.default,
-            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
-          ) @@ withLiveClock,
+          successWithClientCert,
+          failWithoutClientCert,
+          successWithDefaultClientCert,
+          successOnHttpsRedirect,
+          staticFiles,
+          successWithClientEnvCert,
         ),
       ),
   ).provideShared(

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
@@ -1,6 +1,9 @@
 // Copyright (C) 2019-2020 Eaglescience Software B.V.
 package zio.http
 
+import java.io.{ByteArrayInputStream, InputStream}
+import java.nio.charset.StandardCharsets
+
 import zio.Config
 
 sealed trait ClientSSLCertConfig
@@ -11,16 +14,25 @@ object ClientSSLCertConfig {
     val certPath = Config.string("cert-path")
     val keyPath  = Config.string("key-path")
 
+    val certContent = Config.string("cert-content")
+    val keyContent  = Config.string("key-content")
+
     val fromCertFile     = certPath.zipWith(keyPath)(FromClientCertFile(_, _))
     val fromCertResource = certPath.zipWith(keyPath)(FromClientCertResource(_, _))
+    val fromEnv          = certContent.zipWith(keyContent)(FromClientCertContent(_, _))
 
     tpe.switch(
       "FromCertFile"     -> fromCertFile,
       "FromCertResource" -> fromCertResource,
+      "FromCertEnv"      -> fromEnv,
     )
   }
 
+  def toInputStream(content: String): InputStream =
+    new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+
   final case class FromClientCertFile(certPath: String, keyPath: String)     extends ClientSSLCertConfig
   final case class FromClientCertResource(certPath: String, keyPath: String) extends ClientSSLCertConfig
+  final case class FromClientCertContent(cert: String, key: String)          extends ClientSSLCertConfig
 
 }


### PR DESCRIPTION
feat(ssl): add support and tests for ClientSSLCertConfig.FromClientCertContent

- Introduced FromClientCertContent to allow passing cert/key as strings
- Added tests for successful SSL handshake using certs loaded from resources
- Added test for invalid cert/key handling via env stream input

Passing the cert and key via environment variables lets you configure ClientSSLCertConfig.FromClientCertContent without writing files.
