### PR TITLE
Fix #4132: Make PathCodec.Annotated equals symmetric with matching hashCode

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/codec/PathCodecSpec.scala
@@ -267,5 +267,50 @@ object PathCodecSpec extends ZIOHttpSpec {
           assertTrue(roundTripCodec.decode(path) == Right(()))
         },
       ),
+      suite("annotated")(
+        test("equality is symmetric and ignores annotations as metadata") {
+          val inner = PathCodec.empty / PathCodec.literal("users")
+          val a1    = inner ?? Doc.p("first")
+          val a2    = inner ?? Doc.p("second")
+
+          assertTrue(a1 == a2) &&
+          assertTrue(a2 == a1) &&
+          assertTrue(a1.hashCode == a2.hashCode) &&
+          assertTrue(a1.hashCode == inner.hashCode) &&
+          assertTrue(a1.decode(Path("/users")) == Right(()))
+        },
+        test("annotated never equals a non-annotated codec") {
+          val inner     = PathCodec.empty / PathCodec.literal("users")
+          val annotated = inner ?? Doc.p("docs")
+
+          assertTrue(!(annotated == inner)) &&
+          assertTrue(!(inner == annotated)) &&
+          assertTrue(annotated != inner)
+        },
+        test("annotated codecs over different codecs are not equal") {
+          val a1 = (PathCodec.empty / PathCodec.literal("users")) ?? Doc.p("docs")
+          val a2 = (PathCodec.empty / PathCodec.literal("posts")) ?? Doc.p("docs")
+
+          assertTrue(a1 != a2) &&
+          assertTrue(a2 != a1)
+        },
+        test("annotated codecs behave correctly in hash-based collections") {
+          val inner = PathCodec.empty / PathCodec.literal("users")
+          val a1    = inner ?? Doc.p("first")
+          val a2    = inner ?? Doc.p("second")
+
+          assertTrue(Set(a1, a2).size == 1) &&
+          assertTrue(Map(a1 -> "found")(a2) == "found")
+        },
+        test("route patterns over annotated codecs compare by codec") {
+          val r1 = RoutePattern(Method.GET, (PathCodec.empty / PathCodec.literal("users")) ?? Doc.p("first"))
+          val r2 = RoutePattern(Method.GET, (PathCodec.empty / PathCodec.literal("users")) ?? Doc.p("second"))
+          val r3 = RoutePattern(Method.GET, (PathCodec.empty / PathCodec.literal("posts")) ?? Doc.p("first"))
+
+          assertTrue(r1 == r2) &&
+          assertTrue(r1.hashCode == r2.hashCode) &&
+          assertTrue(r1 != r3)
+        },
+      ),
     )
 }

--- a/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
+++ b/zio-http/shared/src/main/scala/zio/http/codec/PathCodec.scala
@@ -757,8 +757,12 @@ object PathCodec {
 
   final case class Annotated[A](codec: PathCodec[A], annotations: Chunk[MetaData[A]]) extends PathCodec[A] {
 
-    override def equals(that: Any): Boolean =
-      codec.equals(that)
+    override def equals(that: Any): Boolean = that match {
+      case o: Annotated[_] => codec.equals(o.codec)
+      case _               => false
+    }
+
+    override def hashCode(): Int = codec.hashCode
 
   }
 


### PR DESCRIPTION
Fixes #4132.\n\n## Summary\n`PathCodec.Annotated` (the public wrapper from `??` / `example` / `annotate`, used for docs + OpenAPI) had:\n```scala\noverride def equals(that: Any): Boolean = codec.equals(that)\n```\nThis was asymmetric, ignored annotations, and used the default case-class `hashCode` (which includes the annotations `Chunk`).\n\nAll core operations peel `Annotated` correctly, but public `==`, `RoutePattern` equality, and hash-based collections were broken.\n\n## Fix\n```scala\noverride def equals(that: Any): Boolean = that match {\n  case o: Annotated[_] => codec.equals(o.codec)\n  case _               => false\n}\n\noverride def hashCode(): Int = codec.hashCode\n```\nAnnotations stay as pure metadata (consistent with how everything else handles them).\n\n(Verified on main + full call-site analysis.)