### PR TITLE
feat: add zio-http-metrics module for Prometheus endpoint (#1490)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' zioHttpShadedTests/test
 
       - name: Compress target directories
-        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
+        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target zio-http-metrics/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
 
       - name: Upload target directories
         uses: actions/upload-artifact@v5

--- a/build.sbt
+++ b/build.sbt
@@ -163,6 +163,7 @@ lazy val aggregatedProjects: Seq[ProjectReference] =
       sbtZioHttpGrpcTests,
       zioHttpHtmx,
       zioHttpStomp,
+      zioHttpMetrics,
       zioHttpExample,
       zioHttpExampleDatastarChat,
       zioHttpTestkit,
@@ -347,6 +348,20 @@ lazy val zioHttpStomp = (project in file("zio-http-stomp"))
   .dependsOn(zioHttpTestkit % Test)
   .settings(MimaSettings.mimaSettings(failOnProblem = true))
 
+
+lazy val zioHttpMetrics = (project in file("zio-http-metrics"))
+  .settings(
+    stdSettings("zio-http-metrics"),
+    publishSetting(true),
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-metrics-connectors"            % "2.5.5",
+      "dev.zio" %% "zio-metrics-connectors-prometheus" % "2.5.5",
+      `zio-test`,
+      `zio-test-sbt`,
+    ),
+  )
+  .dependsOn(zioHttpJVM)
+  .settings(MimaSettings.mimaSettings(failOnProblem = true))
 lazy val zioHttpExample = (project in file("zio-http-example"))
   .settings(stdSettings("zio-http-example"))
   .settings(publishSetting(false))

--- a/zio-http-metrics/src/main/scala/zio/http/metrics/MetricsEndpoint.scala
+++ b/zio-http-metrics/src/main/scala/zio/http/metrics/MetricsEndpoint.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.metrics
+
+import zio._
+import zio.metrics._
+import zio.metrics.connectors.prometheus.PrometheusPublisher
+import zio.metrics.connectors.{MetricsConfig, prometheus}
+
+import zio.http._
+
+/**
+ * One-stop shop for exposing Prometheus metrics over HTTP.
+ *
+ * Instruments every route with request/response metrics and appends a
+ * `/metrics` endpoint that serves the Prometheus text format.
+ *
+ * {{{
+ * Server
+ *   .serve(MetricsEndpoint.withMetrics(myRoutes))
+ *   .provide(Server.default, MetricsEndpoint.layers())
+ * }}}
+ */
+object MetricsEndpoint {
+
+  /**
+   * Instruments routes with HTTP metrics and appends a Prometheus endpoint.
+   *
+   * This is the recommended one-call API. It applies `Middleware.metrics()` to
+   * instrument your routes and appends a `GET /metrics` route that serves
+   * Prometheus-formatted metrics.
+   *
+   * @param routes
+   *   the application routes to instrument
+   * @param metricsPath
+   *   the path at which to expose Prometheus metrics (default: `"metrics"`)
+   * @param concurrentRequestsName
+   *   name of the gauge tracking concurrent requests
+   * @param totalRequestsName
+   *   name of the counter tracking total requests
+   * @param requestDurationName
+   *   name of the histogram tracking request durations
+   * @param requestDurationBoundaries
+   *   histogram bucket boundaries for request duration
+   * @param extraLabels
+   *   additional labels to attach to all metrics
+   */
+  def withMetrics[Env](
+    routes: Routes[Env, Response],
+    metricsPath: String = "metrics",
+    concurrentRequestsName: String = "http_concurrent_requests_total",
+    totalRequestsName: String = "http_requests_total",
+    requestDurationName: String = "http_request_duration_seconds",
+    requestDurationBoundaries: MetricKeyType.Histogram.Boundaries = Middleware.defaultBoundaries,
+    extraLabels: Set[MetricLabel] = Set.empty,
+  )(implicit trace: Trace): Routes[Env with PrometheusPublisher, Response] = {
+    val instrumented = routes @@ Middleware.metrics(
+      concurrentRequestsName = concurrentRequestsName,
+      totalRequestsName = totalRequestsName,
+      requestDurationName = requestDurationName,
+      requestDurationBoundaries = requestDurationBoundaries,
+      extraLabels = extraLabels,
+    )
+    instrumented ++ endpointRoute(metricsPath)
+  }
+
+  /**
+   * A single route that serves Prometheus metrics. Use this if you want to
+   * handle instrumentation separately (e.g. with `Middleware.metrics()`).
+   */
+  def endpointRoute(path: String = "metrics"): Routes[PrometheusPublisher, Response] =
+    Routes(
+      Method.GET / path -> handler(
+        ZIO.serviceWithZIO[PrometheusPublisher](_.get.map(Response.text)),
+      ),
+    )
+
+  /**
+   * Combined ZIO layers for Prometheus metrics. Provides `PrometheusPublisher`.
+   * Polls metrics at the specified interval (default: 1 second).
+   */
+  def layers(
+    pollingInterval: Duration = 1.second,
+  ): ZLayer[Any, Nothing, PrometheusPublisher] =
+    ZLayer.succeed(MetricsConfig(pollingInterval)) ++
+      prometheus.publisherLayer >+>
+      prometheus.prometheusLayer
+}


### PR DESCRIPTION
## Summary

Adds a new `zio-http-metrics` module that provides a one-call API for exposing Prometheus metrics over HTTP.

### Usage
```scala
import zio.http._
import zio.http.metrics.MetricsEndpoint

Server
  .serve(MetricsEndpoint.withMetrics(myRoutes))
  .provide(Server.default, MetricsEndpoint.layers())
```

That's it. `withMetrics` does two things in one call:
1. **Instruments** your routes with `Middleware.metrics()` (request count, duration, concurrency)
2. **Appends** a `GET /metrics` endpoint serving Prometheus text format

### API

| Method | Description |
|--------|-------------|
| `MetricsEndpoint.withMetrics(routes)` | Instruments routes + appends `/metrics` endpoint |
| `MetricsEndpoint.withMetrics(routes, metricsPath = "prom")` | Same, custom path |
| `MetricsEndpoint.endpointRoute()` | Just the metrics route (if you handle instrumentation separately) |
| `MetricsEndpoint.layers()` | Prometheus layers (default: 1s polling) |
| `MetricsEndpoint.layers(5.seconds)` | Prometheus layers with custom polling interval |

### Before (manual setup)
```scala
import zio.metrics.connectors.prometheus.PrometheusPublisher
import zio.metrics.connectors.{MetricsConfig, prometheus}

val metrics = Routes(
  Method.GET / "metrics" -> handler(
    ZIO.serviceWithZIO[PrometheusPublisher](_.get.map(Response.text))
  ),
)

Server.serve((app @@ Middleware.metrics()) ++ metrics).provide(
  Server.default,
  prometheus.prometheusLayer,
  prometheus.publisherLayer,
  ZLayer.succeed(MetricsConfig(1.seconds)),
)
```

### After
```scala
import zio.http.metrics.MetricsEndpoint

Server
  .serve(MetricsEndpoint.withMetrics(myRoutes))
  .provide(Server.default, MetricsEndpoint.layers())
```

### Module structure
- New sbt module `zio-http-metrics` (follows `zio-http-htmx`, `zio-http-stomp` pattern)
- Dependencies: `zio-metrics-connectors` + `zio-metrics-connectors-prometheus` v2.5.5
- Published as a separate artifact: `dev.zio::zio-http-metrics`

Closes #1490