### PR TITLE
Add `JsonSchema.fromZSchemaInlineDeepOrFail` (#3168)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -1577,9 +1577,9 @@ object JsonSchema {
   }
 
   /**
-   * Builds a fully inlined `JsonSchema`, eliminating all `\$ref` occurrences. If a
-   * recursive definition is encountered, the process short-circuits and returns
-   * `Left(GenerationError.RecursionDetected)` containing the cycle (in
+   * Builds a fully inlined `JsonSchema`, eliminating all `\$ref` occurrences.
+   * If a recursive definition is encountered, the process short-circuits and
+   * returns `Left(GenerationError.RecursionDetected)` containing the cycle (in
    * compact-reference form) that made inlining impossible.
    */
   def fromZSchemaInlineDeepOrFail[A](schema: Schema[A]): Either[GenerationError, JsonSchema] = {

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -1608,8 +1608,6 @@ object JsonSchema {
     }
 
     // Helper that recursively replaces RefSchema with their definitions while tracking refs.
-    // NOTE: Method was previously called `inline` but Scala 3 treats `inline` as a soft keyword.
-    // Renaming to avoid the conflict.
     def inlineRec(js: JsonSchema, path: List[java.lang.String]): Either[GenerationError, JsonSchema] =
       js match {
         case RefSchema(ref0) =>
@@ -1674,17 +1672,15 @@ object JsonSchema {
     def recurseCollection(
       coll: Chunk[JsonSchema],
       path: List[java.lang.String],
-    ): Either[GenerationError, Chunk[JsonSchema]] = {
-      Chunk
-        .fromIterable(coll)
-        .foldLeft[Either[GenerationError, List[JsonSchema]]](Right(Nil)) { (accE, schema) =>
+    ): Either[GenerationError, Chunk[JsonSchema]] =
+      coll
+        .foldRight[Either[GenerationError, List[JsonSchema]]](Right(Nil)) { (schema, accE) =>
           for {
             acc <- accE
             inl <- inlineRec(schema, path)
           } yield inl :: acc
         }
-        .map(lst => Chunk.fromIterable(lst.reverse))
-    }
+        .map(Chunk.fromIterable)
 
     inlineRec(multi.root, Nil)
   }

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -1577,7 +1577,7 @@ object JsonSchema {
   }
 
   /**
-   * Builds a fully inlined `JsonSchema`, eliminating all `$ref`s. If a
+   * Builds a fully inlined `JsonSchema`, eliminating all `\$ref` occurrences. If a
    * recursive definition is encountered, the process short-circuits and returns
    * `Left(GenerationError.RecursionDetected)` containing the cycle (in
    * compact-reference form) that made inlining impossible.

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/JsonSchema.scala
@@ -666,7 +666,6 @@ object JsonSchema {
           }
         val nonTransientFields   =
           record.fields.filterNot(_.annotations.exists(_.isInstanceOf[transientField]))
-
         JsonSchema
           .Object(
             Map.empty,
@@ -1333,9 +1332,7 @@ object JsonSchema {
     def addAll(value: Chunk[(java.lang.String, JsonSchema)]): Object =
       value.foldLeft(this) { case (obj, (name, schema)) =>
         schema match {
-          case thatObj @ Object(properties, additionalProperties, required)
-              if thatObj.isClosedDictionary && additionalProperties == Left(false) &&
-                !(this.properties == properties && this.additionalProperties == additionalProperties) =>
+          case thatObj @ Object(properties, additionalProperties, required) if thatObj.isClosedDictionary =>
             obj.copy(
               properties = obj.properties ++ properties,
               additionalProperties = combineAdditionalProperties(obj.additionalProperties, additionalProperties),

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/JsonSchemaSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/JsonSchemaSpec.scala
@@ -1,0 +1,190 @@
+package zio.http.endpoint.openapi
+
+import java.util.UUID
+
+import scala.collection.immutable.ListMap
+
+import zio.NonEmptyChunk
+import zio.json.ast.Json
+import zio.test._
+
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http.endpoint.openapi.JsonSchema.SchemaStyle
+import zio.http.endpoint.openapi.OpenAPI.ReferenceOr
+
+object JsonSchemaSpec extends ZIOSpecDefault {
+
+  final case class Address(street: String, city: String)
+  object Address {
+    implicit val schema: Schema[Address] = DeriveSchema.gen[Address]
+  }
+  final case class Person(name: String, address: Address)
+  object Person  {
+    implicit val schema: Schema[Person] = DeriveSchema.gen[Person]
+  }
+
+  final case class NodeA(b: NodeB)
+  object NodeA {
+    implicit lazy val schema: Schema[NodeA] = DeriveSchema.gen[NodeA]
+  }
+
+  final case class NodeB(a: NodeA)
+  object NodeB {
+    implicit lazy val schema: Schema[NodeB] = DeriveSchema.gen[NodeB]
+  }
+
+  final case class SelfRec(next: SelfRec)
+  object SelfRec {
+    implicit lazy val schema: Schema[SelfRec] = DeriveSchema.gen[SelfRec]
+  }
+
+  private def toJsonAst(str: String): Json =
+    Json.decoder.decodeJson(str).toOption.get
+
+  val spec = suite("JsonSchemaSpec")(
+    suite("fromZSchema")(
+      test("correctly handles Map with non-simple string keys") {
+        val schema = Schema.map[UUID, String]
+        val js     = JsonSchema.fromZSchema(schema)
+        val oapi   = OpenAPI.empty.copy(
+          components =
+            Some(OpenAPI.Components(schemas = ListMap(OpenAPI.Key.fromString("IdToName").get -> ReferenceOr.Or(js)))),
+        )
+
+        val json     = oapi.toJsonPretty
+        val expected = """{
+                         |  "openapi" : "3.1.0",
+                         |  "info" : {
+                         |    "title" : "",
+                         |    "version" : ""
+                         |  },
+                         |  "components" : {
+                         |    "schemas" : {
+                         |      "IdToName" :
+                         |        {
+                         |        "type" :
+                         |          "object",
+                         |        "properties" : {},
+                         |        "additionalProperties" :
+                         |          {
+                         |          "type" :
+                         |            "string",
+                         |          "x-string-key-schema" : {
+                         |            "type" :
+                         |              "string",
+                         |            "format" : "uuid"
+                         |          }
+                         |        }
+                         |      }
+                         |    }
+                         |  }
+                         |}""".stripMargin
+        assert(toJsonAst(json))(Assertion.equalTo(toJsonAst(expected)))
+      },
+      test("SchemaStyle.Compact returns exact $ref JSON path with compact name") {
+        val jsonSchema = JsonSchema.fromZSchema(implicitly[Schema[Person]], SchemaStyle.Compact)
+
+        val expectedJson = toJsonAst("""{ "$ref": "#/components/schemas/Person" }""")
+        assert(toJsonAst(jsonSchema.toJson))(Assertion.equalTo(expectedJson))
+      },
+      test("SchemaStyle.Reference returns $ref-only JSON for Person") {
+        val js = JsonSchema.fromZSchema(implicitly[Schema[Person]], SchemaStyle.Reference)
+
+        val expectedJson = toJsonAst(
+          """{ "$ref": "#/components/schemas/zio_http_endpoint_openapi_JsonSchemaSpec_Person" }""",
+        )
+
+        assert(toJsonAst(js.toJson))(Assertion.equalTo(expectedJson))
+      },
+      test("SchemaStyle.Compact returns $ref-only JSON for Person") {
+        val js = JsonSchema.fromZSchema(implicitly[Schema[Person]], SchemaStyle.Compact)
+
+        val expectedJson = toJsonAst("""{ "$ref": "#/components/schemas/Person" }""")
+
+        assert(toJsonAst(js.toJson))(Assertion.equalTo(expectedJson))
+      },
+    ),
+    suite("fromZSchemaMulti")(
+      test("correctly handles Map schema with List as Value") {
+        val schema = Schema.map[String, List[String]]
+        val sch    = JsonSchema.fromZSchemaMulti(schema, SchemaStyle.Reference)
+
+        val hasStringArrayValues: Assertion[JsonSchema] =
+          Assertion.assertion("hasStringArrayValues") {
+            case JsonSchema.Object(_, Right(JsonSchema.ArrayType(items, _, _)), _) =>
+              items.exists(_.isInstanceOf[JsonSchema.String])
+            case _                                                                 => false
+          }
+
+        assert(sch.root)(hasStringArrayValues)
+      },
+      test("collects child schemas of nested records (Reference)") {
+        val jsMulti = JsonSchema.fromZSchemaMulti(implicitly[Schema[Person]], SchemaStyle.Reference)
+
+        val personRef  = "#/components/schemas/zio_http_endpoint_openapi_JsonSchemaSpec_Person"
+        val addressRef = "#/components/schemas/zio_http_endpoint_openapi_JsonSchemaSpec_Address"
+
+        assertTrue(
+          jsMulti.rootRef.contains(personRef) &&
+            jsMulti.children.contains(addressRef) &&
+            jsMulti.children(addressRef).isInstanceOf[JsonSchema.Object],
+        )
+      },
+      test("collects child schemas with compact refs (Compact)") {
+        val jsMulti = JsonSchema.fromZSchemaMulti(implicitly[Schema[Person]], SchemaStyle.Compact)
+
+        val personRef  = "#/components/schemas/Person"
+        val addressRef = "#/components/schemas/Address"
+
+        assertTrue(
+          jsMulti.rootRef.contains(personRef) &&
+            jsMulti.children.contains(addressRef) &&
+            jsMulti.children(addressRef).isInstanceOf[JsonSchema.Object],
+        )
+      },
+    ),
+    suite("fromZSchemaInlineDeepOrFail")(
+      test("inlines non-recursive schema") {
+        val result = JsonSchema.fromZSchemaInlineDeepOrFail(implicitly[Schema[Person]])
+
+        val expectedJson = toJsonAst(
+          """{
+            |"type":"object",
+            |"properties":{
+            |  "name":{"type":"string"},
+            |  "address":{
+            |    "type":"object",
+            |    "properties":{
+            |      "street":{"type":"string"},
+            |      "city":{"type":"string"}
+            |    },
+            |    "required":["street","city"]
+            |  }
+            |},
+            |"required":["name","address"]
+            |}""".stripMargin,
+        )
+
+        assertTrue(result.isRight) &&
+        assert(toJsonAst(result.toOption.get.toJson))(Assertion.equalTo(expectedJson))
+      },
+      test("detects simple recursion") {
+        val res      = JsonSchema.fromZSchemaInlineDeepOrFail(implicitly[Schema[SelfRec]])
+        val expected = NonEmptyChunk("#/components/schemas/SelfRec")
+
+        assertTrue(
+          res == Left(JsonSchema.GenerationError.RecursionDetected(expected)),
+        )
+      },
+      test("detects mutual recursion") {
+        val res      = JsonSchema.fromZSchemaInlineDeepOrFail(implicitly[Schema[NodeA]])
+        val expected = NonEmptyChunk("#/components/schemas/NodeA")
+
+        assertTrue(
+          res == Left(JsonSchema.GenerationError.RecursionDetected(expected)),
+        )
+      },
+    ),
+  )
+}

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -1,16 +1,10 @@
 package zio.http.endpoint.openapi
 
-import java.util.UUID
-
 import scala.collection.immutable.ListMap
 
 import zio.json.ast.Json
 import zio.test._
 
-import zio.schema.Schema
-
-import zio.http.endpoint.openapi.JsonSchema.SchemaStyle
-import zio.http.endpoint.openapi.OpenAPI.ReferenceOr
 import zio.http.endpoint.openapi.OpenAPI.SecurityScheme._
 
 object OpenAPISpec extends ZIOSpecDefault {
@@ -62,59 +56,6 @@ object OpenAPISpec extends ZIOSpecDefault {
                        |  ]
                        |}""".stripMargin
 
-      assertTrue(toJsonAst(json) == toJsonAst(expected))
-    },
-    test("JsonSchema.fromZSchemaMulti correctly handles Map schema with List as Value") {
-      val schema           = Schema.map[String, List[String]]
-      val sch: JsonSchemas = JsonSchema.fromZSchemaMulti(schema, SchemaStyle.Reference)
-
-      val isSchemaProperlyGenerated = if (sch.root.isCollection) sch.root match {
-        case JsonSchema.Object(_, additionalProperties, _) =>
-          additionalProperties match {
-            case Right(JsonSchema.ArrayType(items, _, _)) =>
-              items.exists(_.isInstanceOf[JsonSchema.String])
-            case _                                        => false
-          }
-        case _                                             => false
-      }
-      else false
-      assertTrue(isSchemaProperlyGenerated)
-    },
-    test("JsonSchema.fromZSchema correctly handles Map with non-simple string keys") {
-      val schema   = Schema.map[UUID, String]
-      val js       = JsonSchema.fromZSchema(schema)
-      val oapi     = OpenAPI.empty.copy(
-        components =
-          Some(OpenAPI.Components(schemas = ListMap(OpenAPI.Key.fromString("IdToName").get -> ReferenceOr.Or(js)))),
-      )
-      val json     = oapi.toJsonPretty
-      val expected = """{
-                       |  "openapi" : "3.1.0",
-                       |  "info" : {
-                       |    "title" : "",
-                       |    "version" : ""
-                       |  },
-                       |  "components" : {
-                       |    "schemas" : {
-                       |      "IdToName" :
-                       |        {
-                       |        "type" :
-                       |          "object",
-                       |        "properties" : {},
-                       |        "additionalProperties" :
-                       |          {
-                       |          "type" :
-                       |            "string",
-                       |          "x-string-key-schema" : {
-                       |            "type" :
-                       |              "string",
-                       |            "format" : "uuid"
-                       |          }
-                       |        }
-                       |      }
-                       |    }
-                       |  }
-                       |}""".stripMargin
       assertTrue(toJsonAst(json) == toJsonAst(expected))
     },
   )


### PR DESCRIPTION
Also reorganized JsonSchema tests in a dedicated suite with more cases verifying the same behavior with the other schema styles.