### PR TITLE
fix(httpgen): handle all schema types in queryVariables without crashing (#3267)

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/http/HttpGen.scala
@@ -1,6 +1,6 @@
 package zio.http.endpoint.http
 
-import zio.Unsafe
+import zio.{Chunk, Unsafe}
 
 import zio.schema.Schema
 import zio.schema.codec.BinaryCodec
@@ -137,23 +137,30 @@ object HttpGen {
 
   def queryVariables(config: CodecConfig, inAtoms: AtomizedMetaCodecs): Seq[HttpVariable] = {
     inAtoms.query.collect { case mc @ MetaCodec(HttpCodec.Query(codec, _), _) =>
-      val recordSchema = (codec.schema match {
-        case value if value.isInstanceOf[Schema.Optional[_]] => value.asInstanceOf[Schema.Optional[Any]].schema
-        case _                                               => codec.schema
-      }).asInstanceOf[Schema.Record[Any]]
-      val examples     = mc.examples.values.headOption.map { ex =>
-        recordSchema.deconstruct(ex)(Unsafe.unsafe)
-      }
-      codec.recordFields.zipWithIndex.map { case ((field, codec), index) =>
-        HttpVariable(
-          field.name,
-          examples.map(values => {
-            val fieldValue = values(index)
-              .orElse(field.defaultValue)
-              .getOrElse(throw new Exception(s"No value or default value for field ${field.name}"))
-            codec.encode(fieldValue)
-          }),
-        )
+      val fields = codec.recordFields
+      if (fields.nonEmpty && codec.recordSchema != null) {
+        val actualSchema = codec.schema match {
+          case value if value.isInstanceOf[Schema.Optional[_]] => value.asInstanceOf[Schema.Optional[Any]].schema
+          case _                                               => codec.schema
+        }
+        val recordSchema = actualSchema.asInstanceOf[Schema.Record[Any]]
+        val examples     = mc.examples.values.headOption.map { ex =>
+          recordSchema.deconstruct(ex)(Unsafe.unsafe)
+        }
+        fields.zipWithIndex.map { case ((field, codec), index) =>
+          HttpVariable(
+            field.name,
+            examples.map(values => {
+              val fieldValue = values(index)
+                .orElse(field.defaultValue)
+                .getOrElse(throw new Exception(s"No value or default value for field ${field.name}"))
+              codec.encode(fieldValue)
+            }),
+          )
+        }
+      } else {
+        val name = mc.name.getOrElse("query")
+        Chunk(HttpVariable(name, mc.examples.values.headOption.map(_.toString)))
       }
     }.flatten
   }

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/http/HttpGenSpec.scala
@@ -278,5 +278,31 @@ object HttpGenSpec extends ZIOSpecDefault {
           |}""".stripMargin
       assertTrue(rendered == expected1 + "\n\n" + expected2)
     },
+    test("Path with case class query parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "users").query[User](HttpCodec.query[User])
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@name=<no value>
+          |@age=<no value>
+          |
+          |GET /api/users?name={{name}}&age={{age}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
+    test("Path with multiple individual query parameters") {
+      val endpoint     = Endpoint(Method.GET / "api" / "search")
+        .query[String](HttpCodec.query[String]("q"))
+        .query[Int](HttpCodec.query[Int]("page"))
+      val httpEndpoint = HttpGen.fromEndpoint(endpoint)
+      val rendered     = httpEndpoint.render
+      val expected     =
+        """
+          |@q=<no value>
+          |@page=<no value>
+          |
+          |GET /api/search?q={{q}}&page={{page}}""".stripMargin
+      assertTrue(rendered == expected)
+    },
   )
 }


### PR DESCRIPTION
## Summary

Fixes `HttpGen.queryVariables` to safely handle all schema types instead of blindly casting to `Schema.Record[Any]`, which could crash with `ClassCastException` for non-record query parameters.

### Problem
The `queryVariables` method (line 143) did `.asInstanceOf[Schema.Record[Any]]` unconditionally. While `StringSchemaCodec.queryFromSchema` currently wraps all schemas into `CaseClass1` records (making the crash unlikely with standard codecs), this was unsafe for:
- Custom `HttpCodec.Query` instances with non-standard `StringSchemaCodec` implementations
- Future changes to `queryFromSchema` that might not wrap all types
- Any schema type where `recordSchema` returns `null`

### Fix
Added a guard check: `if (fields.nonEmpty && codec.recordSchema != null)` before attempting record-based processing. When the condition fails, generates a single `HttpVariable` using the parameter name from `MetaCodec`.

### Changes
- **Modified**: `HttpGen.scala` — defensive guard in `queryVariables`
- **Added**: 2 new tests in `HttpGenSpec` — case class query params and multiple individual query params
- No changes to `OpenAPIGen`, `HttpFile`, or `StringSchemaCodec`

Closes #3267