### PR TITLE
docs: document AuthType default 404 unauthorized status

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/AuthType.scala
@@ -3,11 +3,38 @@ package zio.http.endpoint
 import zio.http._
 import zio.http.codec._
 
+/**
+ * Describes the authentication type for an [[Endpoint]].
+ *
+ * When authentication fails at runtime, the endpoint responds with
+ * [[unauthorizedStatus]], which defaults to `Status.NotFound` (404). This is an
+ * intentional security pattern (information hiding) that prevents attackers
+ * from discovering protected resources. To use a different status:
+ *
+ * {{{
+ * Endpoint(Method.GET / "secret")
+ *   .auth(AuthType.Bearer)
+ *   .unauthorizedStatus(Status.Unauthorized) // respond with 401 instead
+ * }}}
+ */
 sealed trait AuthType { self =>
   type ClientRequirement
   def codec: HttpCodec[HttpCodecType.RequestType, ClientRequirement]
 
-  def unauthorizedStatus: Status                       = Status.NotFound
+  /**
+   * The HTTP status code returned when authentication fails. Defaults to
+   * `Status.NotFound` (404) for security (information hiding). Override with
+   * [[withUnauthorizedStatus]] to use e.g. `Status.Unauthorized` (401).
+   */
+  def unauthorizedStatus: Status = Status.NotFound
+
+  /**
+   * Returns a copy of this auth type with a different unauthorized status.
+   *
+   * {{{
+   * AuthType.Bearer.withUnauthorizedStatus(Status.Unauthorized)
+   * }}}
+   */
   def withUnauthorizedStatus(status: Status): AuthType =
     AuthType
       .WithStatus(self.asInstanceOf[AuthType { type ClientRequirement = self.ClientRequirement }], status)

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/Endpoint.scala
@@ -198,9 +198,15 @@ final case class Endpoint[PathInput, Input, Err, Output, Auth <: AuthType](
       ev((a, b, c, d, e, f, g, h, i, j, k, l)),
     )
 
+  /** Sets the authentication type for this endpoint. */
   def auth[Auth0 <: AuthType](auth: Auth0): Endpoint[PathInput, Input, Err, Output, Auth0] =
     copy(authType = auth)
 
+  /**
+   * Overrides the HTTP status returned when authentication fails. Defaults to
+   * 404 (Not Found) for security. Use `Status.Unauthorized` for standard 401
+   * behavior.
+   */
   def unauthorizedStatus(status: Status): Endpoint[PathInput, Input, Err, Output, Auth] =
     copy(authType = authType.withUnauthorizedStatus(status).asInstanceOf[Auth])
 


### PR DESCRIPTION
Adds Scaladoc to AuthType and Endpoint.auth/unauthorizedStatus explaining the default 404 behavior and how to override it. Relates to #4041.