### PR TITLE
fix: Signal.ref race condition from unsynchronized mutable var (#4023)

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
@@ -23,14 +23,10 @@ final case class Signal[A](
   /** Create a signal update assignment */
   def :=(value: A): SignalUpdate[A] = SignalUpdate(self, value)
 
-  private var ref0: String = null
-
-  /** Render the signal as a datastar expression reference */
-  def ref: String = {
-    if (ref0 == null && schema.isInstanceOf[Schema.Primitive[_]]) ref0 = name.ref
-    else if (!schema.isInstanceOf[Schema.Primitive[_]])
+  lazy val ref: String = {
+    if (!schema.isInstanceOf[Schema.Primitive[_]])
       throw new RuntimeException(s"Signal.ref is only supported for primitive types, got: $schema")
-    ref0
+    name.ref
   }
 
   override def toString: String = ref


### PR DESCRIPTION
## Summary

Fix race condition in `Signal.ref` caused by an unsynchronized mutable `var`.

## Bug

`Signal.ref` used a `private var ref0: String = null` with a check-and-set pattern that was not thread-safe. Concurrent access could result in null returns or duplicate computation.

## Fix

Replace `private var ref0` + `def ref` with `lazy val ref`, which is thread-safe in Scala (uses a synchronized initialization block under the hood, zero-cost after first access).

The primitive-type restriction and `RuntimeException` for non-primitive types are preserved — that semantic constraint is correct and will be improved to a compile-time check in zio-http 4.

Fixes #4023