### PR TITLE
Improve search result metadata for the repository and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 [//]: # (So please do not edit it manually. Instead, change "docs/index.md" file or sbt setting keys)
 [//]: # (e.g. "readmeDocumentation" and "readmeSupport".)
 
-# ZIO Http
+# ZIO HTTP
 
-ZIO HTTP is a scala library for building http apps. It is powered by ZIO and [Netty](https://netty.io/) and aims at being the defacto solution for writing, highly scalable and performant web applications using idiomatic Scala.
+ZIO HTTP is a next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers. Powered by ZIO and [Netty](https://netty.io/), it is the de facto solution for writing highly scalable and performant web applications in idiomatic Scala.
 
 ZIO HTTP is designed in terms of **HTTP as function**, where both server and client are a function from a request to a response, with a focus on type safety, composability, and testability.
 
 [![Production Ready](https://img.shields.io/badge/Project%20Stage-Production%20Ready-brightgreen.svg)](https://github.com/zio/zio/wiki/Project-Stages) ![CI Badge](https://github.com/zio/zio-http/workflows/Continuous%20Integration/badge.svg) [![Maven Central Version](https://img.shields.io/maven-central/v/dev.zio/zio-http_3)
 ](https://repo1.maven.org/maven2/dev/zio/zio-http_3/) ![Maven metadata URL](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fdev%2Fzio%2Fzio-http_3%2Fmaven-metadata.xml)
-[![javadoc](https://javadoc.io/badge2/dev.zio/zio-http_3/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-http_3) [![ZIO Http](https://img.shields.io/github/stars/zio/zio-http?style=social)](https://github.com/zio/zio-http)
+[![javadoc](https://javadoc.io/badge2/dev.zio/zio-http_3/javadoc.svg)](https://javadoc.io/doc/dev.zio/zio-http_3) [![ZIO HTTP](https://img.shields.io/github/stars/zio/zio-http?style=social)](https://github.com/zio/zio-http)
 
 Some of the key features of ZIO HTTP are:
 
@@ -105,7 +105,7 @@ object GreetingClient extends ZIOAppDefault {
 
 ## Documentation
 
-Learn more on the [ZIO Http homepage](https://zio.dev/zio-http)!
+Learn more on the [ZIO HTTP homepage](https://ziohttp.com)!
 
 ## Contributing
 

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ ThisBuild / githubWorkflowBuildPostamble :=
 inThisBuild(
   List(
     organization := "dev.zio",
-    homepage     := Some(url("https://zio.dev/zio-http/")),
+    homepage     := Some(url("https://ziohttp.com/")),
     licenses     := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   ),
 )
@@ -505,7 +505,7 @@ lazy val docs = project
     moduleName                                 := "zio-http-docs",
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
-    projectName                                := "ZIO Http",
+    projectName                                := "ZIO HTTP",
     mainModuleName                             := (zioHttpJVM / moduleName).value,
     projectStage                               := ProjectStage.Development,
     ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(zioHttpJVM),

--- a/docs/guides/securing-communication-with-ssl-tls.md
+++ b/docs/guides/securing-communication-with-ssl-tls.md
@@ -15,9 +15,9 @@ We aim to offer a comprehensive guide on this topic through a series of articles
 
 If you're already familiar with PKI and SSL/TLS, feel free to skip this article and move directly to the implementation guides:
 
-- [Implementing TLS With Self-Signed Server Certificate](./implementing-tls-with-self-signed-server-certificate)
+- [Implementing TLS With Self-Signed Server Certificate](./implementing-tls-with-self-signed-server-certificate.md)
 - [Implementing TLS With Root CA-Signed Server Certificate](./implementing-tls-with-root-ca-signed-server-certificate.md)
-- [Implementing TLS With an Intermediate CA-signed Server Certificate](./implementing-tls-with-intermediate-ca-signed-server-certificate)
+- [Implementing TLS With an Intermediate CA-signed Server Certificate](./implementing-tls-with-intermediate-ca-signed-server-certificate.md)
 - [Implementing Mutual TLS (mTLS)](./implementing-mutual-tls.md)
 
 ## Certificates and Public Key Infrastructure (PKI)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ sidebar_label: "Introduction"
 slug: /introduction
 ---
 
-ZIO HTTP is a scala library for building http apps. It is powered by ZIO and [Netty](https://netty.io/) and aims at being the defacto solution for writing, highly scalable and performant web applications using idiomatic Scala.
+ZIO HTTP is a next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers. Powered by ZIO and [Netty](https://netty.io/), it is the de facto solution for writing highly scalable and performant web applications in idiomatic Scala.
 
 ZIO HTTP is designed in terms of **HTTP as function**, where both server and client are a function from a request to a response, with a focus on type safety, composability, and testability.
 

--- a/docs/reference/zio-http-testkit/examples.md
+++ b/docs/reference/zio-http-testkit/examples.md
@@ -172,12 +172,12 @@ These examples directly correspond to sections in the testkit reference:
 
 | Example File | Reference | Topics |
 |---|---|---|
-| `DirectRouteTestingExamples.scala` | [Direct Route Testing](../../guides/testing-http-apps) | Unit testing, handler logic, routing |
+| `DirectRouteTestingExamples.scala` | [Direct Route Testing](../../guides/testing-http-apps.md) | Unit testing, handler logic, routing |
 | `TestServerExamples.scala` | [TestServer](./test-server.md) | Integration testing, multiple routes, state |
 | `TestClientExamples.scala` | [TestClient](./test-client.md) | Mocking, external services, fallback handling |
 | `WebSocketExamples.scala` | [TestChannel](./test-channel.md) | WebSocket, bidirectional messaging, frames |
-| `ErrorHandlingExamples.scala` | [Error Handling](../../guides/testing-http-apps) | Status codes, error responses |
-| `StatefulHandlerExamples.scala` | [State Persistence](../../guides/testing-http-apps) | Ref, state management, request tracking |
+| `ErrorHandlingExamples.scala` | [Error Handling](../../guides/testing-http-apps.md) | Status codes, error responses |
+| `StatefulHandlerExamples.scala` | [State Persistence](../../guides/testing-http-apps.md) | Ref, state management, request tracking |
 
 ## Writing Your Own Tests
 

--- a/docs/reference/zio-http-testkit/http-test-aspect.md
+++ b/docs/reference/zio-http-testkit/http-test-aspect.md
@@ -271,4 +271,4 @@ See [Reading the Mode](#reading-the-mode) above for available query functions.
 - [Dev / Preprod / Prod Modes](../../concepts/dev-mode.md) — Comprehensive guide to application modes
 - [TestServer](./test-server.md) — Integration testing with mode configuration
 - [TestClient](./test-client.md) — Mocking external services for mode testing
-- [Testing HTTP Applications](../../guides/testing-http-apps) — Comprehensive testing guide
+- [Testing HTTP Applications](../../guides/testing-http-apps.md) — Comprehensive testing guide

--- a/docs/reference/zio-http-testkit/index.md
+++ b/docs/reference/zio-http-testkit/index.md
@@ -166,4 +166,4 @@ printSource("zio-http-example-testing/src/test/scala/example/testing/TestingWebS
 - [TestChannel](./test-channel.md) — Full reference for WebSocket testing
 - [HttpTestAspect](./http-test-aspect.md) — Full reference for test aspects
 - [Running the Examples](./examples.md) — Runnable test examples and how to execute them
-- [Testing HTTP Applications](../../guides/testing-http-apps) — Comprehensive how-to guide with patterns
+- [Testing HTTP Applications](../../guides/testing-http-apps.md) — Comprehensive how-to guide with patterns

--- a/docs/reference/zio-http-testkit/test-server.md
+++ b/docs/reference/zio-http-testkit/test-server.md
@@ -489,4 +489,4 @@ val test = for {
 - [TestClient](./test-client.md) — Mocking external HTTP dependencies
 - [TestChannel](./test-channel.md) — Testing WebSocket handlers
 - [HttpTestAspect](./http-test-aspect.md) — Testing mode-dependent behavior
-- [Testing Guide](../../guides/testing-http-apps) — Comprehensive testing strategies
+- [Testing Guide](../../guides/testing-http-apps.md) — Comprehensive testing strategies

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -110,7 +110,7 @@ object BuildHelper extends ScalaSettings {
   )
 
   def meta = Seq(
-    ThisBuild / homepage   := Some(url("https://zio.dev/zio-http")),
+    ThisBuild / homepage   := Some(url("https://ziohttp.com")),
     ThisBuild / scmInfo    :=
       Some(
         ScmInfo(url("https://github.com/zio/zio-http"), "scm:git@github.com:zio/zio-http.git"),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -45,12 +45,77 @@ const config = {
         content: '630',
       },
     },
+    // Structured data. Helps search engines resolve "ZIO HTTP" as a single
+    // entity across this site, the GitHub repository and Maven Central,
+    // instead of three unrelated pages that happen to share a name.
+    {
+      tagName: 'script',
+      attributes: {
+        type: 'application/ld+json',
+      },
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@graph': [
+          {
+            '@type': 'Organization',
+            '@id': 'https://zio.dev/#organization',
+            name: 'ZIO',
+            url: 'https://zio.dev',
+            logo: {
+              '@type': 'ImageObject',
+              url: 'https://ziohttp.com/img/ZIO.png',
+            },
+            sameAs: ['https://github.com/zio'],
+          },
+          {
+            '@type': 'WebSite',
+            '@id': 'https://ziohttp.com/#website',
+            url: 'https://ziohttp.com/',
+            name: 'ZIO HTTP',
+            description:
+              'ZIO HTTP is a next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers.',
+            inLanguage: 'en-US',
+            publisher: { '@id': 'https://zio.dev/#organization' },
+          },
+          {
+            '@type': 'SoftwareSourceCode',
+            '@id': 'https://ziohttp.com/#software',
+            name: 'ZIO HTTP',
+            alternateName: 'zio-http',
+            description:
+              'ZIO HTTP is a next-generation Scala framework for building scalable, correct, and efficient HTTP clients and servers. Powered by ZIO and Netty, it provides a purely functional, type-safe API for HTTP servers, clients, WebSockets, Server-Sent Events and OpenAPI-documented endpoints.',
+            url: 'https://ziohttp.com/',
+            codeRepository: 'https://github.com/zio/zio-http',
+            programmingLanguage: {
+              '@type': 'ComputerLanguage',
+              name: 'Scala',
+            },
+            runtimePlatform: ['JVM', 'Scala.js', 'Scala Native'],
+            license: 'https://www.apache.org/licenses/LICENSE-2.0',
+            author: { '@id': 'https://zio.dev/#organization' },
+            maintainer: { '@id': 'https://zio.dev/#organization' },
+            isPartOf: { '@id': 'https://ziohttp.com/#website' },
+            keywords: [
+              'ZIO HTTP',
+              'Scala HTTP server',
+              'Scala HTTP client',
+              'functional programming',
+              'WebSocket',
+              'OpenAPI',
+              'Netty',
+            ],
+            discussionUrl:
+              'https://stackoverflow.com/questions/tagged/zio-http',
+          },
+        ],
+      }),
+    },
   ],
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: 'zio',
+  projectName: 'zio-http',
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
@@ -73,8 +138,18 @@ const config = {
           editUrl:
             'https://github.com/zio/zio-http/tree/main/docs/',
         },
+        // No blog posts exist; the classic preset would otherwise publish an
+        // empty /blog listing page and put it in the sitemap.
+        blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
+        },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/search/**'],
+          filename: 'sitemap.xml',
         },
       }),
     ],

--- a/website/src/pages/markdown-page.md
+++ b/website/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,0 +1,8 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+# Search result pages carry no unique content.
+Disallow: /search
+
+Sitemap: https://ziohttp.com/sitemap.xml

--- a/zio-http-docs/src/main/scala/zio/http/docs/ConfigReference.scala
+++ b/zio-http-docs/src/main/scala/zio/http/docs/ConfigReference.scala
@@ -9,13 +9,38 @@ import zio.config.generateDocs
 object ConfigReference {
   private type ObjectWithConfig = Object { def config: Config[Any] }
 
-  def referencePageFor(obj: ObjectWithConfig): String = {
-    val name            = obj.getClass.getName.stripSuffix("$").replace("$", ".")
-    val shortName       = name.replace("zio.http.", "")
-    val pageId          = shortName.toLowerCase.replaceAll("[ .]", "-")
-    val yamlFrontMatter = s"---\nid: $pageId\ntitle: $name\nsidebar_label: $shortName\n---\n"
+  /**
+   * Renders the configuration reference table for a config object. The result
+   * is spliced into a page that already declares its own front matter, so none
+   * is emitted here.
+   */
+  def referencePageFor(obj: ObjectWithConfig): String =
+    numberRepeatedHeadings(generateDocs(obj.config).toTable.toGithubFlavouredMarkdown)
 
-    yamlFrontMatter +
-      generateDocs(obj.config).toTable.toGithubFlavouredMarkdown
+  /**
+   * zio-config emits one "Field Descriptions" heading per nested config node
+   * and links to them using the `-1`, `-2`, ... suffixes that GitHub and
+   * Docusaurus derive from repeated heading text. Those links resolve
+   * correctly, but the headings are indistinguishable in the table of contents,
+   * and mdoc's link checker — which does not replicate that de-duplication —
+   * reports each one as broken.
+   *
+   * Numbering the repeats leaves the generated anchors byte-for-byte identical,
+   * since "Field Descriptions (1)" slugifies to `field-descriptions-1`, while
+   * making every heading unique.
+   */
+  private def numberRepeatedHeadings(markdown: String): String = {
+    val heading = """^(#{2,6})\s+(.*\S)\s*$""".r
+    val seen    = scala.collection.mutable.Map.empty[String, Int]
+
+    val numbered = markdown.linesIterator.map {
+      case line @ heading(hashes, text) =>
+        val occurrence = seen.getOrElse(text, 0)
+        seen.update(text, occurrence + 1)
+        if (occurrence == 0) line else s"$hashes $text ($occurrence)"
+      case line                         => line
+    }
+
+    numbered.mkString("\n") + (if (markdown.endsWith("\n")) "\n" else "")
   }
 }


### PR DESCRIPTION
Searching Google for "zio http" returns the GitHub repository as the first result, titled **ZIO Http**. That title is not Google's invention: `projectName` in `build.sbt` was set to `"ZIO Http"`, `sbt generateReadme` writes it out as the README's `<h1>`, and search engines frequently prefer a page's H1 over its `<title>`. This PR fixes that, aligns the project's description everywhere it is published, and addresses the website metadata gaps found along the way.

### Naming and description

- `projectName` is now `"ZIO HTTP"`, so the generated README heading is spelled correctly.
- The introduction paragraph in `docs/index.md` (the source the README is generated from) described the project as "a scala library for building http apps". It now matches the repository description and the website tagline word for word, so the same sentence is used wherever the project is described.
- `homepage` now points at `ziohttp.com`. The assignment in `build.sbt` had no effect, because `BuildHelper.meta` reassigns `ThisBuild / homepage` and wins; both are updated so they no longer disagree. This URL is published in the POM and shown on Maven Central.

### Generated config reference pages

`ConfigReference.referencePageFor` emitted its own YAML front matter, but each of the five pages calling it already declares front matter. The second block was rendered as body text, so every config reference page on ziohttp.com currently displays a line like:

> Server Config **id: server-config title: zio.http.Server.Config sidebar_label: Server.Config** Configuration Details

The front matter is now left to the host page.

Separately, zio-config emits one `### Field Descriptions` heading per nested config node — 26 of them on the `Server.Config` page — and links to them using the `-1`, `-2`, … suffixes that GitHub and Docusaurus derive from repeated heading text. Those links resolve correctly, but the table of contents was an unusable list of 26 identical entries, and mdoc's link checker (which does not replicate that de-duplication) reported all 55 of them as broken.

Repeats are now numbered. This is deliberately **anchor-preserving**: `Field Descriptions (1)` slugifies to `field-descriptions-1`, byte-identical to what the de-duplication already produced, so no existing anchor changes and no deep link breaks.

### Website metadata

- Added `robots.txt`. The site had none, so nothing advertised the sitemap the classic preset already generates.
- Added JSON-LD: an `Organization` for ZIO, a `WebSite` for ziohttp.com, and a `SoftwareSourceCode` for ZIO HTTP, cross-referenced by `@id` so they describe one subject rather than three unrelated pages sharing a name.
- Removed two Docusaurus template leftovers that were live and listed in the sitemap: the `/markdown-page` example, and an empty `/blog` listing that the classic preset serves even though the repository has no `blog/` directory.
- Set `lastmod` on sitemap entries, excluded the search page, and replaced the placeholder `organizationName` / `projectName` that still read `"facebook"` / `"docusaurus"`.

### Documentation links

Eight relative links omitted the `.md` suffix. Docusaurus only resolves a relative link through the file system, and on to the target's permalink, when the extension is present; without it the link is treated as a raw URL path, bypassing build-time link checking and rotting silently on any rename. Each of these sat alongside correctly suffixed links in the same list.

### Verification

Reproduced the website CI pipeline (`build.sh` = `sbt mdoc` → `yarn build`):

| Check | Result |
| --- | --- |
| `sbt mdoc` | exit 0; `Unknown link` warnings 55 → 0 (total warnings 124 → 69) |
| `yarn build`, `onBrokenLinks: 'throw'` | exit 0, zero broken links |
| Anchors on `/reference/configs/server` | 26 before, 26 after; none lost or added |
| All five config pages, links vs. headings | zero unresolved content anchors |
| Front matter leak | gone from the rendered body |
| `docs/scalafmtCheck`, `docs/scalafix --check OrganizeImports`, `githubWorkflowCheck` | pass |

### Note

`robots.txt` and the sitemap only take effect once submitted in Google Search Console, and reindexing takes days to weeks. The GitHub result will likely hold position one regardless, since it has far more inbound links than ziohttp.com — the point of these changes is that whichever result ranks first is spelled correctly and described consistently.
