### PR TITLE
feat(codec): add form-urlencoded HttpContentCodec for Endpoint API (#3163)

### DIFF
--- a/.sisyphus/notepads/form-codec/learnings.md
+++ b/.sisyphus/notepads/form-codec/learnings.md
@@ -1,0 +1,25 @@
+# Form Codec Implementation Learnings
+
+## Key Patterns
+- `BinaryCodecWithSchema` has two `apply` overloads: `(CodecConfig => BinaryCodec[A], Schema[A])` and `(BinaryCodec[A], Schema[A])` (wraps in `_ => codec`)
+- `HttpContentCodec.Choices(ListMap.empty)` crashes because `defaultMediaType` etc are eager `val`s that throw on empty choices
+- `internal` is ambiguous between `zio.http.internal` and `zio.stream.internal` — must use fully-qualified `zio.http.internal.*`
+
+## StringSchemaCodec.queryFromSchema
+- `encode(input: A, target: Target): Target` — builds QueryParams from value
+- `decode(target: Target): A` — decodes from QueryParams (throws on error, doesn't return Either)
+- `name` parameter: passing `null` prevents single-field records from being wrapped into a new CaseClass1 with a different key name
+- Throws `IllegalArgumentException` for unsupported schemas like Enum (sealed traits)
+
+## QueryParams.encode
+- Returns string with leading `?` (e.g., `?key=value&key2=value2`)
+- Must `.drop(1)` for form body encoding
+
+## fromSchema graceful degradation
+- Not all schemas support form encoding (e.g., Enum/sealed traits)
+- Use try-catch around `form.only[A]` in `fromSchema` to gracefully skip form codec for unsupported types
+- Cannot return empty Choices as fallback — eager val initialization crashes
+
+## Body.fromString
+- Does NOT have a `mediaType` parameter
+- Use `.contentType(mediaType)` method to set content type on body

--- a/zio-http/jvm/src/test/scala/zio/http/codec/HttpContentCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/HttpContentCodecSpec.scala
@@ -1,0 +1,93 @@
+package zio.http.codec
+
+import zio._
+import zio.test._
+
+import zio.schema.{DeriveSchema, Schema}
+
+import zio.http._
+import zio.http.endpoint.Endpoint
+
+object HttpContentCodecSpec extends ZIOHttpSpec {
+
+  final case class LoginForm(username: String, password: String)
+  object LoginForm {
+    implicit val schema: Schema[LoginForm] = DeriveSchema.gen[LoginForm]
+  }
+
+  final case class SingleField(value: String)
+  object SingleField {
+    implicit val schema: Schema[SingleField] = DeriveSchema.gen[SingleField]
+  }
+
+  private val formContentType = Header.ContentType(MediaType.application.`x-www-form-urlencoded`)
+
+  override def spec = suite("HttpContentCodecSpec")(
+    suite("form codec")(
+      test("round-trip encode and decode a case class") {
+        val codec = HttpContentCodec.form.only[LoginForm]
+        val input = LoginForm("admin", "secret123")
+        codec.encode(input) match {
+          case Right(body) =>
+            val request = Request.post("/test", body).addHeader(formContentType)
+            for {
+              decoded <- codec.decodeRequest(request)
+            } yield assertTrue(decoded == input)
+          case Left(err)   =>
+            ZIO.succeed(assertTrue(false))
+        }
+      },
+      test("decode url-encoded body") {
+        val codec   = HttpContentCodec.form.only[LoginForm]
+        val body    = Body
+          .fromString("username=admin&password=secret123")
+          .contentType(MediaType.application.`x-www-form-urlencoded`)
+        val request = Request.post("/test", body).addHeader(formContentType)
+        for {
+          decoded <- codec.decodeRequest(request)
+        } yield assertTrue(decoded == LoginForm("admin", "secret123"))
+      },
+      test("encode produces correct url-encoded format") {
+        val codec = HttpContentCodec.form.only[LoginForm]
+        val input = LoginForm("user1", "pass1")
+        codec.encode(input) match {
+          case Right(body) =>
+            for {
+              str <- body.asString
+            } yield {
+              val parts = str.split("&").toSet
+              assertTrue(parts == Set("username=user1", "password=pass1"))
+            }
+          case Left(_)     =>
+            ZIO.succeed(assertTrue(false))
+        }
+      },
+      test("endpoint with form-encoded input") {
+        val endpoint = Endpoint(Method.POST / "login")
+          .inForm[LoginForm]
+          .out[String]
+
+        val routes = endpoint.implementHandler(Handler.fromFunction[LoginForm] { form =>
+          s"Welcome ${form.username}"
+        })
+
+        val body    =
+          Body.fromString("username=admin&password=secret").contentType(MediaType.application.`x-www-form-urlencoded`)
+        val request = Request.post("/login", body).addHeader(formContentType)
+
+        for {
+          response <- routes.toRoutes.runZIO(request)
+          result   <- response.body.asString
+        } yield assertTrue(result == "\"Welcome admin\"")
+      },
+      test("decode single-field case class") {
+        val codec   = HttpContentCodec.form.only[SingleField]
+        val body    = Body.fromString("value=hello").contentType(MediaType.application.`x-www-form-urlencoded`)
+        val request = Request.post("/test", body).addHeader(formContentType)
+        for {
+          decoded <- codec.decodeRequest(request)
+        } yield assertTrue(decoded == SingleField("hello"))
+      },
+    ),
+  )
+}

--- a/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/HttpContentCodec.scala
@@ -374,6 +374,52 @@ object HttpContentCodec {
 
   }
 
+  object form {
+
+    private var formCodecCache: Map[Schema[_], HttpContentCodec[_]] = Map.empty
+
+    def only[A](implicit schema: Schema[A]): HttpContentCodec[A] =
+      if (formCodecCache.contains(schema)) {
+        formCodecCache(schema).asInstanceOf[HttpContentCodec[A]]
+      } else {
+        val codec = HttpContentCodec.Choices(
+          ListMap(
+            MediaType.application.`x-www-form-urlencoded` ->
+              BinaryCodecWithSchema(formBinaryCodec[A](schema), schema),
+          ),
+        )
+        formCodecCache = formCodecCache + (schema -> codec)
+        codec
+      }
+
+    private def formBinaryCodec[A](implicit schema: Schema[A]): BinaryCodec[A] = new BinaryCodec[A] {
+      private lazy val queryCodec =
+        zio.http.internal.StringSchemaCodec.queryFromSchema[A](schema, zio.http.internal.ErrorConstructor.query, null)
+
+      override def encode(value: A): Chunk[Byte] = {
+        val queryParams = queryCodec.encode(value, QueryParams.empty)
+        val encoded     = queryParams.encode.drop(1) // drop leading '?'
+        Chunk.fromArray(encoded.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+      }
+
+      override def decode(bytes: Chunk[Byte]): Either[DecodeError, A] = {
+        val str         = new String(bytes.toArray, java.nio.charset.StandardCharsets.UTF_8)
+        val queryParams = QueryParams.decode(str)
+        try Right(queryCodec.decode(queryParams))
+        catch {
+          case e: HttpCodecError => Left(DecodeError.ReadError(Cause.fail(e), e.getMessage))
+          case e: Exception      => Left(DecodeError.ReadError(Cause.fail(e), e.getMessage))
+        }
+      }
+
+      override def streamDecoder: ZPipeline[Any, DecodeError, Byte, A] =
+        ZPipeline.chunks[Byte].mapZIO(bytes => ZIO.fromEither(decode(bytes)))
+
+      override def streamEncoder: ZPipeline[Any, Nothing, A, Byte] =
+        ZPipeline.identity[A].map(encode).flattenChunks
+    }
+  }
+
   private[http] implicit val ByteChunkBinaryCodec: BinaryCodec[Chunk[Byte]] = new BinaryCodec[Chunk[Byte]] {
 
     override def encode(value: Chunk[Byte]): Chunk[Byte] = value

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -551,6 +551,36 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
     copy(input = input ++ (HttpCodec.content(name, mediaType) ?? doc))
 
   /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * decoded from `application/x-www-form-urlencoded` data using a zio-schema
+   * [[zio.schema.Schema]].
+   */
+  def inForm[Input2](implicit
+    schema: Schema[Input2],
+    combiner: Combiner[Input, Input2],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input =
+      input ++ HttpCodec.content[Input2](MediaType.application.`x-www-form-urlencoded`)(
+        HttpContentCodec.form.only[Input2],
+      ),
+    )
+
+  /**
+   * Returns a new endpoint derived from this one, whose request content is
+   * decoded from `application/x-www-form-urlencoded` data using a zio-schema
+   * [[zio.schema.Schema]] and is documented.
+   */
+  def inForm[Input2](doc: Doc)(implicit
+    schema: Schema[Input2],
+    combiner: Combiner[Input, Input2],
+  ): Endpoint[PathInput, combiner.Out, Err, Output, Auth] =
+    copy(input =
+      input ++ (HttpCodec.content[Input2](MediaType.application.`x-www-form-urlencoded`)(
+        HttpContentCodec.form.only[Input2],
+      ) ?? doc),
+    )
+
+  /**
    * Returns a new endpoint derived from this one, whose request must satisfy
    * the specified codec.
    */


### PR DESCRIPTION
## Summary

Adds `application/x-www-form-urlencoded` support to the Endpoint API via a dedicated `Endpoint.inForm[A]` method and a new `HttpContentCodec.form.only[A]` codec.

### Usage
```scala
case class LoginForm(username: String, password: String)
object LoginForm {
  implicit val schema: Schema[LoginForm] = DeriveSchema.gen[LoginForm]
}

val endpoint = Endpoint(Method.POST / "login")
  .inForm[LoginForm]
  .out[String]

val routes = endpoint.implementHandler(Handler.fromFunction[LoginForm] { form =>
  s"Welcome ${form.username}"
})
```

### Design
Form encoding is **opt-in** via `Endpoint.inForm[A]`, not auto-included in `fromSchema`. This matches how `inStream` works — form is a specialized content type, not a default wire format.

### Changes
- **`HttpContentCodec.scala`**: Added `object form` with `only[A]` method creating a `BinaryCodecWithSchema` for `application/x-www-form-urlencoded`
- **`Endpoint.scala`**: Added `inForm[Input2]` and `inForm[Input2](doc)` methods (requires `Schema[Input2]`)
- **`HttpContentCodecSpec.scala`**: 5 tests covering round-trip, encode, decode, endpoint integration, and single-field case classes
- Form codec is NOT added to `fromSchema` — it's opt-in only

### Implementation
Uses `StringSchemaCodec.queryFromSchema` (existing internal API) to encode/decode:
- **Encode**: `A` → `QueryParams` → URL-encoded string bytes
- **Decode**: URL-encoded bytes → `QueryParams` → `A`

OpenAPI spec generation automatically picks up the media type from the codec.

Closes #3163