### PR TITLE
Move onBrokenMarkdownLinks under markdown.hooks

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,11 @@ const config = {
   url: 'https://ziohttp.com',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
   favicon: 'img/favicon.png',
 
   headTags: [


### PR DESCRIPTION
The top-level `onBrokenMarkdownLinks` option is deprecated and will be removed in Docusaurus v4. Every build logged the migration notice twice:

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

Moved to the location Docusaurus asks for:

```js
markdown: {
  hooks: {
    onBrokenMarkdownLinks: 'warn',
  },
},
```

The change is behaviour-neutral, in two independent ways. Docusaurus already copies the deprecated option into `markdown.hooks.onBrokenMarkdownLinks` and erases the old key (`configValidation.js`), and the new hook defaults to `warn` in any case, so the value could even have been dropped entirely. Setting it explicitly documents the intent rather than relying on a framework default that may change.

### Verification

`yarn build` exit 0, deprecation warnings 2 -> 0, zero broken links.

Build output is byte-comparable in the ways that matter: 100 `BreadcrumbList` blocks with the same 42 / 53 / 5 distribution across one-, two- and three-element trails, the same `Organization` + `WebSite` + `SoftwareSourceCode` graph on every page, and `robots.txt` unchanged.
