### PR TITLE
perf: bypass java.net.URI for relative URL parsing

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/URLSpec.scala
@@ -422,5 +422,79 @@ object URLSpec extends ZIOHttpSpec {
           )
         },
       ),
+      suite("relative URI fast path")(
+        test("empty string returns URL.empty") {
+          val url = URL.decode("").toOption.get
+          assertTrue(url == URL.empty)
+        },
+        test("path only") {
+          val url = URL.decode("/api/users/123").toOption.get
+          assertTrue(
+            url.path == Path.decode("/api/users/123"),
+            url.queryParams.isEmpty,
+            url.fragment.isEmpty,
+            url.kind == URL.Location.Relative,
+          )
+        },
+        test("path with query") {
+          val url = URL.decode("/api/users?page=2&limit=10").toOption.get
+          assertTrue(
+            url.path == Path.decode("/api/users"),
+            url.queryParams.queryParam("page") == Some("2"),
+            url.queryParams.queryParam("limit") == Some("10"),
+            url.fragment.isEmpty,
+          )
+        },
+        test("path with fragment") {
+          val url = URL.decode("/docs/intro#section-1").toOption.get
+          assertTrue(
+            url.path == Path.decode("/docs/intro"),
+            url.queryParams.isEmpty,
+            url.fragment.map(_.raw) == Some("section-1"),
+          )
+        },
+        test("path with query and fragment") {
+          val url = URL.decode("/search?q=test#results").toOption.get
+          assertTrue(
+            url.path == Path.decode("/search"),
+            url.queryParams.queryParam("q") == Some("test"),
+            url.fragment.map(_.raw) == Some("results"),
+          )
+        },
+        test("matches java.net.URI behavior for relative URLs") {
+          val urls = List(
+            "/",
+            "/api/v1/items",
+            "/users?ord=ASC&txt=scala%20is%20awesome%21&u=1&u=2",
+            "/users#the%20hash",
+            "/a/b/c?x=1&y=2#frag",
+            "/search#results?q=test",
+            "/path?",
+            "/path#",
+            "/path?key=val%26ue&other=123",
+            "/path?empty=&also=",
+            "/%E4%B8%AD%E6%96%87/path",
+            "/a/b/c?x=1&x=2&x=3",
+            "/path?q=hello+world",
+            "/deeply/nested/path/to/resource",
+            "/trailing/slash/",
+          )
+          assertTrue(urls.forall { raw =>
+            val fast = URL.decode(raw).toOption.get
+            val uri  = new java.net.URI(raw)
+            val slow = URL.fromURI(uri).get
+            fast.path == slow.path &&
+            fast.queryParams == slow.queryParams &&
+            fast.fragment.map(_.raw) == slow.fragment.map(_.raw)
+          })
+        },
+        test("absolute URLs still go through java.net.URI") {
+          val url = URL.decode("http://abc.com/users?a=1").toOption.get
+          assertTrue(
+            url.kind.isAbsolute,
+            url.path == Path.decode("/users"),
+          )
+        },
+      ),
     )
 }

--- a/zio-http/shared/src/main/scala/zio/http/URL.scala
+++ b/zio-http/shared/src/main/scala/zio/http/URL.scala
@@ -297,12 +297,35 @@ object URL {
     def invalidURL(e: Throwable = null): Either[MalformedURLException, URL] = Left(new Err(rawUrl = rawUrl, cause = e))
 
     try {
-      val uri = new URI(rawUrl)
-      val url = if (uri.isAbsolute) fromAbsoluteURI(uri) else fromRelativeURI(uri)
+      if (rawUrl.isEmpty) Right(URL.empty)
+      // Fast path for relative URIs (the common case for incoming HTTP requests):
+      // avoid allocating a java.net.URI by splitting on '?' and '#' directly.
+      else if (rawUrl.charAt(0) == '/') {
+        val fragmentIdx = rawUrl.indexOf('#')
+        val rawQueryIdx = rawUrl.indexOf('?')
+        // A '?' after '#' is part of the fragment, not a query delimiter
+        val queryIdx    = if (fragmentIdx >= 0 && rawQueryIdx > fragmentIdx) -1 else rawQueryIdx
 
-      url match {
-        case Some(value) => Right(value)
-        case None        => invalidURL()
+        val pathEnd  = if (queryIdx >= 0) queryIdx else if (fragmentIdx >= 0) fragmentIdx else rawUrl.length
+        val rawPath  = rawUrl.substring(0, pathEnd)
+        val rawQuery = if (queryIdx >= 0) {
+          val queryEnd = if (fragmentIdx > queryIdx) fragmentIdx else rawUrl.length
+          rawUrl.substring(queryIdx + 1, queryEnd)
+        } else null
+        val fragment = if (fragmentIdx >= 0) {
+          val rawFrag = rawUrl.substring(fragmentIdx + 1)
+          Some(Fragment.fromRaw(rawFrag))
+        } else None
+
+        Right(URL(Path.decodeRaw(rawPath), Location.Relative, QueryParams.decode(rawQuery), fragment))
+      } else {
+        val uri = new URI(rawUrl)
+        val url = if (uri.isAbsolute) fromAbsoluteURI(uri) else fromRelativeURI(uri)
+
+        url match {
+          case Some(value) => Right(value)
+          case None        => invalidURL()
+        }
       }
     } catch {
       case NonFatal(e) => invalidURL(e)
@@ -372,6 +395,9 @@ object URL {
       raw     <- Option(uri.getRawFragment)
       decoded <- Option(uri.getFragment)
     } yield Fragment(raw, decoded)
+
+    private[http] def fromRaw(raw: String): Fragment =
+      Fragment(raw, java.net.URLDecoder.decode(raw, "UTF-8"))
   }
 
   private def encode(url: URL): String = {


### PR DESCRIPTION
## Summary

Adds a fast path in `URL.decode` for relative URLs (starting with `/`), avoiding the allocation of `java.net.URI` and its internal parser. This is the common case for incoming HTTP requests.

Rebased version of #3979 by @guizmaii on current main.

### Performance impact
Every incoming HTTP request constructs a `new java.net.URI(rawUrl)`, allocating ~4 objects per request (URI, Parser, path String, query String). For relative URIs like `/api/users?page=2`, this is unnecessary — we can split on `?` and `#` directly.

### Changes
- **`URL.scala`**: Fast path in `decode` that splits relative URLs on `?` and `#` directly, bypassing `java.net.URI`. Absolute URLs still go through the existing `java.net.URI` path.
- **`URLSpec.scala`**: 7 new tests including a comprehensive test that verifies the fast path produces identical results to `java.net.URI` for 15 different URL patterns.

### Edge cases handled
- Empty string → `URL.empty`
- `?` after `#` → treated as part of fragment, not query delimiter
- Fragment-only, query-only, both, neither
- URL-encoded characters in path, query, and fragment

Supersedes #3979
Co-authored-by: Jules Ivanic <jules.ivanic@gmail.com>