### PR TITLE
fix: Datastar SDK — readSignals, enum values, Signal.ref, quote escaping

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
@@ -962,9 +962,8 @@ trait DatastarPackageBase extends Attributes {
     if (request.method == Method.GET) {
       ZIO.fromEither {
         request
-          .header[String]("datastar")
-          .left
-          .map(_.getMessage())
+          .queryParam("datastar")
+          .toRight("Missing 'datastar' query parameter")
           .flatMap(_.fromJson[T](zio.schema.codec.JsonCodec.jsonDecoder(Schema[T])))
       }
     } else {

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
@@ -204,13 +204,13 @@ object DatastarRequestCancellation {
 
   implicit val schema: Schema[DatastarRequestCancellation] = Schema[String].transform[DatastarRequestCancellation](
     {
-      case "Auto"     => Auto
-      case "Disabled" => Disabled
+      case "auto"     => Auto
+      case "disabled" => Disabled
       case other      => Custom(Js(other))
     },
     {
-      case Auto          => "Auto"
-      case Disabled      => "Disabled"
+      case Auto          => "auto"
+      case Disabled      => "disabled"
       case Custom(value) => value.value
     },
   )
@@ -218,18 +218,24 @@ object DatastarRequestCancellation {
 
 sealed trait DatastarRetry
 object DatastarRetry {
-  case object Auto  extends DatastarRetry
-  case object Error extends DatastarRetry
+  case object Auto   extends DatastarRetry
+  case object Error  extends DatastarRetry
+  case object Always extends DatastarRetry
+  case object Never  extends DatastarRetry
 
   implicit val schema: Schema[DatastarRetry] = Schema[String].transformOrFail[DatastarRetry](
     {
-      case "auto"  => Right(Auto)
-      case "error" => Right(Error)
-      case other   => Left(s"Invalid DatastarRetry value: '$other'. Expected 'auto' or 'error'.")
+      case "auto"   => Right(Auto)
+      case "error"  => Right(Error)
+      case "always" => Right(Always)
+      case "never"  => Right(Never)
+      case other    => Left(s"Invalid DatastarRetry value: '$other'. Expected 'auto', 'error', 'always', or 'never'.")
     },
     {
-      case Auto  => Right("auto")
-      case Error => Right("error")
+      case Auto   => Right("auto")
+      case Error  => Right("error")
+      case Always => Right("always")
+      case Never  => Right("never")
     },
   )
 }

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
@@ -23,15 +23,7 @@ final case class Signal[A](
   /** Create a signal update assignment */
   def :=(value: A): SignalUpdate[A] = SignalUpdate(self, value)
 
-  private var ref0: String = null
-
-  /** Render the signal as a datastar expression reference */
-  def ref: String = {
-    if (ref0 == null && schema.isInstanceOf[Schema.Primitive[_]]) ref0 = name.ref
-    else if (!schema.isInstanceOf[Schema.Primitive[_]])
-      throw new RuntimeException(s"Signal.ref is only supported for primitive types, got: $schema")
-    ref0
-  }
+  lazy val ref: String = name.ref
 
   override def toString: String = ref
 
@@ -148,7 +140,7 @@ object SignalUpdate {
     case zio.json.ast.Json.Arr(items)  =>
       val itemStrs = items.map(astToExpression)
       s"[${itemStrs.mkString(", ")}]"
-    case zio.json.ast.Json.Str(value)  => s"'$value'"
+    case zio.json.ast.Json.Str(value)  => s"'${value.replace("'", "\\'")}'"
     case zio.json.ast.Json.Num(value)  => value.toString
     case zio.json.ast.Json.Bool(value) => value.toString
     case zio.json.ast.Json.Null        => "null"

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
@@ -553,7 +553,7 @@ object DatastarRequestSpec extends ZIOSpecDefault {
         assertTrue(
           request.render.contains("@delete"),
           request.render.contains("/api/delete/123"),
-          request.render.contains("Disabled"),
+          request.render.contains("disabled"),
         )
       },
       test("should render request with multiple custom options") {

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ReadSignalsSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/ReadSignalsSpec.scala
@@ -26,11 +26,10 @@ object ReadSignalsSpec extends ZIOSpecDefault {
 
   override def spec = suite("ReadSignalsSpec")(
     suite("readSignals with GET requests")(
-      test("should read signals from datastar header with simple data") {
+      test("should read signals from datastar query parameter with simple data") {
         val jsonData = """{"count":42}"""
         val request  = Request
-          .get(URL.root / "test")
-          .addHeader(Header.Custom("datastar", jsonData))
+          .get((URL.root / "test").addQueryParams(QueryParams("datastar" -> jsonData)))
 
         for {
           result <- readSignals[SimpleSignal](request)
@@ -38,11 +37,10 @@ object ReadSignalsSpec extends ZIOSpecDefault {
           result.count == 42,
         )
       },
-      test("should read signals from datastar header with complex data") {
+      test("should read signals from datastar query parameter with complex data") {
         val jsonData = """{"name":"John Doe","age":30,"email":"john@example.com"}"""
         val request  = Request
-          .get(URL.root / "test")
-          .addHeader(Header.Custom("datastar", jsonData))
+          .get((URL.root / "test").addQueryParams(QueryParams("datastar" -> jsonData)))
 
         for {
           result <- readSignals[User](request)
@@ -52,11 +50,10 @@ object ReadSignalsSpec extends ZIOSpecDefault {
           result.email == "john@example.com",
         )
       },
-      test("should read signals from datastar header with nested data") {
+      test("should read signals from datastar query parameter with nested data") {
         val jsonData = """{"user":{"name":"Jane","age":25,"email":"jane@test.com"},"active":true}"""
         val request  = Request
-          .get(URL.root / "test")
-          .addHeader(Header.Custom("datastar", jsonData))
+          .get((URL.root / "test").addQueryParams(QueryParams("datastar" -> jsonData)))
 
         for {
           result <- readSignals[NestedData](request)
@@ -67,7 +64,7 @@ object ReadSignalsSpec extends ZIOSpecDefault {
           result.active == true,
         )
       },
-      test("should fail when datastar header is missing in GET request") {
+      test("should fail when datastar query parameter is missing in GET request") {
         val request = Request.get(URL.root / "test")
 
         for {
@@ -76,10 +73,9 @@ object ReadSignalsSpec extends ZIOSpecDefault {
           result.isLeft,
         )
       },
-      test("should fail when datastar header contains invalid JSON") {
+      test("should fail when datastar query parameter contains invalid JSON") {
         val request = Request
-          .get(URL.root / "test")
-          .addHeader(Header.Custom("datastar", "{invalid json"))
+          .get((URL.root / "test").addQueryParams(QueryParams("datastar" -> "{invalid json")))
 
         for {
           result <- readSignals[SimpleSignal](request).either
@@ -90,8 +86,7 @@ object ReadSignalsSpec extends ZIOSpecDefault {
       test("should fail when JSON doesn't match schema") {
         val jsonData = """{"wrong":"field"}"""
         val request  = Request
-          .get(URL.root / "test")
-          .addHeader(Header.Custom("datastar", jsonData))
+          .get((URL.root / "test").addQueryParams(QueryParams("datastar" -> jsonData)))
 
         for {
           result <- readSignals[SimpleSignal](request).either


### PR DESCRIPTION
## Summary

Fix 5 bugs in the Datastar SDK to align with the [official Datastar JS SDK](https://github.com/starfederation/datastar/blob/main/library/src/plugins/actions/fetch.ts) behavior.

## Bugs Fixed

### 1. `readSignals` reads GET signals from header instead of query parameter (#4020)
The Datastar JS SDK sends signals as a `datastar` query parameter for GET requests, not as a header. The Scala SDK was reading from the header, causing GET signal reads to always fail.

### 2. `DatastarRetry` missing `Always` and `Never` enum values (#4021)
The JS SDK supports `retry: 'auto' | 'error' | 'always' | 'never'`, but the Scala SDK only had `Auto` and `Error`.

### 3. `DatastarRequestCancellation` invalid PascalCase enum values (#4022)
The JS SDK uses lowercase `"auto"` and `"disabled"`, but the Scala SDK was encoding/decoding `"Auto"` and `"Disabled"`, causing client-side mismatches.

### 4. `Signal.ref` incorrect primitive restriction + race condition (#4023)
`Signal.ref` threw a runtime exception for non-primitive types (e.g., case classes) and used an unsynchronized mutable `var`. Replaced with `lazy val` delegating to `name.ref`, which is thread-safe and works for all types.

### 5. `astToExpression` single-quote escaping bug (#4024)
String values containing single quotes would produce invalid JavaScript expressions. Added proper escaping.

## Files Changed
- `DatastarPackageBase.scala` — `readSignals` GET path
- `DatastarRequest.scala` — `DatastarRetry` + `DatastarRequestCancellation`
- `Signal.scala` — `ref` field + `astToExpression`
- `ReadSignalsSpec.scala` — Updated GET tests to use query params
- `DatastarRequestSpec.scala` — Updated assertion to match lowercase enum

## Testing
All 406 tests pass (`sbt zioHttpDatastarSdk/test`).

Fixes #4020, #4021, #4022, #4023, #4024