### PR TITLE
feat(snapshot): auto version via mill.util.VcsVersion (sbt-dynver parity)

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,6 +8,11 @@ concurrency:
   cancel-in-progress: false
 permissions:
   contents: read
+env:
+  JDK_JAVA_OPTIONS: >-
+    -XX:+PrintCommandLineFlags -Xms4G -Xmx8G -XX:+UseG1GC -Xss10M
+    -XX:ReservedCodeCacheSize=1G -XX:NonProfiledCodeHeapSize=512m
+    -Dfile.encoding=UTF-8
 jobs:
   publishSnapshot:
     name: Publish Snapshot
@@ -18,6 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Setup JDK
         uses: coursier/setup-action@v3
         with:

--- a/build.mill
+++ b/build.mill
@@ -8,6 +8,7 @@ import mill.scalajslib.*
 import mill.scalalib.*
 import mill.contrib.jmh.JmhModule
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
+import mill.util.VcsVersion
 
 object Versions {
   val Scala213              = "2.13.18"
@@ -23,8 +24,25 @@ val scalaVersions = Seq(Versions.Scala213, Versions.Scala3)
 val wsRoot        = BuildCtx.workspaceRoot
 
 trait ZioHttpPublishModule extends PublishModule {
-  def publishVersion = Task {
-    sys.env.getOrElse("ZIO_HTTP_SNAPSHOT_VERSION", "4.0.0-SNAPSHOT")
+  def publishVersion = Task.Input {
+    sys.env.get("ZIO_HTTP_SNAPSHOT_VERSION").getOrElse {
+      val state = VcsVersion.calcVcsState(Task.log)
+      val cleanState = if (Task.env.contains("CI")) state.copy(dirtyHash = None) else state
+      cleanState.lastTag match {
+        case Some(tag) if tag.startsWith("v4") || tag.startsWith("4.") =>
+          // On or after v4 tag — use standard dynver format (tag on exact → release, distance → snapshot)
+          cleanState.format(untaggedSuffix = "-SNAPSHOT")
+        case Some(tag) if tag.startsWith("v3") || tag.startsWith("3.") =>
+          // No v4 tag yet — we are on v4 development branch but git describe finds latest v3 tag.
+          // Snapshots must be 4.0.0, not 3.11.x. Use constant snapshot until first v4 tag is cut.
+          "4.0.0-SNAPSHOT"
+        case None =>
+          // No tag found (e.g., shallow clone without tags, or jj workspace without .git)
+          "4.0.0-SNAPSHOT"
+        case _ =>
+          cleanState.format(untaggedSuffix = "-SNAPSHOT")
+      }
+    }
   }
   def pomSettings = Task {
     PomSettings(


### PR DESCRIPTION
## Summary

Follow-up to #4277: replace hardcoded `4.0.0-SNAPSHOT` with auto version via `mill.util.VcsVersion` (Mill built-in, no extra deps), matching `sbt-dynver` / `sbt-ci-release` on `main`.

Closes gap noted after merge: version should be generated, not manual.

## Changes

**`build.mill`**
- Add `import mill.util.VcsVersion` (bundled in `mill-libs-util_3:1.1.7`)
- `ZioHttpPublishModule.publishVersion = Task.Input { sys.env.get("ZIO_HTTP_SNAPSHOT_VERSION").getOrElse { VcsVersion.calcVcsState.format(untaggedSuffix="-SNAPSHOT") } }` with v4-aware fallback:
  - `lastTag` `v4*`/`4.*` → standard dynver: `tag` on exact → release (`4.0.0`), distance → `4.0.0-2-gabc123-SNAPSHOT`
  - `lastTag` `v3*`/`3.*` → constant `4.0.0-SNAPSHOT` (no `v4` tag yet on `v4.x`; avoids publishing `3.11.4-...-SNAPSHOT` for v4 code)
  - `None` → `4.0.0-SNAPSHOT` (shallow clone / jj workspace without `.git`)
  - `Task.Input` + `copy(dirtyHash=None)` when `CI` env (parity with Mill's own `build.mill` and reviewer feedback: avoids stale cache, clean CI version)

**`.github/workflows/snapshot.yml`**
- `fetch-tags: true` (ensure `v*` tags visible to `VcsVersion.calcVcsState`; required after switching to dynver — reviewer noted `fetch-depth: 50` would miss tags)
- `env: JDK_JAVA_OPTIONS: -Xms4G -Xmx8G -XX:+UseG1GC ...` (reviewer low-priority: prevents OOM for 18-artifact publish)

## Verification

- `mill show core.jvm.2_13_18.publishVersion` → `4.0.0-SNAPSHOT` (jj workspace, no `.git` fallback; also case for `v3` tag)
- `ZIO_HTTP_SNAPSHOT_VERSION=9.9.9-SNAPSHOT mill --no-server show ...` → `9.9.9-SNAPSHOT` (env override still works)
- `mill mill.scalalib.scalafmt/checkFormatAll` → SUCCESS
- `MILL_TESTS_PUBLISH_DRY_RUN` still works (version feeds `SonatypeCentralPublishModule` routing to `central.sonatype.com/repository/maven-snapshots`)

## Future

Once first `v4` tag (`v4.0.0` / `v4.0.0-RC1`) is cut, snapshots automatically become `v4.0.0-1-g...-SNAPSHOT` via same path — no further `build.mill` change needed. Exact tag → release without `-SNAPSHOT` (Central Releases).

