### PR TITLE
Give sidebar categories links so breadcrumbs form a full trail

### DIFF
--- a/docs/migration/_category_.json
+++ b/docs/migration/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Migration",
+  "link": {
+    "type": "generated-index",
+    "description": "Guides for migrating an existing application to a newer version of ZIO HTTP."
+  }
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -27,6 +27,11 @@ const sidebars = {
       type: "category",
       label: "Routing",
       collapsed: false,
+      link: {
+        type: "generated-index",
+        description:
+          "How ZIO HTTP matches an incoming request to a handler: routes, route patterns, and path codecs.",
+      },
       items: [
         "reference/routing/routes",
         "reference/routing/route_pattern",
@@ -38,6 +43,11 @@ const sidebars = {
       type: "category",
       label: "HTTP Messages",
       collapsed: false,
+      link: {
+        type: "generated-index",
+        description:
+          "The data types that model HTTP requests and responses, including headers and bodies.",
+      },
       items: [
         "reference/request",
         "reference/response/response",
@@ -45,8 +55,8 @@ const sidebars = {
         {
           type: "category",
           label: "Headers",
+          link: { type: "doc", id: "reference/headers/headers" },
           items: [
-            "reference/headers/headers",
             "reference/headers/session/cookies",
             "reference/headers/session/flash",
           ],
@@ -54,8 +64,8 @@ const sidebars = {
         {
           type: "category",
           label: "Message Body",
+          link: { type: "doc", id: "reference/body/body" },
           items: [
-            "reference/body/body",
             "reference/body/form",
             "reference/body/binary_codecs",
             "reference/body/template",
@@ -68,13 +78,19 @@ const sidebars = {
       type: "category",
       label: "Declarative Endpoints",
       collapsed: false,
-      items: ["reference/endpoint", "reference/http-codec"],
+      link: { type: "doc", id: "reference/endpoint" },
+      items: ["reference/http-codec"],
     },
 
     // Aspects subsection
     {
       type: "category",
       label: "Aspects",
+      link: {
+        type: "generated-index",
+        description:
+          "Cross-cutting concerns in ZIO HTTP: protocol stacks, middleware, and handler aspects.",
+      },
       items: [
         "reference/aop/protocol-stack",
         "reference/aop/middleware",
@@ -97,7 +113,8 @@ const sidebars = {
     {
       type: "category",
       label: "WebSocket",
-      items: ["reference/socket/socket", "reference/socket/websocketframe"],
+      link: { type: "doc", id: "reference/socket/socket" },
+      items: ["reference/socket/websocketframe"],
     },
 
     // ZIO HTTP Testkit subsection
@@ -118,8 +135,8 @@ const sidebars = {
     {
       type: "category",
       label: "Configs",
+      link: { type: "doc", id: "reference/configs/introduction" },
       items: [
-        "reference/configs/introduction",
         "reference/configs/connection-pool",
         "reference/configs/dns-resolver",
         "reference/configs/server",
@@ -166,6 +183,11 @@ const sidebars = {
        type: "category",
        collapsed: false,
        label: "Authentication",
+       link: {
+         type: "generated-index",
+         description:
+           "Guides for adding authentication to a ZIO HTTP application, from basic authentication to OAuth and WebAuthn.",
+       },
        items: [
           "guides/basic-authentication",
           "guides/cookie-based-authentication",
@@ -181,6 +203,11 @@ const sidebars = {
         type: "category",
         collapsed: false,
         label: "Datastar",
+        link: {
+          type: "generated-index",
+          description:
+            "Guides for building real-time applications with the ZIO HTTP Datastar integration.",
+        },
         items: [
            "guides/real-time-chat-with-datastar",
         ],
@@ -207,6 +234,11 @@ const sidebars = {
       type: "category",
       collapsed: false,
       label: "Concepts",
+      link: {
+        type: "generated-index",
+        description:
+          "The core ideas behind ZIO HTTP: servers, clients, routing, request handling, middleware, and endpoints.",
+      },
       items: [
         "concepts/server",
         "concepts/client",


### PR DESCRIPTION
Follow-up to #4260, and related to #4264.

Docusaurus already emits `BreadcrumbList` structured data on every docs page — `theme-classic` ships a `DocBreadcrumbs/StructuredData` component — and the markup it produces is spec-clean, with absolute `item` URLs on every element. The problem is what it has to work with.

A breadcrumb step must be somewhere you can navigate to: schema.org requires an `item` URL on every element except the last. A sidebar category that is only a grouping label has no URL, so Docusaurus drops it from the trail rather than emit an invalid step. Eleven of the fifteen categories in `sidebars.js` had no `link`, which left **76 of 93 pages** emitting a single-element breadcrumb naming only the page itself.

For example, `/guides/digest-authentication` described its own trail as:

```json
[{ "@type": "ListItem", "position": 1, "name": "Digest Authentication",
   "item": "https://ziohttp.com/guides/digest-authentication" }]
```

A trail whose only stop is the destination. The `Authentication` group it belongs to was invisible — even though the visual breadcrumb on the page displays it, as unlinked text.

### Approach

Categories that already have an overview document now point at it, and that document is removed from the category's `items` so it is not listed twice. This matches how `Testing (Testkit)`, `Datastar SDK`, `Request-scoped Context` and `SSL/TLS` were already configured:

| Category | Now links to |
| --- | --- |
| Headers | `reference/headers/headers` |
| Message Body | `reference/body/body` |
| Declarative Endpoints | `reference/endpoint` |
| WebSocket | `reference/socket/socket` |
| Configs | `reference/configs/introduction` |

The remaining categories have no such page and use `generated-index`: `Routing`, `HTTP Messages`, `Aspects`, `Authentication`, `Datastar`, `Concepts` and `Migration`. Each is given a `description`, which becomes the generated page's meta description. This adds seven pages at `/category/...`.

Documents were only promoted to a category link where they genuinely introduce the whole group — `reference/configs/introduction` opens with "This section describes…". Where the first child is just one data type among siblings, such as `reference/routing/routes` or `reference/aop/protocol-stack` (which describes itself as low-level and used by other abstractions), a generated index is used instead.

`Migration` is an autogenerated category, so it is configured through `docs/migration/_category_.json` rather than `sidebars.js`. This also capitalizes its label, previously derived from the directory name and rendered as `migration`.

### Result

`/guides/digest-authentication` now emits:

```json
[{ "@type": "ListItem", "position": 1, "name": "Authentication",
   "item": "https://ziohttp.com/category/authentication" },
 { "@type": "ListItem", "position": 2, "name": "Digest Authentication",
   "item": "https://ziohttp.com/guides/digest-authentication" }]
```

Pages whose breadcrumb carries real hierarchy go from **17 to 58**.

The 42 pages still emitting a single element are correct, not missed cases:

| Count | Reason |
| --- | --- |
| 17 | the `examples` sidebar is a flat list with no categories |
| 13 | top-level reference and guides documents, or category link targets, which sit at the top of their own trail |
| 7 | the generated index pages themselves |
| 5 | root documents (`introduction`, `installation`, `faq`, …) |

Grouping the examples sidebar into categories would improve those 17 further, but that is a docs reorganization rather than a metadata fix, so it is left out here.

### Verification

- `sbt mdoc` exit 0, zero `Unknown link` warnings; confirms `_category_.json` is copied into the site alongside the markdown
- `yarn build` exit 0 with `onBrokenLinks: 'throw'`, zero broken links
- Every `BreadcrumbList` in the output re-parsed and measured: 53 two-element, 5 three-element, 42 single-element as classified above
- All seven `/category/...` pages appear in `sitemap.xml`; `/category/authentication` renders with its eight child cards and the configured description as its `<meta name="description">`

Worth noting that none of this is visible in production yet: `site.yml` gates the deploy job on `release: published || workflow_dispatch`, so ziohttp.com still serves the pre-#4260 build. That is tracked in #4264.
