### PR TITLE
fix(openapi): produce binary schema for non-multipart `outStream[Byte]`

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/endpoint/openapi/OpenAPIGenSpec.scala
@@ -3882,6 +3882,48 @@ object OpenAPIGenSpec extends ZIOSpecDefault {
             |""".stripMargin
         assertTrue(json == toJsonAst(expectedJson))
       },
+      test("Stream schema for Byte produces binary format") {
+        val endpoint     = Endpoint(RoutePattern.GET / "download")
+          .outStream[Byte](MediaType.application.`octet-stream`)
+        val openApi      = OpenAPIGen.fromEndpoints(endpoint)
+        val json         = toJsonAst(openApi)
+        val expectedJson =
+          """
+            |{
+            |  "openapi" : "3.1.0",
+            |  "info" : {
+            |    "title" : "",
+            |    "version" : ""
+            |  },
+            |  "paths" : {
+            |    "/download" : {
+            |      "get" : {
+            |        "responses" : {
+            |          "200" :
+            |            {
+            |            "content" : {
+            |              "application/octet-stream" : {
+            |                "schema" :
+            |                  {
+            |                  "type" :
+            |                    "string",
+            |                  "contentEncoding" : "binary",
+            |                  "contentMediaType" : "application/octet-stream"
+            |                }
+            |              }
+            |            }
+            |          }
+            |        }
+            |      }
+            |    }
+            |  },
+            |  "components" : {
+            |
+            |  }
+            |}
+            |""".stripMargin
+        assertTrue(json == toJsonAst(expectedJson))
+      },
       test("Stream schema multipart") {
         val endpoint     = Endpoint(RoutePattern.POST / "folder")
           .outCodec(

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -408,31 +408,27 @@ object OpenAPIGen {
               .description(descriptionFromMeta)
               .deprecated(deprecated(metadata))
               .nullable(optional(metadata))
-          case HttpCodec.ContentStream(codec, _, _)
-              if codec
-                .lookup(mediaType)
-                .map(_._2.schema)
-                .getOrElse(codec.defaultSchema) == Schema[Byte] =>
-            JsonSchema
-              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
-              .description(descriptionFromMeta)
-              .deprecated(deprecated(metadata))
-              .nullable(optional(metadata))
-              .contentEncoding(JsonSchema.ContentEncoding.Binary)
-              .contentMediaType(mediaType.fullType)
           case HttpCodec.ContentStream(codec, _, _)                         =>
-            JsonSchema
-              .ArrayType(
-                Some(
-                  JsonSchema
-                    .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType),
-                ),
-                None,
-                uniqueItems = false,
-              )
-              .description(descriptionFromMeta)
-              .deprecated(deprecated(metadata))
-              .nullable(optional(metadata))
+            val schema = codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema)
+            if (schema == Schema[Byte]) {
+              JsonSchema
+                .fromZSchema(schema, refType)
+                .description(descriptionFromMeta)
+                .deprecated(deprecated(metadata))
+                .nullable(optional(metadata))
+                .contentEncoding(JsonSchema.ContentEncoding.Binary)
+                .contentMediaType(mediaType.fullType)
+            } else {
+              JsonSchema
+                .ArrayType(
+                  Some(JsonSchema.fromZSchema(schema, refType)),
+                  None,
+                  uniqueItems = false,
+                )
+                .description(descriptionFromMeta)
+                .deprecated(deprecated(metadata))
+                .nullable(optional(metadata))
+            }
           case _                                                            => JsonSchema.Null
         }
       case HttpCodec.Annotated(codec, data)                        =>

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -366,23 +366,22 @@ object OpenAPIGen {
                 .nullable(optional(metadata)),
             )
           case HttpCodec.ContentStream(codec, maybeName, _)
-              if codec
+              if wrapInObject && codec
                 .lookup(mediaType)
                 .map(_._2.schema)
                 .getOrElse(codec.defaultSchema) == Schema[Byte] =>
-            val schema = JsonSchema
-              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
-              .description(descriptionFromMeta)
-              .deprecated(deprecated(metadata))
-              .nullable(optional(metadata))
-              // currently we have no information about the encoding. So we just assume binary
-              .contentEncoding(JsonSchema.ContentEncoding.Binary)
-              .contentMediaType(MediaType.application.`octet-stream`.fullType)
-            if (wrapInObject) {
-              val name =
-                findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
-              JsonSchema.obj(name -> schema)
-            } else schema
+            val name =
+              findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
+            JsonSchema.obj(
+              name -> JsonSchema
+                .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
+                .description(descriptionFromMeta)
+                .deprecated(deprecated(metadata))
+                .nullable(optional(metadata))
+                // currently we have no information about the encoding. So we just assume binary
+                .contentEncoding(JsonSchema.ContentEncoding.Binary)
+                .contentMediaType(MediaType.application.`octet-stream`.fullType),
+            )
           case HttpCodec.ContentStream(codec, maybeName, _) if wrapInObject =>
             val name =
               findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
@@ -409,6 +408,18 @@ object OpenAPIGen {
               .description(descriptionFromMeta)
               .deprecated(deprecated(metadata))
               .nullable(optional(metadata))
+          case HttpCodec.ContentStream(codec, _, _)
+              if codec
+                .lookup(mediaType)
+                .map(_._2.schema)
+                .getOrElse(codec.defaultSchema) == Schema[Byte] =>
+            JsonSchema
+              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
+              .description(descriptionFromMeta)
+              .deprecated(deprecated(metadata))
+              .nullable(optional(metadata))
+              .contentEncoding(JsonSchema.ContentEncoding.Binary)
+              .contentMediaType(mediaType.fullType)
           case HttpCodec.ContentStream(codec, _, _)                         =>
             JsonSchema
               .ArrayType(

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -408,6 +408,18 @@ object OpenAPIGen {
               .description(descriptionFromMeta)
               .deprecated(deprecated(metadata))
               .nullable(optional(metadata))
+          case HttpCodec.ContentStream(codec, _, _)
+              if codec
+                .lookup(mediaType)
+                .map(_._2.schema)
+                .getOrElse(codec.defaultSchema) == Schema[Byte] =>
+            JsonSchema
+              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
+              .description(descriptionFromMeta)
+              .deprecated(deprecated(metadata))
+              .nullable(optional(metadata))
+              .contentEncoding(JsonSchema.ContentEncoding.Binary)
+              .contentMediaType(MediaType.application.`octet-stream`.fullType)
           case HttpCodec.ContentStream(codec, _, _)                         =>
             JsonSchema
               .ArrayType(

--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPIGen.scala
@@ -366,22 +366,23 @@ object OpenAPIGen {
                 .nullable(optional(metadata)),
             )
           case HttpCodec.ContentStream(codec, maybeName, _)
-              if wrapInObject && codec
+              if codec
                 .lookup(mediaType)
                 .map(_._2.schema)
                 .getOrElse(codec.defaultSchema) == Schema[Byte] =>
-            val name =
-              findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
-            JsonSchema.obj(
-              name -> JsonSchema
-                .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
-                .description(descriptionFromMeta)
-                .deprecated(deprecated(metadata))
-                .nullable(optional(metadata))
-                // currently we have no information about the encoding. So we just assume binary
-                .contentEncoding(JsonSchema.ContentEncoding.Binary)
-                .contentMediaType(MediaType.application.`octet-stream`.fullType),
-            )
+            val schema = JsonSchema
+              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
+              .description(descriptionFromMeta)
+              .deprecated(deprecated(metadata))
+              .nullable(optional(metadata))
+              // currently we have no information about the encoding. So we just assume binary
+              .contentEncoding(JsonSchema.ContentEncoding.Binary)
+              .contentMediaType(MediaType.application.`octet-stream`.fullType)
+            if (wrapInObject) {
+              val name =
+                findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
+              JsonSchema.obj(name -> schema)
+            } else schema
           case HttpCodec.ContentStream(codec, maybeName, _) if wrapInObject =>
             val name =
               findName(metadata).orElse(maybeName).getOrElse(throw new Exception("Multipart content without name"))
@@ -408,18 +409,6 @@ object OpenAPIGen {
               .description(descriptionFromMeta)
               .deprecated(deprecated(metadata))
               .nullable(optional(metadata))
-          case HttpCodec.ContentStream(codec, _, _)
-              if codec
-                .lookup(mediaType)
-                .map(_._2.schema)
-                .getOrElse(codec.defaultSchema) == Schema[Byte] =>
-            JsonSchema
-              .fromZSchema(codec.lookup(mediaType).map(_._2.schema).getOrElse(codec.defaultSchema), refType)
-              .description(descriptionFromMeta)
-              .deprecated(deprecated(metadata))
-              .nullable(optional(metadata))
-              .contentEncoding(JsonSchema.ContentEncoding.Binary)
-              .contentMediaType(MediaType.application.`octet-stream`.fullType)
           case HttpCodec.ContentStream(codec, _, _)                         =>
             JsonSchema
               .ArrayType(


### PR DESCRIPTION
Closes https://github.com/zio/zio-http/issues/4091

This PR adds the same `Schema[Byte]` binary schema handling for  the non-multipart `ContentStream` path in `OpenAPIGen.contentAsJsonSchema`, which already exists for multipart.