### PR TITLE
fix: use set() by default for header encoding, add() only for multi-valued headers

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -94,31 +94,12 @@ private[netty] object Conversions {
       (headers: HttpHeaders, key: CharSequence) => headers.contains(key),
     )
 
-  private val singletonHeaders: java.util.HashSet[String] = {
-    val set = new java.util.HashSet[String](32)
-    set.add("age")
-    set.add("authorization")
-    set.add("content-length")
-    set.add("content-type")
-    set.add("content-location")
-    set.add("content-range")
-    set.add("date")
-    set.add("etag")
-    set.add("expect")
-    set.add("expires")
-    set.add("from")
-    set.add("host")
-    set.add("if-modified-since")
-    set.add("if-range")
-    set.add("if-unmodified-since")
-    set.add("last-modified")
-    set.add("location")
-    set.add("max-forwards")
-    set.add("proxy-authorization")
-    set.add("referer")
-    set.add("retry-after")
-    set.add("server")
-    set.add("user-agent")
+  private val multiValueHeaders: java.util.HashSet[String] = {
+    val set = new java.util.HashSet[String](8)
+    set.add("set-cookie")
+    set.add("www-authenticate")
+    set.add("proxy-authenticate")
+    set.add("via")
     set
   }
 
@@ -127,10 +108,11 @@ private[netty] object Conversions {
     val iter         = headers.iterator
     while (iter.hasNext) {
       val header = iter.next()
-      if (singletonHeaders.contains(header.headerName)) {
-        nettyHeaders.set(header.headerName, header.renderedValueAsCharSequence)
+      val name   = header.headerName
+      if (multiValueHeaders.contains(name)) {
+        nettyHeaders.add(name, header.renderedValueAsCharSequence)
       } else {
-        nettyHeaders.add(header.headerName, header.renderedValueAsCharSequence)
+        nettyHeaders.set(name, header.renderedValueAsCharSequence)
       }
     }
     nettyHeaders

--- a/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/model/ConversionsSpec.scala
@@ -70,10 +70,13 @@ object ConversionsSpec extends ZIOHttpSpec {
             result.get("content-type") == "application/json",
           )
         },
-        test("should preserve duplicate list-based Accept headers") {
+        test("should deduplicate Accept headers (last wins)") {
           val headers = Headers("accept", "text/html") ++ Headers("accept", "application/json")
           val result  = Conversions.headersToNetty(headers)
-          assertTrue(result.entries().size() == 2)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("accept") == "application/json",
+          )
         },
         test("should preserve duplicate Set-Cookie headers") {
           val headers = Headers("set-cookie", "a=1") ++ Headers("set-cookie", "b=2")
@@ -101,10 +104,32 @@ object ConversionsSpec extends ZIOHttpSpec {
             result.get("authorization") == "Bearer token2",
           )
         },
-        test("should preserve duplicate unknown custom headers") {
+        test("should deduplicate custom headers (last wins)") {
           val headers = Headers("x-custom", "value1") ++ Headers("x-custom", "value2")
           val result  = Conversions.headersToNetty(headers)
-          assertTrue(result.entries().size() == 2)
+          assertTrue(
+            result.entries().size() == 1,
+            result.get("x-custom") == "value2",
+          )
+        },
+        test("should preserve duplicate Via headers") {
+          val headers = Headers("via", "1.0 proxy1") ++ Headers("via", "1.1 proxy2")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 2,
+            result.getAll("via").get(0) == "1.0 proxy1",
+            result.getAll("via").get(1) == "1.1 proxy2",
+          )
+        },
+        test("should preserve duplicate Proxy-Authenticate headers") {
+          val headers =
+            Headers("proxy-authenticate", "Bearer") ++ Headers("proxy-authenticate", "Basic")
+          val result  = Conversions.headersToNetty(headers)
+          assertTrue(
+            result.entries().size() == 2,
+            result.getAll("proxy-authenticate").get(0) == "Bearer",
+            result.getAll("proxy-authenticate").get(1) == "Basic",
+          )
         },
       ),
       suite("scheme")(


### PR DESCRIPTION
## Summary

Flips the header encoding default in `Conversions.encodeHeaderListToNetty`:
- **Before** (3.9.0+): `add()` for all headers except 23 singleton headers which used `set()`
- **After**: `set()` for all headers except 4 genuinely multi-valued headers which use `add()`

### Multi-valued headers (using `add()`):
- `set-cookie` (RFC 6265)
- `www-authenticate` (RFC 9110 §11.6.1)
- `proxy-authenticate` (RFC 9110 §11.7.1)
- `via` (RFC 9110 §7.6.3)

### Why

PR #3954 changed header encoding from `set()` (all except Set-Cookie) to `add()` (all). This caused duplicate headers on the wire when `Headers.Concat` chains contain the same header from multiple sources (e.g. endpoint encoding + client defaults + forwarded headers).

PR #4003 partially fixed this by introducing a singleton list of 23 headers, but headers not in that list (like `accept`, custom `auth-info-*` headers, etc.) were still duplicated.

This caused regressions for downstream services that reject requests with unexpected duplicate headers (e.g. 403 Forbidden from services that validate header uniqueness).

This PR restores the pre-3.9.0 behavior: `set()` by default (last value wins, deduplication on wire), `add()` only for headers that genuinely need multiple values per the HTTP spec.