### PR TITLE
feat: add composable methods with #| operator (#3842)

### DIFF
--- a/zio-http/js/src/main/scala/zio/http/internal/FetchDriver.scala
+++ b/zio-http/js/src/main/scala/zio/http/internal/FetchDriver.scala
@@ -74,6 +74,8 @@ object FetchDriver {
     case Method.CUSTOM(name) => throw new IllegalArgumentException(s"Custom method $name is not supported")
     case Method.TRACE        => throw new IllegalArgumentException("TRACE is not supported")
     case Method.CONNECT      => throw new IllegalArgumentException("CONNECT is not supported")
+    case Method.Methods(_)   =>
+      throw new IllegalArgumentException("Methods composite cannot be converted to a single HTTP method")
   }
 
   private[http] def fromZBody(body: Body): ZIO[Any, Throwable, js.UndefOr[BodyInit]] =

--- a/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/model/Conversions.scala
@@ -55,6 +55,8 @@ private[netty] object Conversions {
       case Method.CONNECT      => HttpMethod.CONNECT
       case Method.ANY          => HttpMethod.GET
       case Method.CUSTOM(name) => new HttpMethod(name)
+      case Method.Methods(_)   =>
+        throw new IllegalArgumentException("Methods composite cannot be converted to a single Netty method")
     }
 
   def headersToNetty(headers: Headers): HttpHeaders =

--- a/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/RouteSpec.scala
@@ -456,6 +456,51 @@ object RouteSpec extends ZIOHttpSpec {
         )
       },
     ),
+    suite("composable methods (Method.#|)")(
+      test("composable methods route matches both GET and POST") {
+        val routes = Routes(
+          Method.GET #| Method.POST / "test" -> handler(Response.text("ok")),
+        )
+        for {
+          getResp  <- routes.runZIO(Request.get("/test"))
+          postResp <- routes.runZIO(Request.post("/test", Body.empty))
+        } yield assertTrue(
+          getResp.status == Status.Ok,
+          postResp.status == Status.Ok,
+        )
+      },
+      test("composable methods route doesn't match other methods") {
+        val routes = Routes(
+          Method.GET #| Method.POST / "test" -> handler(Response.text("ok")),
+        )
+        for {
+          putResp <- routes.runZIO(Request.put("/test", Body.empty))
+        } yield assertTrue(putResp.status == Status.NotFound)
+      },
+      test("Method.matches works with composite methods") {
+        val composite = Method.GET #| Method.POST
+        assertTrue(
+          composite.matches(Method.GET),
+          composite.matches(Method.POST),
+          !composite.matches(Method.PUT),
+          !composite.matches(Method.DELETE),
+        )
+      },
+      test("three methods can be combined") {
+        val composite = Method.GET #| Method.POST #| Method.PUT
+        assertTrue(
+          composite.matches(Method.GET),
+          composite.matches(Method.POST),
+          composite.matches(Method.PUT),
+          !composite.matches(Method.DELETE),
+        )
+      },
+      test("composable method route renders correctly") {
+        val pattern  = Method.GET #| Method.POST / "test"
+        val rendered = pattern.render
+        assertTrue(rendered == "GET#|POST /test")
+      },
+    ),
     test("Handled#toHandler should not suspend") {
       val request = Request(headers = Headers.empty, method = Method.GET)
       val ok      = (Method.GET / "foo" -> handler(Response.ok)).toHandler

--- a/zio-http/shared/src/main/scala/zio/http/Method.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Method.scala
@@ -31,6 +31,17 @@ sealed trait Method { self: Product =>
     if (that == Method.ANY) self
     else that
 
+  def #|(that: Method): Method =
+    if (self == Method.ANY || that == Method.ANY) Method.ANY
+    else
+      (self, that) match {
+        case (Method.Methods(a), Method.Methods(b)) => Method.Methods(a ++ b)
+        case (Method.Methods(a), _)                 => Method.Methods(a + that)
+        case (_, Method.Methods(b))                 => Method.Methods(b + self)
+        case _ if self == that                      => self
+        case _                                      => Method.Methods(Set(self, that))
+      }
+
   def /[A](that: PathCodec[A]): RoutePattern[A] =
     if (that == PathCodec.empty) RoutePattern.fromMethod(self).asInstanceOf[RoutePattern[A]]
     else RoutePattern.fromMethod(self) / that
@@ -38,7 +49,15 @@ sealed trait Method { self: Product =>
   def matches(that: Method): Boolean =
     if (self == Method.ANY) true
     else if (that == Method.ANY) true
-    else self == that
+    else
+      self match {
+        case Method.Methods(methods) => methods.exists(_.matches(that))
+        case _                       =>
+          that match {
+            case Method.Methods(methods) => methods.exists(_.matches(self))
+            case _                       => self == that
+          }
+      }
 
   /**
    * The name of the method, as it appears in the HTTP request.
@@ -69,6 +88,10 @@ object Method {
     }
 
   final case class CUSTOM(name: String) extends Method
+
+  final case class Methods(methods: Set[Method]) extends Method {
+    val name: String = methods.toList.sortBy(_.render).map(_.render).mkString("#|")
+  }
 
   case object OPTIONS extends Method { val name = "OPTIONS" }
   case object GET     extends Method { val name = "GET"     }

--- a/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
+++ b/zio-http/shared/src/main/scala/zio/http/RoutePattern.scala
@@ -77,7 +77,11 @@ final case class RoutePattern[A](method: Method, pathCodec: PathCodec[A]) { self
 
   def alternatives: List[RoutePattern[A]] = pathCodec.alternatives.flatMap { path =>
     if (method == Method.ANY) Method.standardMethods.map(RoutePattern(_, path))
-    else List(RoutePattern(method, path))
+    else
+      method match {
+        case Method.Methods(ms) => ms.toList.map(m => RoutePattern(m, path))
+        case _                  => List(RoutePattern(method, path))
+      }
   }
 
   /**
@@ -252,16 +256,16 @@ object RoutePattern                                                       {
       val empty = Tree.empty[Env]
 
       routePattern.method match {
-        case Method.GET       => empty.copy(getRoot = subtree)
-        case Method.POST      => empty.copy(postRoot = subtree)
-        case Method.PUT       => empty.copy(putRoot = subtree)
-        case Method.DELETE    => empty.copy(deleteRoot = subtree)
-        case Method.CONNECT   => empty.copy(connectRoot = subtree)
-        case Method.HEAD      => empty.copy(headRoot = subtree)
-        case Method.OPTIONS   => empty.copy(optionsRoot = subtree)
-        case Method.PATCH     => empty.copy(patchRoot = subtree)
-        case Method.TRACE     => empty.copy(traceRoot = subtree)
-        case Method.ANY       =>
+        case Method.GET        => empty.copy(getRoot = subtree)
+        case Method.POST       => empty.copy(postRoot = subtree)
+        case Method.PUT        => empty.copy(putRoot = subtree)
+        case Method.DELETE     => empty.copy(deleteRoot = subtree)
+        case Method.CONNECT    => empty.copy(connectRoot = subtree)
+        case Method.HEAD       => empty.copy(headRoot = subtree)
+        case Method.OPTIONS    => empty.copy(optionsRoot = subtree)
+        case Method.PATCH      => empty.copy(patchRoot = subtree)
+        case Method.TRACE      => empty.copy(traceRoot = subtree)
+        case Method.ANY        =>
           empty.copy(
             getRoot = subtree,
             postRoot = subtree,
@@ -273,7 +277,11 @@ object RoutePattern                                                       {
             patchRoot = subtree,
             traceRoot = subtree,
           )
-        case m: Method.CUSTOM => empty.copy(customRoots = Map(m -> subtree))
+        case m: Method.Methods =>
+          m.methods.foldLeft(empty) { (acc, singleMethod) =>
+            acc ++ Tree(RoutePattern(singleMethod, routePattern.pathCodec), value)
+          }
+        case m: Method.CUSTOM  => empty.copy(customRoots = Map(m -> subtree))
       }
     }
 


### PR DESCRIPTION
## Summary

Adds a `#|` operator to `Method` that combines methods into a composite, allowing a single route to match multiple HTTP methods without duplication.

### Usage
```scala
// No parentheses needed — #| binds tighter than /
val routes = Routes(
  Method.GET #| Method.POST / "graphql" -> handler(Response.text("ok")),
)

// GET /graphql → 200
// POST /graphql → 200
// PUT /graphql → 404

// Three or more methods:
Method.GET #| Method.POST #| Method.PUT / "resource" -> handler
```

### Why `#|` instead of `|`?
Scala operator precedence: `|` (group 9) binds **looser** than `/` (group 2), so `Method.GET | Method.POST / "foo"` would parse as `Method.GET | (Method.POST / "foo")` — wrong. `#|` starts with `#` (group 1, highest), so it binds tighter than `/` and no parentheses are needed.

### Changes
- **`Method.scala`**: Added `#|` operator and `Methods(methods: Set[Method])` case class. Updated `matches` to handle composite methods.
- **`RoutePattern.scala`**: Updated `alternatives` and `Tree.addRoute` to expand composite methods into individual subtree entries.
- **`Conversions.scala`** / **`FetchDriver.scala`**: Added exhaustive match cases for `Methods` (throws — composite can't be used as a single wire method).
- **`RouteSpec.scala`**: 5 tests covering routing, matching, three-method combination, and render format.

### Binary compatible
MiMa passes — `Methods` is a new additive case, `#|` is a new method, `matches` is a behavioral change.

Closes #3842