### PR TITLE
Optimize `ServerSentEvent::encode` code && put the `event:` part first

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
@@ -144,15 +144,10 @@ object ServerSentEventSpec extends ZIOHttpSpec {
       test("empty string data") {
         val event  = ServerSentEvent(data = "")
         val result = event.encode
-        assertTrue(
-          result ==
-            """data:
-              |
-              |""".stripMargin,
-        )
+        assertTrue(result == "data: \n\n")
       },
       test("eventType with carriage returns gets flattened") {
-        val event  = ServerSentEvent(data = "data", eventType = Some("message\r\nwith\rreturns"))
+        val event  = ServerSentEvent(data = "data", eventType = Some("message\nwith\nreturns"))
         val result = event.encode
         assertTrue(
           result ==

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
@@ -146,6 +146,11 @@ object ServerSentEventSpec extends ZIOHttpSpec {
         val result = event.encode
         assertTrue(result == "data: \n\n")
       },
+      test("empty string data with eventType") {
+        val event  = ServerSentEvent(data = "", eventType = Some("message"))
+        val result = event.encode
+        assertTrue(result == "event: message\ndata: \n\n")
+      },
       test("eventType with carriage returns gets flattened") {
         val event  = ServerSentEvent(data = "data", eventType = Some("message\nwith\nreturns"))
         val result = event.encode

--- a/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerSentEventSpec.scala
@@ -10,7 +10,12 @@ import zio.test._
 
 import zio.stream.ZStream
 
+import zio.schema.codec.BinaryCodec
+
+import zio.http.codec.HttpContentCodec
+
 object ServerSentEventSpec extends ZIOHttpSpec {
+  implicit val stringCodec: BinaryCodec[String] = HttpContentCodec.text.only[String].defaultCodec
 
   val stream: ZStream[Any, Nothing, ServerSentEvent[String]] =
     ZStream.repeatWithSchedule(
@@ -39,8 +44,129 @@ object ServerSentEventSpec extends ZIOHttpSpec {
           )(_.body.asServerSentEvents[String])
     } yield event
 
+  private val encodeSpec =
+    suite("::encode")(
+      test("single string data") {
+        val event  = ServerSentEvent(data = "hello world")
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data: hello world
+              |
+              |""".stripMargin,
+        )
+      },
+      test("multiline string data") {
+        val event  = ServerSentEvent(data = "line1\nline2\nline3")
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data: line1
+              |data: line2
+              |data: line3
+              |
+              |""".stripMargin,
+        )
+      },
+      test("data with eventType") {
+        val event  = ServerSentEvent(data = "test data", eventType = Some("message"))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """event: message
+              |data: test data
+              |
+              |""".stripMargin,
+        )
+      },
+      test("data with id") {
+        val event  = ServerSentEvent(data = "test data", id = Some("123"))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data: test data
+              |id: 123
+              |
+              |""".stripMargin,
+        )
+      },
+      test("data with retry") {
+        val event  = ServerSentEvent(data = "test data", retry = Some(5000.milliseconds))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data: test data
+              |retry: 5000
+              |
+              |""".stripMargin,
+        )
+      },
+      test("all fields") {
+        val event  = ServerSentEvent(
+          "test data",
+          eventType = Some("update"),
+          id = Some("456"),
+          retry = Some(3000.milliseconds),
+        )
+        val result = event.encode
+        assertTrue(
+          result ==
+            """event: update
+              |data: test data
+              |id: 456
+              |retry: 3000
+              |
+              |""".stripMargin,
+        )
+      },
+      test("eventType with newlines gets flattened") {
+        val event  = ServerSentEvent(data = "data", eventType = Some("message\nwith\nnewlines"))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """event: message with newlines
+              |data: data
+              |
+              |""".stripMargin,
+        )
+      },
+      test("id with newlines gets flattened") {
+        val event  = ServerSentEvent(data = "data", id = Some("id\nwith\nnewlines"))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data: data
+              |id: id with newlines
+              |
+              |""".stripMargin,
+        )
+      },
+      test("empty string data") {
+        val event  = ServerSentEvent(data = "")
+        val result = event.encode
+        assertTrue(
+          result ==
+            """data:
+              |
+              |""".stripMargin,
+        )
+      },
+      test("eventType with carriage returns gets flattened") {
+        val event  = ServerSentEvent(data = "data", eventType = Some("message\r\nwith\rreturns"))
+        val result = event.encode
+        assertTrue(
+          result ==
+            """event: message with returns
+              |data: data
+              |
+              |""".stripMargin,
+        )
+      },
+    )
+
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("ServerSentEventSpec")(
+      encodeSpec,
       test("Send and receive ServerSentEvent with string payload") {
         for {
           _      <- server.fork

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -54,9 +54,7 @@ final case class ServerSentEvent[T](
 
     val dataLines: Array[String] = dataString.split("\n")
 
-    /**
-     * See https://github.com/zio/zio-http/pull/3596#discussion_r2235083078
-     */
+    // See https://github.com/zio/zio-http/pull/3596#discussion_r2235083078
     @inline def allocationFreeFold(option: Option[?])(ifEmpty: Int, ifNonEmpty: Int): Int =
       if (option.isEmpty) ifEmpty else ifNonEmpty
 

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -156,13 +156,7 @@ object ServerSentEvent {
               event.copy(eventType = Some(line.replaceFirst("event: ?", "")).filter(_.nonEmpty))
             case Some("event")  => event.copy(eventType = None)
             case Some("retry:") =>
-              event.copy(retry =
-                Some(line.replaceFirst("retry: ?", ""))
-                  .filter(_.nonEmpty)
-                  .flatMap(_.toIntOption)
-                  .filter(_ >= 0)
-                  .map(_.milliseconds),
-              )
+              event.copy(retry = line.replaceFirst("retry: ?", "").toIntOption.filter(_ >= 0).map(_.milliseconds))
             case Some("retry")  => event.copy(retry = None)
             case Some("id:")    => event.copy(id = Some(line.replaceFirst("id: ?", "")).filter(_.nonEmpty))
             case Some("id")     => event.copy(id = None)

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -16,13 +16,16 @@
 
 package zio.http
 
+import scala.util.Try
+
 import zio._
-import zio.http.codec._
-import zio.schema.codec._
-import zio.schema.{DeriveSchema, Schema}
+
 import zio.stream.ZPipeline
 
-import scala.util.Try
+import zio.schema.codec._
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http.codec._
 
 /**
  * Server-Sent Event (SSE) as defined by
@@ -48,7 +51,7 @@ final case class ServerSentEvent[T](
     val dataLines: Array[String] =
       data match {
         case s: String => s.split('\n')
-        case _ => binaryCodec.encode(data).asString(Charsets.Utf8).split('\n')
+        case _         => binaryCodec.encode(data).asString(Charsets.Utf8).split('\n')
       }
 
     val initialCapacity: Int =

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -81,9 +81,11 @@ final case class ServerSentEvent[T](
     id.foreach { i =>
       sb.append("id: ")
       val iterator = i.linesIterator
-      while (iterator.hasNext) {
+      var hasNext  = iterator.hasNext
+      while (hasNext) {
         sb.append(iterator.next())
-        if (iterator.hasNext) sb.append(' ')
+        hasNext = iterator.hasNext
+        if (hasNext) sb.append(' ')
       }
       sb.append('\n')
     }

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -167,6 +167,7 @@ object ServerSentEvent {
               event.copy(eventType = Some(line.replaceFirst("event: ?", "")).filter(_.nonEmpty))
             case Some("event")  => event.copy(eventType = None)
             case Some("retry:") =>
+              import scala.collection.compat._
               event.copy(retry = line.replaceFirst("retry: ?", "").toIntOption.filter(_ >= 0).map(_.milliseconds))
             case Some("retry")  => event.copy(retry = None)
             case Some("id:")    => event.copy(id = Some(line.replaceFirst("id: ?", "")).filter(_.nonEmpty))

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -54,13 +54,24 @@ final case class ServerSentEvent[T](
 
     val dataLines: Array[String] = dataString.split("\n")
 
+    /**
+     * See https://github.com/zio/zio-http/pull/3596#discussion_r2235083078
+     */
+    @inline def allocationFreeFold(option: Option[?])(ifEmpty: Int, ifNonEmpty: Int): Int =
+      if (option.isEmpty) ifEmpty else ifNonEmpty
+
     val initialCapacity: Int =
       (
-        (6 + dataString.length + dataLines.length) // 6 for "data: ", the data itself, and the newlines
-          + eventType.fold(0)(_ => 24) // 24 because 7 for "event: ", 1 for the newline, 16 for the event type itself
-          + id.fold(0)(_ => 21)        // 21 because 4 for "id: ", 1 for the newline, 16 for the id itself
-          + retry.fold(0)(_ => 24)     // 24 because 7 for "retry: ", 1 for the newline, 16 for the retry value
-          + 1                          // for the final newline
+        // 6 for "data: ", the data itself, and the newlines
+        (6 + dataString.length + dataLines.length)
+        // 24 because 7 for "event: ", 1 for the newline, 16 for the event type itself
+          + allocationFreeFold(eventType)(0, 24)
+          // 21 because 4 for "id: ", 1 for the newline, 16 for the id itself
+          + allocationFreeFold(id)(0, 21)
+          // 24 because 7 for "retry: ", 1 for the newline, 16 for the retry value
+          + allocationFreeFold(retry)(0, 24)
+          // for the final newline
+          + 1
       )
 
     val sb = new java.lang.StringBuilder(initialCapacity)

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -16,13 +16,16 @@
 
 package zio.http
 
+import scala.util.Try
+
 import zio._
-import zio.http.codec._
-import zio.schema.codec._
-import zio.schema.{DeriveSchema, Schema}
+
 import zio.stream.ZPipeline
 
-import scala.util.Try
+import zio.schema.codec._
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http.codec._
 
 /**
  * Server-Sent Event (SSE) as defined by

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -16,8 +16,6 @@
 
 package zio.http
 
-import scala.util.Try
-
 import zio._
 
 import zio.stream.ZPipeline
@@ -161,7 +159,7 @@ object ServerSentEvent {
               event.copy(retry =
                 Some(line.replaceFirst("retry: ?", ""))
                   .filter(_.nonEmpty)
-                  .flatMap(retry => Try(retry.toInt).toOption)
+                  .flatMap(_.toIntOption)
                   .filter(_ >= 0)
                   .map(_.milliseconds),
               )

--- a/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ServerSentEvent.scala
@@ -54,20 +54,16 @@ final case class ServerSentEvent[T](
 
     val dataLines: Array[String] = dataString.split("\n")
 
-    // See https://github.com/zio/zio-http/pull/3596#discussion_r2235083078
-    @inline def allocationFreeFold(option: Option[?])(ifEmpty: Int, ifNonEmpty: Int): Int =
-      if (option.isEmpty) ifEmpty else ifNonEmpty
-
     val initialCapacity: Int =
       (
         // 6 for "data: ", the data itself, and the newlines
         (6 + dataString.length + dataLines.length)
         // 24 because 7 for "event: ", 1 for the newline, 16 for the event type itself
-          + allocationFreeFold(eventType)(0, 24)
+          + (if (eventType.isEmpty) 0 else 24)
           // 21 because 4 for "id: ", 1 for the newline, 16 for the id itself
-          + allocationFreeFold(id)(0, 21)
+          + (if (id.isEmpty) 0 else 21)
           // 24 because 7 for "retry: ", 1 for the newline, 16 for the retry value
-          + allocationFreeFold(retry)(0, 24)
+          + (if (retry.isEmpty) 0 else 24)
           // for the final newline
           + 1
       )


### PR DESCRIPTION
The `event:` part doesn't need, per spec, to be first but it seems to be a common practice to put it first