### PR TITLE
refactor(client): rename ZClient.requiringConfig to fromConfig

### DIFF
--- a/zio-http/js/src/main/scala/zio/http/ZClientPlatformSpecific.scala
+++ b/zio-http/js/src/main/scala/zio/http/ZClientPlatformSpecific.scala
@@ -7,7 +7,7 @@ import zio.http.internal.FetchDriver
 
 trait ZClientPlatformSpecific {
 
-  def requiringConfig: ZLayer[ZClient.Config, Throwable, Client] =
+  def fromConfig: ZLayer[ZClient.Config, Throwable, Client] =
     live
 
   def customized: ZLayer[Config with ZClient.Driver[Any, Scope, Throwable], Throwable, Client] = {
@@ -38,7 +38,7 @@ trait ZClientPlatformSpecific {
 
   def default: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
-    ZLayer.succeed(Config.default) >>> requiringConfig
+    ZLayer.succeed(Config.default) >>> fromConfig
   }
 
 }

--- a/zio-http/jvm/src/main/scala/zio/http/ZClientPlatformSpecific.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/ZClientPlatformSpecific.scala
@@ -8,7 +8,7 @@ import zio.http.netty.client.NettyClientDriver
 
 trait ZClientPlatformSpecific {
 
-  def requiringConfig: ZLayer[ZClient.Config, Throwable, Client] = {
+  def fromConfig: ZLayer[ZClient.Config, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
     (ZLayer.succeed(NettyConfig.defaultWithFastShutdown) ++ DnsResolver.default) >>> live
   }
@@ -46,7 +46,7 @@ trait ZClientPlatformSpecific {
 
   def default: ZLayer[Any, Throwable, Client] = {
     implicit val trace: Trace = Trace.empty
-    ZLayer.succeed(Config.default) >>> requiringConfig
+    ZLayer.succeed(Config.default) >>> fromConfig
   }
 
 }


### PR DESCRIPTION
## Summary

Renames `ZClient.requiringConfig` (added in #3727) to `ZClient.fromConfig` per @987Nabil's naming suggestion.

### Change
- `requiringConfig` → `fromConfig` in both JVM and JS platform implementations
- All internal usages (`default` delegates to `fromConfig`) updated

This is a simple rename — no logic changes.