### PR TITLE
feat(body): add Body.asForm[A] for form-encoded body decoding (#3513)

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/BodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/BodySpec.scala
@@ -256,5 +256,13 @@ object BodySpec extends ZIOHttpSpec {
           assertTrue(body.materializedAsString == Some(text))
         },
       ),
+      suite("asForm schema-based form decoding")(
+        test("asForm decodes URL-encoded form body to case class") {
+          val body = Body
+            .fromString("name=John&age=30")
+            .contentType(MediaType.application.`x-www-form-urlencoded`)
+          body.asForm[Person].map(person => assertTrue(person == Person("John", 30)))
+        },
+      ),
     ) @@ timeout(10 seconds)
 }

--- a/zio-http/shared/src/main/scala/zio/http/Body.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Body.scala
@@ -27,6 +27,7 @@ import zio.stream.ZStream
 import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
 
+import zio.http.internal.{ErrorConstructor, StringSchemaCodec}
 import zio.http.multipart.mixed.MultipartMixed
 
 /**
@@ -181,6 +182,26 @@ trait Body { self =>
    */
   def asURLEncodedForm(implicit trace: Trace): Task[Form] =
     asString.flatMap(string => ZIO.fromEither(Form.fromURLEncoded(string, Charsets.Http)))
+
+  /**
+   * Decodes the content of the body as a URL-encoded form and maps it to a case
+   * class using a zio-schema [[zio.schema.Schema]].
+   *
+   * Example:
+   * {{{
+   * case class Login(username: String, password: String)
+   * implicit val schema: Schema[Login] = DeriveSchema.gen[Login]
+   * val body = Body.fromString("username=john&password=secret")
+   *   .contentType(MediaType.application.`x-www-form-urlencoded`)
+   * val login: Task[Login] = body.asForm[Login]
+   * }}}
+   */
+  def asForm[A](implicit schema: Schema[A], trace: Trace): Task[A] =
+    asURLEncodedForm.flatMap { form =>
+      val queryParams = form.toQueryParams
+      val codec       = StringSchemaCodec.queryFromSchema[A](schema, ErrorConstructor.query, "body")
+      ZIO.attempt(codec.decode(queryParams))
+    }
 
   def contentType: Option[Body.ContentType]
 


### PR DESCRIPTION
## Summary

Adds `Body.asForm[A](implicit schema: Schema[A]): Task[A]` to decode URL-encoded form bodies directly to case classes using zio-schema.

This is the form-encoded equivalent of the existing `Body.asJson[A]` — no new patterns, just a missing sibling method.

### Usage
```scala
case class Login(username: String, password: String)
implicit val schema: Schema[Login] = DeriveSchema.gen[Login]

val body = Body.fromString("username=john&password=secret")
  .contentType(MediaType.application.`x-www-form-urlencoded`)

val login: Task[Login] = body.asForm[Login]
```

### Implementation
Uses the existing pipeline: `asURLEncodedForm` → `Form.toQueryParams` → `StringSchemaCodec.queryFromSchema`

Closes #3513