### PR TITLE
Fix #4133: Add matching hashCode override to OpenAPI.Parameter

### DIFF
--- a/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
+++ b/zio-http/shared/src/main/scala/zio/http/endpoint/openapi/OpenAPI.scala
@@ -700,6 +700,8 @@ object OpenAPI {
       case p: Parameter if name == p.name && in == p.in => true
       case _                                            => false
     }
+
+    override def hashCode(): Int = (name, in).hashCode
   }
 
   object Parameter {

--- a/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
+++ b/zio-http/shared/src/test/scala/zio/http/endpoint/openapi/OpenAPISpec.scala
@@ -232,5 +232,19 @@ object OpenAPISpec extends ZIOSpecDefault {
 
       assertTrue(toJsonAst(json) == toJsonAst(expected))
     },
+    test("Parameter equals/hashCode contract (#4133)") {
+      import OpenAPI._
+      val a = Parameter.queryParameter("id", None, None, Map.empty)
+      val b = Parameter.queryParameter("id", None, None, Map.empty, required = true)
+      val c = Parameter.queryParameter("other", None, None, Map.empty)
+      val d = Parameter.headerParameter("id", None, required = false, examples = Map.empty)
+      assertTrue(a == b) &&
+      assertTrue(a.hashCode == b.hashCode) &&
+      assertTrue(Set(a, b).size == 1) &&
+      assertTrue(Map(a -> 1, b -> 2).size == 1) &&
+      assertTrue(List(a, b).distinct.size == 1) &&
+      assertTrue(a != c) &&
+      assertTrue(a != d)
+    },
   )
 }


### PR DESCRIPTION
Fixes #4133.\n\n## Summary\n`OpenAPI.Parameter` (used in `Operation.parameters`, `PathItem.parameters`, generation, merges, etc.) overrode `equals` to only consider `(name, in)` (per OpenAPI spec for uniqueness) but inherited the default case-class `hashCode` (all fields). This violates the contract and breaks `Set`/`Map`/`distinct` behavior when the same `(name, in)` has different metadata.\n\n## Fix\nAdded the matching override:\n```scala\noverride def hashCode(): Int = (name, in).hashCode\n```\n(Immediately after the existing `equals`.)\n\nMinimal change, no other behavior affected.\n\n(Verified present on main + runtime repro of the contract violation.)