### PR TITLE
Add Context7 configuration file

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -6,5 +6,7 @@
   "excludeFolders": ["docs/examples"],
   "excludeFiles": [],
   "rules": ["Ignore anything with the term `printSource`."],
-  "previousVersions": []
+  "previousVersions": [],
+  "url": "https://context7.com/zio/zio-http",
+  "public_key": "pk_3NVpTNBUFjXEiGh6hR3Te"
 }

--- a/context7.json
+++ b/context7.json
@@ -6,7 +6,5 @@
   "excludeFolders": ["docs/examples"],
   "excludeFiles": [],
   "rules": ["Ignore anything with the term `printSource`."],
-  "previousVersions": [],
-  "url": "https://context7.com/zio/zio-http",
-  "public_key": "pk_3NVpTNBUFjXEiGh6hR3Te"
+  "previousVersions": []
 }

--- a/website/static/context7.json
+++ b/website/static/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/zio/zio-http",
-  "public_key": "pk_3NVpTNBUFjXEiGh6hR3Te"
-}

--- a/website/static/context7.json
+++ b/website/static/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/zio/zio-http",
+  "public_key": "pk_3NVpTNBUFjXEiGh6hR3Te"
+}


### PR DESCRIPTION
## Summary
- Add context7.json configuration file to the website static directory
- Enables Context7 integration for the ZIO HTTP documentation site

## Test plan
- [ ] Verify file is accessible at https://ziohttp.com/context7.json once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)