### PR TITLE
Fix HandlerAspect with path params and request input

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
@@ -45,6 +45,29 @@ object HandlerAspectSpec extends ZIOSpecDefault {
           bodyString <- response.body.asString
         } yield assertTrue(bodyString == "1 test")
       },
+      test("HandlerAspect with context preserves path parameters and request input") {
+        final case class WebSession(id: Int)
+
+        val handlerAspect: HandlerAspect[Any, Option[WebSession]] =
+          HandlerAspect.interceptIncomingHandler(
+            Handler.fromFunction[Request](request => (request, Some(WebSession(1)))),
+          )
+
+        val routeHandler: Handler[Any, Response, (String, Request), Response] =
+          (handler { (id: String, request: Request) =>
+              withContext { (session: Option[WebSession]) =>
+                Response.text(s"$id:${request.path.encode}:${session.map(_.id).getOrElse(0)}")
+              }
+            } @@ handlerAspect)
+
+        val route =
+          Method.GET / "base" / string("id") -> routeHandler
+
+        for {
+          response   <- route.toRoutes.runZIO(Request.get(URL(Path.root / "base" / "abc")))
+          bodyString <- response.body.asString
+        } yield assertTrue(bodyString == "abc:/base/abc:1")
+      },
       // format: on
     )
 }

--- a/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
@@ -10,12 +10,12 @@ trait HandlerVersionSpecific {
       out: Out <:< Response,
       err: Err <:< Response,
       trace: Trace,
-    ): Handler[Env0 with Env1, Response, Request, Response] =
-      aspect.applyHandlerContext {
+    ): Handler[Env0 with Env1, Response, In1, Response] =
+      aspect.applyHandlerContextInput {
         Handler.scoped[Env0] {
-          handler { (ctx: Ctx, req: Request) =>
+          handler { (ctx: Ctx, in: In1) =>
             val handler: ZIO[Scope & Env, Response, Response] =
-              self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
+              self.asInstanceOf[Handler[Env, Response, In1, Response]](in)
             handler.provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx).asInstanceOf[ZEnvironment[Scope & Env]])
           }
         }

--- a/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
@@ -10,11 +10,11 @@ trait HandlerVersionSpecific {
       out: Out <:< Response,
       err: Err <:< Response,
       trace: Trace,
-    ): Handler[Env0 with Env1, Response, Request, Response] =
-      aspect.applyHandlerContext {
+    ): Handler[Env0 with Env1, Response, In1, Response] =
+      aspect.applyHandlerContextInput {
         Handler.scoped[Env0] {
-          handler { (ctx: Ctx, req: Request) =>
-            val handler: ZIO[Scope & Env, Response, Response] = self.asInstanceOf[Handler[Env, Response, Request, Response]](req)
+          handler { (ctx: Ctx, in: In1) =>
+            val handler: ZIO[Scope & Env, Response, Response] = self.asInstanceOf[Handler[Env, Response, In1, Response]](in)
             handler.provideSomeEnvironment[Scope & Env0](_.add(ctx).asInstanceOf[ZEnvironment[Scope & Env]])
           }
         }

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -38,11 +38,11 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     in: Handler.IsRequest[In1],
     out: Out <:< Response,
     err: Err <:< Response,
-  ): Handler[Env1, Response, Request, Response] = {
-    def convert(handler: Handler[R, Err, In, Out]): Handler[R, Response, Request, Response] =
-      handler.asInstanceOf[Handler[R, Response, Request, Response]]
+  ): Handler[Env1, Response, In1, Response] = {
+    def convert(handler: Handler[R, Err, In, Out]): Handler[Env1, Response, In1, Response] =
+      handler.asInstanceOf[Handler[Env1, Response, In1, Response]]
 
-    aspect.applyHandler(convert(self))
+    aspect.applyHandlerInput(convert(self))
   }
 
   def @@[Env0, Ctx <: R, In1 <: In](aspect: HandlerAspect[Env0, Ctx])(implicit
@@ -51,13 +51,13 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
     err: Err <:< Response,
     trace: Trace,
     tag: Tag[Ctx],
-  ): Handler[Env0, Response, Request, Response] =
-    aspect.applyHandlerContext {
+  ): Handler[Env0, Response, In1, Response] =
+    aspect.applyHandlerContextInput {
       Handler.scoped[Env0] {
-        handler { (ctx: Ctx, req: Request) =>
+        handler { (ctx: Ctx, in: In1) =>
           val handler: ZIO[Scope & Ctx, Response, Response] =
             self
-              .asInstanceOf[Handler[Ctx, Response, Request, Response]](req)
+              .asInstanceOf[Handler[Ctx, Response, In1, Response]](in)
           handler.provideSomeEnvironment[Scope & Env0](_.add[Ctx](ctx))
         }
       }
@@ -703,10 +703,63 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
 
   private val errorMediaTypes = List(MediaType.text.html, MediaType.application.json, MediaType.text.plain)
 
-  sealed trait IsRequest[-A]
+  sealed trait IsRequest[A] {
+    def get(value: A): Request
+    def replace(value: A, request: Request): A
+  }
 
-  object IsRequest {
-    implicit val request: IsRequest[Request] = new IsRequest[Request] {}
+  object IsRequest extends IsRequestLowPriority {
+    implicit val request: IsRequest[Request] = new IsRequest[Request] {
+      def get(value: Request): Request                       = value
+      def replace(value: Request, request: Request): Request = request
+    }
+  }
+
+  private[http] trait IsRequestLowPriority {
+    implicit def tuple2[A]: IsRequest[(A, Request)] = new IsRequest[(A, Request)] {
+      def get(value: (A, Request)): Request                       = value._2
+      def replace(value: (A, Request), request: Request): (A, Request) = (value._1, request)
+    }
+
+    implicit def tuple3[A, B]: IsRequest[(A, B, Request)] = new IsRequest[(A, B, Request)] {
+      def get(value: (A, B, Request)): Request = value._3
+      def replace(value: (A, B, Request), request: Request): (A, B, Request) =
+        (value._1, value._2, request)
+    }
+
+    implicit def tuple4[A, B, C]: IsRequest[(A, B, C, Request)] = new IsRequest[(A, B, C, Request)] {
+      def get(value: (A, B, C, Request)): Request = value._4
+      def replace(value: (A, B, C, Request), request: Request): (A, B, C, Request) =
+        (value._1, value._2, value._3, request)
+    }
+
+    implicit def tuple5[A, B, C, D]: IsRequest[(A, B, C, D, Request)] =
+      new IsRequest[(A, B, C, D, Request)] {
+        def get(value: (A, B, C, D, Request)): Request = value._5
+        def replace(value: (A, B, C, D, Request), request: Request): (A, B, C, D, Request) =
+          (value._1, value._2, value._3, value._4, request)
+      }
+
+    implicit def tuple6[A, B, C, D, E]: IsRequest[(A, B, C, D, E, Request)] =
+      new IsRequest[(A, B, C, D, E, Request)] {
+        def get(value: (A, B, C, D, E, Request)): Request = value._6
+        def replace(value: (A, B, C, D, E, Request), request: Request): (A, B, C, D, E, Request) =
+          (value._1, value._2, value._3, value._4, value._5, request)
+      }
+
+    implicit def tuple7[A, B, C, D, E, F]: IsRequest[(A, B, C, D, E, F, Request)] =
+      new IsRequest[(A, B, C, D, E, F, Request)] {
+        def get(value: (A, B, C, D, E, F, Request)): Request = value._7
+        def replace(value: (A, B, C, D, E, F, Request), request: Request): (A, B, C, D, E, F, Request) =
+          (value._1, value._2, value._3, value._4, value._5, value._6, request)
+      }
+
+    implicit def tuple8[A, B, C, D, E, F, G]: IsRequest[(A, B, C, D, E, F, G, Request)] =
+      new IsRequest[(A, B, C, D, E, F, G, Request)] {
+        def get(value: (A, B, C, D, E, F, G, Request)): Request = value._8
+        def replace(value: (A, B, C, D, E, F, G, Request), request: Request): (A, B, C, D, E, F, G, Request) =
+          (value._1, value._2, value._3, value._4, value._5, value._6, value._7, request)
+      }
   }
 
   def asChunkBounded(request: Request, limit: Int)(implicit trace: Trace): Handler[Any, Throwable, Any, Chunk[Byte]] =

--- a/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
+++ b/zio-http/shared/src/main/scala/zio/http/HandlerAspect.scala
@@ -132,6 +132,31 @@ final case class HandlerAspect[-Env, +CtxOut](
     }
   }
 
+  def applyHandlerContextInput[Env1 <: Env, In](
+    handler: Handler[Env1, Response, (CtxOut, In), Response],
+  )(implicit input: Handler.IsRequest[In]): Handler[Env1, Response, In, Response] = {
+    if (self == HandlerAspect.identity) handler.contramap[In](in => (().asInstanceOf[CtxOut], in))
+    else {
+      Handler.scoped[Env1] {
+        Handler.fromFunctionZIO[In] { in =>
+          protocol.incoming(input.get(in)).flatMap { case (state, (request, ctxOut)) =>
+            val updatedInput = input.replace(in, request)
+            handler((ctxOut, updatedInput)).either.flatMap { either =>
+              protocol.outgoing(state, either.merge).flatMap { response =>
+                if (either.isLeft) ZIO.fail(response) else ZIO.succeed(response)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def applyHandlerInput[Env1 <: Env, In](
+    handler: Handler[Env1, Response, In, Response],
+  )(implicit input: Handler.IsRequest[In]): Handler[Env1, Response, In, Response] =
+    applyHandlerContextInput(handler.contramap[(CtxOut, In)](_._2))
+
   def applyHandler[Env1 <: Env](handler: RequestHandler[Env1, Response]): RequestHandler[Env1, Response] =
     if (self == HandlerAspect.identity) handler
     else {


### PR DESCRIPTION
Fixes #3141

## Summary

This fixes the `ClassCastException` that happens when a context-producing `HandlerAspect` is applied to a route handler that accepts both path parameters and the incoming `Request`.

Previously, `Handler.@@` coerced aspect-wrapped handlers down to `Request => Response`. That loses the original route input shape, so handlers with inputs like `(String, Request)` could be invoked with only a `Request` and fail at runtime.

## Changes

- Preserve the original handler input when applying `HandlerAspect`.
- Add request extraction/replacement support for route inputs that end with `Request`, such as `(A, Request)` and `(A, B, Request)`.
- Keep context injection behavior unchanged for plain `Request` handlers.
- Add a regression test covering a path parameter, `Request`, and `withContext` together.

## Verification

Ran locally with a portable JDK 17 and the repo's sbt 1.12.11 launcher:

```text
zioHttpJVM/testOnly zio.http.HandlerAspectSpec
4 tests passed. 0 tests failed. 0 tests ignored.
```