### PR TITLE
fix: escape single quotes in astToExpression string values

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/signal/Signal.scala
@@ -148,7 +148,8 @@ object SignalUpdate {
     case zio.json.ast.Json.Arr(items)  =>
       val itemStrs = items.map(astToExpression)
       s"[${itemStrs.mkString(", ")}]"
-    case zio.json.ast.Json.Str(value)  => s"'$value'"
+    case s: zio.json.ast.Json.Str      =>
+      s"'${s.value.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")}'"
     case zio.json.ast.Json.Num(value)  => value.toString
     case zio.json.ast.Json.Bool(value) => value.toString
     case zio.json.ast.Json.Null        => "null"


### PR DESCRIPTION
## Summary

Fix `astToExpression` to properly escape special characters in string values when producing JavaScript single-quoted literals.

## Bug

String values containing single quotes, backslashes, newlines, or carriage returns would produce invalid JavaScript expressions. For example, `it's` would generate `'it's'` which is broken JS.

## Fix

- Escape `\` → `\\` (must be first to avoid double-escaping)
- Escape `'` → `\'`
- Escape newline → `\n`
- Escape carriage return → `\r`
- Use type-match `s: Json.Str` instead of extractor `Str(value)` to avoid `Option` allocation

Fixes #4024