### PR TITLE
perf: skip Netty header validation in headers encoding (#1063)

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -62,7 +62,7 @@ private[netty] object Conversions {
       case Headers.FromIterable(_)           => encodeHeaderListToNetty(headers)
       case Headers.Native(value, _, _, _, _) => value.asInstanceOf[HttpHeaders]
       case Headers.Concat(_, _)              => encodeHeaderListToNetty(headers)
-      case Headers.Empty                     => new DefaultHttpHeaders()
+      case Headers.Empty                     => noValidationHeadersFactory.newHeaders()
     }
 
   def urlToNetty(url: URL): String = {
@@ -94,6 +94,8 @@ private[netty] object Conversions {
       (headers: HttpHeaders, key: CharSequence) => headers.contains(key),
     )
 
+  private val noValidationHeadersFactory = DefaultHttpHeadersFactory.headersFactory().withValidation(false)
+
   private val multiValueHeaders: java.util.HashSet[String] = {
     val set = new java.util.HashSet[String](8)
     set.add("set-cookie")
@@ -104,7 +106,7 @@ private[netty] object Conversions {
   }
 
   private def encodeHeaderListToNetty(headers: Iterable[Header]): HttpHeaders = {
-    val nettyHeaders = new DefaultHttpHeaders()
+    val nettyHeaders = noValidationHeadersFactory.newHeaders()
     val iter         = headers.iterator
     while (iter.hasNext) {
       val header = iter.next()

--- a/zio-http/shared/src/main/scala/zio/http/Header.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Header.scala
@@ -56,6 +56,20 @@ sealed trait Header {
 
 object Header {
 
+  private[http] def validateHeaderCharSequence(cs: CharSequence, kind: String): Unit = {
+    var i   = 0
+    val len = cs.length()
+    while (i < len) {
+      val c = cs.charAt(i)
+      if (c == '\r' || c == '\n') {
+        throw new IllegalArgumentException(
+          s"$kind contains prohibited character at index $i: 0x${c.toInt.toHexString}",
+        )
+      }
+      i += 1
+    }
+  }
+
   sealed trait HeaderTypeBase {
     type HeaderValue
 
@@ -218,8 +232,14 @@ object Header {
       ht
     }
 
-    private[http] override def headerNameAsCharSequence: CharSequence    = customName
-    private[http] override def renderedValueAsCharSequence: CharSequence = value
+    private[http] override def headerNameAsCharSequence: CharSequence    = {
+      Header.validateHeaderCharSequence(customName, "Header name")
+      customName
+    }
+    private[http] override def renderedValueAsCharSequence: CharSequence = {
+      Header.validateHeaderCharSequence(value, "Header value")
+      value
+    }
 
     override def hashCode(): Int = {
       var h       = 0


### PR DESCRIPTION
## Summary

Improves header encoding performance by skipping Netty's redundant header validation, after adding CR/LF validation to `Header.Custom` in ZIO HTTP itself.

### Changes

**1. `Header.scala` — CR/LF validation for custom headers**
- Adds `Header.validateHeaderCharSequence` that rejects `\r` and `\n` in header names/values
- Applied in `Header.Custom.headerNameAsCharSequence` and `renderedValueAsCharSequence`
- Prevents response splitting / request smuggling via custom header injection
- Typed headers (e.g. `Header.ContentType`, `Header.Authorization`) are unaffected — their `render` methods always produce safe values

**2. `Conversions.scala` — skip Netty validation**
- Uses `DefaultHttpHeadersFactory.headersFactory().withValidation(false).newHeaders()` instead of `new DefaultHttpHeaders()`
- Hoisted factory to a `private val` to avoid repeated setup
- Safe because ZIO HTTP now validates custom headers at its own layer

### Why this is safe
- Typed headers produce values from controlled `render` methods — always valid
- `Header.Custom` now validates on encode — rejects `\r`/`\n`
- The server pipeline already uses `.setValidateHeaders(false)` on the request decoder (line 68 of `ServerChannelInitializer.scala`)

Closes #1063