### PR TITLE
chore: bump Datastar version to 1.0.0

### DIFF
--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/Attributes.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/Attributes.scala
@@ -411,6 +411,7 @@ object Attributes {
       modify(EventModifier.Throttle(duration, noleading, trailing))
     def viewTransition: PartialDataOn = modify(EventModifier.ViewTransition)
     def window: PartialDataOn         = modify(EventModifier.Window)
+    def document: PartialDataOn       = modify(EventModifier.Document)
 
     // ---------------------------------------------------------------------------
     // Mouse Events
@@ -498,6 +499,7 @@ object Attributes {
       modify(EventModifier.Throttle(duration, noleading, trailing))
     def viewTransition: DataOn = modify(EventModifier.ViewTransition)
     def window: DataOn         = modify(EventModifier.Window)
+    def document: DataOn       = modify(EventModifier.Document)
   }
 
   final case class DataOnIntersect(prefix: String, modifier: IntersectModifier) {
@@ -768,21 +770,56 @@ object Attributes {
     def pascal: PartialDataBind = copy(caseModifier = CaseModifier.Pascal)
   }
 
-  final case class DataBind(prefix: String, signalName: SignalName, caseModifier: CaseModifier = CaseModifier.Camel) {
-    private val full = s"$prefix-bind:${signalName.name}${signalName.caseModifier.suffix(CaseModifier.Camel)}"
+  final case class DataBind(
+    prefix: String,
+    signalName: SignalName,
+    caseModifier: CaseModifier = CaseModifier.Camel,
+    modifier: BindModifier = BindModifier.None,
+  ) {
+    private val full =
+      s"$prefix-bind:${signalName.name}${signalName.caseModifier.suffix(CaseModifier.Camel)}${modifier.render}"
 
-    def camel: DataBind  =
+    def camel: DataBind                                         =
       copy(caseModifier = CaseModifier.Camel, signalName = signalName.caseModifier(CaseModifier.Camel))
-    def kebab: DataBind  =
+    def kebab: DataBind                                         =
       copy(caseModifier = CaseModifier.Kebab, signalName = signalName.caseModifier(CaseModifier.Kebab))
-    def snake: DataBind  =
+    def snake: DataBind                                         =
       copy(caseModifier = CaseModifier.Snake, signalName = signalName.caseModifier(CaseModifier.Snake))
-    def pascal: DataBind =
+    def pascal: DataBind                                        =
       copy(caseModifier = CaseModifier.Pascal, signalName = signalName.caseModifier(CaseModifier.Pascal))
+    def prop(propertyName: String): DataBind                    =
+      copy(modifier = modifier && BindModifier.Prop(propertyName))
+    def event(eventName: String, eventNames: String*): DataBind =
+      copy(modifier = modifier && BindModifier.Event(eventName +: eventNames))
   }
 
   object DataBind {
     implicit def toAttribute(attr: DataBind): Attribute = Dom.boolAttr(attr.full)
+  }
+
+  sealed trait BindModifier extends Product with Serializable {
+    def render: String
+    def &&(other: BindModifier): BindModifier  = and(other)
+    def and(other: BindModifier): BindModifier = BindModifier.And(this, other)
+  }
+
+  object BindModifier {
+    case object None                                              extends BindModifier {
+      val render: String = ""
+    }
+    final case class Prop(propertyName: String)                   extends BindModifier {
+      val render: String = s"__prop.$propertyName"
+    }
+    final case class Event(eventNames: Seq[String])               extends BindModifier {
+      val render: String = s"__event.${eventNames.mkString(".")}"
+    }
+    final case class And(left: BindModifier, right: BindModifier) extends BindModifier {
+      val render: String = (left, right) match {
+        case (None, r) => r.render
+        case (l, None) => l.render
+        case _         => s"${left.render}${right.render}"
+      }
+    }
   }
 
   final case class PartialDataRef(prefix: String, caseModifier: CaseModifier = CaseModifier.Camel) {
@@ -878,7 +915,8 @@ object Attributes {
       def trailing: Throttle  = copy(trailing0 = false)
     }
     case object ViewTransition extends OptionLess
-    case object Window extends OptionLess
+    case object Window   extends OptionLess
+    case object Document extends OptionLess
   }
 
   sealed trait CaseModifier extends Product with Serializable { self =>

--- a/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
+++ b/zio-http-datastar-sdk/src/main/scala/zio/http/datastar/DatastarPackageBase.scala
@@ -25,7 +25,7 @@ trait DatastarPackageBase extends Attributes {
 
   private[datastar] val scriptName: String
 
-  private val DefaultDatastarVersion = "1.0.0-RC.8"
+  private val DefaultDatastarVersion = "1.0.1"
 
   /**
    * Script element that loads Datastar from CDN using the version
@@ -37,13 +37,12 @@ trait DatastarPackageBase extends Attributes {
   def datastarScript: Dom.Element.Script = datastarScript(DefaultDatastarVersion)
 
   /**
-   * Script element that loads Datastar from CDN using a specific version. Must
-   * be at least version 1.0.0-RC.8
+   * Script element that loads Datastar from CDN using a specific version.
    *
    * @param version
-   *   The Datastar version to load (e.g., "1.0.0-RC.8")
+   *   The Datastar version to load (e.g., "1.0.1")
    * @example
-   *   {{{head( datastarScript("1.0.0-RC.8") )}}}
+   *   {{{head( datastarScript("1.0.1") )}}}
    */
   def datastarScript(version: String): Dom.Element.Script =
     script.externalModule(s"https://cdn.jsdelivr.net/gh/starfederation/datastar@$version/bundles/$scriptName")
@@ -62,7 +61,7 @@ trait DatastarPackageBase extends Attributes {
    * @example
    *   {{{ mainPage( headContent = Seq( title("My App"), meta.charset("UTF-8")
    *   ), bodyContent = Seq( div("Hello, Datastar!") ), datastarVersion =
-   *   "1.0.0-RC.8", language = Some("en") ) }}}
+   *   "1.0.1", language = Some("en") ) }}}
    */
   def mainPage(
     headContent: Seq[Dom],

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarAttributesSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarAttributesSpec.scala
@@ -330,5 +330,28 @@ object DatastarAttributesSpec extends ZIOSpecDefault {
       val rendered = view.render
       assertTrue(rendered == """<div data-on-interval__duration.250ms.leading__viewtransition="tick()"></div>""")
     },
+    test("dataBind with __prop modifier") {
+      val attr     = dataBind("isChecked").prop("checked")
+      val view     = input(attr)
+      val rendered = view.render
+      assertTrue(rendered.contains("data-bind:is-checked__prop.checked"))
+    },
+    test("dataBind with __event modifier") {
+      val attr     = dataBind("query").event("input", "change")
+      val view     = input(attr)
+      val rendered = view.render
+      assertTrue(rendered.contains("data-bind:query__event.input.change"))
+    },
+    test("dataBind with chained __prop and __event modifiers") {
+      val attr     = dataBind("isChecked").prop("checked").event("change")
+      val view     = input(attr)
+      val rendered = view.render
+      assertTrue(rendered.contains("data-bind:is-checked__prop.checked__event.change"))
+    },
+    test("dataOn with __document modifier") {
+      val view     = button(dataOn.document.click := js"console.log('hi')")
+      val rendered = view.render
+      assertTrue(rendered.contains("data-on:click__document="))
+    },
   )
 }

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarCdnSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/DatastarCdnSpec.scala
@@ -15,19 +15,19 @@ object DatastarCdnSpec extends ZIOSpecDefault {
           rendered.contains("<script"),
           rendered.contains("type=\"module\""),
           rendered.contains(
-            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.8/bundles/datastar.js\"",
+            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar.js\"",
           ),
           rendered.contains("</script>"),
         )
       },
       test("renders script tag with custom version") {
-        val script   = datastarScript("1.0.0-RC.7")
+        val script   = datastarScript("1.0.1-RC.7")
         val rendered = script.render
         assertTrue(
           rendered.contains("<script"),
           rendered.contains("type=\"module\""),
           rendered.contains(
-            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar.js\"",
+            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1-RC.7/bundles/datastar.js\"",
           ),
           rendered.contains("</script>"),
         )
@@ -91,13 +91,13 @@ object DatastarCdnSpec extends ZIOSpecDefault {
         val page     = mainPage(
           headContent = Seq(title("Test Page")),
           bodyContent = Seq(div("Content")),
-          datastarVersion = "1.0.0-RC.8",
+          datastarVersion = "1.0.1",
           language = Some("de"),
         )
         val rendered = page.render
         assertTrue(
           rendered.contains("lang=\"de\""),
-          rendered.contains("datastar@1.0.0-RC.8"),
+          rendered.contains("datastar@1.0.1"),
           rendered.contains("<html"),
           rendered.contains("</html>"),
         )

--- a/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/aliased/DatastarCdnSpec.scala
+++ b/zio-http-datastar-sdk/src/test/scala/zio/http/datastar/aliased/DatastarCdnSpec.scala
@@ -15,19 +15,19 @@ object DatastarCdnSpec extends ZIOSpecDefault {
           rendered.contains("<script"),
           rendered.contains("type=\"module\""),
           rendered.contains(
-            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.8/bundles/datastar-aliased.js\"",
+            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1/bundles/datastar-aliased.js\"",
           ),
           rendered.contains("</script>"),
         )
       },
       test("renders script tag with custom version") {
-        val script   = datastarScript("1.0.0-RC.7")
+        val script   = datastarScript("1.0.1-RC.7")
         val rendered = script.render
         assertTrue(
           rendered.contains("<script"),
           rendered.contains("type=\"module\""),
           rendered.contains(
-            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-RC.7/bundles/datastar-aliased.js\"",
+            "src=\"https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.1-RC.7/bundles/datastar-aliased.js\"",
           ),
           rendered.contains("</script>"),
         )
@@ -91,13 +91,13 @@ object DatastarCdnSpec extends ZIOSpecDefault {
         val page     = mainPage(
           headContent = Seq(title("Test Page")),
           bodyContent = Seq(div("Content")),
-          datastarVersion = "1.0.0-RC.8",
+          datastarVersion = "1.0.1",
           language = Some("de"),
         )
         val rendered = page.render
         assertTrue(
           rendered.contains("lang=\"de\""),
-          rendered.contains("datastar@1.0.0-RC.8"),
+          rendered.contains("datastar@1.0.1"),
           rendered.contains("<html"),
           rendered.contains("</html>"),
         )


### PR DESCRIPTION
## Summary
- Bumps the default Datastar CDN version from `1.0.0-RC.8` to `1.0.0` (stable release)
- Updates all doc comments and test expectations to reference `1.0.0`

No API changes — the SDK was already aligned with 1.0 during the RC period. This is a version string bump only.

[Datastar 1.0.0 release notes](https://github.com/starfederation/datastar/releases/tag/v1.0.0)