### PR TITLE
Fix duplicate titles and missing page descriptions

### DIFF
--- a/docs/concepts/client.md
+++ b/docs/concepts/client.md
@@ -1,3 +1,9 @@
+---
+title: "Client Concepts"
+sidebar_label: "Client"
+description: "How the ZIO HTTP client works as a function from Request to Response, including connection pooling, streaming and middleware."
+---
+
 # Client
 
 The ZIO HTTP Client allows your application to make outbound HTTP requests to external services. Built on ZIO and Netty, it provides a purely functional, type-safe API for HTTP communication with support for connection pooling, streaming, and middleware.

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -1,3 +1,9 @@
+---
+title: "Middleware Concepts"
+sidebar_label: "Middleware"
+description: "What middleware is in ZIO HTTP, and how it intercepts requests and responses to implement cross-cutting concerns."
+---
+
 # Middleware
 
 A middleware has the purpose of intercepting a request, a response or both. It helps in implementing cross-cutting concerns like access logging, authentication, etc.

--- a/docs/concepts/routing.md
+++ b/docs/concepts/routing.md
@@ -1,3 +1,9 @@
+---
+title: "Routing Concepts"
+sidebar_label: "Routing"
+description: "Why ZIO HTTP models routing as a declarative data structure, and how that differs from other Scala HTTP libraries."
+---
+
 # Routing
 
 ZIO HTTP routing does some things differently than other (Scala) HTTP libraries.

--- a/docs/concepts/server.md
+++ b/docs/concepts/server.md
@@ -1,3 +1,9 @@
+---
+title: "Server Concepts"
+sidebar_label: "Server"
+description: "How the ZIO HTTP server is modeled as a ZIO resource, and how its lifecycle, configuration and graceful shutdown fit together."
+---
+
 # Server
 
 The ZIO HTTP Server is the component that listens for incoming HTTP connections, processes requests through your application's routes, and sends back responses. It handles all the low-level networking concerns so you can focus on your application logic.

--- a/docs/examples/cli.md
+++ b/docs/examples/cli.md
@@ -2,6 +2,7 @@
 id: cli
 title: "Command-line Interface (CLI)"
 sidebar_label: "Command-line Interface (CLI)"
+description: "Generate a command-line client from a ZIO HTTP endpoint description using zio-http-cli."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/concrete-entity.md
+++ b/docs/examples/concrete-entity.md
@@ -2,6 +2,7 @@
 id: concrete-entity
 title: "Concrete Entity Example"
 sidebar_label: "Concrete Entity"
+description: "Define a ZIO HTTP handler over concrete domain types instead of Request and Response, using contramap and map."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/endpoint-scala3.md
+++ b/docs/examples/endpoint-scala3.md
@@ -2,6 +2,7 @@
 id: endpoint-scala3
 title: "Endpoint Scala 3 Syntax"
 sidebar_label: "Endpoint Scala 3 Syntax"
+description: "Define ZIO HTTP endpoints using Scala 3 syntax."
 ---
 
 ```scala

--- a/docs/examples/endpoint.md
+++ b/docs/examples/endpoint.md
@@ -2,6 +2,7 @@
 id: endpoint
 title: "Endpoint Examples"
 sidebar_label: "Endpoint"
+description: "Describe HTTP endpoints declaratively with the ZIO HTTP Endpoint API, then implement and serve them."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/graceful-shutdown.md
+++ b/docs/examples/graceful-shutdown.md
@@ -2,6 +2,7 @@
 id: graceful-shutdown
 title: "Graceful Shutdown Example"
 sidebar_label: "Graceful Shutdown"
+description: "Shut a ZIO HTTP server down gracefully, letting in-flight requests complete before releasing resources."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/html-templating.md
+++ b/docs/examples/html-templating.md
@@ -2,6 +2,7 @@
 id: html-templating
 title: "HTML Templating Example"
 sidebar_label: "HTML Templating"
+description: "Render HTML from Scala code using the ZIO HTTP template DSL."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/middleware-cors-handling.md
+++ b/docs/examples/middleware-cors-handling.md
@@ -2,6 +2,7 @@
 id: middleware-cors-handling
 title: "Middleware CORS Handling Example"
 sidebar_label: "Middleware CORS Handling"
+description: "Apply the CORS middleware to a ZIO HTTP application to handle cross-origin requests."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/examples/server-sent-events-in-endpoints.md
+++ b/docs/examples/server-sent-events-in-endpoints.md
@@ -2,6 +2,7 @@
 id: server-sent-events-in-endpoints
 title: "Server Sent Events in Endpoints Example"
 sidebar_label: "Server Sent Events in Endpoints"
+description: "Stream Server-Sent Events from a declaratively described ZIO HTTP endpoint."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/guides/implementing-mutual-tls.md
+++ b/docs/guides/implementing-mutual-tls.md
@@ -1,6 +1,7 @@
 ---
 id: implementing-mutual-tls
 title: Implementing Mutual TLS (mTLS) 
+description: "Configure mutual TLS in ZIO HTTP so that server and client authenticate each other with certificates."
 ---
 
 ## Introduction

--- a/docs/guides/implementing-tls-with-intermediate-ca-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-intermediate-ca-signed-server-certificate.md
@@ -1,6 +1,7 @@
 ---
 id: implementing-tls-with-intermediate-ca-signed-server-certificate
 title: Implementing TLS with an Intermediate CA-signed Server Certificate
+description: "Secure a ZIO HTTP server with TLS using a certificate signed by an intermediate certificate authority."
 ---
 
 ## Introduction

--- a/docs/guides/implementing-tls-with-root-ca-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-root-ca-signed-server-certificate.md
@@ -1,6 +1,7 @@
 ---
 id: implementing-tls-with-root-ca-signed-server-certificate
 title: Implementing TLS with Root CA-Signed Server Certificate
+description: "Secure a ZIO HTTP server with TLS using a certificate signed by a root certificate authority."
 ---
 
 ## Introduction

--- a/docs/guides/implementing-tls-with-self-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-self-signed-server-certificate.md
@@ -1,6 +1,7 @@
 ---
 id: implementing-tls-with-self-signed-server-certificate
 title: Implementing TLS with Self-signed Server Certificate
+description: "Secure a ZIO HTTP server with TLS using a self-signed certificate, and configure a client to trust it."
 ---
 
 ## Introduction

--- a/docs/guides/testing-http-apps.md
+++ b/docs/guides/testing-http-apps.md
@@ -1,6 +1,7 @@
 ---
 id: testing-http-apps
 title: Testing HTTP Applications
+description: "Write fast, reliable tests for ZIO HTTP applications without starting a live server, using the testkit."
 ---
 
 ## Introduction

--- a/docs/reference/configs/connection-pool-config.md
+++ b/docs/reference/configs/connection-pool-config.md
@@ -1,6 +1,7 @@
 ---
 id: connection-pool
 title: "ConnectionPoolConfig"
+description: "Reference for the ZIO HTTP client connection pool configuration, covering fixed, dynamic and per-host pooling."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/reference/configs/dns-resolver-config.md
+++ b/docs/reference/configs/dns-resolver-config.md
@@ -1,6 +1,7 @@
 ---
 id: dns-resolver
 title: "DNS Resolver Config"
+description: "Reference for the ZIO HTTP DNS resolver configuration, including cache sizes, TTLs and retry behaviour."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/reference/configs/netty-config.md
+++ b/docs/reference/configs/netty-config.md
@@ -1,6 +1,7 @@
 ---
 id: netty
 title: "Netty Config"
+description: "Reference for every NettyConfig field in ZIO HTTP, covering event loop groups, thread counts and shutdown timeouts."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/reference/configs/openapi-config.md
+++ b/docs/reference/configs/openapi-config.md
@@ -1,6 +1,7 @@
 ---
 id: openapi
 title: "OpenAPI Config"
+description: "Reference for the OpenAPI configuration fields used when generating OpenAPI documents in ZIO HTTP."
 ---
 
 ```scala mdoc:passthrough

--- a/docs/reference/configs/server-config.md
+++ b/docs/reference/configs/server-config.md
@@ -1,6 +1,7 @@
 ---
 id: server
 title: "Server Config"
+description: "Reference for every Server.Config field in ZIO HTTP, including binding, SSL, decompression and request limits."
 ---
 
 ```scala mdoc:passthrough


### PR DESCRIPTION
Two title and description problems found by auditing the `<title>` and `<meta name="description">` of all 109 built pages.

### Duplicate titles

Four concepts pages rendered exactly the same `<title>` as their reference counterparts, so each pair competed for the same query and Google had to pick one arbitrarily:

| Title | Pages |
| --- | --- |
| `Server \| ZIO HTTP` | `/concepts/server`, `/reference/server` |
| `Client \| ZIO HTTP` | `/concepts/client`, `/reference/client` |
| `Middleware \| ZIO HTTP` | `/concepts/middleware`, `/reference/aop/middleware` |
| `Routing \| ZIO HTTP` | `/concepts/routing`, `/category/routing` |

The concepts pages are retitled rather than the reference pages, since people search for the bare type name and should land on the reference.

These four files had no front matter at all, so their title came from the markdown heading. Front matter now sets an explicit `title`, with `sidebar_label` preserving the short form, so the sidebar and the breadcrumb trail still read `Server` rather than `Server Concepts`, and the in-page heading is untouched. No `id` is set: front matter `id` replaces the whole path-derived document id, which would move these pages to the site root.

### Absent and shared descriptions

Eighteen pages had an absent or meaningless description, leaving Google to invent one from the page body:

- **Eight example pages** consist only of an `mdoc:passthrough` block, so there was no prose to derive a description from and the tag was omitted entirely: `cli`, `concrete-entity`, `endpoint`, `endpoint-scala3`, `graceful-shutdown`, `html-templating`, `middleware-cors-handling`, `server-sent-events-in-endpoints`.
- **Five pages shared the description `"Introduction"`**, taken from their first heading: the four TLS guides and the testing guide.
- **Five generated configuration pages shared `"Configuration Details"`**, taken from the first heading of the zio-config output.

Each now sets a `description` in its front matter.

### Verification

`sbt mdoc` exit 0 with zero `Unknown link` warnings; `yarn build` exit 0 with `onBrokenLinks: 'throw'` and zero broken links.

Re-auditing the build output:

| | Before | After |
| --- | --- | --- |
| Duplicate titles | 4 | 0 |
| Duplicate descriptions | 2 (10 pages) | 0 |
| Pages with no description | 10 | 2 |

The two remaining are `/search`, which Docusaurus already marks `noindex`, and `/algolia`, a helper page.

Confirmed unchanged: `/concepts/server` renders `<title>Server Concepts | ZIO HTTP</title>` with `<h1>Server</h1>`, and its breadcrumb still reads `Concepts > Server`.
