### PR TITLE
fix(ci): replace EOL GraalVM 17/21 with GraalVM 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.21, 2.13.18, 3.3.7]
-        java:
-          - graal_graalvm@17
-          - graal_graalvm@21
-          - temurin@17
-          - temurin@21
+        java: [graal_graalvm@25, temurin@17, temurin@25]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -41,21 +37,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup GraalVM (graal_graalvm@17)
-        if: matrix.java == 'graal_graalvm@17'
+      - name: Setup GraalVM (graal_graalvm@25)
+        if: matrix.java == 'graal_graalvm@25'
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: 17
-          distribution: graalvm
-          components: native-image
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: sbt
-
-      - name: Setup GraalVM (graal_graalvm@21)
-        if: matrix.java == 'graal_graalvm@21'
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: 21
+          java-version: 25
           distribution: graalvm
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,12 +55,12 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt
@@ -125,7 +111,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18]
-        java: [graal_graalvm@17]
+        java: [graal_graalvm@25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -133,21 +119,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup GraalVM (graal_graalvm@17)
-        if: matrix.java == 'graal_graalvm@17'
+      - name: Setup GraalVM (graal_graalvm@25)
+        if: matrix.java == 'graal_graalvm@25'
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: 17
-          distribution: graalvm
-          components: native-image
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache: sbt
-
-      - name: Setup GraalVM (graal_graalvm@21)
-        if: matrix.java == 'graal_graalvm@21'
-        uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: 21
+          java-version: 25
           distribution: graalvm
           components: native-image
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,12 +137,12 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,9 @@ ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 ThisBuild / libraryDependencySchemes += "dev.zio" %% "zio-json" % VersionScheme.Always
 
 ThisBuild / githubWorkflowJavaVersions   := Seq(
-  JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "17"),
-  JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21"),
+  JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "25"),
   JavaSpec.temurin("17"),
-  JavaSpec.temurin("21"),
+  JavaSpec.temurin("25"),
 )
 ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowPREventTypes   := Seq(


### PR DESCRIPTION
## Summary
- GraalVM JDK 17 is EOL — `gu install native-image` consistently fails because Oracle's download server (`gds.oracle.com`) is dead/unreliable
- This has been breaking CI on every PR (e.g. #4092)
- Replace both `graalvm@17` and `graalvm@21` with a single `graalvm@25` (latest, native-image bundled)
- JDK 17 and 21 compatibility still covered by `temurin@17` and `temurin@21`
- CI matrix drops from 12 to 9 jobs (faster feedback)