### PR TITLE
fix: add missing Always and Never values to DatastarRetry

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
@@ -218,18 +218,24 @@ object DatastarRequestCancellation {
 
 sealed trait DatastarRetry
 object DatastarRetry {
-  case object Auto  extends DatastarRetry
-  case object Error extends DatastarRetry
+  case object Auto   extends DatastarRetry
+  case object Error  extends DatastarRetry
+  case object Always extends DatastarRetry
+  case object Never  extends DatastarRetry
 
   implicit val schema: Schema[DatastarRetry] = Schema[String].transformOrFail[DatastarRetry](
     {
-      case "auto"  => Right(Auto)
-      case "error" => Right(Error)
-      case other   => Left(s"Invalid DatastarRetry value: '$other'. Expected 'auto' or 'error'.")
+      case "auto"   => Right(Auto)
+      case "error"  => Right(Error)
+      case "always" => Right(Always)
+      case "never"  => Right(Never)
+      case other    => Left(s"Invalid DatastarRetry value: '$other'. Expected 'auto', 'error', 'always', or 'never'.")
     },
     {
-      case Auto  => Right("auto")
-      case Error => Right("error")
+      case Auto   => Right("auto")
+      case Error  => Right("error")
+      case Always => Right("always")
+      case Never  => Right("never")
     },
   )
 }

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
@@ -945,6 +945,26 @@ object DatastarRequestSpec extends ZIOSpecDefault {
           request.render == """@get('/api/data', {"retry":"error"})""",
         )
       },
+      test("DatastarRetry.Always serializes as always in JSON") {
+        val options = DatastarRequestOptions.default.copy(
+          retry = Some(DatastarRetry.Always),
+        )
+        val request = DatastarRequest(Method.GET, url"/api/data", options)
+
+        assertTrue(
+          request.render == """@get('/api/data', {"retry":"always"})""",
+        )
+      },
+      test("DatastarRetry.Never serializes as never in JSON") {
+        val options = DatastarRequestOptions.default.copy(
+          retry = Some(DatastarRetry.Never),
+        )
+        val request = DatastarRequest(Method.GET, url"/api/data", options)
+
+        assertTrue(
+          request.render == """@get('/api/data', {"retry":"never"})""",
+        )
+      },
       test("retry None is excluded from JSON output") {
         val options = DatastarRequestOptions.default.copy(
           retry = None,


### PR DESCRIPTION
Fixes #4021

The Datastar JS SDK supports `retry: 'auto' | 'error' | 'always' | 'never'`, but the Scala SDK was missing the `Always` and `Never` enum values.

## Changes
- Added `Always` case object to `DatastarRetry`
- Added `Never` case object to `DatastarRetry`
- Updated schema transformation to handle "always" and "never" strings
- Updated error message to list all 4 valid values