### PR TITLE
feat(ssl): add key password support for client cert config (#3871)

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
@@ -25,7 +25,12 @@ import scala.util.Using
 import zio.Config.Secret
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import zio.http.ClientSSLCertConfig.{FromClientCertFile, FromClientCertResource}
+import zio.http.ClientSSLCertConfig.{
+  FromClientCertFile,
+  FromClientCertFileWithPassword,
+  FromClientCertResource,
+  FromClientCertResourceWithPassword,
+}
 import zio.http.ClientSSLConfig
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
@@ -107,6 +112,27 @@ private[netty] object ClientSSLConverter {
         val certInputStream = use(classLoader.getResourceAsStream(certPath))
         val keyInputStream  = use(classLoader.getResourceAsStream(keyPath))
         newBuilder.keyManager(certInputStream, keyInputStream)
+      }.get
+    case ClientSSLConfig.FromClientAndServerCert(
+          serverCertConfig,
+          FromClientCertFileWithPassword(certPath, keyPath, keyPassword),
+        ) =>
+      val newBuilder = buildNettySslContextBuilder(serverCertConfig, sslContextBuilder)
+      Using.Manager { use =>
+        val certInputStream = use(new FileInputStream(new File(certPath)))
+        val keyInputStream  = use(new FileInputStream(new File(keyPath)))
+        newBuilder.keyManager(certInputStream, keyInputStream, keyPassword.value.mkString)
+      }.get
+    case ClientSSLConfig.FromClientAndServerCert(
+          serverCertConfig,
+          FromClientCertResourceWithPassword(certPath, keyPath, keyPassword),
+        ) =>
+      val newBuilder = buildNettySslContextBuilder(serverCertConfig, sslContextBuilder)
+      Using.Manager { use =>
+        val classLoader     = getClass.getClassLoader
+        val certInputStream = use(classLoader.getResourceAsStream(certPath))
+        val keyInputStream  = use(classLoader.getResourceAsStream(keyPath))
+        newBuilder.keyManager(certInputStream, keyInputStream, keyPassword.value.mkString)
       }.get
     case ClientSSLConfig.FromTrustStoreFile(trustStorePath, trustStorePassword)                               =>
       val trustStoreStream = new FileInputStream(trustStorePath)

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
@@ -7,20 +7,32 @@ sealed trait ClientSSLCertConfig
 
 object ClientSSLCertConfig {
   val config: Config[ClientSSLCertConfig] = {
-    val tpe      = Config.string("type")
-    val certPath = Config.string("cert-path")
-    val keyPath  = Config.string("key-path")
+    val tpe         = Config.string("type")
+    val certPath    = Config.string("cert-path")
+    val keyPath     = Config.string("key-path")
+    val keyPassword = Config.secret("key-password")
 
-    val fromCertFile     = certPath.zipWith(keyPath)(FromClientCertFile(_, _))
-    val fromCertResource = certPath.zipWith(keyPath)(FromClientCertResource(_, _))
+    val fromCertFile                 = certPath.zipWith(keyPath)(FromClientCertFile(_, _))
+    val fromCertResource             = certPath.zipWith(keyPath)(FromClientCertResource(_, _))
+    val fromCertFileWithPassword     =
+      certPath.zip(keyPath).zip(keyPassword).map(t => FromClientCertFileWithPassword(t._1, t._2, t._3))
+    val fromCertResourceWithPassword =
+      certPath.zip(keyPath).zip(keyPassword).map(t => FromClientCertResourceWithPassword(t._1, t._2, t._3))
 
     tpe.switch(
-      "FromCertFile"     -> fromCertFile,
-      "FromCertResource" -> fromCertResource,
+      "FromCertFile"                 -> fromCertFile,
+      "FromCertResource"             -> fromCertResource,
+      "FromCertFileWithPassword"     -> fromCertFileWithPassword,
+      "FromCertResourceWithPassword" -> fromCertResourceWithPassword,
     )
   }
 
   final case class FromClientCertFile(certPath: String, keyPath: String)     extends ClientSSLCertConfig
   final case class FromClientCertResource(certPath: String, keyPath: String) extends ClientSSLCertConfig
+
+  final case class FromClientCertFileWithPassword(certPath: String, keyPath: String, keyPassword: Config.Secret)
+      extends ClientSSLCertConfig
+  final case class FromClientCertResourceWithPassword(certPath: String, keyPath: String, keyPassword: Config.Secret)
+      extends ClientSSLCertConfig
 
 }


### PR DESCRIPTION
## Summary

Adds `FromClientCertFileWithPassword` and `FromClientCertResourceWithPassword` case classes to `ClientSSLCertConfig`, allowing password-protected private keys in client certificate configuration.

### Usage
```scala
// Without password (unchanged)
ClientSSLCertConfig.FromClientCertFile("cert.pem", "key.pem")

// With password (new)
ClientSSLCertConfig.FromClientCertFileWithPassword("cert.pem", "key.pem", "mypassword")
ClientSSLCertConfig.FromClientCertResourceWithPassword("cert.pem", "key.pem", "mypassword")
```

### Config file
```hocon
cert.client {
  type = "FromCertFileWithPassword"
  cert-path = "cert.pem"
  key-path = "key.pem"
  key-password = "mypassword"
}
```

### Design
New case classes instead of modifying existing ones to preserve binary compatibility. Existing `FromClientCertFile` and `FromClientCertResource` are untouched — no MiMa filters needed.

Closes #3871