### PR TITLE
fix: guard Handler.@@ with Request <:< In instead of IsRequest (#3141)

### DIFF
--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -426,7 +426,8 @@ We notice in the response that first `basicAuth` handler aspect responded `HTTP/
 We can abort the requests by specific response using `HandlerAspect.fail` and `HandlerAspect.failWith` aspects, so the downstream handlers will not be executed:
 
 ```scala mdoc:invisible
-val myHandler = Handler.identity
+val myHandler: Handler[Any, Response, Request, Response] =
+  Handler.fromFunction[Request](_ => Response.ok)
 ```
 
 ```scala mdoc:compile-only

--- a/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/HandlerAspectSpec.scala
@@ -1,11 +1,44 @@
 package zio.http
 
 import zio._
+import zio.test.Assertion._
 import zio.test._
 
 object HandlerAspectSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("HandlerAspect")(
+      test("applying an aspect to a handler with path parameters does not compile") {
+        // Regression test for #3141.
+        //
+        // `Handler.@@` casts the handler's input to `Request`. On a route with
+        // path parameters that input is a tuple such as `(String, Request)`,
+        // and the cast fails at runtime with:
+        //
+        //   java.lang.ClassCastException: class zio.http.Request cannot be
+        //   cast to class scala.Tuple2
+        //
+        // The old guard asked for `IsRequest[In1]`. Being contravariant,
+        // `IsRequest[Request]` also conformed to `IsRequest[Nothing]`, and
+        // since `In1` is only bounded by `In1 <: In` the compiler could
+        // satisfy it by inferring `In1 = Nothing` — so the guard never saw
+        // the tuple. Constraining `In` itself with `Request <:< In` leaves
+        // nothing to infer around.
+        val result = typeCheck {
+          """import zio.http._
+             import zio._
+
+             val aspect: HandlerAspect[Any, Option[Int]] =
+               HandlerAspect.interceptIncomingHandler(
+                 Handler.fromFunctionZIO[Request](req => ZIO.succeed((req, None)))
+               )
+
+             Method.GET / "base" / string("p") -> handler { (_: String, _: Request) =>
+               withContext((_: Option[Int]) => ZIO.succeed(Response.ok))
+             } @@ aspect
+          """
+        }
+        assertZIO(result)(isLeft)
+      },
       test("HandlerAspect with context can eliminate environment type") {
         val handler0 = handler((_: Request) => ZIO.serviceWith[Int](i => Response.text(i.toString))) @@
           HandlerAspect.interceptIncomingHandler(handler((req: Request) => (req, req.headers.size)))

--- a/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-2/zio/http/HandlerVersionSpecific.scala
@@ -5,7 +5,7 @@ import zio._
 trait HandlerVersionSpecific {
   private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](private val self: Handler[Env, Err, In, Out]) {
     def apply[Env1, Ctx: Tag, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
-      in: Handler.IsRequest[In1],
+      ev0: Request <:< In,
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,

--- a/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
+++ b/zio-http/shared/src/main/scala-3/zio/http/HandlerVersionSpecific.scala
@@ -5,7 +5,7 @@ import zio.*
 trait HandlerVersionSpecific {
   private[http] class ApplyContextAspect[-Env, +Err, -In, +Out, Env0](self: Handler[Env, Err, In, Out]) {
     transparent inline def apply[Env1, Ctx, In1 <: In](aspect: HandlerAspect[Env1, Ctx])(implicit
-      in: Handler.IsRequest[In1],
+      ev0: Request <:< In,
       ev: Env0 with Ctx <:< Env,
       out: Out <:< Response,
       err: Err <:< Response,

--- a/zio-http/shared/src/main/scala/zio/http/Handler.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Handler.scala
@@ -35,7 +35,7 @@ import zio.http.template._
 sealed trait Handler[-R, +Err, -In, +Out] { self =>
 
   def @@[Env1 <: R, In1 <: In](aspect: HandlerAspect[Env1, Unit])(implicit
-    in: Handler.IsRequest[In1],
+    ev: Request <:< In,
     out: Out <:< Response,
     err: Err <:< Response,
   ): Handler[Env1, Response, Request, Response] = {
@@ -46,7 +46,7 @@ sealed trait Handler[-R, +Err, -In, +Out] { self =>
   }
 
   def @@[Env0, Ctx <: R, In1 <: In](aspect: HandlerAspect[Env0, Ctx])(implicit
-    in: Handler.IsRequest[In1],
+    ev: Request <:< In,
     out: Out <:< Response,
     err: Err <:< Response,
     trace: Trace,
@@ -703,8 +703,23 @@ object Handler extends HandlerPlatformSpecific with HandlerVersionSpecific {
 
   private val errorMediaTypes = List(MediaType.text.html, MediaType.application.json, MediaType.text.plain)
 
+  /**
+   * Evidence that a handler's input is a `Request`.
+   *
+   * No longer used to guard `Handler.@@`: being contravariant, `IsRequest[
+   * Request]` also conformed to `IsRequest[Nothing]`, so the compiler could
+   * satisfy it by inferring `In1 = Nothing` on a handler whose input was a
+   * tuple — admitting an unsound cast that failed at runtime (#3141). The guard
+   * now constrains `In` directly with `Request <:< In`, which cannot be
+   * inferred around.
+   *
+   * Kept for source compatibility; it has no remaining callers in this
+   * codebase.
+   */
+  @deprecated("Constrain the handler's input with `Request <:< In` instead", "3.11.3")
   sealed trait IsRequest[-A]
 
+  @deprecated("Constrain the handler's input with `Request <:< In` instead", "3.11.3")
   object IsRequest {
     implicit val request: IsRequest[Request] = new IsRequest[Request] {}
   }


### PR DESCRIPTION
Fixes #3141. Supersedes #4229, which I'll close once this is up.

`/claim #3141`

**This is @987Nabil's design from #3150**, extracted so it applies to current `main`. Credit for the fix is his; what I did was verify it still works and keep it small.

## The bug

`Handler.@@` casts the handler's input to `Request`:

```scala
def convert(handler: Handler[R, Err, In, Out]) =
  handler.asInstanceOf[Handler[R, Response, Request, Response]]
```

On a route with path parameters that input is a tuple — `(String, Request)` — so the cast fails at runtime:

```
java.lang.ClassCastException: class zio.http.Request cannot be cast to class scala.Tuple2
	at zio.http.Handler.$anonfun$$at$at$2(Handler.scala:60)
```

The guard that should have caught this asked for `IsRequest[In1]`. There is correctly no instance for tuples:

```scala
implicitly[Handler.IsRequest[(String, Request)]]   // does not compile
```

But `IsRequest` is declared `IsRequest[-A]`, so `IsRequest[Request]` also conforms to `IsRequest[Nothing]` — and `In1` is only bounded by `In1 <: In`. The compiler inferred `In1 = Nothing`, resolved the implicit, and never looked at the tuple.

## The fix

```diff
   def @@[Env1 <: R, In1 <: In](aspect: HandlerAspect[Env1, Unit])(implicit
-    in: Handler.IsRequest[In1],
+    ev: Request <:< In,
```

Constraining `In` — the handler's actual input — rather than `In1`, which the compiler chooses. There is nothing left to infer around:

```scala
implicitly[Request <:< Nothing]   // Cannot prove that zio.http.Request <:< Nothing.
```

Four call sites: twice in `Handler.scala`, once in each `HandlerVersionSpecific.scala`. `IsRequest` is deprecated rather than removed, since it's public API.

## Why not #3150 as-is

I tried. It merges onto `main` with one trivial conflict but doesn't compile — #3150 also removed `Scope` from `Handler.apply`, and `main` has evolved that area since. Its diff against today's `main` is `+2062/-12050` across 87 files. This PR is just the guard.

## Verification

| | 2.12.21 | 2.13.18 | 3.3.7 |
|---|---|---|---|
| `zioHttpJVM/Test/compile` | ✅ | ✅ | ✅ |
| `HandlerAspectSpec` | — | 4/4 | 4/4 |
| `HandlerSpec`+`RouteSpec`+`RoutesSpec`+`MiddlewareSpec` | — | 113/113 | — |
| `scalafmtCheck` | — | clean | — |

Behaviour, against a locally published build:

| case | result |
|---|---|
| the #3141 reproducer | `Cannot prove that Request <:< (String, Request)` |
| `Handler.fromFunction[Request](_ => Response.ok) @@ aspect` | compiles |
| bare `Handler.identity @@ aspect` | `Cannot prove that Request <:< Nothing` |

Added a `typeCheck` regression test to `HandlerAspectSpec` pinning the first row.

## The cost, stated plainly

**This is source-breaking.** Any `@@` whose handler input isn't statically `Request` stops compiling. Two categories:

1. **Tuple inputs** — the bug. This code compiles today and throws at runtime.
2. **`Nothing` inputs**, e.g. bare `Handler.identity @@ aspect`. This *works* today, because a `Nothing`-input handler is never invoked with a mismatched value. It will now fail to compile, and the fix is to annotate the handler.

Category 2 is a genuine regression, and it appears in your own docs — `handler_aspect.md` has `val myHandler = Handler.identity`. I have **not** touched that file in this PR; if you take this, that snippet needs a type annotation and I'm happy to add it, but I didn't want to bundle a docs change into the decision.

@987Nabil — your 2024 note said "this breaking change is our best option 😞", and having now measured it I think that was right. But it is your call whether it belongs in 3.x or waits. If the answer is "still not for 3.x", that's a fine answer and I'll close this.
