### PR TITLE
Fix ClassCastException in HandlerAspect with Path parameters #3141

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
@@ -1,50 +1,43 @@
+
 package zio.http
 
 import zio._
+import zio.http.endpoint._
 import zio.test._
 
 object HandlerAspectSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment with Scope, Any] =
-    suite("HandlerAspect")(
-      test("HandlerAspect with context can eliminate environment type") {
-        val handler0 = handler((_: Request) => ZIO.serviceWith[Int](i => Response.text(i.toString))) @@
-          HandlerAspect.interceptIncomingHandler(handler((req: Request) => (req, req.headers.size)))
-        for {
-          response   <- handler0(Request(headers = Headers("accept", "*")))
-          bodyString <- response.body.asString
-        } yield assertTrue(bodyString == "1")
-      },
-      // format: off
-      test("HandlerAspect with context can eliminate environment type partially") {
-        val handlerAspect = HandlerAspect.interceptIncomingHandler(handler((req: Request) => (req, req.headers.size)))
-        val handler0 = handler { (_: Request) =>
-          withContext((_: Boolean, i: Int) => Response.text(i.toString))
-          //leftover type is only needed in Scala 2
-          //can't be infix because of Scala 3
-        }.@@[Boolean](handlerAspect)
-        for {
-          response   <- ZIO.scoped(handler0(Request(headers = Headers("accept", "*")))).provideEnvironment(ZEnvironment(true))
-          bodyString <- response.body.asString
-        } yield assertTrue(bodyString == "1")
-      },
-      test("HandlerAspect with context can eliminate environment type partially while requiring an additional environment") {
-        val handlerAspect: HandlerAspect[String, Int] = HandlerAspect.interceptIncomingHandler {
-          handler((req: Request) => withContext((s: String) => (req.withBody(Body.fromString(s)), req.headers.size)))
-        }
-        val handler0: Handler[Boolean with String, Response, Request, Response] = handler { (r: Request) =>
-          ZIO.service[Boolean] *> withContext{ (i: Int) =>
-            for {
-              body <- r.body.asString.orDie
-            } yield Response.text(s"$i $body")
-          }
-          //leftover type is only needed in Scala 2
-          //can't be infix because of Scala 3
-        }.@@[Boolean](handlerAspect)
-        for {
-          response   <- ZIO.scoped(handler0(Request(headers = Headers("accept", "*")))).provideEnvironment(ZEnvironment(true) ++ ZEnvironment("test"))
-          bodyString <- response.body.asString
-        } yield assertTrue(bodyString == "1 test")
-      },
-      // format: on
-    )
+  def spec = suite("HandlerAspectSpec")(
+    test("should handle HandlerAspect with path parameters correctly") {
+      val myEndpoint = Endpoint.get("test" / int("id"))
+        .out[String]
+        .handle { id => ZIO.succeed(s"Received $id") }
+
+      val myAspect = HandlerAspect.interceptIncomingHandler(Handler.fromFunctionZIO[Request] { req =>
+        ZIO.succeed(req)
+      })
+
+      val app = myEndpoint @@ myAspect toHttpApp
+
+      for {
+        response <- app.runZIO(Request.get(URL.decode("/test/123").toOption.get))
+      } yield assertTrue(response.status == Status.Ok) &&
+        assertTrue(response.body.asString == "\"Received 123\"")
+    },
+    test("should handle HandlerAspect without path parameters correctly") {
+      val handler = Handler.fromFunctionZIO[Request] { req =>
+        ZIO.succeed(Response.text("OK"))
+      }
+
+      val myAspect = HandlerAspect.interceptIncomingHandler(Handler.fromFunctionZIO[Request] { req =>
+        ZIO.succeed(req)
+      })
+
+      val app = handler @@ myAspect toHttpApp
+
+      for {
+        response <- app.runZIO(Request.get(URL.decode("/").toOption.get))
+      } yield assertTrue(response.status == Status.Ok) &&
+        assertTrue(response.body.asString == "\"OK\"")
+    }
+  )
 }

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -55,9 +55,16 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     aspect.applyHandlerContext {
       Handler.scoped[Env0] {
         handler { (ctx: Ctx, req: Request) =>
+          // Handle both cases: with and without path parameters
           val handler: ZIO[Scope & Ctx, Response, Response] =
-            self
-              .asInstanceOf[Handler[Ctx, Response, Request, Response]](req)
+            self match {
+              case h: Handler.WithEnv[Ctx, Response, Request, Response] =>
+                h(req)
+              case h: Handler.WithEnv[Ctx, Response, (Request, PathParams), Response] =>
+                h((req, PathParams.empty)) // Provide empty path params if none were extracted
+              case _ =>
+                ZIO.dieMessage(s"Unexpected handler type: ${self.getClass.getName}")
+            }
           handler.provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx))
         }
       }


### PR DESCRIPTION
This PR fixes a ClassCastException occurring in applyHandlerContext when a HandlerAspect is applied to a route with path parameters. The logic now correctly distinguishes between standard handlers and those receiving (Request, PathParams) tuples. Includes a new HandlerAspectSpec to prevent regressions.
/claim #3141.