### PR TITLE
Shorten guide titles that were truncated in search results

### DIFF
--- a/docs/guides/authentication-with-jwt-bearer-and-refresh-tokens.md
+++ b/docs/guides/authentication-with-jwt-bearer-and-refresh-tokens.md
@@ -1,6 +1,6 @@
 ---
 id: authentication-with-jwt-bearer-and-refresh-tokens
-title: "Securing Your APIs: Authentication with JWT Bearer and Refresh Tokens"
+title: "Authentication with JWT Bearer and Refresh Tokens"
 sidebar_label: "Authentication with JWT Bearer and Refresh Tokens"
 ---
 

--- a/docs/guides/authentication-with-jwt-bearer-tokens.md
+++ b/docs/guides/authentication-with-jwt-bearer-tokens.md
@@ -1,6 +1,6 @@
 ---
 id: authentication-with-jwt-bearer-tokens
-title: "Securing Your APIs: Authentication with JWT Bearer Tokens"
+title: "Authentication with JWT Bearer Tokens"
 sidebar_label: "Authentication with JWT Bearer Tokens"
 ---
 

--- a/docs/guides/authentication-with-opaque-bearer-tokens.md
+++ b/docs/guides/authentication-with-opaque-bearer-tokens.md
@@ -1,6 +1,6 @@
 ---
 id: authentication-with-opaque-bearer-tokens
-title: "Securing Your APIs: Authentication with Opaque Bearer Tokens"
+title: "Authentication with Opaque Bearer Tokens"
 sidebar_label: "Authentication with Opaque Bearer Tokens"
 ---
 

--- a/docs/guides/authentication-wtih-a-third-party-oauth-provider.md
+++ b/docs/guides/authentication-wtih-a-third-party-oauth-provider.md
@@ -1,6 +1,6 @@
 ---
 id: authentication-with-a-third-party-oauth-provider
-title: "Securing Your APIs: Authentication with a Third-party OAuth Provider"
+title: "Authentication with a Third-party OAuth Provider"
 sidebar_label: "Authentication with a Third-party OAuth Provider"
 ---
 

--- a/docs/guides/implementing-mutual-tls.md
+++ b/docs/guides/implementing-mutual-tls.md
@@ -1,6 +1,6 @@
 ---
 id: implementing-mutual-tls
-title: Implementing Mutual TLS (mTLS) 
+title: "Mutual TLS (mTLS)" 
 description: "Configure mutual TLS in ZIO HTTP so that server and client authenticate each other with certificates."
 ---
 

--- a/docs/guides/implementing-tls-with-intermediate-ca-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-intermediate-ca-signed-server-certificate.md
@@ -1,6 +1,6 @@
 ---
 id: implementing-tls-with-intermediate-ca-signed-server-certificate
-title: Implementing TLS with an Intermediate CA-signed Server Certificate
+title: "TLS with an Intermediate CA-signed Certificate"
 description: "Secure a ZIO HTTP server with TLS using a certificate signed by an intermediate certificate authority."
 ---
 

--- a/docs/guides/implementing-tls-with-root-ca-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-root-ca-signed-server-certificate.md
@@ -1,6 +1,6 @@
 ---
 id: implementing-tls-with-root-ca-signed-server-certificate
-title: Implementing TLS with Root CA-Signed Server Certificate
+title: "TLS with a Root CA-signed Certificate"
 description: "Secure a ZIO HTTP server with TLS using a certificate signed by a root certificate authority."
 ---
 

--- a/docs/guides/implementing-tls-with-self-signed-server-certificate.md
+++ b/docs/guides/implementing-tls-with-self-signed-server-certificate.md
@@ -1,6 +1,6 @@
 ---
 id: implementing-tls-with-self-signed-server-certificate
-title: Implementing TLS with Self-signed Server Certificate
+title: "TLS with a Self-signed Certificate"
 description: "Secure a ZIO HTTP server with TLS using a self-signed certificate, and configure a client to trust it."
 ---
 

--- a/docs/guides/webauthn.md
+++ b/docs/guides/webauthn.md
@@ -1,6 +1,6 @@
 ---
 id: passwordless-authentication-with-webauthn
-title: "Securing Your APIs: Passwordless Authentication with WebAuthn"
+title: "Passwordless Authentication with WebAuthn"
 sidebar_label: "Passwordless Authentication with WebAuthn"
 ---
 


### PR DESCRIPTION
Last item from #4264. Eight guide titles exceeded the roughly 60 characters Google renders before truncating, so they were cut off mid-phrase in search results. The budget includes the ` | ZIO HTTP` suffix Docusaurus appends, leaving 49 characters for the title itself.

### Authentication guides

Five carried a `Securing Your APIs: ` prefix worth 20 characters. The site name already supplies that context and the guides sit under an Authentication category, so the prefix was pure overhead — removing it alone brought all five within budget. Their `sidebar_label` values already omitted it and are unchanged.

| Before | chars | After | chars |
| --- | --- | --- | --- |
| Securing Your APIs: Authentication with JWT Bearer and Refresh Tokens | 80 | Authentication with JWT Bearer and Refresh Tokens | 60 |
| Securing Your APIs: Authentication with a Third-party OAuth Provider | 79 | Authentication with a Third-party OAuth Provider | 59 |
| Securing Your APIs: Passwordless Authentication with WebAuthn | 72 | Passwordless Authentication with WebAuthn | 52 |
| Securing Your APIs: Authentication with Opaque Bearer Tokens | 71 | Authentication with Opaque Bearer Tokens | 51 |
| Securing Your APIs: Authentication with JWT Bearer Tokens | 68 | Authentication with JWT Bearer Tokens | 48 |

### TLS guides

These drop `Implementing` and `Server`, keeping the load-bearing `-signed`, since the certificate is signed *by* the CA rather than being the CA's own certificate.

| Before | chars | After | chars |
| --- | --- | --- | --- |
| Implementing TLS with an Intermediate CA-signed Server Certificate | 77 | TLS with an Intermediate CA-signed Certificate | 57 |
| Implementing TLS with Root CA-Signed Server Certificate | 66 | TLS with a Root CA-signed Certificate | 48 |
| Implementing TLS with Self-signed Server Certificate | 63 | TLS with a Self-signed Certificate | 45 |

These pages have no `sidebar_label` of their own, so their sidebar entries shorten along with the titles, which reads better in a four-item list.

The mutual TLS guide is also retitled, from `Implementing Mutual TLS (mTLS)` to `Mutual TLS (mTLS)`. It was within budget already, but leaving it would have made the section look half-edited:

```
TLS with a Self-signed Certificate
TLS with a Root CA-signed Certificate
TLS with an Intermediate CA-signed Certificate
Mutual TLS (mTLS)
```

### Verification

`sbt mdoc` exit 0 with zero `Unknown link` warnings; `yarn build` exit 0 with `onBrokenLinks: 'throw'` and zero broken links.

Auditing the build output: **titles over 60 characters: 8 to 0**, longest now exactly 60, duplicate titles still 0, duplicate descriptions still 0.

Headings and breadcrumbs verified intact, for example `/guides/implementing-tls-with-root-ca-signed-server-certificate` renders `<h1>TLS with a Root CA-signed Certificate</h1>` with the trail `SSL/TLS > TLS with a Root CA-signed Certificate`. No URLs change, since only `title` is touched.

### Unrelated observation

`docs/guides/authentication-wtih-a-third-party-oauth-provider.md` has a typo in its filename ("wtih"). It is invisible in the URL because the front matter `id` spells it correctly, so it is left alone here.
