### PR TITLE
Fix: Discard an unconsumed request body when the response completes

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
@@ -46,6 +46,8 @@ private[netty] abstract class AsyncBodyReader(
   // before the consumer connects. `ArrayBuilder#knownSize` is unreliable on
   // Scala 2.12, so we count bytes ourselves.
   private var bufferedBytes: Int              = 0
+  // Budget left for throwing away an unconsumed request body; see discardRemainingBody.
+  private var discardableBytes: Long          = 0L
   private var previousAutoRead: Boolean       = false
   private var readingDone: Boolean            = false
   private var ctx: ChannelHandlerContext      = _
@@ -89,6 +91,33 @@ private[netty] abstract class AsyncBodyReader(
     }
   }
 
+  /**
+   * Reads and throws away whatever is left of the request body, so that the
+   * connection can be used for the next request.
+   *
+   * Called when a response has been written while this reader is still in the
+   * pipeline, which means the body was never consumed or was only consumed in
+   * part. Reading stops in that situation - `handlerAdded` disables `autoRead`
+   * and the only calls to `ctx.read()` come from a consumer asking for the next
+   * chunk - so without this the connection stays open but is never read from
+   * again, and the next request the client sends over it is silently dropped.
+   *
+   * HTTP/1.1 gives a server no way to ask a client to stop sending, so the only
+   * two correct options once a response has been sent early are to read the
+   * rest and discard it, or to close the connection. This discards up to
+   * `maxDiscardedBytes` and closes the connection if the body turns out to be
+   * larger than that.
+   */
+  private[zio] def discardRemainingBody(maxDiscardedBytes: Long): Unit =
+    self.synchronized {
+      if (!readingDone && ctx.channel().isOpen) {
+        cancelTimeoutTask()
+        discardableBytes = maxDiscardedBytes
+        state = State.Discarding
+        ctx.read(): Unit
+      }
+    }
+
   override def handlerAdded(ctx: ChannelHandlerContext): Unit = {
     previousAutoRead = ctx.channel().config().isAutoRead
     ctx.channel().config().setAutoRead(false)
@@ -121,6 +150,15 @@ private[netty] abstract class AsyncBodyReader(
 
       val readMore =
         state match {
+          case State.Discarding                                           =>
+            // The consumer is gone; read on until the body ends so that the connection stays usable,
+            // and give up on the connection if the client turns out to be sending more than we are
+            // willing to throw away.
+            discardableBytes -= content.length
+            if (discardableBytes < 0) {
+              ctx.close(): Unit
+              false
+            } else !isLast
           case State.Buffering                                            =>
             // `connect` method hasn't been called yet, add all incoming content to the buffer.
             // Cap the pre-connect buffer to avoid unbounded heap growth when a fast producer
@@ -197,6 +235,7 @@ private[netty] abstract class AsyncBodyReader(
       cancelTimeoutTask()
       state match {
         case State.Buffering        =>
+        case State.Discarding       =>
         case State.Direct(callback) =>
           callback.fail(cause)
       }
@@ -210,6 +249,7 @@ private[netty] abstract class AsyncBodyReader(
 
       state match {
         case State.Buffering                        =>
+        case State.Discarding                       =>
         case State.Direct(callback) if !readingDone =>
           // Step 4: Premature channel closure detection
           // This is the core issue from #2383 - server sent headers but closed before body completed
@@ -243,6 +283,13 @@ private[netty] object AsyncBodyReader {
     case object Buffering extends State
 
     final case class Direct(callback: UnsafeAsync) extends State
+
+    /**
+     * The consumer is gone and whatever is left of the body is read and thrown
+     * away, so that the connection is left in a state where the next request on
+     * it can be read.
+     */
+    case object Discarding extends State
   }
 
   // For Scala 2.12. In Scala 2.13+, the methods directly implemented on ArrayBuilder[Byte] are selected over syntax.

--- a/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
@@ -107,11 +107,14 @@ private[netty] abstract class AsyncBodyReader(
    * rest and discard it, or to close the connection. This discards up to
    * `maxDiscardedBytes` and closes the connection if the body turns out to be
    * larger than that.
+   *
+   * Any body read timeout is deliberately left running: it is the only thing
+   * that would stop a client that goes quiet half way from holding on to the
+   * connection while we are draining it.
    */
   private[zio] def discardRemainingBody(maxDiscardedBytes: Long): Unit =
     self.synchronized {
       if (!readingDone && ctx.channel().isOpen) {
-        cancelTimeoutTask()
         discardableBytes = maxDiscardedBytes
         state = State.Discarding
         ctx.read(): Unit

--- a/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/AsyncBodyReader.scala
@@ -139,7 +139,8 @@ private[netty] abstract class AsyncBodyReader(
 
     self.synchronized {
       val isLast  = msg.isInstanceOf[LastHttpContent]
-      val content = ByteBufUtil.getBytes(msg.content())
+      // A discarded chunk is only ever counted, so its bytes are copied out of the ByteBuf lazily.
+      def content = ByteBufUtil.getBytes(msg.content())
 
       // Cancel timeout task since we received data
       if (isLast) {
@@ -153,9 +154,11 @@ private[netty] abstract class AsyncBodyReader(
           case State.Discarding                                           =>
             // The consumer is gone; read on until the body ends so that the connection stays usable,
             // and give up on the connection if the client turns out to be sending more than we are
-            // willing to throw away.
-            discardableBytes -= content.length
+            // willing to throw away. Flushed first, so that a response still sitting in the outbound
+            // buffer is not dropped along with the connection.
+            discardableBytes -= msg.content().readableBytes()
             if (discardableBytes < 0) {
+              ctx.flush()
               ctx.close(): Unit
               false
             } else !isLast
@@ -163,8 +166,9 @@ private[netty] abstract class AsyncBodyReader(
             // `connect` method hasn't been called yet, add all incoming content to the buffer.
             // Cap the pre-connect buffer to avoid unbounded heap growth when a fast producer
             // outpaces a slow-to-start consumer (see issue #3173).
-            buffer0.addAll(content)
-            bufferedBytes += content.length
+            val bytes = content
+            buffer0.addAll(bytes)
+            bufferedBytes += bytes.length
             bufferedBytes < maxPreConnectBufferSize
           case State.Direct(callback) if isLast && buffer0.knownSize == 0 =>
             // Buffer is empty, we can just use the array directly

--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/ServerInboundHandler.scala
@@ -94,12 +94,17 @@ private[zio] final case class ServerInboundHandler(
             )
             releaseRequest()
           } else {
-            val req  = makeZioRequest(ctx, jReq)
-            val exit = handler(req)
+            val req        = makeZioRequest(ctx, jReq)
+            val exit       = handler(req)
+            // Captured here, on the event loop, while this request's reader is the one in the pipeline. Looking it up when the
+            // response completes would be a race: on a keep-alive connection the next request may have installed its own reader
+            // by then, and discarding its body would break a request that did nothing wrong.
+            val bodyReader = unfinishedBodyReader(ctx)
+            val done       = () => { releaseRequest(); discardRemainingRequestBody(bodyReader) }
             if (attemptImmediateWrite(ctx, req.method, exit)) {
-              releaseRequest()
+              done()
             } else {
-              writeResponse(ctx, runtime, exit, req)(releaseRequest)
+              writeResponse(ctx, runtime, exit, req)(done)
             }
           }
         } finally {
@@ -136,6 +141,24 @@ private[zio] final case class ServerInboundHandler(
             super.exceptionCaught(ctx, t)
         }
     }
+
+  private def unfinishedBodyReader(ctx: ChannelHandlerContext): AsyncBodyReader =
+    ctx.pipeline().get(Names.HttpContentHandler) match {
+      case reader: AsyncBodyReader => reader
+      case _                       => null
+    }
+
+  /**
+   * A response has been written; if the body of the request it answers was
+   * never consumed, or only consumed in part, this connection has stopped
+   * reading and would silently drop whatever the client sends next. Reading is
+   * driven by the consumer of the body, and there is no consumer any more.
+   *
+   * A reader that has seen the last chunk has already removed itself and
+   * ignores this.
+   */
+  private def discardRemainingRequestBody(bodyReader: AsyncBodyReader): Unit =
+    if (bodyReader ne null) bodyReader.discardRemainingBody(config.maxDiscardedRequestBodySize)
 
   private def addAsyncBodyHandler(ctx: ChannelHandlerContext): AsyncBodyReader = {
     val handler = new ServerAsyncBodyHandler(config.requestBodyPreConnectBufferSize)

--- a/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerUnconsumedRequestBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerUnconsumedRequestBodySpec.scala
@@ -111,7 +111,11 @@ object ServerUnconsumedRequestBodySpec extends ZIOHttpSpec {
       readHeaders(Chunk.empty)
     }
 
-  private final case class Exchange(rejected: String, reused: String)
+  /**
+   * The status line of the rejection, and what came of reusing that same
+   * connection afterwards.
+   */
+  private final case class Exchange(rejected: String, reused: Either[Throwable, String])
 
   private def scenario(
     readBody: Request => ZIO[Any, Nothing, Unit],
@@ -125,8 +129,8 @@ object ServerUnconsumedRequestBodySpec extends ZIOHttpSpec {
       _        <- ZIO.sleep(300.millis)
       _        <- sendBody(socket, bodySize)
       rejected <- readStatusLine(socket)
-      _        <- sendHead(socket, "GET /ping HTTP/1.1", contentLength = 0)
-      reused   <- readStatusLine(socket)
+      _        <- sendHead(socket, "GET /ping HTTP/1.1", contentLength = 0).either
+      reused   <- readStatusLine(socket).either
     } yield Exchange(rejected, reused)
 
   override def spec: Spec[TestEnvironment with Scope, Any] =
@@ -134,25 +138,39 @@ object ServerUnconsumedRequestBodySpec extends ZIOHttpSpec {
       test("a handler that never touches the body leaves the connection usable") {
         for {
           exchange <- scenario(_ => ZIO.unit)
-        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+        } yield assertTrue(
+          exchange.rejected.startsWith("HTTP/1.1 400"),
+          exchange.reused.exists(_.startsWith("HTTP/1.1 200")),
+        )
       },
       test("a handler that consumes only part of the body leaves the connection usable") {
         for {
           exchange <- scenario(_.body.asStream.take(1).runDrain.orDie)
-        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+        } yield assertTrue(
+          exchange.rejected.startsWith("HTTP/1.1 400"),
+          exchange.reused.exists(_.startsWith("HTTP/1.1 200")),
+        )
       },
       test("a handler that consumes the whole body leaves the connection usable") {
         for {
           exchange <- scenario(_.body.asStream.runDrain.orDie)
-        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+        } yield assertTrue(
+          exchange.rejected.startsWith("HTTP/1.1 400"),
+          exchange.reused.exists(_.startsWith("HTTP/1.1 200")),
+        )
       },
-      test("a body too large to discard closes the connection instead of leaving it unreadable") {
+      test("a body too large to discard is answered, and then the connection is closed rather than left unreadable") {
         for {
-          result <- scenario(
+          exchange <- scenario(
             _ => ZIO.unit,
             Server.Config.default.maxDiscardedRequestBodySize(bodySize.toLong / 2),
-          ).either
-        } yield assertTrue(result.isLeft)
+          )
+        } yield assertTrue(
+          // The response to the request that was rejected still has to arrive ...
+          exchange.rejected.startsWith("HTTP/1.1 400"),
+          // ... and only then may the connection go, rather than silently swallowing the next request.
+          exchange.reused.isLeft,
+        )
       },
     ) @@ withLiveClock @@ sequential @@ timeout(2.minutes)
 }

--- a/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerUnconsumedRequestBodySpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/netty/server/ServerUnconsumedRequestBodySpec.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 - 2023 Sporta Technologies PVT LTD & the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.http.netty.server
+
+import java.io.{InputStream, OutputStream}
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.tailrec
+
+import zio._
+import zio.test.TestAspect._
+import zio.test._
+
+import zio.http._
+
+/**
+ * A response that is written without the request body having been read leaves
+ * the connection unreadable unless the server does something about it.
+ *
+ * With request streaming, reading is driven by the consumer of the body: the
+ * channel is put in autoRead = false and the next read is only issued when the
+ * next chunk is asked for. A handler that answers without consuming the body -
+ * one that rejects the request before decoding it, an unmatched route, or a
+ * handler that simply ignores the body - therefore stops the connection from
+ * ever being read again, and the next request the client sends over that
+ * connection is silently dropped.
+ *
+ * The body has to arrive in a later read than the headers for this to show,
+ * which is why the requests here are written in two parts over a plain socket
+ * rather than through a client: a client is free to decide how to frame and
+ * whether to reuse a connection, and both are exactly what is being tested.
+ */
+object ServerUnconsumedRequestBodySpec extends ZIOHttpSpec {
+
+  private val bodySize: Int = 16 * 1024
+
+  private val readTimeout: Duration = 10.seconds
+
+  private def routes(readBody: Request => ZIO[Any, Nothing, Unit]): Routes[Any, Response] =
+    Routes(
+      Method.POST / "reject" -> handler((request: Request) => readBody(request).as(Response.status(Status.BadRequest))),
+      Method.GET / "ping"    -> handler(Response.text("pong")),
+    )
+
+  private def startServer(
+    readBody: Request => ZIO[Any, Nothing, Unit],
+    config: Server.Config,
+  ): ZIO[Scope, Throwable, Int] =
+    for {
+      server <- (ZLayer.succeed(config.onAnyOpenPort.enableRequestStreaming) >>> Server.live).build
+      port   <- Server.installRoutes(routes(readBody)).provideEnvironment(server)
+    } yield port
+
+  private def connect(port: Int): ZIO[Scope, Throwable, Socket] =
+    ZIO.acquireRelease(
+      ZIO.attemptBlocking {
+        val socket = new Socket("localhost", port)
+        socket.setTcpNoDelay(true)
+        socket.setSoTimeout(readTimeout.toMillis.toInt)
+        socket
+      },
+    )(socket => ZIO.attemptBlocking(socket.close()).orDie)
+
+  private def sendHead(socket: Socket, requestLine: String, contentLength: Int): Task[Unit] =
+    ZIO.attemptBlocking {
+      val out: OutputStream = socket.getOutputStream
+      out.write(
+        s"$requestLine\r\nHost: localhost\r\nContent-Length: $contentLength\r\n\r\n".getBytes(StandardCharsets.US_ASCII),
+      )
+      out.flush()
+    }
+
+  private def sendBody(socket: Socket, size: Int): Task[Unit] =
+    ZIO.attemptBlocking {
+      val out: OutputStream = socket.getOutputStream
+      out.write(Array.fill[Byte](size)('x'.toByte))
+      out.flush()
+    }
+
+  /** Reads the status line of the next response, or fails if none arrives. */
+  private def readStatusLine(socket: Socket): Task[String] =
+    ZIO.attemptBlocking {
+      val in: InputStream = socket.getInputStream
+
+      @tailrec
+      def readHeaders(read: Chunk[Byte]): String =
+        in.read() match {
+          case -1   => throw new IllegalStateException("Connection closed before a response was received")
+          case byte =>
+            val readSoFar = read :+ byte.toByte
+            if (readSoFar.endsWith(Chunk[Byte]('\r', '\n', '\r', '\n')))
+              new String(readSoFar.toArray, StandardCharsets.US_ASCII).linesIterator.next()
+            else readHeaders(readSoFar)
+        }
+
+      readHeaders(Chunk.empty)
+    }
+
+  private final case class Exchange(rejected: String, reused: String)
+
+  private def scenario(
+    readBody: Request => ZIO[Any, Nothing, Unit],
+    config: Server.Config = Server.Config.default,
+  ): ZIO[Scope, Throwable, Exchange] =
+    for {
+      port     <- startServer(readBody, config)
+      socket   <- connect(port)
+      _        <- sendHead(socket, "POST /reject HTTP/1.1", bodySize)
+      // The body lands in a read of its own, which is when reading stops.
+      _        <- ZIO.sleep(300.millis)
+      _        <- sendBody(socket, bodySize)
+      rejected <- readStatusLine(socket)
+      _        <- sendHead(socket, "GET /ping HTTP/1.1", contentLength = 0)
+      reused   <- readStatusLine(socket)
+    } yield Exchange(rejected, reused)
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("ServerUnconsumedRequestBody")(
+      test("a handler that never touches the body leaves the connection usable") {
+        for {
+          exchange <- scenario(_ => ZIO.unit)
+        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+      },
+      test("a handler that consumes only part of the body leaves the connection usable") {
+        for {
+          exchange <- scenario(_.body.asStream.take(1).runDrain.orDie)
+        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+      },
+      test("a handler that consumes the whole body leaves the connection usable") {
+        for {
+          exchange <- scenario(_.body.asStream.runDrain.orDie)
+        } yield assertTrue(exchange.rejected.startsWith("HTTP/1.1 400"), exchange.reused.startsWith("HTTP/1.1 200"))
+      },
+      test("a body too large to discard closes the connection instead of leaving it unreadable") {
+        for {
+          result <- scenario(
+            _ => ZIO.unit,
+            Server.Config.default.maxDiscardedRequestBodySize(bodySize.toLong / 2),
+          ).either
+        } yield assertTrue(result.isLeft)
+      },
+    ) @@ withLiveClock @@ sequential @@ timeout(2.minutes)
+}

--- a/zio-http/shared/src/main/scala/zio/http/Server.scala
+++ b/zio-http/shared/src/main/scala/zio/http/Server.scala
@@ -78,6 +78,8 @@ object Server extends ServerPlatformSpecific {
     generateHeadRoutes: Boolean = false,
     @unroll
     requestBodyPreConnectBufferSize: Int = 64 * 1024,
+    @unroll
+    maxDiscardedRequestBodySize: Long = 1024 * 1024,
   ) { self =>
 
     /**
@@ -218,6 +220,24 @@ object Server extends ServerPlatformSpecific {
     }
 
     /**
+     * How much of an unconsumed request body the server is willing to read and
+     * throw away in order to keep a connection usable.
+     *
+     * When a handler answers a request without reading its body to the end -
+     * because it rejected the request before decoding, because no route
+     * matched, or because it simply ignored the body - the remainder of that
+     * body is still on its way. HTTP/1.1 offers no way to tell the client to
+     * stop, so the server either reads the rest and discards it, or closes the
+     * connection. Bodies up to this size are discarded; anything larger closes
+     * the connection instead of spending unbounded time reading bytes nobody
+     * wants.
+     */
+    def maxDiscardedRequestBodySize(size: Long): Config = {
+      require(size >= 0, "maxDiscardedRequestBodySize must be >= 0")
+      self.copy(maxDiscardedRequestBodySize = size)
+    }
+
+    /**
      * Sets the maximum number of connection requests that will be queued before
      * being rejected
      */
@@ -255,7 +275,10 @@ object Server extends ServerPlatformSpecific {
         zio.Config.boolean("tcp-nodelay").withDefault(Config.default.tcpNoDelay) ++
         zio.Config
           .int("request-body-pre-connect-buffer-size")
-          .withDefault(Config.default.requestBodyPreConnectBufferSize)
+          .withDefault(Config.default.requestBodyPreConnectBufferSize) ++
+        zio.Config
+          .long("max-discarded-request-body-size")
+          .withDefault(Config.default.maxDiscardedRequestBodySize)
 
     }.map {
       case (
@@ -276,6 +299,7 @@ object Server extends ServerPlatformSpecific {
             soBacklog,
             tcpNoDelay,
             requestBodyPreConnectBufferSize,
+            maxDiscardedRequestBodySize,
           ) =>
         default.copy(
           sslConfig = sslConfig,
@@ -294,6 +318,7 @@ object Server extends ServerPlatformSpecific {
           soBacklog = soBacklog,
           tcpNoDelay = tcpNoDelay,
           requestBodyPreConnectBufferSize = requestBodyPreConnectBufferSize,
+          maxDiscardedRequestBodySize = maxDiscardedRequestBodySize,
         )
     }
 
@@ -315,6 +340,7 @@ object Server extends ServerPlatformSpecific {
       soBacklog = 100,
       tcpNoDelay = true,
       requestBodyPreConnectBufferSize = 64 * 1024,
+      maxDiscardedRequestBodySize = 1024 * 1024,
     )
 
     final case class ResponseCompressionConfig(


### PR DESCRIPTION
**Issue**:
With request streaming, reading is driven by the consumer of the body: the channel is put in autoRead = false and the next read is only issued when the next chunk is asked for. A handler that answers without consuming the body to its end (i.e. one that rejects a request before decoding it, an unmatched route, a handler that ignores the body, or a reader that gives up half way) therefore leaves the connection open but never read from again, and the next request the client sends over it is silently dropped.

**Possible solutions**
HTTP/1.1 gives a server no way to ask a client to stop sending, so the two options once a response has been written early are:
- read the rest and discard it, or 
- close the connection. 

**Current PR**
The changes in this PR do the former, up to maxDiscardedRequestBodySize, and the latter beyond it.

I personally think this is a nice solution, since it keeps the connection alive for smaller requests, but stops endlessly listening for larger ones, but it's definitely something you could have an different opinion about (and different use-cases might want different settings).
Also, the default size for maxDiscardedRequestBodySize is quite arbitrary. Someone with an opinion should make a judgement on that as well.

**Context**
It took a while to find the root cause of this issue when we ran into this issue in our own application, since the symptoms were flaky tests in our CI, which are obviously hard to diagnose. After having a reasonable idea where the issue could lie, I found the issue was already posted by someone else here:

https://github.com/zio/zio-http/issues/4193

I've used LLM tools with the diagnosing and the fix, but also had to use my own brain, since it alone wouldn't have found/fixed it.
I've also tested this fix in our own API and it did seem to fix the issue.