### PR TITLE
Update zio, zio-streams, zio-test to 2.1.25

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   val JwtCoreVersion               = "11.0.4"
   val NettyVersion                 = "4.2.12.Final"
   val ScalaCompatCollectionVersion = "2.14.0"
-  val ZioVersion                   = "2.1.24"
+  val ZioVersion                   = "2.1.25"
   val ZioCliVersion                = "0.8.0"
   val ZioJsonVersion               = "0.9.1"
   val ZioSchemaVersion             = "1.8.3"

--- a/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CliSpec.scala
+++ b/zio-http-cli/src/test/scala/zio/http/endpoint/cli/CliSpec.scala
@@ -133,7 +133,7 @@ object CliSpec extends ZIOSpecDefault {
           check(EndpointGen.anyCliEndpoint) { case CliRepr(endpoint, repr) =>
             assertTrue(endpoint == repr)
           }
-        },
+        } @@ samples(20) @@ timeout(60.seconds),
         test("CliEndpoint generates correct Options") {
           check(OptionsGen.anyCliEndpoint) { case CliRepr(options, repr) =>
             assertTrue(
@@ -141,7 +141,7 @@ object CliSpec extends ZIOSpecDefault {
                 && HttpCommand.addOptionsTo(repr).uid == options.uid,
             )
           }
-        },
+        } @@ samples(20) @@ timeout(60.seconds),
         test("fromEndpoints generates correct Command") {
           check(CommandGen.anyEndpoint) { case CliRepr(endpoint, helpDoc) =>
             val command = HttpCommand.fromEndpoints("cli", Chunk(endpoint), cliStyle = true)


### PR DESCRIPTION
## Summary
- Updates ZIO from `2.1.24` to `2.1.25`
- Supersedes #4076 which had merge conflicts with the CI matrix changes

[Release notes](https://github.com/zio/zio/releases/tag/v2.1.25)