### PR TITLE
fix(ci): update Mima check to JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.13.18]
-        java: [temurin@21]
+        java: [temurin@25]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -223,12 +223,12 @@ jobs:
         with:
           apps: sbt
 
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
           cache: sbt
 
       - run: sbt mimaChecks

--- a/build.sbt
+++ b/build.sbt
@@ -44,10 +44,10 @@ ThisBuild / githubWorkflowAddedJobs :=
       steps = List(
         WorkflowStep.Use(UseRef.Public("actions", "checkout", "v4"), Map("fetch-depth" -> "0")),
         coursierSetup,
-      ) ++ WorkflowStep.SetupJava(List(JavaSpec.temurin("21"))) :+ WorkflowStep.Sbt(List("mimaChecks")),
+      ) ++ WorkflowStep.SetupJava(List(JavaSpec.temurin("25"))) :+ WorkflowStep.Sbt(List("mimaChecks")),
       cond = Option("${{ github.event_name == 'pull_request' }}"),
       scalas = List(Scala213),
-      javas = List(JavaSpec.temurin("21")),
+      javas = List(JavaSpec.temurin("25")),
     ),
   ) ++ ScoverageWorkFlow(50, 60) ++ JmhBenchmarkWorkflow(1) ++ BenchmarkWorkFlow()
 


### PR DESCRIPTION
## Summary
- Updates the Mima binary compatibility check from `temurin@21` to `temurin@25`, aligning with the JDK matrix change in #4096