### PR TITLE
docs(website): add llms.txt support for AI/LLM consumers

### DIFF
--- a/docs/reference/body/body.md
+++ b/docs/reference/body/body.md
@@ -1,6 +1,7 @@
 ---
 id: body
 title: Body
+slug: /reference/body
 ---
 
 `Body` is a domain to model content for `Request` and `Response`. The body can be a fixed chunk of bytes, a stream of bytes, or form data, or any type that can be encoded into such representations (such as textual data using some character encoding, the contents of files, JSON, etc.).

--- a/docs/reference/headers/headers.md
+++ b/docs/reference/headers/headers.md
@@ -1,6 +1,7 @@
 ---
 id: headers
 title: Headers
+slug: /reference/headers
 ---
 
 **ZIO HTTP** provides support for all HTTP headers (as defined in [RFC2616](https://datatracker.ietf.org/doc/html/rfc2616)) along with custom headers.

--- a/docs/reference/response/response.md
+++ b/docs/reference/response/response.md
@@ -1,6 +1,7 @@
 ---
 id: response
 title: Response
+slug: /reference/response
 ---
 
 **ZIO HTTP** `Response` is designed to encode HTTP Response.

--- a/docs/reference/socket/socket.md
+++ b/docs/reference/socket/socket.md
@@ -1,6 +1,7 @@
 ---
 id: socket
 title: "Socket"
+slug: /reference/socket
 ---
 
 Websocket support can be added to your Http application using the same `Http` domain, something like this —

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'ZIO HTTP',
-  tagline: ' A next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers',
+  tagline: 'A next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers',
   url: 'https://ziohttp.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -57,9 +57,7 @@ const config = {
         generateMarkdownFiles: true,
         docsDir: 'docs',
         ignoreFiles: [],
-        title: 'ZIO HTTP',
-        description:
-          'A next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers.',
+        // title/description fall back to siteConfig.title/siteConfig.tagline
         includeBlog: false,
         pathTransformation: {
           ignorePaths: ['docs'],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -47,6 +47,42 @@ const config = {
     ],
   ],
 
+  plugins: [
+    [
+      'docusaurus-plugin-llms',
+      /** @type {import('docusaurus-plugin-llms').PluginOptions} */
+      ({
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        docsDir: 'docs',
+        ignoreFiles: [],
+        title: 'ZIO HTTP',
+        description:
+          'A next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers.',
+        includeBlog: false,
+        pathTransformation: {
+          ignorePaths: ['docs'],
+          addPaths: [],
+        },
+        includeOrder: [
+          'index.md',
+          'installation.md',
+          'reference/**',
+          'guides/**',
+          'examples/**',
+          'concepts/**',
+          'migration/**',
+          'faq.md',
+        ],
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+        includeUnmatchedLast: true,
+        preserveDirectoryStructure: false,
+      }),
+    ],
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-llms": "0.4.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1494,7 +1494,7 @@
     "@docusaurus/theme-search-algolia" "2.2.0"
     "@docusaurus/types" "2.2.0"
 
-"@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -2717,6 +2717,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
+  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
@@ -3488,6 +3495,15 @@ dns-packet@^5.2.2:
   integrity sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+docusaurus-plugin-llms@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz#020f00d83459c7feb71c7b6e61774d864336d8ae"
+  integrity sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==
+  dependencies:
+    gray-matter "^4.0.3"
+    minimatch "^9.0.3"
+    yaml "^2.8.1"
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -5258,6 +5274,13 @@ minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^9.0.3:
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
 minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -6238,14 +6261,6 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   integrity sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==
   dependencies:
     "@babel/runtime" "^7.10.3"
-
-"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
-  version "5.5.2"
-  resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
-  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
-  dependencies:
-    "@types/react" "*"
-    prop-types "^15.6.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"
@@ -7788,6 +7803,11 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.8.1:
+  version "2.8.3"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
+  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary

- Adds [`docusaurus-plugin-llms`](https://github.com/rachfop/docusaurus-plugin-llms) to the website so every build produces `/llms.txt` and `/llms-full.txt` at the site root per the [llmstxt.org](https://llmstxt.org/) standard.
- Generates a `.md` variant for every documentation URL (e.g. `/reference/routing/routes` is also served as `/reference/routing/routes.md`), letting LLMs and AI agents ingest clean markdown without HTML scraping.
- Configures `pathTransformation.ignorePaths: ['docs']` and `preserveDirectoryStructure: false` so the generated links match the site's `routeBasePath: '/'` (no `/docs/` prefix).

Closes #4103.

## Notes

- `docusaurus-plugin-llms@0.4.0` declares `@docusaurus/core@^3.0.0` as a peer dependency; the website is on Docusaurus 2.2.0. The plugin only uses the `postBuild` hook and common `LoadContext` fields (`siteDir`, `outDir`, `siteConfig.url/baseUrl/title/tagline`), and gracefully no-ops its Docusaurus 3-only `routesPaths` branch. yarn produces a peer-dependency warning but installs and runs correctly.
- Verified locally (Node 18.19.1, yarn 1.22.19): build succeeds, 80 individual `.md` files land at `website/build/<path>.md`, and `llms.txt` / `llms-full.txt` are generated at the build root with the expected URLs.

## Test plan

- [ ] CI / Netlify build succeeds with the new plugin.
- [ ] Deploy preview serves `/llms.txt` and `/llms-full.txt` at the site root.
- [ ] Sample page URLs such as `/reference/routing/routes.md` and `/installation.md` return the generated markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)