### PR TITLE
fix: use lowercase enum values for DatastarRequestCancellation (#4022)

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala
@@ -204,13 +204,13 @@ object DatastarRequestCancellation {
 
   implicit val schema: Schema[DatastarRequestCancellation] = Schema[String].transform[DatastarRequestCancellation](
     {
-      case "Auto"     => Auto
-      case "Disabled" => Disabled
+      case "auto"     => Auto
+      case "disabled" => Disabled
       case other      => Custom(Js(other))
     },
     {
-      case Auto          => "Auto"
-      case Disabled      => "Disabled"
+      case Auto          => "auto"
+      case Disabled      => "disabled"
       case Custom(value) => value.value
     },
   )

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala
@@ -553,7 +553,7 @@ object DatastarRequestSpec extends ZIOSpecDefault {
         assertTrue(
           request.render.contains("@delete"),
           request.render.contains("/api/delete/123"),
-          request.render.contains("Disabled"),
+          request.render.contains("disabled"),
         )
       },
       test("should render request with multiple custom options") {


### PR DESCRIPTION
Fixes #4022

## Changes
- Updated `DatastarRequestCancellation` schema to use lowercase enum values (`"auto"` and `"disabled"`) instead of PascalCase (`"Auto"` and `"Disabled"`)
- Updated corresponding test assertion
- These lowercase values are required by the Datastar JS SDK

## Files Changed
- `zio-http-datastar-sdk/src/main/scala/zio/http/datastar/model/DatastarRequest.scala`
- `zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarRequestSpec.scala`