### PR TITLE
chore: update sbt-scalafix 0.14.6, coursier/setup-action v3, regenerate workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: sbt
 
@@ -94,7 +94,7 @@ jobs:
       - name: Build project
         run: sbt '++ ${{ matrix.scala }}' test
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: sbt
 
@@ -202,11 +202,11 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: sbt
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: sbt
 
@@ -243,7 +243,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: coursier/setup-action@v1
+      - uses: coursier/setup-action@v3
         with:
           apps: sbt
 

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ ThisBuild / githubWorkflowPREventTypes   := Seq(
 
 val coursierSetup =
   WorkflowStep.Use(
-    UseRef.Public("coursier", "setup-action", "v1"),
+    UseRef.Public("coursier", "setup-action", "v3"),
     params = Map("apps" -> "sbt"),
   )
 
@@ -57,7 +57,7 @@ ThisBuild / githubWorkflowPublishTargetBranches += RefPredicate.StartsWith(Ref.T
 ThisBuild / githubWorkflowPublishPreamble := Seq(coursierSetup)
 ThisBuild / githubWorkflowPublish         :=
   Seq(
-    WorkflowStep.Use(UseRef.Public("coursier", "setup-action", "v1"), Map("apps" -> "sbt")),
+    WorkflowStep.Use(UseRef.Public("coursier", "setup-action", "v3"), Map("apps" -> "sbt")),
     WorkflowStep.Sbt(
       List("ci-release"),
       name = Some("Release"),

--- a/profiling/project/plugins.sbt
+++ b/profiling/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.eed3si9n"  % "sbt-assembly" % "1.2.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.5")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.6")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("ch.epfl.scala"       % "sbt-scalafix"              % "0.14.5")
+addSbtPlugin("ch.epfl.scala"       % "sbt-scalafix"              % "0.14.6")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"              % "2.5.6")
 addSbtPlugin("pl.project13.scala"  % "sbt-jmh"                   % "0.4.8")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"               % "0.6.4")

--- a/zio-http-stomp/src/test/scala/zio/http/stomp/StompIntegrationSpec.scala
+++ b/zio-http-stomp/src/test/scala/zio/http/stomp/StompIntegrationSpec.scala
@@ -22,7 +22,7 @@ import zio.test._
 import zio.stream._
 
 import zio.http._
-import zio.http.stomp._ // Import syntax extensions
+import zio.http.stomp._
 
 object StompIntegrationSpec extends ZIOSpecDefault {
 

--- a/zio-http-stomp/src/test/scala/zio/http/stomp/StompWebSocketSpec.scala
+++ b/zio-http-stomp/src/test/scala/zio/http/stomp/StompWebSocketSpec.scala
@@ -19,7 +19,7 @@ package zio.http.stomp
 import zio._
 import zio.test._
 
-import zio.http._ // Import syntax extensions
+import zio.http._
 
 /**
  * Tests for STOMP protocol over WebSocket


### PR DESCRIPTION
## Summary

Combines and supersedes:
- #3965 — Update sbt-scalafix to 0.14.6
- #4052 — Bump coursier/setup-action from 1 to 3

### Changes
- **`project/plugins.sbt`** + **`profiling/project/plugins.sbt`**: sbt-scalafix 0.14.5 → 0.14.6
- **`build.sbt`**: `coursier/setup-action` v1 → v3 (fixes Node.js 20 deprecation warning)
- **`.github/workflows/ci.yml`**: Regenerated via `sbt githubWorkflowGenerate`

### Note on other dependabot PRs
- **#3988** (upload-artifact 4→7) and **#3987** (download-artifact 4→8) edit the generated workflow file directly, which fails the "workflows up to date" check. These need to be updated via the `sbt-github-actions` plugin version or settings, not by editing `ci.yml` directly.
- **#4035** (release-drafter 6→7), **#4032**, **#3996**, **#3947** (website deps) — independent, not included here.