### PR TITLE
Fix #4130: Remove allowedMethods gate from non-preflight CORS actual requests

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/middlewares/CorsSpec.scala
@@ -95,6 +95,27 @@ object CorsSpec extends ZIOHttpSpec with TestExtensions {
     ),
   )
 
+  // App where an actual-request method is NOT listed in allowedMethods.
+  // Per the Fetch spec (https://fetch.spec.whatwg.org/#http-cors-protocol) the
+  // allowedMethods / Access-Control-Allow-Methods check is preflight-only, so an
+  // actual request with an allowed origin must succeed regardless of its method.
+  // See: https://github.com/zio/zio-http/issues/4130
+  val appActualMethodNotAllowed = Routes(
+    Method.GET / "success"  -> handler(Response.ok),
+    Method.POST / "success" -> handler(Response.ok),
+  ).handleErrorCause { cause =>
+    Response(Status.InternalServerError, body = Body.fromString(cause.prettyPrint))
+  } @@ cors(
+    CorsConfig(
+      allowedOrigin = {
+        case Header.Origin.Value(_, host, _) if host == "allowed.com" =>
+          Some(Header.AccessControlAllowOrigin.Specific(Header.Origin.Value("http", host, None)))
+        case _                                                        => None
+      },
+      allowedMethods = AccessControlAllowMethods(Method.GET),
+    ),
+  )
+
   override def spec = suite("CorsSpec")(
     test("OPTIONS request with allowAllHeaders server config") {
       val request =
@@ -293,6 +314,61 @@ object CorsSpec extends ZIOHttpSpec with TestExtensions {
       } yield assertTrue(
         extractStatus(res) == Status.Ok,
         res.hasHeader(Header.AccessControlAllowOrigin("http", "allowed.com")),
+      )
+    },
+    // Tests for https://github.com/zio/zio-http/issues/4130
+    // Per the Fetch spec the allowedMethods check is preflight-only: an actual
+    // (non-preflight) request with an allowed origin must succeed even when its
+    // method is not listed in allowedMethods.
+    test("POST actual request from allowed origin succeeds when method is not in allowedMethods - issue #4130") {
+      val request =
+        Request
+          .post(URL(Path.root / "success"), Body.empty)
+          .copy(
+            headers = Headers(
+              Header.Origin("http", "allowed.com"),
+            ),
+          )
+
+      for {
+        res <- appActualMethodNotAllowed.runZIO(request)
+      } yield assertTrue(
+        extractStatus(res) == Status.Ok,
+        res.hasHeader(Header.AccessControlAllowOrigin("http", "allowed.com")),
+      )
+    },
+    test("POST actual request from disallowed origin is still rejected - issue #4130") {
+      val request =
+        Request
+          .post(URL(Path.root / "success"), Body.empty)
+          .copy(
+            headers = Headers(
+              Header.Origin("http", "notallowed.com"),
+            ),
+          )
+
+      for {
+        res <- appActualMethodNotAllowed.runZIO(request)
+      } yield assertTrue(
+        extractStatus(res) == Status.Forbidden,
+      )
+    },
+    test("OPTIONS preflight with method not in allowedMethods is still rejected - issue #4130") {
+      val request =
+        Request
+          .options(URL(Path.root / "success"))
+          .copy(
+            headers = Headers(
+              Header.Origin("http", "allowed.com"),
+              Header.AccessControlRequestMethod(Method.POST),
+            ),
+          )
+
+      for {
+        res <- appActualMethodNotAllowed.runZIO(request)
+      } yield assertTrue(
+        extractStatus(res) == Status.NotFound,
+        !res.hasHeader(Header.AccessControlAllowOrigin.name),
       )
     },
     test("OPTIONS request with AllowedHeaders.Some returns intersection of requested and allowed headers") {

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -149,9 +149,9 @@ object Middleware extends HandlerAspects {
           originHeader match {
             case Some(origin) =>
               config.allowedOrigin(origin) match {
-                case Some(allowOrigin) if config.allowedMethods.contains(request.method) =>
+                case Some(allowOrigin) =>
                   ZIO.succeed((corsHeaders(allowOrigin, acrhHeader, isPreflight = false), (request, ())))
-                case _                                                                   =>
+                case _ =>
                   // Origin is not allowed - reject the request with 403 Forbidden
                   ZIO.fail(Response.status(Status.Forbidden))
               }

--- a/zio-http/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Middleware.scala
@@ -149,9 +149,9 @@ object Middleware extends HandlerAspects {
           originHeader match {
             case Some(origin) =>
               config.allowedOrigin(origin) match {
-                case Some(allowOrigin) if config.allowedMethods.contains(request.method) =>
+                case Some(allowOrigin) =>
                   ZIO.succeed((corsHeaders(allowOrigin, acrhHeader, isPreflight = false), (request, ())))
-                case _                                                                   =>
+                case _                 =>
                   // Origin is not allowed - reject the request with 403 Forbidden
                   ZIO.fail(Response.status(Status.Forbidden))
               }


### PR DESCRIPTION
Fixes #4130.\n\n## Summary\nIn `Middleware.cors(...)`, the non-preflight (actual request) handler in the `HandlerAspect` was still doing:\n```scala\ncase Some(allowOrigin) if config.allowedMethods.contains(request.method) =>\n  ...\ncase _ =>\n  403 Forbidden\n```\n\nPer the Fetch spec (and the library's own docs), the `allowedMethods` / `Access-Control-Allow-Methods` check is **preflight-only**. The browser already enforces the method during preflight. For the actual request the server should only gate on origin (and emit the CORS headers if allowed).\n\nThis caused 403s on valid post-preflight requests (e.g. PATCH/DELETE when not explicitly listed) even after a successful preflight.\n\n## Fix\nNon-preflight path now only checks origin:\n```scala\ncase Some(allowOrigin) =>\n  ZIO.succeed((corsHeaders(allowOrigin, acrhHeader, isPreflight = false), (request, ())))\n```\n(The 403 case is now only for disallowed origin.)\n\nThe preflight `optionsRoute` + all other CORS logic (header prebuilding, etc.) is untouched.\n\n(Verified on main + matches the original report + spec reference.)