### PR TITLE
docs: fix 2 typos across 2 files

### DIFF
--- a/docs/reference/body/template.md
+++ b/docs/reference/body/template.md
@@ -3,7 +3,7 @@ id: template
 title: Template
 ---
 
-The package `zio.http.template._` contains lightweight helpers for generating statically typed, safe html similiar in spirit to `scalatags`. 
+The package `zio.http.template._` contains lightweight helpers for generating statically typed, safe html similar in spirit to `scalatags`. 
 
 ## Html and DOM
 

--- a/docs/reference/routing/routes.md
+++ b/docs/reference/routing/routes.md
@@ -71,7 +71,7 @@ Using the `Routes.fromIterable` constructor, we can build routes from an iterabl
 
 ## Nested Routes
 
-Routes can be nested, which means that we can have routes that are themselves collections of other routes. This is useful for organizing routes into hierarchical structures, and for sharing common paths accross routes.
+Routes can be nested, which means that we can have routes that are themselves collections of other routes. This is useful for organizing routes into hierarchical structures, and for sharing common paths across routes.
 
 Let's see an example of nested routes:
 


### PR DESCRIPTION
﻿Light docs cleanup. No code paths touched.

## Files

- `docs/reference/body/template.md`
  - line 6: `similiar` → `similar`
- `docs/reference/routing/routes.md`
  - line 74: `accross` → `across`

Each correction is from a curated typo dictionary.
