### PR TITLE
Update tapir-http4s-server, tapir-json-circe to 1.13.16

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,8 +279,8 @@ lazy val zioHttpBenchmarks = (project in file("zio-http-benchmarks"))
   .settings(
     libraryDependencies ++= Seq(
 //      "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "1.1.0",
-      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server" % "1.13.14",
-      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"    % "1.13.14",
+      "com.softwaremill.sttp.tapir"   %% "tapir-http4s-server" % "1.13.16",
+      "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"    % "1.13.16",
       "com.softwaremill.sttp.client3" %% "core"                % "3.11.0",
 //      "dev.zio"                     %% "zio-interop-cats"    % "3.3.0",
       "org.slf4j"                      % "slf4j-api"           % "2.0.17",


### PR DESCRIPTION
## Summary
- Updates tapir from `1.13.14` to `1.13.16`
- Supersedes #4094 which was stale on the old CI matrix