### PR TITLE
Parse NC Parameter as Hexadecimal in Digest Authentication per RFC 7616

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -1365,7 +1365,7 @@ object Header {
           qop           <- params.get("qop")
           cnonce        <- params.get("cnonce")
           nonce         <- params.get("nonce")
-          nc            <- params.get("nc").flatMap(v => Try(v.toInt).toOption)
+          nc            <- params.get("nc").flatMap(v => Try(Integer.parseInt(v, 16)).toOption)
         } yield Digest(response, usernameFinal, realm, uri, opaque, algo, qop, cnonce, nonce, nc, userhash)
 
         maybeDigest


### PR DESCRIPTION
## Description

This PR fixes the parsing of the `nc` (nonce count) parameter in the digest authentication parser to comply with RFC 7616 specification.

## Problem

The current implementation incorrectly parses the `nc` parameter as a decimal integer using `v.toInt`, but according to RFC 7616, the `nc` parameter should be parsed as a hexadecimal value. This causes authentication failures when clients send properly formatted hexadecimal nonce count values.
