### PR TITLE
Add in-memory PEM bytes client SSL config variants

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
@@ -16,7 +16,7 @@
 
 package zio.http.netty.client
 
-import java.io.{File, FileInputStream, InputStream}
+import java.io.{ByteArrayInputStream, File, FileInputStream, InputStream}
 import java.security.KeyStore
 import javax.net.ssl.{KeyManagerFactory, TrustManagerFactory}
 
@@ -26,6 +26,8 @@ import zio.Config.Secret
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import zio.http.ClientSSLCertConfig.{
+  FromClientCertBytes,
+  FromClientCertBytesWithPassword,
   FromClientCertFile,
   FromClientCertFileWithPassword,
   FromClientCertResource,
@@ -95,6 +97,9 @@ private[netty] object ClientSSLConverter {
     case ClientSSLConfig.FromCertResource(certPath)                                                           =>
       val certStream = getClass.getClassLoader.getResourceAsStream(certPath)
       sslContextBuilder.trustManager(certStream)
+    case ClientSSLConfig.FromCertBytes(certBytes)                                                             =>
+      val certStream = new ByteArrayInputStream(certBytes.toArray)
+      sslContextBuilder.trustManager(certStream)
     case ClientSSLConfig.FromTrustStoreResource(trustStorePath, trustStorePassword)                           =>
       val trustStoreStream = getClass.getClassLoader.getResourceAsStream(trustStorePath)
       trustStoreToSslContext(trustStoreStream, trustStorePassword, sslContextBuilder)
@@ -112,6 +117,23 @@ private[netty] object ClientSSLConverter {
         val certInputStream = use(classLoader.getResourceAsStream(certPath))
         val keyInputStream  = use(classLoader.getResourceAsStream(keyPath))
         newBuilder.keyManager(certInputStream, keyInputStream)
+      }.get
+    case ClientSSLConfig.FromClientAndServerCert(serverCertConfig, FromClientCertBytes(certBytes, keyBytes))  =>
+      val newBuilder = buildNettySslContextBuilder(serverCertConfig, sslContextBuilder)
+      Using.Manager { use =>
+        val certInputStream = use(new ByteArrayInputStream(certBytes.toArray))
+        val keyInputStream  = use(new ByteArrayInputStream(keyBytes.toArray))
+        newBuilder.keyManager(certInputStream, keyInputStream)
+      }.get
+    case ClientSSLConfig.FromClientAndServerCert(
+          serverCertConfig,
+          FromClientCertBytesWithPassword(certBytes, keyBytes, keyPassword),
+        ) =>
+      val newBuilder = buildNettySslContextBuilder(serverCertConfig, sslContextBuilder)
+      Using.Manager { use =>
+        val certInputStream = use(new ByteArrayInputStream(certBytes.toArray))
+        val keyInputStream  = use(new ByteArrayInputStream(keyBytes.toArray))
+        newBuilder.keyManager(certInputStream, keyInputStream, keyPassword.value.mkString)
       }.get
     case ClientSSLConfig.FromClientAndServerCert(
           serverCertConfig,

--- a/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/client/ClientSSLConverter.scala
@@ -25,14 +25,7 @@ import scala.util.Using
 import zio.Config.Secret
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import zio.http.ClientSSLCertConfig.{
-  FromClientCertBytes,
-  FromClientCertBytesWithPassword,
-  FromClientCertFile,
-  FromClientCertFileWithPassword,
-  FromClientCertResource,
-  FromClientCertResourceWithPassword,
-}
+import zio.http.ClientSSLCertConfig._
 import zio.http.ClientSSLConfig
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory

--- a/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
@@ -16,11 +16,12 @@
 
 package zio.http
 
+import java.nio.file.{Files, Paths}
 import java.security.cert.X509Certificate
 
-import zio.ZLayer
+import zio.{Chunk, Config, ZLayer}
 import zio.test.Assertion.equalTo
-import zio.test.{Gen, assertCompletes, assertNever, assertZIO}
+import zio.test.{Gen, assertCompletes, assertNever, assertTrue, assertZIO}
 
 import zio.http.SSLConfig.HttpBehaviour
 import zio.http.netty.NettyConfig
@@ -39,6 +40,14 @@ object DualSSLSpec extends ZIOHttpSpec {
   val clientSSLWithClientCert2 = ClientSSLConfig.FromClientAndServerCert(
     clientSSL1,
     ClientSSLCertConfig.FromClientCertResource("client_other.crt", "client_other.key"),
+  )
+
+  private def resourceBytes(name: String): Chunk[Byte] =
+    Chunk.fromArray(Files.readAllBytes(Paths.get(getClass.getResource("/" + name).toURI)))
+
+  val clientSSLWithClientCertBytes = ClientSSLConfig.FromClientAndServerCert(
+    ClientSSLConfig.FromCertBytes(resourceBytes("server.crt")),
+    ClientSSLCertConfig.FromClientCertBytes(resourceBytes("client.crt"), resourceBytes("client.key")),
   )
 
   val sslConfigWithTrustedClient = SSLConfig.fromResource(
@@ -73,6 +82,19 @@ object DualSSLSpec extends ZIOHttpSpec {
       .installRoutes(routes)
       .as(
         List(
+          test("in-memory client cert configs keep the private key out of their rendered form") {
+            val keyBytes     = resourceBytes("client.key")
+            val nested       = ZClient.Config.default.ssl(clientSSLWithClientCertBytes).toString
+            val withPassword = ClientSSLCertConfig
+              .FromClientCertBytesWithPassword(resourceBytes("client.crt"), keyBytes, Config.Secret("key-password"))
+              .toString
+
+            assertTrue(
+              !nested.contains(keyBytes.toString),
+              !withPassword.contains(keyBytes.toString),
+              !withPassword.contains("key-password"),
+            )
+          },
           test("succeed when client has the server certificate and client certificate is configured") {
             val actual =
               Client.batched(Request.get(httpsUrl)).flatMap(r => r.body.asString.map(body => (r.status, body)))
@@ -80,6 +102,17 @@ object DualSSLSpec extends ZIOHttpSpec {
           }.provide(
             Client.customized,
             ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCert)),
+            NettyClientDriver.live,
+            DnsResolver.default,
+            ZLayer.succeed(NettyConfig.defaultWithFastShutdown),
+          ),
+          test("succeed when server trust and client certificate are supplied as in-memory bytes") {
+            val actual =
+              Client.batched(Request.get(httpsUrl)).flatMap(r => r.body.asString.map(body => (r.status, body)))
+            assertZIO(actual)(equalTo((Status.Ok, "O=client1,ST=Some-State,C=AU")))
+          }.provide(
+            Client.customized,
+            ZLayer.succeed(ZClient.Config.default.ssl(clientSSLWithClientCertBytes)),
             NettyClientDriver.live,
             DnsResolver.default,
             ZLayer.succeed(NettyConfig.defaultWithFastShutdown),

--- a/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/DualSSLSpec.scala
@@ -19,9 +19,9 @@ package zio.http
 import java.nio.file.{Files, Paths}
 import java.security.cert.X509Certificate
 
-import zio.{Chunk, Config, ZLayer}
 import zio.test.Assertion.equalTo
 import zio.test.{Gen, assertCompletes, assertNever, assertTrue, assertZIO}
+import zio.{Chunk, Config, ZLayer}
 
 import zio.http.SSLConfig.HttpBehaviour
 import zio.http.netty.NettyConfig

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLCertConfig.scala
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2020 Eaglescience Software B.V.
 package zio.http
 
-import zio.Config
+import zio.{Chunk, Config}
 
 sealed trait ClientSSLCertConfig
 
@@ -34,5 +34,38 @@ object ClientSSLCertConfig {
       extends ClientSSLCertConfig
   final case class FromClientCertResourceWithPassword(certPath: String, keyPath: String, keyPassword: Config.Secret)
       extends ClientSSLCertConfig
+
+  /**
+   * Client certificate and private key supplied directly as in-memory PEM bytes
+   */
+  final case class FromClientCertBytes(certBytes: Chunk[Byte], keyBytes: Chunk[Byte]) extends ClientSSLCertConfig {
+    override def toString: String = s"FromClientCertBytes(<${certBytes.size} cert bytes>, <redacted key>)"
+  }
+  object FromClientCertBytes {
+    def apply(certBytes: Array[Byte], keyBytes: Array[Byte]): FromClientCertBytes =
+      FromClientCertBytes(Chunk.fromArray(certBytes), Chunk.fromArray(keyBytes))
+  }
+
+  /**
+   * Same as [[FromClientCertBytes]] but for a password-encrypted private key.
+   */
+  final case class FromClientCertBytesWithPassword(
+    certBytes: Chunk[Byte],
+    keyBytes: Chunk[Byte],
+    keyPassword: Config.Secret,
+  ) extends ClientSSLCertConfig {
+
+    /** @see [[FromClientCertBytes.toString]] */
+    override def toString: String =
+      s"FromClientCertBytesWithPassword(<${certBytes.size} cert bytes>, <redacted key>, <redacted password>)"
+  }
+  object FromClientCertBytesWithPassword {
+    def apply(
+      certBytes: Array[Byte],
+      keyBytes: Array[Byte],
+      keyPassword: Config.Secret,
+    ): FromClientCertBytesWithPassword =
+      FromClientCertBytesWithPassword(Chunk.fromArray(certBytes), Chunk.fromArray(keyBytes), keyPassword)
+  }
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
@@ -16,7 +16,7 @@
 
 package zio.http
 
-import zio.Config
+import zio.{Chunk, Config}
 import zio.Config.Secret
 
 sealed trait ClientSSLConfig
@@ -97,9 +97,15 @@ object ClientSSLConfig {
     )
   }
 
-  case object Default                                                                         extends ClientSSLConfig
-  final case class FromCertFile(certPath: String)                                             extends ClientSSLConfig
-  final case class FromCertResource(certPath: String)                                         extends ClientSSLConfig
+  case object Default                                    extends ClientSSLConfig
+  final case class FromCertFile(certPath: String)        extends ClientSSLConfig
+  final case class FromCertResource(certPath: String)    extends ClientSSLConfig
+  // No redacted toString: these are server trust bytes (a public certificate), not secret key material.
+  final case class FromCertBytes(certBytes: Chunk[Byte]) extends ClientSSLConfig
+  object FromCertBytes {
+    def apply(certBytes: Array[Byte]): FromCertBytes = FromCertBytes(Chunk.fromArray(certBytes))
+  }
+
   final case class FromTrustStoreResource(trustStorePath: String, trustStorePassword: Secret) extends ClientSSLConfig
   final case class FromClientAndServerCert(
     serverCertConfig: ClientSSLConfig,

--- a/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
+++ b/zio-http/shared/src/main/scala/zio/http/ClientSSLConfig.scala
@@ -16,8 +16,8 @@
 
 package zio.http
 
-import zio.{Chunk, Config}
 import zio.Config.Secret
+import zio.{Chunk, Config}
 
 sealed trait ClientSSLConfig
 


### PR DESCRIPTION
Adds byte-based alternatives to the existing file and resource based client SSL configs, so callers can supply certificates and keys that are already in memory (e.g. loaded from a vault or secret manager) instead of requiring an on-disk path or classpath resource.

Closes https://github.com/zio/zio-http/issues/4281