### PR TITLE
fix(netty): correct stale Scaladoc on sortAddresses

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/NettyConnectionPool.scala
@@ -188,9 +188,8 @@ private[netty] object NettyConnectionPool {
   }
 
   /**
-   * Returns a sequence of connection attempts with their delays. Per RFC 8305,
-   * we start with IPv6, then after firstAddressFamilyDelay we try IPv4, then
-   * alternate between families.
+   * Sorts resolved addresses by interleaving IPv6 and IPv4 per RFC 8305, with
+   * IPv6 preferred first.
    */
   private[client] def sortAddresses(resolvedHosts: Chunk[InetAddress]): List[InetAddress] = {
     val (ipv6Addresses, ipv4Addresses) = resolvedHosts.partition(_.isInstanceOf[Inet6Address])


### PR DESCRIPTION
## Summary
- Fixes stale Scaladoc on `sortAddresses` method in `NettyConnectionPool` that incorrectly described it as returning "connection attempts with their delays" and referenced a nonexistent `firstAddressFamilyDelay` parameter.
- Updated to accurately describe the method's behavior: sorting resolved addresses by interleaving IPv6 and IPv4 per RFC 8305.

Follows up on Copilot review comment from #3876.