### PR TITLE
feat(snapshot): publish 4.0.0-SNAPSHOT to Central Snapshots on push to v4.x

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,34 @@
+name: Snapshot
+on:
+  push:
+    branches: ['v4.x']
+  workflow_dispatch:
+concurrency:
+  group: snapshot-${{ github.ref }}
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  publishSnapshot:
+    name: Publish Snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup JDK
+        uses: coursier/setup-action@v3
+        with:
+          jvm: temurin:25
+      - name: Cache
+        uses: coursier/cache-action@v8
+      - name: Publish snapshot
+        run: |
+          chmod +x ./mill && ./mill mill.javalib.SonatypeCentralPublishModule/publishAll \
+            --publishArtifacts "{core,server,client,endpoint,h2Codec,serverLoom,clientJava,zio,testkit}.jvm.__.publishArtifacts" \
+            --username $SONATYPE_USERNAME --password $SONATYPE_PASSWORD
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.mill
+++ b/build.mill
@@ -7,6 +7,7 @@ import mill.contrib.scoverage._
 import mill.scalajslib.*
 import mill.scalalib.*
 import mill.contrib.jmh.JmhModule
+import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 
 object Versions {
   val Scala213              = "2.13.18"
@@ -20,6 +21,26 @@ object Versions {
 
 val scalaVersions = Seq(Versions.Scala213, Versions.Scala3)
 val wsRoot        = BuildCtx.workspaceRoot
+
+trait ZioHttpPublishModule extends PublishModule {
+  def publishVersion = Task {
+    sys.env.getOrElse("ZIO_HTTP_SNAPSHOT_VERSION", "4.0.0-SNAPSHOT")
+  }
+  def pomSettings = Task {
+    PomSettings(
+      description = "ZIO HTTP is a scala library for building http apps.",
+      organization = "dev.zio",
+      url = "https://github.com/zio/zio-http",
+      licenses = Seq(License.`Apache-2.0`),
+      versionControl = VersionControl.github("zio", "zio-http"),
+      developers = Seq(
+        Developer("jdegoes", "John De Goes", "https://github.com/jdegoes"),
+        Developer("vigoo", "Daniel Vigovszky", "https://github.com/vigoo"),
+        Developer("987Nabil", "Nabil Abdel-Hafeez", "https://github.com/987Nabil"),
+      ),
+    )
+  }
+}
 
 trait ZioHttpModule extends CrossScalaModule {
 
@@ -76,14 +97,14 @@ trait ZioHttpModule extends CrossScalaModule {
   }
 }
 
-trait ZioHttpJvmModule extends ZioHttpModule with ScoverageModule {
+trait ZioHttpJvmModule extends ZioHttpModule with ScoverageModule with ZioHttpPublishModule {
 
   def scoverageVersion      = "2.5.2"
   def statementCoverageMin  = Some(85.0)
   def branchCoverageMin     = Some(85.0)
 }
 
-trait ZioHttpJSModule extends ZioHttpModule with ScalaJSModule {
+trait ZioHttpJSModule extends ZioHttpModule with ScalaJSModule with ZioHttpPublishModule {
   def scalaJSVersion = Versions.ScalaJS
 }
 
@@ -176,6 +197,9 @@ object core extends Module {
         "PathVarHandler.scala",
         "PathVarHandlerMacros.scala",
         "HandlerMacros.scala",
+        "MiddlewareMacro.scala",
+        "ContextHandlerAPI.scala",
+        "ContextHandlerMacro.scala",
       )
       val sourceFiles = BuildCtx.watchValue {
         sourceDirs.flatMap(dir => os.walk(dir).filter(_.ext == "scala")).filterNot { path =>


### PR DESCRIPTION
## Summary

Snapshot publishing for `v4.x` (Mill build) to Sonatype Central Snapshots.

Closes the gap where `v4.x` had no publishing — `main` uses `sbt ci-release` to Central, but `v4.x` is Mill 1.1.7 without a `PublishModule`.

## Changes

**`build.mill`**
- Add `import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}`
- New `ZioHttpPublishModule extends PublishModule` with:
  - `publishVersion = Task { sys.env.getOrElse("ZIO_HTTP_SNAPSHOT_VERSION", "4.0.0-SNAPSHOT") }` — `-SNAPSHOT` suffix routes through `SonatypeCentralPublishModule`'s snapshot path (`https://central.sonatype.com/repository/maven-snapshots/`, no PGP)
  - `pomSettings` (`dev.zio`, Apache-2.0, `VersionControl.github("zio","zio-http")`, developers `jdegoes`/`vigoo`/`987Nabil`)
- Mix into `ZioHttpJvmModule with ScoverageModule with ZioHttpPublishModule` and `ZioHttpJSModule with ScalaJSModule with ZioHttpPublishModule` → all 18 cross modules publishable
- Fix `core.js` `excludedNames` (13→16): add `MiddlewareMacro.scala`, `ContextHandlerAPI.scala`, `ContextHandlerMacro.scala` so `core.js.3_8_3.compile` succeeds (JVM-only handlers)

**`.github/workflows/snapshot.yml`** (new)
- Trigger `push: branches: [v4.x]` + `workflow_dispatch`
- `concurrency: snapshot-${{ github.ref }}`, `permissions: contents: read`, `timeout 30m`
- Steps: `actions/checkout@v6` (fetch-depth 0) → `coursier/setup-action@v3` (temurin:25) → `coursier/cache-action@v8` → `mill.javalib.SonatypeCentralPublishModule/publishAll --publishArtifacts "{core,server,client,endpoint,h2Codec,serverLoom,clientJava,zio,testkit}.jvm.__.publishArtifacts" --username $SONATYPE_USERNAME --password $SONATYPE_PASSWORD` (JVM-only, avoids broken `server.js`/`client.js` shared `Connector/Secret`)
- `MILL_TESTS_PUBLISH_DRY_RUN=1` dry-run verified 18 `4.0.0-SNAPSHOT` artifacts publishing to snapshots repo

## Verification

- `mill mill.scalalib.scalafmt/checkFormatAll` — SUCCESS
- `mill resolve __.publishVersion` → 18 artifacts
- `mill show core.jvm.2_13_18.publishVersion` → `"4.0.0-SNAPSHOT"`
- `mill core.js.3_8_3.compile` — SUCCESS
- Dry-run `mill.javalib.SonatypeCentralPublishModule/publishAll` with JVM brace expansion — SUCCESS (all DeployResults to `central.sonatype.com/repository/maven-snapshots`)

## Base

`v4.x` @ `04e82cfc` — clean workspace `zio-http-v4-snapshot`, isolated from `middleware-v4-final` work

