### PR TITLE
feat(h2): P1 hardening deltas — body cap, deadlines, proxy trust, access log

### DIFF
--- a/docs/reference/h2-server.md
+++ b/docs/reference/h2-server.md
@@ -89,6 +89,81 @@ timeouts surface as `RST_STREAM(CANCEL)`. Both run on Loom virtual threads,
 sharing the connection's single write lock. See `IdleTimeoutGoAwaySpec` and
 the idle leg of `H2HardeningIntegrationSpec`.
 
+## Hardening: bounds, trust, access log, raw-body tap
+
+Operator reference for the general hardening knobs. Every default below is
+read off `Connector` (`zio-http-server/shared/src/main/scala/zio/http/Connector.scala`,
+companion `Default*` vals) or `ClientConfig`
+(`zio-http-client/shared/src/main/scala/zio/http/ClientConfig.scala`) — not
+guessed. The server knobs live on the top-level `Connector` and apply across
+H2/H3 at the config-concept level; only the H2 transport enforces them today
+(H3 wiring is future work). Wire-only settings stay on `Http2Config` (see
+above).
+
+| Knob | Default | Enforcement point | Violation signal |
+| ---- | ------- | ----------------- | ---------------- |
+| `maxRequestBodySize` | `1 MiB` (`1024L * 1024L`, `DefaultMaxRequestBodySize`) | `H2Transport.readRequestBody`: DATA payloads accounted incrementally, never buffered past the cap; a declared `content-length` over the cap is rejected before any body bytes are read | Over cap: `RST_STREAM(FLOW_CONTROL_ERROR)`; declared-vs-received mismatch or malformed length: `RST_STREAM(PROTOCOL_ERROR)`; per-stream, connection survives |
+| `requestTimeoutMs` | `30000` (30 s, `DefaultRequestTimeoutMs`) | Per-stream request timer: whole-request deadline from stream start until the response completes. Non-positive disables | `RST_STREAM(CANCEL)`, per-stream; connection survives |
+| `headerTimeoutMs` | `5000` (5 s, `DefaultHeaderTimeoutMs`) | `H2Connection` pending headers + `H2Transport.awaitHeaders`: time-to-complete from stream start covering trailing `CONTINUATION` frames and first `HEADERS` delivery. Non-positive disables | `RST_STREAM(CANCEL)`, per-stream; connection survives |
+| `bodyTimeoutMs` | `10000` (10 s, `DefaultBodyTimeoutMs`) | `H2Transport.readRequestBody` / `awaitFrame`: time-to-complete from stream start until the full body arrives — total elapsed, so a drip that keeps moving but too slowly still times out. Non-positive disables | `RST_STREAM(CANCEL)`, per-stream; connection survives |
+| `trustedProxy` | default-deny (`TrustedProxyConfig.default`: empty `trustedCidrs`, `trustPeerCert = false`) | `H2Transport.resolveProxyTrust`: forwarding headers (`X-Forwarded-For/Proto/Host`, RFC 7239 `Forwarded`) are honored only for allowlisted-CIDR or mTLS-authenticated peers; otherwise stripped with zero effect. Either way the raw forwarding headers plus any wire `x-client-ip` / `x-peer-address` are removed and re-added as normalized `x-peer-address` (socket peer) + `x-client-ip` (resolved client) | Spoofed headers ignored; client IP falls back to the socket peer address |
+| `ClientConfig.maxResponseBodySize` | `16 MiB` (`16L * 1024L * 1024L`, `ClientConfig.DefaultMaxResponseBodySize`) | Every client leg accounts response bytes incrementally and fails fast past the cap: the one-shot `H2WireClient` leg (cap threaded from the driver), the pooled `PooledLoomH2Client` leg (lazy streaming bodies), the JDK `JavaH2Client` leg (bounded subscriber). Non-positive fails fast at config construction | `ResponseBodyTooLarge(maxBytes)` on every leg. Deliberately unchecked: the pooled leg streams through `Body.toArray`, which treats a mid-pull `IOException` as truncation — a checked cap would fail silently there. The one-shot driver never falls back to the JDK h1.1 leg on this error (the H2 exchange itself succeeded) |
+| Log sink | `Middleware.accessLog(sink)` opt-in; transports emit nothing by default (no console noise, no per-request record) | One `AccessLogRecord` per served request that reaches a route: method, path (logged verbatim — standard access-log behavior, no scrub hook), route, status, duration (handler wall-clock only — response-body send time is excluded), request-id (sanitized: `[A-Za-z0-9-._~]` only, truncated to 128 chars, generated UUID when absent or empty after sanitizing), peer/client addresses, trust decision, deadline outcome (`ok` — the only outcome any built-in emitter reports; `header-timeout` / `body-timeout` are reserved for future transport-side timeout reporting and never emitted today, and streams reset by a deadline yield no record at all), protocol (request version string). The record is metadata-only by construction (no body/header-map/stream handle — verified by reflection in `H2AccessLogSpec`). `AccessLog.emit` swallows sink failures, so logging can never fail a request | N/A (never fails requests) |
+| Raw-body tap | `request.body.toChunk` (synchronous, zio-blocks http-model `Body`) | `H2Transport` reassembles DATA payloads byte-identically under `maxRequestBodySize`; handlers tap `request.body.toChunk` FIRST and decode into domain types second. No verification logic lives here | N/A |
+
+Example:
+
+```scala mdoc:compile-only
+import zio.http._
+
+val connector = Connector(
+  bind = BindAddress.localhost(8080),
+  protocol = Protocol.H2C(),
+  maxRequestBodySize = Connector.DefaultMaxRequestBodySize, // 1 MiB
+  requestTimeoutMs = Connector.DefaultRequestTimeoutMs,     // 30 s
+  headerTimeoutMs = Connector.DefaultHeaderTimeoutMs,       // 5 s
+  bodyTimeoutMs = Connector.DefaultBodyTimeoutMs,           // 10 s
+  trustedProxy = TrustedProxyConfig(trustedCidrs = Set("10.0.0.0/8")),
+)
+
+val logged = routes @@ Middleware.accessLog(AccessLogSink.console)
+```
+
+### Isolation contract
+
+Every bound/timeout violation above is per-stream: the offending stream is
+reset with the listed code and sibling streams on the same connection keep
+working. The one exception is a peer that violates the HPACK contract itself
+(e.g. an undecodable header block): that corrupts connection-level
+compression state, so the server tears the connection down instead of serving
+anything on it. The combined matrix (`H2HardeningMatrixSpec`) pins all of
+this against a real loopback `LoomServer`.
+
+### Qaizn handoff
+
+v4 preserves bytes; Qaizn decides what they mean.
+
+- The v4 contract ends at the `toChunk` tap: `H2Transport` delivers the DATA
+  payloads byte-identically, and the handler hashes `request.body.toChunk`
+  BEFORE any decoding (`H2RawBodySpec` pins this with the RFC 4231 Test Case 1
+  HMAC-SHA256 vector). v4 performs no HMAC verification, no dedup, no
+  reconciliation.
+- Qaizn consumes `(keyId, messageBytes, macHex)` triples produced exactly at
+  that tap point and owns accept/reject: it verifies the HMAC against stored
+  keys, dedupes repeat deliveries, and reconciles MACs across its own store.
+- Access/audit logging stays metadata-only: body bytes must never reach the
+  log sink (pinned by `H2AccessLogSpec` and the matrix sink cell), so any
+  payload Qaizn needs for reconciliation must travel via its own channel, not
+  the access log.
+
+### Migration note (strict defaults)
+
+Defaults are strict: 1 MiB body cap (`maxRequestBodySize`), 10 s total body
+timeout (`bodyTimeoutMs`), 8192-byte header cap (`maxHeaderListSize`), 16 MiB
+response cap (`ClientConfig.maxResponseBodySize`). Raise them via the general
+`Connector` / `ClientConfig` knobs when legitimate traffic exceeds them — the
+violation signals above tell you which knob to turn.
+
 ## Outbound client: `PooledLoomH2Client`
 
 `PooledLoomH2Client` is a blocking, virtual-thread H2 client that reuses the

--- a/zio-http-client-java/src/main/scala/zio/http/H2WireClient.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/H2WireClient.scala
@@ -37,13 +37,19 @@ import zio.http.h2.hpack.Hpack
 @experimental
 private[http] object H2WireClient {
 
-  private val Preface: Array[Byte]           = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
-  private val StreamId: Int                  = 1
-  private val DefaultMaxFrame: Int           = 16384
-  private val DefaultSendWindow: Int         = 65535
-  private val ConnectionStream: Int          = 0
-  private val MaxHeaderBytes: Int            = 65536
-  private val MaxBodyBytes: Long             = 16L * 1024L * 1024L
+  private val Preface: Array[Byte]   = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+  private val StreamId: Int          = 1
+  private val DefaultMaxFrame: Int   = 16384
+  private val DefaultSendWindow: Int = 65535
+  private val ConnectionStream: Int  = 0
+  private val MaxHeaderBytes: Int    = 65536
+
+  /**
+   * Default response-body cap, sourced from [[ClientConfig]] so every client
+   * leg enforces the same bound. Callers with a config pass
+   * `config.maxResponseBodySize` explicitly via [[execute]].
+   */
+  private val MaxBodyBytes: Long             = ClientConfig.DefaultMaxResponseBodySize
   private val ConnectionHeaders: Set[String] =
     Set("connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade")
 
@@ -61,6 +67,7 @@ private[http] object H2WireClient {
     scheme: String,
     authority: String,
     target: String,
+    maxBodyBytes: Long = MaxBodyBytes,
   ): Response = {
     val reader = new FrameReader(input)
     output.write(Preface)
@@ -75,7 +82,7 @@ private[http] object H2WireClient {
     output.flush()
     sendBody(output, reader, body, negotiated)
 
-    readResponse(reader, output)
+    readResponse(reader, output, maxBodyBytes)
   }
 
   private final class Negotiated(var maxFrameSize: Int, var sendWindow: Int)
@@ -168,7 +175,7 @@ private[http] object H2WireClient {
       case _                                         => ()
     }
 
-  private def readResponse(reader: FrameReader, output: OutputStream): Response = {
+  private def readResponse(reader: FrameReader, output: OutputStream, maxBodyBytes: Long): Response = {
     val headerBytes = new ByteArrayOutputStream()
     var endStream   = false
     var headersDone = false
@@ -215,7 +222,7 @@ private[http] object H2WireClient {
 
     val bodyBytes   =
       if (endStream) Array.emptyByteArray
-      else readBody(reader, output)
+      else readBody(reader, output, maxBodyBytes)
     val contentType =
       headers.get(Header.ContentType).map(_.value).getOrElse(ContentType.`application/octet-stream`)
 
@@ -250,7 +257,7 @@ private[http] object H2WireClient {
     }
   }
 
-  private def readBody(reader: FrameReader, output: OutputStream): Array[Byte] = {
+  private def readBody(reader: FrameReader, output: OutputStream, maxBodyBytes: Long): Array[Byte] = {
     val collected = new ByteArrayOutputStream()
     var total     = 0L
     var done      = false
@@ -259,7 +266,7 @@ private[http] object H2WireClient {
         case Data(StreamId, data, streamEnd, _)       =>
           val bytes = data.toArray
           total += bytes.length
-          if (total > MaxBodyBytes) throw new IOException("HTTP/2 response body exceeds 16 MiB cap (T15: streaming)")
+          if (total > maxBodyBytes) throw ResponseBodyTooLarge(maxBodyBytes)
           collected.write(bytes, 0, bytes.length)
           // Replenish connection- and stream-level flow-control windows as we
           // consume, so multi-DATA-frame responses never stall.

--- a/zio-http-client-java/src/main/scala/zio/http/H2WireClient.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/H2WireClient.scala
@@ -264,10 +264,11 @@ private[http] object H2WireClient {
     while (!done) {
       reader.readFrame() match {
         case Data(StreamId, data, streamEnd, _)       =>
+          val len   = data.length
+          if (total + len > maxBodyBytes) throw ResponseBodyTooLarge(maxBodyBytes)
           val bytes = data.toArray
-          total += bytes.length
-          if (total > maxBodyBytes) throw ResponseBodyTooLarge(maxBodyBytes)
           collected.write(bytes, 0, bytes.length)
+          total += bytes.length
           // Replenish connection- and stream-level flow-control windows as we
           // consume, so multi-DATA-frame responses never stall.
           writeFrame(output, WindowUpdate(ConnectionStream, bytes.length))

--- a/zio-http-client-java/src/main/scala/zio/http/JavaH2Client.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/JavaH2Client.scala
@@ -1,15 +1,22 @@
 package zio.http
 
+import java.io.ByteArrayOutputStream
+import java.io.IOException
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Flow
 
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLHandshakeException
 
 import scala.annotation.experimental
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 /**
  * JDK `HttpClient`-backed [[Client]].
@@ -39,7 +46,7 @@ class JavaH2Client(
 
   def send(request: Request): Response = {
     val javaRequest  = toJavaRequest(request)
-    val javaResponse = httpClient.send(javaRequest, HttpResponse.BodyHandlers.ofByteArray())
+    val javaResponse = httpClient.send(javaRequest, JavaH2Client.boundedByteArrayHandler(config.maxResponseBodySize))
 
     val response = toResponse(javaResponse)
     enforcePolicy(response.version)
@@ -121,6 +128,14 @@ class JavaH2Client(
 
 object JavaH2Client {
 
+  /**
+   * Default response-body cap, sourced from [[ClientConfig]] so every client
+   * leg enforces the same bound. Raise via
+   * `ClientConfig(maxResponseBodySize = ...)`; the default preserves existing
+   * call sites.
+   */
+  val DefaultMaxResponseBodySize: Long = ClientConfig.DefaultMaxResponseBodySize
+
   def default: JavaH2Client = apply(ClientConfig())
 
   def apply(config: ClientConfig): JavaH2Client = {
@@ -158,6 +173,62 @@ object JavaH2Client {
    */
   private def selectedVersion(config: ClientConfig): HttpClient.Version =
     HttpClient.Version.HTTP_2
+
+  /**
+   * Response-body handler that accounts bytes incrementally and fails fast past
+   * `maxBytes`: the subscription is cancelled the moment the cap is exceeded,
+   * so a malicious server cannot force unbounded `ofByteArray` buffering on the
+   * client.
+   */
+  private[http] def boundedByteArrayHandler(
+    maxBytes: Long = DefaultMaxResponseBodySize,
+  ): HttpResponse.BodyHandler[Array[Byte]] =
+    new HttpResponse.BodyHandler[Array[Byte]] {
+      override def apply(responseInfo: HttpResponse.ResponseInfo): HttpResponse.BodySubscriber[Array[Byte]] =
+        new BoundedByteArraySubscriber(maxBytes)
+    }
+
+  private final class BoundedByteArraySubscriber(maxBytes: Long) extends HttpResponse.BodySubscriber[Array[Byte]] {
+    private val buffer       = new ByteArrayOutputStream()
+    private val result       = new CompletableFuture[Array[Byte]]()
+    private var subscription = Option.empty[Flow.Subscription]
+    private var total: Long  = 0L
+
+    override def onSubscribe(subscription: Flow.Subscription): Unit = {
+      this.subscription = Some(subscription)
+      subscription.request(Long.MaxValue)
+    }
+
+    override def onNext(items: java.util.List[ByteBuffer]): Unit =
+      try {
+        val iterator = items.iterator()
+        while (iterator.hasNext) {
+          val chunk = iterator.next()
+          val size  = chunk.remaining().toLong
+          if (total + size > maxBytes) {
+            subscription.foreach(_.cancel())
+            result.completeExceptionally(ResponseBodyTooLarge(maxBytes))
+            return
+          }
+          val bytes = new Array[Byte](chunk.remaining())
+          chunk.get(bytes)
+          buffer.write(bytes, 0, bytes.length)
+          total += size
+        }
+      } catch {
+        case NonFatal(error) =>
+          subscription.foreach(_.cancel())
+          result.completeExceptionally(error)
+      }
+
+    override def onError(throwable: Throwable): Unit =
+      result.completeExceptionally(throwable)
+
+    override def onComplete(): Unit =
+      result.complete(buffer.toByteArray)
+
+    override def getBody: CompletionStage[Array[Byte]] = result
+  }
 
   private def configuredHttpClient(
     config: ClientConfig,

--- a/zio-http-client-java/src/main/scala/zio/http/JavaH2Client.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/JavaH2Client.scala
@@ -189,14 +189,14 @@ object JavaH2Client {
     }
 
   private final class BoundedByteArraySubscriber(maxBytes: Long) extends HttpResponse.BodySubscriber[Array[Byte]] {
-    private val buffer       = new ByteArrayOutputStream()
-    private val result       = new CompletableFuture[Array[Byte]]()
-    private var subscription = Option.empty[Flow.Subscription]
-    private var total: Long  = 0L
+    private val buffer                          = new ByteArrayOutputStream()
+    private val result                          = new CompletableFuture[Array[Byte]]()
+    private var subscription: Flow.Subscription = null
+    private var total: Long                     = 0L
 
-    override def onSubscribe(subscription: Flow.Subscription): Unit = {
-      this.subscription = Some(subscription)
-      subscription.request(Long.MaxValue)
+    override def onSubscribe(s: Flow.Subscription): Unit = {
+      subscription = s
+      s.request(Long.MaxValue)
     }
 
     override def onNext(items: java.util.List[ByteBuffer]): Unit =
@@ -206,7 +206,8 @@ object JavaH2Client {
           val chunk = iterator.next()
           val size  = chunk.remaining().toLong
           if (total + size > maxBytes) {
-            subscription.foreach(_.cancel())
+            val s = subscription
+            if (s != null) s.cancel()
             result.completeExceptionally(ResponseBodyTooLarge(maxBytes))
             return
           }
@@ -217,7 +218,8 @@ object JavaH2Client {
         }
       } catch {
         case NonFatal(error) =>
-          subscription.foreach(_.cancel())
+          val s = subscription
+          if (s != null) s.cancel()
           result.completeExceptionally(error)
       }
 

--- a/zio-http-client-java/src/main/scala/zio/http/LoomH2ClientDriver.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/LoomH2ClientDriver.scala
@@ -89,8 +89,21 @@ class LoomH2ClientDriver(
     val socket = connectPlain(host, port)
     try {
       val (scheme, authority, target) = pseudoParts(request, 80)
-      H2WireClient.execute(socket.getInputStream, socket.getOutputStream, request, scheme, authority, target)
+      H2WireClient.execute(
+        socket.getInputStream,
+        socket.getOutputStream,
+        request,
+        scheme,
+        authority,
+        target,
+        config.maxResponseBodySize,
+      )
     } catch {
+      // The H2 exchange itself succeeded: a fallback would only re-download
+      // the same over-cap body under another protocol and mask the cause.
+      case cap: ResponseBodyTooLarge                                                       =>
+        closeQuietly(socket)
+        throw cap
       case NonFatal(failure) if config.alpn == ClientAlpnPolicy.H2PreferredWithH11Fallback =>
         closeQuietly(socket)
         h11Fallback().send(request)
@@ -116,7 +129,15 @@ class LoomH2ClientDriver(
         case "h2"       =>
           try {
             val (scheme, authority, target) = pseudoParts(request, 443)
-            H2WireClient.execute(socket.getInputStream, socket.getOutputStream, request, scheme, authority, target)
+            H2WireClient.execute(
+              socket.getInputStream,
+              socket.getOutputStream,
+              request,
+              scheme,
+              authority,
+              target,
+              config.maxResponseBodySize,
+            )
           } finally {
             closeQuietly(socket)
           }

--- a/zio-http-client-java/src/main/scala/zio/http/PooledLoomH2Client.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/PooledLoomH2Client.scala
@@ -510,9 +510,16 @@ final class PooledLoomH2Client private (
         // fromReader keeps the error channel at Nothing: transport failures
         // surface as thrown defects (uniform with the blocking Client style),
         // and pulls stay chunk-granular (heap-bounded, no per-byte boxing).
+        // The cap counts response bytes incrementally and fails fast past
+        // `config.maxResponseBodySize`, so a malicious server cannot force
+        // unbounded lazy accumulation on the client; the uncapped raw input
+        // stays on the checkout, so a capped body never reports clean
+        // completion and its connection is evicted, never repooled.
         val stream: zio.blocks.streams.Stream[Nothing, Byte] =
           zio.blocks.streams.Stream.fromReader(
-            zio.blocks.streams.io.Reader.fromInputStream(exchange.bodyInput.orNull),
+            zio.blocks.streams.io.Reader.fromInputStream(
+              new PooledLoomH2Client.CappedResponseStream(exchange.bodyInput.orNull, config.maxResponseBodySize),
+            ),
           )
         val lazyBody = stream.ensuring(if (released.compareAndSet(false, true)) checkout.finish())
         Response(
@@ -539,7 +546,6 @@ final class PooledLoomH2Client private (
 
 @experimental
 object PooledLoomH2Client {
-
   final case class Stats(checkedOut: Int, idle: Int, queued: Int)
 
   def apply(config: ClientConfig): PooledLoomH2Client =
@@ -552,6 +558,35 @@ object PooledLoomH2Client {
    */
   def apply(config: ClientConfig, sslContext: SSLContext): PooledLoomH2Client =
     new PooledLoomH2Client(config, Some(sslContext))
+
+  /**
+   * Response-body cap for the pooled (lazy-streaming) leg: counts bytes
+   * incrementally across `read` calls and throws [[IOException]] the moment the
+   * total crosses `maxBytes`, so a malicious server cannot force unbounded
+   * accumulation. Same fail-fast idiom as the one-shot [[H2WireClient]] cap,
+   * applied at the `InputStream` seam so no connection machinery changes.
+   */
+  private[http] final class CappedResponseStream(underlying: java.io.InputStream, maxBytes: Long)
+      extends java.io.FilterInputStream(underlying) {
+    private var total: Long = 0L
+
+    private def check(count: Int): Int = {
+      if (count > 0) {
+        total += count.toLong
+        if (total > maxBytes) throw ResponseBodyTooLarge(maxBytes)
+      }
+      count
+    }
+
+    override def read(): Int = {
+      val byte = super.read()
+      check(if (byte < 0) 0 else 1)
+      byte
+    }
+
+    override def read(buffer: Array[Byte], offset: Int, length: Int): Int =
+      check(super.read(buffer, offset, length))
+  }
 }
 
 /**

--- a/zio-http-client-java/src/main/scala/zio/http/ResponseBodyTooLarge.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/ResponseBodyTooLarge.scala
@@ -1,0 +1,25 @@
+package zio.http
+
+/**
+ * Thrown when a response body crosses `ClientConfig.maxResponseBodySize`.
+ *
+ * Every client leg (one-shot [[H2WireClient]], pooled [[PooledLoomH2Client]],
+ * JDK [[JavaH2Client]]) accounts body bytes incrementally and fails fast with
+ * this error the moment the cap is exceeded, so a malicious server cannot force
+ * unbounded buffering. It carries the configured cap for operability.
+ *
+ * Deliberately unchecked: the pooled leg streams bodies lazily through
+ * `Body.toArray`, which treats a mid-pull [[java.io.IOException]] as truncation
+ * and returns collected-so-far silently — a checked cap would fail silently
+ * there. As a [[RuntimeException]] the trip surfaces loudly on every leg; catch
+ * it explicitly.
+ *
+ * Control-flow note: [[LoomH2ClientDriver]] never falls back to the JDK
+ * HTTP/1.1 leg on this error — the H2 exchange itself succeeded, so a fallback
+ * would only re-download the same over-cap body under another protocol and mask
+ * the cause.
+ */
+final case class ResponseBodyTooLarge(maxBytes: Long)
+    extends RuntimeException(
+      s"HTTP response body exceeded client cap of $maxBytes bytes",
+    )

--- a/zio-http-client-java/src/main/scala/zio/http/ResponseBodyTooLarge.scala
+++ b/zio-http-client-java/src/main/scala/zio/http/ResponseBodyTooLarge.scala
@@ -19,7 +19,14 @@ package zio.http
  * would only re-download the same over-cap body under another protocol and mask
  * the cause.
  */
-final case class ResponseBodyTooLarge(maxBytes: Long)
+final class ResponseBodyTooLarge(val maxBytes: Long)
     extends RuntimeException(
       s"HTTP response body exceeded client cap of $maxBytes bytes",
     )
+
+object ResponseBodyTooLarge {
+  def apply(maxBytes: Long): ResponseBodyTooLarge = new ResponseBodyTooLarge(maxBytes)
+
+  def unapply(error: ResponseBodyTooLarge): Option[Long] =
+    if (error == null) None else Some(error.maxBytes)
+}

--- a/zio-http-client-java/src/test/scala/zio/http/ClientResponseCapSpec.scala
+++ b/zio-http-client-java/src/test/scala/zio/http/ClientResponseCapSpec.scala
@@ -1,0 +1,244 @@
+package zio.http
+
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+
+/**
+ * Response-body caps on every client leg, all sourced from
+ * `ClientConfig.maxResponseBodySize` (default 16 MiB, matching the one-shot
+ * wire cap).
+ *
+ * A malicious server must not force unbounded buffering: bodies are accounted
+ * incrementally and the request fails fast past the cap — the one-shot
+ * [[H2WireClient]] leg (via [[LoomH2ClientDriver]]), the pooled
+ * [[PooledLoomH2Client]] leg (lazy streaming bodies), and the JDK
+ * [[JavaH2Client]] leg (bounded subscriber instead of `ofByteArray`).
+ *
+ * Real servers, tiny caps (4 KiB) against a 256 KiB body: H2 legs run against a
+ * real [[LoomServer]]; the JDK leg runs against the JDK-built-in HTTP/1.1
+ * server (no new dependencies — the JDK client downgrades to `http/1.1` there,
+ * which also proves the cap lives on the body handler, not the protocol leg).
+ */
+@experimental
+object ClientResponseCapSpec extends ZIOSpecDefault {
+
+  private val BigBodySize: Int = 256 * 1024
+  private val TinyCap: Long    = 4096L
+
+  private val BigBytes: Array[Byte] = Array.fill(BigBodySize)(0x41.toByte)
+
+  private val BigRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.GET,
+        handler { (_: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = Body.fromArray(BigBytes)))
+        },
+      ),
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("ClientResponseCapSpec")(
+      test("one-shot leg fails fast past a tiny cap") {
+        withLoomServer { port =>
+          ZIO.attemptBlocking {
+            val driver  = LoomH2ClientDriver(ClientConfig(maxResponseBodySize = TinyCap))
+            val failure =
+              try {
+                driver.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+                None
+              } catch {
+                case failure: ResponseBodyTooLarge => Some(failure)
+                case failure: Throwable            => None
+              }
+            assertTrue(failure.exists(_.maxBytes == TinyCap))
+          }
+        }
+      },
+      test("one-shot leg succeeds under the default cap") {
+        withLoomServer { port =>
+          ZIO.attemptBlocking {
+            val driver   = LoomH2ClientDriver(ClientConfig())
+            val response = driver.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+            assertTrue(
+              response.status == Status.Ok,
+              response.body.toArray.sameElements(BigBytes),
+            )
+          }
+        }
+      },
+      test("pooled leg fails fast past a tiny cap") {
+        withLoomServer { port =>
+          ZIO.attemptBlocking {
+            val pool = PooledLoomH2Client(ClientConfig(maxResponseBodySize = TinyCap))
+            try {
+              val response = pool.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+              val failure  =
+                try {
+                  response.body.toArray
+                  None
+                } catch {
+                  case failure: ResponseBodyTooLarge => Some(failure)
+                  case failure: Throwable            => None
+                }
+              assertTrue(response.status == Status.Ok, failure.exists(_.maxBytes == TinyCap))
+            } finally pool.close()
+          }
+        }
+      },
+      test("pooled leg succeeds under the default cap") {
+        withLoomServer { port =>
+          ZIO.attemptBlocking {
+            val pool = PooledLoomH2Client(ClientConfig())
+            try {
+              val response = pool.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+              assertTrue(
+                response.status == Status.Ok,
+                response.body.toArray.sameElements(BigBytes),
+              )
+            } finally pool.close()
+          }
+        }
+      },
+      test("JDK leg fails fast past a tiny cap") {
+        withJdkServer { port =>
+          ZIO.attemptBlocking {
+            val client  = JavaH2Client(ClientConfig(maxResponseBodySize = TinyCap))
+            val failure =
+              try {
+                client.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+                None
+              } catch {
+                case failure: Throwable => Some(failureToString(failure))
+              }
+            assertTrue(failure.exists(_.contains("client cap")))
+          }
+        }
+      },
+      test("JDK leg succeeds under the default cap") {
+        withJdkServer { port =>
+          ZIO.attemptBlocking {
+            val client   = JavaH2Client(ClientConfig())
+            val response = client.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
+            assertTrue(
+              response.status == Status.Ok,
+              response.body.toArray.sameElements(BigBytes),
+            )
+          }
+        }
+      },
+      test("default cap is 16 MiB and non-positive caps fail fast") {
+        ZIO.attempt {
+          val rejectsZero     = rejects(ClientConfig(maxResponseBodySize = 0L))
+          val rejectsNegative = rejects(ClientConfig(maxResponseBodySize = -1L))
+          assertTrue(
+            ClientConfig.DefaultMaxResponseBodySize == 16L * 1024L * 1024L,
+            ClientConfig().maxResponseBodySize == ClientConfig.DefaultMaxResponseBodySize,
+            JavaH2Client.DefaultMaxResponseBodySize == ClientConfig.DefaultMaxResponseBodySize,
+            rejectsZero,
+            rejectsNegative,
+          )
+        }
+      },
+      test("capped stream counts incrementally and trips exactly past the cap") {
+        ZIO.attempt {
+          val under     = new PooledLoomH2Client.CappedResponseStream(
+            new java.io.ByteArrayInputStream(Array.fill(100)(1.toByte)),
+            100L,
+          )
+          val underRead = under.read(new Array[Byte](100), 0, 100)
+          val over      = new PooledLoomH2Client.CappedResponseStream(
+            new java.io.ByteArrayInputStream(Array.fill(101)(1.toByte)),
+            100L,
+          )
+          val tripped   =
+            try {
+              val buf = new Array[Byte](101)
+              var got = 0
+              var n   = over.read(buf, 0, 101)
+              while (n >= 0) { got += n; n = over.read(buf, 0, 101) }
+              None
+            } catch {
+              case failure: ResponseBodyTooLarge => Some(failure.maxBytes)
+            }
+          assertTrue(underRead == 100, tripped.contains(100L))
+        }
+      },
+    ) @@ sequential
+
+  private def rejects(thunk: => Any): Boolean =
+    try {
+      thunk
+      false
+    } catch {
+      case _: IllegalArgumentException => true
+    }
+
+  /** Unwraps ExecutionException chains so the cap message is observable. */
+  private def failureToString(failure: Throwable): String = {
+    val builder = new StringBuilder()
+    var current = failure
+    while (current != null) {
+      builder.append(current.toString).append(" <- ")
+      current = current.getCause
+    }
+    builder.toString
+  }
+
+  private def absUrl(raw: String): URL =
+    URL.parse(raw).fold(err => throw new IllegalArgumentException("Invalid test URL: " + err), identity)
+
+  private def withLoomServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          new LoomServer(Connector(bind = BindAddress.localhost(0))).serve(BigRoutes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private def withJdkServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val server = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+          server.createContext(
+            "/",
+            (exchange: com.sun.net.httpserver.HttpExchange) => {
+              exchange.sendResponseHeaders(200, BigBytes.length.toLong)
+              val out = exchange.getResponseBody
+              try out.write(BigBytes, 0, BigBytes.length)
+              finally {
+                out.close()
+                exchange.close()
+              }
+            },
+          )
+          server.setExecutor(null)
+          server.start()
+          server
+        },
+      )(server => ZIO.succeed(server.stop(0)))
+      .flatMap(server => use(server.getAddress.getPort))
+}

--- a/zio-http-client-java/src/test/scala/zio/http/ClientResponseCapSpec.scala
+++ b/zio-http-client-java/src/test/scala/zio/http/ClientResponseCapSpec.scala
@@ -59,8 +59,9 @@ object ClientResponseCapSpec extends ZIOSpecDefault {
                 driver.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
                 None
               } catch {
-                case failure: ResponseBodyTooLarge => Some(failure)
-                case failure: Throwable            => None
+                case cap: ResponseBodyTooLarge => Some(cap)
+                case unexpected: Throwable     =>
+                  throw new AssertionError("one-shot leg failed without ResponseBodyTooLarge", unexpected)
               }
             assertTrue(failure.exists(_.maxBytes == TinyCap))
           }
@@ -89,8 +90,9 @@ object ClientResponseCapSpec extends ZIOSpecDefault {
                   response.body.toArray
                   None
                 } catch {
-                  case failure: ResponseBodyTooLarge => Some(failure)
-                  case failure: Throwable            => None
+                  case cap: ResponseBodyTooLarge => Some(cap)
+                  case unexpected: Throwable     =>
+                    throw new AssertionError("pooled leg failed without ResponseBodyTooLarge", unexpected)
                 }
               assertTrue(response.status == Status.Ok, failure.exists(_.maxBytes == TinyCap))
             } finally pool.close()
@@ -120,9 +122,18 @@ object ClientResponseCapSpec extends ZIOSpecDefault {
                 client.send(Request.get(absUrl(s"http://127.0.0.1:$port/")))
                 None
               } catch {
-                case failure: Throwable => Some(failureToString(failure))
+                case failure: Throwable => Some(failure)
               }
-            assertTrue(failure.exists(_.contains("client cap")))
+            // The JDK leg surfaces the cap through a completion chain: unwind
+            // to the ResponseBodyTooLarge itself and pin its cap value. Any
+            // other outcome rethrows the real cause instead of failing silent.
+            val cap     = failure.flatMap(unwindCap)
+            if (failure.isDefined && cap.isEmpty)
+              throw new AssertionError(
+                "JDK leg failed without ResponseBodyTooLarge: " + failureToString(failure.get),
+                failure.get,
+              )
+            assertTrue(cap.exists(_.maxBytes == TinyCap))
           }
         }
       },
@@ -140,14 +151,12 @@ object ClientResponseCapSpec extends ZIOSpecDefault {
       },
       test("default cap is 16 MiB and non-positive caps fail fast") {
         ZIO.attempt {
-          val rejectsZero     = rejects(ClientConfig(maxResponseBodySize = 0L))
-          val rejectsNegative = rejects(ClientConfig(maxResponseBodySize = -1L))
           assertTrue(
             ClientConfig.DefaultMaxResponseBodySize == 16L * 1024L * 1024L,
             ClientConfig().maxResponseBodySize == ClientConfig.DefaultMaxResponseBodySize,
             JavaH2Client.DefaultMaxResponseBodySize == ClientConfig.DefaultMaxResponseBodySize,
-            rejectsZero,
-            rejectsNegative,
+            rejects(ClientConfig(maxResponseBodySize = 0L)),
+            rejects(ClientConfig(maxResponseBodySize = -1L)),
           )
         }
       },
@@ -194,6 +203,19 @@ object ClientResponseCapSpec extends ZIOSpecDefault {
       current = current.getCause
     }
     builder.toString
+  }
+
+  /** Walks the cause chain for the cap failure itself (JDK leg wraps it). */
+  private def unwindCap(failure: Throwable): Option[ResponseBodyTooLarge] = {
+    var current: Throwable                  = failure
+    var found: Option[ResponseBodyTooLarge] = None
+    while (current != null && found.isEmpty) {
+      current match {
+        case cap: ResponseBodyTooLarge => found = Some(cap)
+        case _                         => current = current.getCause
+      }
+    }
+    found
   }
 
   private def absUrl(raw: String): URL =

--- a/zio-http-client/shared/src/main/scala/zio/http/ClientConfig.scala
+++ b/zio-http-client/shared/src/main/scala/zio/http/ClientConfig.scala
@@ -31,9 +31,19 @@ final case class ClientConfig(
   alpn: ClientAlpnPolicy = ClientAlpnPolicy.H2PreferredWithH11Fallback,
   pool: PoolConfig = PoolConfig(),
   deadline: DeadlineConfig = DeadlineConfig(),
+  /**
+   * Maximum response body size in bytes buffered per request. Bodies are
+   * accounted incrementally as chunks arrive and the request fails fast past
+   * the cap, so a malicious server cannot force unbounded buffering.
+   */
+  maxResponseBodySize: Long = ClientConfig.DefaultMaxResponseBodySize,
 ) {
   if (maxRedirects < 0)
     throw new IllegalArgumentException(s"ClientConfig.maxRedirects must be >= 0, got $maxRedirects")
+  if (maxResponseBodySize <= 0L)
+    throw new IllegalArgumentException(
+      s"ClientConfig.maxResponseBodySize must be positive, got $maxResponseBodySize",
+    )
 
   /** Deadline override wins, else the legacy top-level [[connectTimeout]]. */
   def effectiveConnectTimeout: Duration =
@@ -49,5 +59,12 @@ final case class ClientConfig(
 }
 
 object ClientConfig {
+
+  /**
+   * Default response-body cap: 16 MiB per request. Matches the one-shot H2
+   * wire-client cap, so every client leg enforces the same bound by default.
+   */
+  val DefaultMaxResponseBodySize: Long = 16L * 1024L * 1024L
+
   implicit val schema: Schema[ClientConfig] = Schema.derived[ClientConfig]
 }

--- a/zio-http-core/jvm/src/test/scala/zio/http/AccessLogRequestIdSpec.scala
+++ b/zio-http-core/jvm/src/test/scala/zio/http/AccessLogRequestIdSpec.scala
@@ -1,0 +1,39 @@
+package zio.http
+
+import zio.test._
+
+object AccessLogRequestIdSpec extends ZIOSpecDefault {
+
+  private val Esc: String = "" + 27.toChar
+
+  private def headersWith(id: String): Headers =
+    Headers.empty.add("x-request-id", id)
+
+  override def spec: Spec[Any, Any] =
+    suite("AccessLogRequestIdSpec")(
+      test("newline characters are stripped") {
+        assertTrue(AccessLog.sanitizeRequestId("abc\ndef\r\nGHI") == "abcdefGHI")
+      },
+      test("ANSI escape sequences are stripped end to end") {
+        val id = AccessLog.requestId(headersWith("abc" + Esc + "[31mdef"))
+        assertTrue(id == "abc31mdef")
+      },
+      test("5KB header value is truncated to 128 chars") {
+        val big = "a" * 5120
+        val id  = AccessLog.requestId(headersWith(big))
+        assertTrue(id.length == 128, id == "a" * 128)
+      },
+      test("value that is empty after sanitizing yields a generated UUID") {
+        val id = AccessLog.requestId(headersWith("!!!"))
+        assertTrue(id.nonEmpty, id.length == 36, !id.contains("!"))
+      },
+      test("plain token passes through unchanged") {
+        val id = AccessLog.requestId(headersWith("req-1_~.abcXYZ"))
+        assertTrue(id == "req-1_~.abcXYZ")
+      },
+      test("absent header yields a generated UUID") {
+        val id = AccessLog.requestId(Headers.empty)
+        assertTrue(id.nonEmpty, id.length == 36)
+      },
+    )
+}

--- a/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
@@ -54,7 +54,7 @@ final case class AccessLogRecord(
   /**
    * Client-supplied `x-request-id` sanitized by [[AccessLog.sanitizeRequestId]]
    * (restricted charset, truncated to [[AccessLog.MaxRequestIdLength]]), or a
-   * generated id when absent or empty after sanitizing.
+   * generated UUID when absent or empty after sanitizing.
    */
   requestId: String,
   /** Socket peer address (`x-peer-address`, G3 trust gate). */
@@ -190,31 +190,30 @@ object AccessLog {
 
   /**
    * Resolves the request id: the client-supplied `x-request-id` header when
-   * present and non-empty, otherwise a freshly generated id.
+   * present and non-empty, otherwise a freshly generated UUID.
    *
    * The header value is sanitized before it reaches the record (see
    * [[sanitizeRequestId]]): only alphanumerics plus `-._~` survive, the result
    * is truncated to [[MaxRequestIdLength]] chars, and a value that is empty
-   * after sanitizing yields a generated id — so newline/ANSI log injection
+   * after sanitizing yields a generated UUID — so newline/ANSI log injection
    * and cardinality bombs cannot pass through.
    *
-   * Generated ids are process-unique counter+clock values (see
-   * [[freshRequestId]]), deliberately not `java.util.UUID`: UUID's
-   * SecureRandom-backed generation is unavailable on Scala.js, while a
-   * synchronized counter plus `nanoTime` works on every platform and is
-   * cheaper on the serving path.
+   * Note: id-less traffic pays one `UUID.randomUUID()` per request on the
+   * serving path; high-throughput services that do not need request ids should
+   * supply their own cheaper id (or reuse the peer/client tuple) in a custom
+   * emitter rather than calling this per request.
    */
   def requestId(headers: Headers): String =
     headers
       .rawGet(RequestIdHeader)
       .filter(_.nonEmpty)
       .map(sanitizeRequestId)
-      .getOrElse(freshRequestId())
+      .getOrElse(java.util.UUID.randomUUID().toString)
 
   /**
    * Sanitizes a client-supplied request id for safe logging: strips every
    * character outside `[A-Za-z0-9-._~]`, truncates to [[MaxRequestIdLength]]
-   * characters, and returns a generated id when nothing survives.
+   * characters, and returns a generated UUID when nothing survives.
    */
   def sanitizeRequestId(raw: String): String = {
     val kept = new StringBuilder()
@@ -227,37 +226,7 @@ object AccessLog {
       ) kept.append(c)
       i += 1
     }
-    if (kept.isEmpty) freshRequestId() else kept.toString
-  }
-
-  private val HexDigits = "0123456789abcdef"
-  private val idLock    = new Object
-  private var idCounter = 0L
-
-  /**
-   * Portable process-unique id (`req-<counter-hex><nanotime-hex>`): counter
-   * plus clock under one lock, hex-encoded with manual digit loops. Uses only
-   * `charAt`, arithmetic, and `synchronized`, so it works identically on JVM,
-   * Scala.js, and Native — unlike `UUID.randomUUID()`.
-   */
-  private def freshRequestId(): String = {
-    val (count, nanos) = idLock.synchronized {
-      idCounter += 1L
-      (idCounter, System.nanoTime())
-    }
-    val out = new StringBuilder(4 + 16 + 16)
-    out.append("req-")
-    appendHex(out, count)
-    appendHex(out, nanos)
-    out.toString
-  }
-
-  private def appendHex(out: StringBuilder, value: Long): Unit = {
-    var shift = 60
-    while (shift >= 0) {
-      out.append(HexDigits.charAt(((value >>> shift) & 0xfL).toInt))
-      shift -= 4
-    }
+    if (kept.isEmpty) java.util.UUID.randomUUID().toString else kept.toString
   }
 
   /**

--- a/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
@@ -63,20 +63,22 @@ final case class AccessLogRecord(
   clientIp: Option[String],
   /**
    * Whether proxy forwarding headers were honored for this request:
-   * [[AccessLog.TrustTrusted]] when the resolved client IP differs from the
-   * peer address (forwarding applied), [[AccessLog.TrustUntrusted]] when it
-   * falls back to the peer (ignored or absent). `None` when neither address is
-   * known (non-H2 transports).
+   * [[AccessLog.TrustDecision.Trusted]] when the resolved client IP differs
+   * from the peer address (forwarding applied),
+   * [[AccessLog.TrustDecision.Untrusted]] when it falls back to the peer
+   * (ignored or absent). `None` when neither address is known (non-H2
+   * transports).
    */
-  trustDecision: Option[String],
+  trustDecision: Option[AccessLog.TrustDecision],
   /**
-   * Slow-stream deadline outcome (G2): [[AccessLog.DeadlineOk]] — the only
-   * outcome any built-in emitter reports. [[AccessLog.DeadlineHeaderTimeout]] /
-   * [[AccessLog.DeadlineBodyTimeout]] are reserved for future transport-side
-   * timeout reporting and are never emitted today; streams reset by a deadline
-   * yield no record at all.
+   * Slow-stream deadline outcome (G2): [[AccessLog.DeadlineOutcome.Ok]] — the
+   * only outcome any built-in emitter reports.
+   * [[AccessLog.DeadlineOutcome.HeaderTimeout]] /
+   * [[AccessLog.DeadlineOutcome.BodyTimeout]] are reserved for future
+   * transport-side timeout reporting and are never emitted today; streams reset
+   * by a deadline yield no record at all.
    */
-  deadlineOutcome: Option[String],
+  deadlineOutcome: Option[AccessLog.DeadlineOutcome],
   /**
    * Request version string (same vocab as the transport and the middleware).
    */
@@ -106,7 +108,14 @@ object AccessLogSink {
       def log(record: AccessLogRecord): Unit = ()
     }
 
-  /** Writes one [[AccessLog.formatLine]] per record to standard out. */
+  /**
+   * Writes one [[AccessLog.formatLine]] per record to standard out.
+   *
+   * Each request performs one synchronized console write on the serving path;
+   * fine for development, but for production prefer an async batching sink
+   * (e.g. a queue drained by a background writer) to avoid serializing handlers
+   * on I/O.
+   */
   val console: AccessLogSink =
     new AccessLogSink {
       def log(record: AccessLogRecord): Unit = Console.out.println(AccessLog.formatLine(record))
@@ -120,6 +129,42 @@ object AccessLogSink {
 }
 
 object AccessLog {
+
+  /**
+   * Proxy-trust decision for [[AccessLogRecord.trustDecision]].
+   *
+   * `Trusted` renders as `"trusted"`, `Untrusted` as `"untrusted"` (stable log
+   * vocabulary, unchanged from the former string constants).
+   */
+  sealed abstract class TrustDecision(val value: String) {
+    override def toString: String = value
+  }
+
+  object TrustDecision {
+    case object Trusted extends TrustDecision("trusted")
+
+    case object Untrusted extends TrustDecision("untrusted")
+  }
+
+  /**
+   * Slow-stream deadline outcome for [[AccessLogRecord.deadlineOutcome]].
+   *
+   * `Ok` renders as `"ok"` — the only outcome any built-in emitter reports.
+   * `HeaderTimeout` (`"header-timeout"`) and `BodyTimeout` (`"body-timeout"`)
+   * are reserved for future transport-side timeout reporting and are never
+   * emitted today.
+   */
+  sealed abstract class DeadlineOutcome(val value: String) {
+    override def toString: String = value
+  }
+
+  object DeadlineOutcome {
+    case object Ok extends DeadlineOutcome("ok")
+
+    case object HeaderTimeout extends DeadlineOutcome("header-timeout")
+
+    case object BodyTimeout extends DeadlineOutcome("body-timeout")
+  }
 
   /** Request-id header honored (and echoed into the record) per request. */
   val RequestIdHeader: String = "x-request-id"
@@ -143,21 +188,6 @@ object AccessLog {
    */
   val ClientIpHeader: String = "x-client-ip"
 
-  /** [[AccessLogRecord.trustDecision]] when forwarding was honored. */
-  val TrustTrusted: String = "trusted"
-
-  /** [[AccessLogRecord.trustDecision]] when the peer address was kept. */
-  val TrustUntrusted: String = "untrusted"
-
-  /** [[AccessLogRecord.deadlineOutcome]] when the request completed in time. */
-  val DeadlineOk: String = "ok"
-
-  /** [[AccessLogRecord.deadlineOutcome]] when header completion timed out. */
-  val DeadlineHeaderTimeout: String = "header-timeout"
-
-  /** [[AccessLogRecord.deadlineOutcome]] when body completion timed out. */
-  val DeadlineBodyTimeout: String = "body-timeout"
-
   /**
    * Resolves the request id: the client-supplied `x-request-id` header when
    * present and non-empty, otherwise a freshly generated UUID.
@@ -167,6 +197,11 @@ object AccessLog {
    * is truncated to [[MaxRequestIdLength]] chars, and a value that is empty
    * after sanitizing yields a generated UUID — so newline/ANSI log injection
    * and cardinality bombs cannot pass through.
+   *
+   * Note: id-less traffic pays one `UUID.randomUUID()` per request on the
+   * serving path; high-throughput services that do not need request ids should
+   * supply their own cheaper id (or reuse the peer/client tuple) in a custom
+   * emitter rather than calling this per request.
    */
   def requestId(headers: Headers): String =
     headers
@@ -199,9 +234,10 @@ object AccessLog {
    * forwarding was honored exactly when the resolved client IP differs from the
    * socket peer. `None` when either address is unknown.
    */
-  def trustDecision(peerAddress: Option[String], clientIp: Option[String]): Option[String] =
+  def trustDecision(peerAddress: Option[String], clientIp: Option[String]): Option[TrustDecision] =
     (peerAddress, clientIp) match {
-      case (Some(peer), Some(client)) => Some(if (client != peer) TrustTrusted else TrustUntrusted)
+      case (Some(peer), Some(client)) =>
+        Some(if (client != peer) TrustDecision.Trusted else TrustDecision.Untrusted)
       case _                          => None
     }
 
@@ -217,14 +253,28 @@ object AccessLog {
 
   /** Renders one stable, greppable log line for [[AccessLogSink.console]]. */
   def formatLine(record: AccessLogRecord): String = {
-    def show(value: Option[String]): String = value.getOrElse("-")
-    record.method + " " + record.path + " " + record.status + " " + record.durationMs + "ms" +
-      " id=" + record.requestId +
-      " peer=" + show(record.peerAddress) +
-      " client=" + show(record.clientIp) +
-      " trust=" + show(record.trustDecision) +
-      " deadline=" + show(record.deadlineOutcome) +
-      " route=" + show(record.route) +
-      " proto=" + record.protocol
+    val sb = new StringBuilder(192)
+    sb.append(record.method)
+      .append(' ')
+      .append(record.path)
+      .append(' ')
+      .append(record.status)
+      .append(' ')
+      .append(record.durationMs)
+      .append("ms id=")
+      .append(record.requestId)
+      .append(" peer=")
+      .append(record.peerAddress.getOrElse("-"))
+      .append(" client=")
+      .append(record.clientIp.getOrElse("-"))
+      .append(" trust=")
+      .append(record.trustDecision.map(_.value).getOrElse("-"))
+      .append(" deadline=")
+      .append(record.deadlineOutcome.map(_.value).getOrElse("-"))
+      .append(" route=")
+      .append(record.route.getOrElse("-"))
+      .append(" proto=")
+      .append(record.protocol)
+    sb.toString
   }
 }

--- a/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2026 the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.http
+
+import scala.util.control.NonFatal
+
+/**
+ * Composable access/audit logging with a pluggable sink (v4-native).
+ *
+ * Every request that reaches a route produces one [[AccessLogRecord]] carrying
+ * method, path, the matched route, status, duration, and request-id, plus the
+ * proxy-trust decision (G3 headers) and the slow-stream deadline outcome (G2
+ * headers) when the transport attached them. Records are metadata only: the
+ * case class has no body, header-map, or stream handle, so body bytes cannot
+ * reach the sink by construction.
+ *
+ * Middleware-only by design: transports emit nothing by default (no console
+ * noise, no per-request record). Custom sinks (capture, file, structured audit)
+ * attach opt-in via [[Middleware.accessLog]]; the transport's internal
+ * OpenTelemetry span (`H2Transport.instrumentRequest`) is a separate surface
+ * and is never touched by this middleware.
+ *
+ * A throwing sink never fails the request: [[AccessLog.emit]] (used by every
+ * built-in emitter) swallows sink failures.
+ */
+final case class AccessLogRecord(
+  method: String,
+  /**
+   * Request path, logged verbatim (standard access-log behavior: no scrub
+   * hook).
+   */
+  path: String,
+  /** Matched route pattern, if the request reached a route. */
+  route: Option[String],
+  status: Int,
+  /**
+   * Handler wall-clock time in milliseconds: measured around the route handler
+   * only, so response-body send time is excluded.
+   */
+  durationMs: Long,
+  /**
+   * Client-supplied `x-request-id` sanitized by [[AccessLog.sanitizeRequestId]]
+   * (restricted charset, truncated to [[AccessLog.MaxRequestIdLength]]), or a
+   * generated UUID when absent or empty after sanitizing.
+   */
+  requestId: String,
+  /** Socket peer address (`x-peer-address`, G3 trust gate). */
+  peerAddress: Option[String],
+  /** Resolved client IP (`x-client-ip`, G3 trust gate). */
+  clientIp: Option[String],
+  /**
+   * Whether proxy forwarding headers were honored for this request:
+   * [[AccessLog.TrustTrusted]] when the resolved client IP differs from the
+   * peer address (forwarding applied), [[AccessLog.TrustUntrusted]] when it
+   * falls back to the peer (ignored or absent). `None` when neither address is
+   * known (non-H2 transports).
+   */
+  trustDecision: Option[String],
+  /**
+   * Slow-stream deadline outcome (G2): [[AccessLog.DeadlineOk]] — the only
+   * outcome any built-in emitter reports. [[AccessLog.DeadlineHeaderTimeout]] /
+   * [[AccessLog.DeadlineBodyTimeout]] are reserved for future transport-side
+   * timeout reporting and are never emitted today; streams reset by a deadline
+   * yield no record at all.
+   */
+  deadlineOutcome: Option[String],
+  /**
+   * Request version string (same vocab as the transport and the middleware).
+   */
+  protocol: String,
+)
+
+/**
+ * Pluggable receiver for [[AccessLogRecord]]s.
+ *
+ * Implementations run on the server I/O path, so `log` should be fast and
+ * non-blocking; it receives metadata only and must never retain request bodies
+ * (it cannot: the record carries none). Throwing is tolerated but pointless:
+ * built-in emitters route through [[AccessLog.emit]], which swallows sink
+ * failures so logging can never fail a request.
+ */
+trait AccessLogSink {
+
+  /** Receives one metadata-only record per served request. */
+  def log(record: AccessLogRecord): Unit
+}
+
+object AccessLogSink {
+
+  /** Discards every record. */
+  val disabled: AccessLogSink =
+    new AccessLogSink {
+      def log(record: AccessLogRecord): Unit = ()
+    }
+
+  /** Writes one [[AccessLog.formatLine]] per record to standard out. */
+  val console: AccessLogSink =
+    new AccessLogSink {
+      def log(record: AccessLogRecord): Unit = Console.out.println(AccessLog.formatLine(record))
+    }
+
+  /** Builds a sink from a plain function (e.g. test capture, file append). */
+  def apply(f: AccessLogRecord => Unit): AccessLogSink =
+    new AccessLogSink {
+      def log(record: AccessLogRecord): Unit = f(record)
+    }
+}
+
+object AccessLog {
+
+  /** Request-id header honored (and echoed into the record) per request. */
+  val RequestIdHeader: String = "x-request-id"
+
+  /**
+   * Maximum length of a sanitized request id: longer client-supplied values are
+   * truncated to bound log cardinality.
+   */
+  val MaxRequestIdLength: Int = 128
+
+  /**
+   * Socket peer-address header. Mirrors `TrustedProxyConfig.PeerAddressHeader`
+   * (zio-http-server); the literal is repeated here so core middleware stays
+   * dependency-free.
+   */
+  val PeerAddressHeader: String = "x-peer-address"
+
+  /**
+   * Resolved client-IP header. Mirrors `TrustedProxyConfig.ClientIpHeader`
+   * (zio-http-server); see [[PeerAddressHeader]].
+   */
+  val ClientIpHeader: String = "x-client-ip"
+
+  /** [[AccessLogRecord.trustDecision]] when forwarding was honored. */
+  val TrustTrusted: String = "trusted"
+
+  /** [[AccessLogRecord.trustDecision]] when the peer address was kept. */
+  val TrustUntrusted: String = "untrusted"
+
+  /** [[AccessLogRecord.deadlineOutcome]] when the request completed in time. */
+  val DeadlineOk: String = "ok"
+
+  /** [[AccessLogRecord.deadlineOutcome]] when header completion timed out. */
+  val DeadlineHeaderTimeout: String = "header-timeout"
+
+  /** [[AccessLogRecord.deadlineOutcome]] when body completion timed out. */
+  val DeadlineBodyTimeout: String = "body-timeout"
+
+  /**
+   * Resolves the request id: the client-supplied `x-request-id` header when
+   * present and non-empty, otherwise a freshly generated UUID.
+   *
+   * The header value is sanitized before it reaches the record (see
+   * [[sanitizeRequestId]]): only alphanumerics plus `-._~` survive, the result
+   * is truncated to [[MaxRequestIdLength]] chars, and a value that is empty
+   * after sanitizing yields a generated UUID — so newline/ANSI log injection
+   * and cardinality bombs cannot pass through.
+   */
+  def requestId(headers: Headers): String =
+    headers
+      .rawGet(RequestIdHeader)
+      .filter(_.nonEmpty)
+      .map(sanitizeRequestId)
+      .getOrElse(java.util.UUID.randomUUID().toString)
+
+  /**
+   * Sanitizes a client-supplied request id for safe logging: strips every
+   * character outside `[A-Za-z0-9-._~]`, truncates to [[MaxRequestIdLength]]
+   * characters, and returns a generated UUID when nothing survives.
+   */
+  def sanitizeRequestId(raw: String): String = {
+    val kept = new StringBuilder()
+    var i    = 0
+    while (i < raw.length && kept.length < MaxRequestIdLength) {
+      val c = raw.charAt(i)
+      if (
+        (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+        c == '-' || c == '.' || c == '_' || c == '~'
+      ) kept.append(c)
+      i += 1
+    }
+    if (kept.isEmpty) java.util.UUID.randomUUID().toString else kept.toString
+  }
+
+  /**
+   * Derives the trust decision from the addresses the transport attached:
+   * forwarding was honored exactly when the resolved client IP differs from the
+   * socket peer. `None` when either address is unknown.
+   */
+  def trustDecision(peerAddress: Option[String], clientIp: Option[String]): Option[String] =
+    (peerAddress, clientIp) match {
+      case (Some(peer), Some(client)) => Some(if (client != peer) TrustTrusted else TrustUntrusted)
+      case _                          => None
+    }
+
+  /**
+   * Delivers `record` to `sink`, swallowing any sink failure so logging can
+   * never fail the request being served.
+   */
+  def emit(sink: AccessLogSink, record: AccessLogRecord): Unit =
+    try sink.log(record)
+    catch {
+      case NonFatal(_) => ()
+    }
+
+  /** Renders one stable, greppable log line for [[AccessLogSink.console]]. */
+  def formatLine(record: AccessLogRecord): String = {
+    def show(value: Option[String]): String = value.getOrElse("-")
+    record.method + " " + record.path + " " + record.status + " " + record.durationMs + "ms" +
+      " id=" + record.requestId +
+      " peer=" + show(record.peerAddress) +
+      " client=" + show(record.clientIp) +
+      " trust=" + show(record.trustDecision) +
+      " deadline=" + show(record.deadlineOutcome) +
+      " route=" + show(record.route) +
+      " proto=" + record.protocol
+  }
+}

--- a/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/AccessLog.scala
@@ -54,7 +54,7 @@ final case class AccessLogRecord(
   /**
    * Client-supplied `x-request-id` sanitized by [[AccessLog.sanitizeRequestId]]
    * (restricted charset, truncated to [[AccessLog.MaxRequestIdLength]]), or a
-   * generated UUID when absent or empty after sanitizing.
+   * generated id when absent or empty after sanitizing.
    */
   requestId: String,
   /** Socket peer address (`x-peer-address`, G3 trust gate). */
@@ -190,30 +190,31 @@ object AccessLog {
 
   /**
    * Resolves the request id: the client-supplied `x-request-id` header when
-   * present and non-empty, otherwise a freshly generated UUID.
+   * present and non-empty, otherwise a freshly generated id.
    *
    * The header value is sanitized before it reaches the record (see
    * [[sanitizeRequestId]]): only alphanumerics plus `-._~` survive, the result
    * is truncated to [[MaxRequestIdLength]] chars, and a value that is empty
-   * after sanitizing yields a generated UUID — so newline/ANSI log injection
+   * after sanitizing yields a generated id — so newline/ANSI log injection
    * and cardinality bombs cannot pass through.
    *
-   * Note: id-less traffic pays one `UUID.randomUUID()` per request on the
-   * serving path; high-throughput services that do not need request ids should
-   * supply their own cheaper id (or reuse the peer/client tuple) in a custom
-   * emitter rather than calling this per request.
+   * Generated ids are process-unique counter+clock values (see
+   * [[freshRequestId]]), deliberately not `java.util.UUID`: UUID's
+   * SecureRandom-backed generation is unavailable on Scala.js, while a
+   * synchronized counter plus `nanoTime` works on every platform and is
+   * cheaper on the serving path.
    */
   def requestId(headers: Headers): String =
     headers
       .rawGet(RequestIdHeader)
       .filter(_.nonEmpty)
       .map(sanitizeRequestId)
-      .getOrElse(java.util.UUID.randomUUID().toString)
+      .getOrElse(freshRequestId())
 
   /**
    * Sanitizes a client-supplied request id for safe logging: strips every
    * character outside `[A-Za-z0-9-._~]`, truncates to [[MaxRequestIdLength]]
-   * characters, and returns a generated UUID when nothing survives.
+   * characters, and returns a generated id when nothing survives.
    */
   def sanitizeRequestId(raw: String): String = {
     val kept = new StringBuilder()
@@ -226,7 +227,37 @@ object AccessLog {
       ) kept.append(c)
       i += 1
     }
-    if (kept.isEmpty) java.util.UUID.randomUUID().toString else kept.toString
+    if (kept.isEmpty) freshRequestId() else kept.toString
+  }
+
+  private val HexDigits = "0123456789abcdef"
+  private val idLock    = new Object
+  private var idCounter = 0L
+
+  /**
+   * Portable process-unique id (`req-<counter-hex><nanotime-hex>`): counter
+   * plus clock under one lock, hex-encoded with manual digit loops. Uses only
+   * `charAt`, arithmetic, and `synchronized`, so it works identically on JVM,
+   * Scala.js, and Native — unlike `UUID.randomUUID()`.
+   */
+  private def freshRequestId(): String = {
+    val (count, nanos) = idLock.synchronized {
+      idCounter += 1L
+      (idCounter, System.nanoTime())
+    }
+    val out = new StringBuilder(4 + 16 + 16)
+    out.append("req-")
+    appendHex(out, count)
+    appendHex(out, nanos)
+    out.toString
+  }
+
+  private def appendHex(out: StringBuilder, value: Long): Unit = {
+    var shift = 60
+    while (shift >= 0) {
+      out.append(HexDigits.charAt(((value >>> shift) & 0xfL).toInt))
+      shift -= 4
+    }
   }
 
   /**

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -1093,25 +1093,34 @@ object Middleware {
         Routes.fromIterable(routes.routes.toList.map(logged))
 
       private def logged(route: Route[Any]): Route[Any] = {
-        val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
-          val startedAtNanos = System.nanoTime()
-          try {
-            val result: Response | Halt = route.handler.handle(request, context, vars, scope)
-            emitFor(request, statusOf(result), startedAtNanos, route)
-            result
-          } catch {
-            case throwable: Throwable =>
-              emitFor(request, 500, startedAtNanos, route)
-              throw throwable
+        // Hoisted per-route invariant: pattern rendering happens once at
+        // build time, not per request on the serving path.
+        val routePattern = route.pattern.toString
+        // Disabled sink: pass the handler through untouched — no timer read,
+        // no record build, no UUID generation per request.
+        if (sink eq AccessLogSink.disabled) route
+        else {
+          val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
+            val startedAtNanos = System.nanoTime()
+            try {
+              val result: Response | Halt = route.handler.handle(request, context, vars, scope)
+              emitFor(request, statusOf(result), startedAtNanos, routePattern)
+              result
+            } catch {
+              case throwable: Throwable =>
+                emitFor(request, 500, startedAtNanos, routePattern)
+                throw throwable
+            }
           }
+          Route(route.pattern, wrapped)
         }
-        Route(route.pattern, wrapped)
       }
 
       private def statusOf(result: Response | Halt): Int =
         foldResult(result)(_.status.code, _.response.status.code)
 
-      private def emitFor(request: Request, status: Int, startedAtNanos: Long, route: Route[Any]): Unit = {
+      private def emitFor(request: Request, status: Int, startedAtNanos: Long, routePattern: String): Unit = {
+        if (sink eq AccessLogSink.disabled) return
         val peerAddress = request.headers.rawGet(AccessLog.PeerAddressHeader)
         val clientIp    = request.headers.rawGet(AccessLog.ClientIpHeader)
         AccessLog.emit(
@@ -1119,14 +1128,14 @@ object Middleware {
           AccessLogRecord(
             method = request.method.toString,
             path = request.url.path.encode,
-            route = Some(route.pattern.toString),
+            route = Some(routePattern),
             status = status,
             durationMs = (System.nanoTime() - startedAtNanos) / 1000000L,
             requestId = AccessLog.requestId(request.headers),
             peerAddress = peerAddress,
             clientIp = clientIp,
             trustDecision = AccessLog.trustDecision(peerAddress, clientIp),
-            deadlineOutcome = Some(AccessLog.DeadlineOk),
+            deadlineOutcome = Some(AccessLog.DeadlineOutcome.Ok),
             protocol = request.version.toString,
           ),
         )

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -1072,4 +1072,64 @@ object Middleware {
         code >= 200 && code < 300
       }
     }
+
+  /**
+   * Opt-in access logging to a pluggable [[AccessLogSink]].
+   *
+   * Each wrapped route emits one metadata-only [[AccessLogRecord]] per request
+   * (method, path, matched route, status, duration, request-id, plus the
+   * `x-peer-address` / `x-client-ip` addresses the transport attached and the
+   * trust decision derived from them). The record carries no body handle, so
+   * body bytes can never reach the sink, and [[AccessLog.emit]] swallows sink
+   * failures, so logging can never fail the request.
+   *
+   * The original handler result (`Response` or `Halt`) is returned untouched;
+   * only its status carrier is read for the record. Transports emit nothing by
+   * default: attach this middleware to opt in.
+   */
+  def accessLog(sink: AccessLogSink): Middleware[Any, Any] =
+    new Middleware[Any, Any] {
+      def apply(routes: Routes[Any]): Routes[Any] =
+        Routes.fromIterable(routes.routes.toList.map(logged))
+
+      private def logged(route: Route[Any]): Route[Any] = {
+        val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
+          val startedAtNanos = System.nanoTime()
+          try {
+            val result: Response | Halt = route.handler.handle(request, context, vars, scope)
+            emitFor(request, statusOf(result), startedAtNanos, route)
+            result
+          } catch {
+            case throwable: Throwable =>
+              emitFor(request, 500, startedAtNanos, route)
+              throw throwable
+          }
+        }
+        Route(route.pattern, wrapped)
+      }
+
+      private def statusOf(result: Response | Halt): Int =
+        foldResult(result)(_.status.code, _.response.status.code)
+
+      private def emitFor(request: Request, status: Int, startedAtNanos: Long, route: Route[Any]): Unit = {
+        val peerAddress = request.headers.rawGet(AccessLog.PeerAddressHeader)
+        val clientIp    = request.headers.rawGet(AccessLog.ClientIpHeader)
+        AccessLog.emit(
+          sink,
+          AccessLogRecord(
+            method = request.method.toString,
+            path = request.url.path.encode,
+            route = Some(route.pattern.toString),
+            status = status,
+            durationMs = (System.nanoTime() - startedAtNanos) / 1000000L,
+            requestId = AccessLog.requestId(request.headers),
+            peerAddress = peerAddress,
+            clientIp = clientIp,
+            trustDecision = AccessLog.trustDecision(peerAddress, clientIp),
+            deadlineOutcome = Some(AccessLog.DeadlineOk),
+            protocol = request.version.toString,
+          ),
+        )
+      }
+    }
 }

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
@@ -450,7 +450,7 @@ final class H2Connection(
    * decoded size, so the wire cap is a multiple rather than the decoded limit
    * itself; past it the peer is flooding and the stream is reset with CANCEL.
    */
-  @inline private def pendingHeaderCapBytes: Long = maxHeaderListSize.toLong * 4L
+  private def pendingHeaderCapBytes: Long = maxHeaderListSize.toLong * 4L
 
   /**
    * Refuses a new stream opened after our GOAWAY (RFC 9113 6.8): the client

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
@@ -28,11 +28,13 @@ final class H2Connection(
   maxHeaderListSize: Int = 8192,
   idleTimeoutMs: Long = 60000,
   requestTimeoutMs: Long = 30000,
+  drainTimeoutMs: Long = 1000,
   // Header-fragment (CONTINUATION) completion deadline for an incomplete
   // header block. Expiry resets the stream with RST_STREAM(CANCEL).
   // Non-positive disables. Forwarded from Connector.headerTimeoutMs.
+  // Appended last (never inserted mid-list) so existing positional call
+  // sites cannot silently rebind.
   headerTimeoutMs: Long = 5000,
-  drainTimeoutMs: Long = 1000,
 ) {
   import H2Connection._
   import H2Frame._
@@ -448,7 +450,7 @@ final class H2Connection(
    * decoded size, so the wire cap is a multiple rather than the decoded limit
    * itself; past it the peer is flooding and the stream is reset with CANCEL.
    */
-  private def pendingHeaderCapBytes: Long = maxHeaderListSize.toLong * 4L
+  @inline private def pendingHeaderCapBytes: Long = maxHeaderListSize.toLong * 4L
 
   /**
    * Refuses a new stream opened after our GOAWAY (RFC 9113 6.8): the client
@@ -728,26 +730,49 @@ private object H2Connection {
     ) ++ maxHeaderListSize.map(size => Setting(Setting.MAX_HEADER_LIST_SIZE, size.toLong)).toList
   }
 
+  /**
+   * One incomplete (CONTINUATION-fragmented) header block. Fragments are
+   * buffered as a chunk list (newest first) and concatenated exactly once in
+   * `toHeaders`, so N CONTINUATIONs cost O(total bytes) instead of the O(N *
+   * total) quadratic copy a per-append `++` would pay within the cap. Empty
+   * fragments contribute no bytes and are skipped, so a flood of empty
+   * CONTINUATIONs cannot grow the list without tripping the byte cap either.
+   * `totalLength` tracks the encoded bytes for the cap check without walking
+   * the list. Byte content delivered to `toHeaders` is identical to eager
+   * concatenation in arrival order.
+   */
   private final case class PendingHeaders(
     streamId: Int,
-    headerBlock: Chunk[Byte],
+    fragments: List[Chunk[Byte]],
+    totalLength: Long,
     endStream: Boolean,
     priority: Option[Priority],
     padLength: Int,
   ) {
-    def append(frame: H2Frame.Continuation, capBytes: Long): Option[PendingHeaders] = {
-      val combined = headerBlock ++ frame.headerBlock
-      if (combined.length.toLong > capBytes) None
-      else Some(copy(headerBlock = combined))
-    }
+    def append(frame: H2Frame.Continuation, capBytes: Long): Option[PendingHeaders] =
+      if (frame.headerBlock.isEmpty) Some(this)
+      else {
+        val next = totalLength + frame.headerBlock.length.toLong
+        if (next > capBytes) None
+        else Some(copy(fragments = frame.headerBlock :: fragments, totalLength = next))
+      }
 
-    def toHeaders: H2Frame.Headers =
-      H2Frame.Headers(streamId, headerBlock, endStream, endHeaders = true, priority, padLength)
+    def toHeaders: H2Frame.Headers = {
+      val combined = fragments.reverse.foldLeft(Chunk.empty[Byte])(_ ++ _)
+      H2Frame.Headers(streamId, combined, endStream, endHeaders = true, priority, padLength)
+    }
   }
 
   private object PendingHeaders {
     def apply(frame: H2Frame.Headers): PendingHeaders =
-      PendingHeaders(frame.streamId, frame.headerBlock, frame.endStream, frame.priority, frame.padLength)
+      PendingHeaders(
+        frame.streamId,
+        List(frame.headerBlock),
+        frame.headerBlock.length.toLong,
+        frame.endStream,
+        frame.priority,
+        frame.padLength,
+      )
   }
 
   private def runnable(body: => Unit): Runnable =

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Connection.scala
@@ -3,6 +3,7 @@ package zio.http.h2
 import java.io.{EOFException, IOException, InputStream, OutputStream}
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -27,6 +28,10 @@ final class H2Connection(
   maxHeaderListSize: Int = 8192,
   idleTimeoutMs: Long = 60000,
   requestTimeoutMs: Long = 30000,
+  // Header-fragment (CONTINUATION) completion deadline for an incomplete
+  // header block. Expiry resets the stream with RST_STREAM(CANCEL).
+  // Non-positive disables. Forwarded from Connector.headerTimeoutMs.
+  headerTimeoutMs: Long = 5000,
   drainTimeoutMs: Long = 1000,
 ) {
   import H2Connection._
@@ -49,9 +54,16 @@ final class H2Connection(
   private var readBuffer: Chunk[Byte]               = Chunk.empty
   private var peerSettings: List[Setting]           = Nil
   private var pendingHeaders: PendingHeaders        = null
-  @volatile private var settingsAcknowledged        = false
-  @volatile private var highestStreamId             = 0
-  @volatile private var lastGoAwayStreamId          = Int.MaxValue
+  @volatile private var pendingTimer: ScheduledFuture[?] = null
+  // Stream whose partial header block was discarded by the flood cap or the
+  // header-timeout expiry (RST CANCEL already sent): trailing in-flight
+  // CONTINUATIONs for it are ignored per RFC 9113 section 5.1 tolerance so
+  // the connection survives. Cleared when a new header block starts. 0 = none
+  // (0 is never a valid stream id).
+  @volatile private var resetPendingStreamId: Int        = 0
+  @volatile private var settingsAcknowledged             = false
+  @volatile private var highestStreamId                  = 0
+  @volatile private var lastGoAwayStreamId               = Int.MaxValue
 
   /**
    * Live control plane for this connection (T5): shares this connection's
@@ -143,6 +155,7 @@ final class H2Connection(
         shutdown(connectionCancelled("failure: " + error.getMessage))
         throw error
     } finally {
+      cancelPendingDeadline()
       control.stopIdleTimer()
       shutdown(connectionCancelled("closed"))
       writer.interrupt()
@@ -156,21 +169,46 @@ final class H2Connection(
   private def handleFrame(frame: H2Frame, onStream: MuxStream[Int, H2Frame, H2Frame] => Unit): Unit = {
     // Any inbound frame is connection activity: keep the idle timer honest.
     control.resetIdleTimer()
-    if (pendingHeaders != null) {
+    // Snapshot once: the header-timeout thread nulls pendingHeaders on
+    // expiry, so triple-reading the volatile across the match below is a
+    // TOCTOU race (NPE/stale-stream mismatch). All branches use the local.
+    val pending = pendingHeaders
+    if (pending != null) {
       frame match {
-        case continuation: Continuation if continuation.streamId == pendingHeaders.streamId =>
-          val next = pendingHeaders.append(continuation)
-          if (continuation.endHeaders) {
-            pendingHeaders = null
-            deliverRequestHeaders(next.toHeaders, onStream)
-          } else pendingHeaders = next
-        case _                                                                              =>
-          throw protocolError("Expected CONTINUATION for stream " + pendingHeaders.streamId + ", received: " + frame)
+        case continuation: Continuation if continuation.streamId == pending.streamId =>
+          pending.append(continuation, pendingHeaderCapBytes) match {
+            case None       =>
+              // Encoded-fragment flood: reset only this stream with CANCEL and
+              // discard the partial block so the connection stays usable for
+              // sibling streams (mirrors the header-timeout expiry cleanup).
+              discardPendingBlock(continuation.streamId)
+            case Some(next) =>
+              if (continuation.endHeaders) {
+                pendingHeaders = null
+                cancelPendingDeadline()
+                deliverRequestHeaders(next.toHeaders, onStream)
+              } else pendingHeaders = next
+          }
+        case _                                                                       =>
+          throw protocolError("Expected CONTINUATION for stream " + pending.streamId + ", received: " + frame)
       }
     } else {
       frame match {
-        case headers: Headers if !headers.endHeaders => pendingHeaders = PendingHeaders(headers)
+        case headers: Headers if !headers.endHeaders =>
+          if (headers.headerBlock.length.toLong > pendingHeaderCapBytes) {
+            // A single fragment already over the encoded cap: reset without
+            // buffering anything, connection stays usable.
+            discardPendingBlock(headers.streamId)
+          } else {
+            pendingHeaders = PendingHeaders(headers)
+            resetPendingStreamId = 0
+            startPendingDeadline(headers.streamId)
+          }
         case headers: Headers                        => deliverRequestHeaders(headers, onStream)
+        case c: Continuation if c.streamId == resetPendingStreamId && resetPendingStreamId != 0 =>
+          () // Trailing CONTINUATION for a flood/timed-out header block already reset; ignore per 5.1 tolerance.
+        case c: Continuation if isKnownStream(c.streamId) =>
+          () // Trailing CONTINUATION after a timed-out header block was reset; ignore per 5.1 tolerance.
         case _: Continuation => throw protocolError("Unexpected CONTINUATION frame without open header block")
         case other if other.streamId == 0 => handleConnectionFrame(other)
         case other                        => deliverStreamFrame(other, onStream)
@@ -318,6 +356,99 @@ final class H2Connection(
     sendReset(streamId, errorCode)
     if (streamId > highestStreamId) highestStreamId = streamId
   }
+
+  /**
+   * Discards an incomplete header block and resets its stream with CANCEL: the
+   * single cleanup for the flood-cap and header-timeout paths. The RST goes
+   * through the single shared send site (`H2ConnectionControl.sendRstStream`,
+   * which shares this connection's `writeLock`), so the connection stays usable
+   * for sibling streams. The id is consumed (like `rejectHeaders`) so a later
+   * reuse trips the monotonic stream-id check, and trailing in-flight
+   * CONTINUATIONs for it are ignored via `resetPendingStreamId` (RFC 9113
+   * section 5.1 tolerance).
+   */
+  private def discardPendingBlock(streamId: Int): Unit = {
+    cancelPendingDeadline()
+    // The RST goes through the single shared send site
+    // (`H2ConnectionControl.sendRstStream`, which shares this connection's
+    // `writeLock`), so the connection stays usable for sibling streams. Best
+    // effort: if the peer already went away the send failure is swallowed.
+    // Sent only by the first claimer (see takePendingDiscard): exactly one
+    // RST goes out per discarded block.
+    if (takePendingDiscard(streamId, freshOk = true)) {
+      try control.sendRstStream(streamId, H2Error.Code.CANCEL)
+      catch {
+        case NonFatal(_) => ()
+      }
+    }
+  }
+
+  /**
+   * Header-fragment (slow-loris) deadline for an incomplete header block.
+   * Reuses the shared `H2ConnectionControl.scheduleTimeoutRst` mechanism
+   * (virtual-thread sleep, never a ZIO fiber; single shared wire-write lock).
+   * Pre-open blocks have no mux entry yet, so `requireOpenStream = false` and
+   * expiry predicates purely on the block still being pending. On expiry the
+   * stream is reset with CANCEL and the partial block discarded so the
+   * connection stays usable for sibling streams.
+   */
+  private def startPendingDeadline(streamId: Int): Unit = {
+    cancelPendingDeadline()
+    if (headerTimeoutMs <= 0L) return
+    pendingTimer = control.scheduleTimeoutRst(
+      streamId,
+      headerTimeoutMs,
+      H2Error.Code.CANCEL,
+      () => takePendingDiscard(streamId, freshOk = false),
+      requireOpenStream = false,
+    )
+  }
+
+  /**
+   * Claims the discard of the incomplete header block for `streamId` and
+   * reports whether this claimer owes the RST: records the discard (nulls the
+   * block, consumes the id like `rejectHeaders` so a later reuse trips the
+   * monotonic stream-id check, arms trailing-CONTINUATION tolerance via
+   * `resetPendingStreamId` per RFC 9113 section 5.1) once, exactly-once across
+   * the reader-side flood discard and the timer-thread expiry. The first claim
+   * wins — a buffered block, or (reader only, `freshOk`) a fresh single
+   * fragment already over the cap that was never buffered; the loser observes
+   * the recorded id and stands down, so exactly one RST goes out per discarded
+   * block. The timer never claims fresh (`freshOk = false`): a
+   * normally-completed block records no id, and must not draw a spurious RST. A
+   * pending block for another stream is never claimed (unreachable by protocol:
+   * no other frame may intervene before the block completes).
+   *
+   * Best-effort like the upstream request-timer cancel race: a CONTINUATION
+   * completing the block in the same instant as the expiry may still lose to a
+   * concurrently-claiming timer.
+   */
+  private def takePendingDiscard(streamId: Int, freshOk: Boolean): Boolean = {
+    val pending = pendingHeaders
+    if (pending != null && pending.streamId != streamId) return false
+    if (pending == null && (!freshOk || resetPendingStreamId == streamId)) return false
+    pendingHeaders = null
+    resetPendingStreamId = streamId
+    activeStreams.remove(streamId)
+    if (streamId > highestStreamId) highestStreamId = streamId
+    true
+  }
+
+  private def cancelPendingDeadline(): Unit = {
+    val timer = pendingTimer
+    if (timer != null) {
+      pendingTimer = null
+      timer.cancel(true)
+    }
+  }
+
+  /**
+   * Encoded-byte budget for one buffered (incomplete) header block: a multiple
+   * of the advertised decoded budget. HPACK encoding can expand relative to
+   * decoded size, so the wire cap is a multiple rather than the decoded limit
+   * itself; past it the peer is flooding and the stream is reset with CANCEL.
+   */
+  private def pendingHeaderCapBytes: Long = maxHeaderListSize.toLong * 4L
 
   /**
    * Refuses a new stream opened after our GOAWAY (RFC 9113 6.8): the client
@@ -604,8 +735,11 @@ private object H2Connection {
     priority: Option[Priority],
     padLength: Int,
   ) {
-    def append(frame: H2Frame.Continuation): PendingHeaders =
-      copy(headerBlock = headerBlock ++ frame.headerBlock)
+    def append(frame: H2Frame.Continuation, capBytes: Long): Option[PendingHeaders] = {
+      val combined = headerBlock ++ frame.headerBlock
+      if (combined.length.toLong > capBytes) None
+      else Some(copy(headerBlock = combined))
+    }
 
     def toHeaders: H2Frame.Headers =
       H2Frame.Headers(streamId, headerBlock, endStream, endHeaders = true, priority, padLength)

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2ConnectionControl.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2ConnectionControl.scala
@@ -90,11 +90,69 @@ final class H2ConnectionControl(
    * Stops the idle timer thread. Safe to call from any thread, including the
    * timer thread itself (self-interrupt is skipped).
    */
-  def stopIdleTimer(): Unit                                = {
+  def stopIdleTimer(): Unit = {
     closedState.set(true)
     val thread = idleTimerThread.get()
     if (thread != null && (thread ne Thread.currentThread())) thread.interrupt()
   }
+
+  /**
+   * Generic stream completion deadline on a virtual thread (same
+   * `VirtualTimerFuture` pattern as `startRequestTimer`).
+   *
+   * Sleeps `timeoutMs` then resets `streamId` with `errorCode` iff
+   * `stillPending()` holds. `stillPending()` and (when `requireOpenStream`)
+   * `isStreamOpen()` are re-checked immediately before the wire write: the
+   * stream may have completed in the gap between wake-up and the send, and an
+   * RST after completion would kill a healthy stream. Pre-open deadlines (an
+   * incomplete header block has no mux entry yet) pass
+   * `requireOpenStream = false` and predicate purely on `stillPending()`. The
+   * caller cancels the returned future when the stream completes, so healthy
+   * streams pay no lingering thread. Never uses ZIO fibers for the blocking
+   * sleep.
+   */
+  def scheduleTimeoutRst(
+    streamId: Int,
+    timeoutMs: Long,
+    errorCode: H2Error.Code,
+    stillPending: () => Boolean,
+    requireOpenStream: Boolean = true,
+  ): ScheduledFuture[?] = {
+    val future = new VirtualTimerFuture(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs.max(0L)))
+    if (timeoutMs <= 0L) {
+      future.complete()
+      return future
+    }
+    val thread = Thread
+      .ofVirtual()
+      .name("zio-http-h2-stream-timeout-" + streamId)
+      .start(runnable {
+        try {
+          TimeUnit.MILLISECONDS.sleep(timeoutMs)
+          // Re-check at send time (mirrors startRequestTimer's isStreamOpen
+          // guard): the stream may have completed between the wake-up check
+          // and the wire write below — never RST a completed stream.
+          if (!future.isCancelled && stillPending() && (!requireOpenStream || isStreamOpen(streamId))) {
+            try sendRstStream(streamId, errorCode)
+            catch {
+              case NonFatal(_) => ()
+            }
+          }
+          future.complete()
+        } catch {
+          case _: InterruptedException =>
+            if (future.isCancelled) future.complete()
+            else {
+              Thread.currentThread().interrupt()
+              future.complete()
+            }
+          case NonFatal(error)         => future.fail(error)
+        }
+      })
+    future.attach(thread)
+    future
+  }
+
   def startRequestTimer(streamId: Int): ScheduledFuture[?] = {
     val future = new VirtualTimerFuture(System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(requestTimeoutMs.max(0L)))
     if (requestTimeoutMs <= 0L) {

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
@@ -32,6 +32,7 @@ import zio.http.{
   Route,
   Routes,
   Scheme,
+  TrustedProxyConfig,
   URL,
   Version,
 }
@@ -70,7 +71,7 @@ final class H2Transport[Ctx](
           host,
           port,
           tlsConfig,
-          (input, output) => {
+          (input, output, peer) => {
             activeConnectionCount.incrementAndGet()
             activeConnections.add(1L, "protocol" -> protocolName)
             try {
@@ -90,7 +91,7 @@ final class H2Transport[Ctx](
                   connector.requestTimeoutMs,
                   connector.headerTimeoutMs,
                 )
-              connection.run(stream => handleStream(stream, flowController, hpackCodec, connection))
+              connection.run(stream => handleStream(stream, flowController, hpackCodec, connection, peer))
             } catch {
               case e: Throwable =>
                 logger.error(
@@ -128,6 +129,7 @@ final class H2Transport[Ctx](
     flowController: FlowController,
     hpackCodec: HpackCodec,
     connection: H2Connection,
+    peer: PeerInfo,
   ): Unit = {
     // Request timeout lives on the connection's control plane: RST_STREAM
     // (CANCEL) fires from a Loom virtual thread if the handler overruns.
@@ -154,7 +156,7 @@ final class H2Transport[Ctx](
       else null
     try {
       val requestFrame = awaitHeaders(stream, connection)
-      val request      = decodeRequest(requestFrame, stream, connection, bodyDeadlineNanos(streamStartNanos))
+      val request      = decodeRequest(requestFrame, stream, connection, bodyDeadlineNanos(streamStartNanos), peer)
       bodyDone.set(true)
       if (bodyTimer != null) bodyTimer.cancel(true)
       val response     = instrumentRequest(request)
@@ -239,6 +241,7 @@ final class H2Transport[Ctx](
     stream: MuxStream[Int, H2Frame, H2Frame],
     connection: H2Connection,
     bodyDeadlineNanos: Long,
+    peer: PeerInfo,
   ): Request = {
     // Decoded on the reader thread in wire order (see H2Connection.takeDecodedRequestHeaders);
     // decoding here would desync the shared decoder across concurrent streams (RFC 7541 2.3.2).
@@ -251,18 +254,69 @@ final class H2Transport[Ctx](
         checkEmptyBodyLength(stream, connection, declaredLength)
         Body.empty
       } else Body.fromChunk(readRequestBody(stream, connection, declaredLength, bodyDeadlineNanos))
+    val proxy          = resolveProxyTrust(httpHeaders, peer)
 
     Request(
       method = parseMethod(pseudoHeaders.method),
-      url = parseUrl(
-        pseudoHeaders.path,
-        pseudoHeaders.scheme,
-        pseudoHeaders.authority,
+      url = applyProxyUrl(
+        parseUrl(
+          pseudoHeaders.path,
+          pseudoHeaders.scheme,
+          pseudoHeaders.authority,
+        ),
+        proxy,
       ),
-      headers = httpHeaders,
+      headers = proxy.headers,
       body = body,
       version = Version.`HTTP/2.0`,
     )
+  }
+
+  /**
+   * Gates forwarding headers on proxy trust (default-deny).
+   *
+   * When `peer` is trusted, `X-Forwarded-For/Proto/Host` (or RFC 7239
+   * `Forwarded`) resolve the client IP, scheme, and host; otherwise the headers
+   * are ignored entirely and the socket peer address is the client IP. Either
+   * way the raw forwarding headers are stripped before route handlers run (an
+   * attacker must not smuggle them through, nor spoof the normalized
+   * `x-client-ip` / `x-peer-address` headers, which are removed from the wire
+   * set and re-added here), and the peer address plus the resolved client IP
+   * are attached as `x-peer-address` / `x-client-ip`.
+   */
+  private def resolveProxyTrust(headers: zio.http.Headers, peer: PeerInfo): H2Transport.ResolvedProxy = {
+    val trusted   = connector.trustedProxy.isTrusted(peer.address, peer.hasPeerCert)
+    val forwarded = if (trusted) H2Transport.parseForwarded(headers) else None
+    val clientIp  = forwarded.flatMap(_.clientIp).getOrElse(peer.address)
+    val stripped  = H2Transport.ProxyHeaderNames.foldLeft(headers)((acc, name) => acc.remove(name))
+    val enriched  = stripped
+      .add(TrustedProxyConfig.PeerAddressHeader, peer.address)
+      .add(TrustedProxyConfig.ClientIpHeader, clientIp)
+    val withHost  = forwarded.flatMap(_.host) match {
+      case Some(host) => enriched.set(Header.Host.name, host)
+      case None       => enriched
+    }
+    H2Transport.ResolvedProxy(withHost, forwarded.flatMap(_.proto), forwarded.flatMap(_.host))
+  }
+
+  private def applyProxyUrl(url: URL, proxy: H2Transport.ResolvedProxy): URL = {
+    val withScheme = proxy.proto match {
+      case Some(proto) => url.scheme(Scheme.fromString(proto))
+      case None        => url
+    }
+    proxy.host match {
+      case Some(host) =>
+        Header.Host.parse(host) match {
+          case Right(parsed) =>
+            val withHost = withScheme.host(parsed.host)
+            parsed.port match {
+              case Some(port) => withHost.port(port)
+              case None       => withHost
+            }
+          case Left(_)       => withScheme.host(host)
+        }
+      case None       => withScheme
+    }
   }
 
   private def handleRequest(request: Request): Response = {
@@ -1030,6 +1084,90 @@ object H2Transport {
     scheme: String,
     authority: String,
   )
+
+  /**
+   * Forwarding headers stripped before route handlers run. Includes the
+   * normalized `x-client-ip` / `x-peer-address` headers themselves so a peer
+   * cannot spoof them: they are removed from the wire set and re-added by
+   * `resolveProxyTrust` after trust gating.
+   */
+  private val ProxyHeaderNames: List[String] =
+    List("x-forwarded-for", "x-forwarded-proto", "x-forwarded-host", "forwarded", "x-client-ip", "x-peer-address")
+
+  private final case class ForwardedValues(clientIp: Option[String], proto: Option[String], host: Option[String])
+
+  private final case class ResolvedProxy(headers: zio.http.Headers, proto: Option[String], host: Option[String])
+
+  /**
+   * Extracts forwarding values from `X-Forwarded-For/Proto/Host`, falling back
+   * to RFC 7239 `Forwarded` when no `X-Forwarded-For` is present. Only the
+   * first (leftmost, closest-to-client) element is used. Returns `None` when
+   * neither header family is present.
+   */
+  private def parseForwarded(headers: zio.http.Headers): Option[ForwardedValues] = {
+    val xff = headers.rawGet("x-forwarded-for").map(firstListValue).filter(_.nonEmpty)
+    if (xff.isDefined)
+      Some(
+        ForwardedValues(
+          clientIp = xff.map(normalizeForwardedIp),
+          proto = headers.rawGet("x-forwarded-proto").map(firstListValue).filter(_.nonEmpty).map(_.toLowerCase),
+          host = headers.rawGet("x-forwarded-host").map(firstListValue).filter(_.nonEmpty),
+        ),
+      )
+    else headers.rawGet("forwarded").map(parseRfc7239Forwarded)
+  }
+
+  private def firstListValue(value: String): String = {
+    val comma = value.indexOf(',')
+    (if (comma < 0) value else value.substring(0, comma)).trim
+  }
+
+  /**
+   * Normalizes one `for=` / `X-Forwarded-For` element to a bare IP: strips
+   * quotes, IPv6 brackets (with optional port), and an IPv4 port suffix.
+   */
+  private def normalizeForwardedIp(value: String): String = {
+    val trimmed = value.trim.stripPrefix("\"").stripSuffix("\"").trim
+    if (trimmed.startsWith("[")) {
+      val close = trimmed.indexOf(']')
+      if (close > 0) trimmed.substring(1, close) else trimmed
+    } else {
+      val colon = trimmed.indexOf(':')
+      if (colon >= 0 && trimmed.indexOf(':', colon + 1) < 0 && trimmed.contains(".")) trimmed.substring(0, colon)
+      else trimmed
+    }
+  }
+
+  /**
+   * Parses the first element of an RFC 7239 `Forwarded` header
+   * (`for=…;proto=…;host=…`). Obfuscated (`_…`) and `unknown` identifiers
+   * resolve to no client IP.
+   */
+  private def parseRfc7239Forwarded(value: String): ForwardedValues = {
+    var clientIp: Option[String] = None
+    var proto: Option[String]    = None
+    var host: Option[String]     = None
+    val pairs                    = value.split(",", 2)(0).split(";")
+    var index                    = 0
+    while (index < pairs.length) {
+      val pair = pairs(index)
+      val eq   = pair.indexOf('=')
+      if (eq > 0) {
+        val key = pair.substring(0, eq).trim.toLowerCase
+        val raw = pair.substring(eq + 1).trim.stripPrefix("\"").stripSuffix("\"").trim
+        key match {
+          case "for"   =>
+            if (raw.nonEmpty && !raw.equalsIgnoreCase("unknown") && !raw.startsWith("_"))
+              clientIp = Some(normalizeForwardedIp(raw))
+          case "proto" => if (raw.nonEmpty) proto = Some(raw.toLowerCase)
+          case "host"  => if (raw.nonEmpty) host = Some(raw)
+          case _       => ()
+        }
+      }
+      index += 1
+    }
+    ForwardedValues(clientIp, proto, host)
+  }
 
   private implicit final class EitherOps[A](private val either: Either[String, A]) extends AnyVal {
     def getOrElse(default: => A): A =

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
@@ -87,6 +87,8 @@ final class H2Transport[Ctx](
                   Some(localSettings),
                   http2Config.maxHeaderListSize,
                   H2ConnectionControl.idleTimeoutMs(connector),
+                  connector.requestTimeoutMs,
+                  connector.headerTimeoutMs,
                 )
               connection.run(stream => handleStream(stream, flowController, hpackCodec, connection))
             } catch {
@@ -131,10 +133,30 @@ final class H2Transport[Ctx](
     // (CANCEL) fires from a Loom virtual thread if the handler overruns.
     // handleStream itself already runs on a per-stream virtual thread, so no
     // ZIO fiber ever blocks here.
-    val requestTimer = connection.connectionControl.startRequestTimer(stream.id)
+    val requestTimer     = connection.connectionControl.startRequestTimer(stream.id)
+    // Body-completion (time-to-complete) deadline, measured from stream start:
+    // total elapsed time is enforced, not just the gap between frames, so a
+    // drip that keeps moving but too slowly still times out. Enforced both by
+    // a virtual-thread timer (shared H2ConnectionControl path, never ZIO
+    // fibers) and by polling checks in awaitFrame: the timer covers a fully
+    // stalled peer, the polls cover a slow-but-moving drip. Expiry resets the
+    // stream with RST_STREAM(CANCEL).
+    val streamStartNanos = System.nanoTime()
+    val bodyDone         = new AtomicBoolean(false)
+    val bodyTimer        =
+      if (connector.bodyTimeoutMs > 0L)
+        connection.connectionControl.scheduleTimeoutRst(
+          stream.id,
+          connector.bodyTimeoutMs,
+          H2Error.Code.CANCEL,
+          () => !bodyDone.get(),
+        )
+      else null
     try {
-      val requestFrame = awaitHeaders(stream)
-      val request      = decodeRequest(requestFrame, stream, connection)
+      val requestFrame = awaitHeaders(stream, connection)
+      val request      = decodeRequest(requestFrame, stream, connection, bodyDeadlineNanos(streamStartNanos))
+      bodyDone.set(true)
+      if (bodyTimer != null) bodyTimer.cancel(true)
       val response     = instrumentRequest(request)
       sendResponse(stream, request.method, response, flowController, hpackCodec, connection)
     } catch {
@@ -165,6 +187,8 @@ final class H2Transport[Ctx](
           }
         }
     } finally {
+      bodyDone.set(true)
+      if (bodyTimer != null) bodyTimer.cancel(true)
       requestTimer.cancel(true)
       flowController.removeStream(stream.id)
     }
@@ -204,8 +228,8 @@ final class H2Transport[Ctx](
     }
   }
 
-  private def awaitHeaders(stream: MuxStream[Int, H2Frame, H2Frame]): Headers =
-    awaitFrame(stream) match {
+  private def awaitHeaders(stream: MuxStream[Int, H2Frame, H2Frame], connection: H2Connection): Headers =
+    awaitFrame(stream, connection, Long.MaxValue) match {
       case headers: Headers => headers
       case other            => throw new IllegalStateException("Expected HTTP/2 HEADERS frame but received: " + other)
     }
@@ -214,6 +238,7 @@ final class H2Transport[Ctx](
     initialHeaders: Headers,
     stream: MuxStream[Int, H2Frame, H2Frame],
     connection: H2Connection,
+    bodyDeadlineNanos: Long,
   ): Request = {
     // Decoded on the reader thread in wire order (see H2Connection.takeDecodedRequestHeaders);
     // decoding here would desync the shared decoder across concurrent streams (RFC 7541 2.3.2).
@@ -225,7 +250,7 @@ final class H2Transport[Ctx](
       if (initialHeaders.endStream) {
         checkEmptyBodyLength(stream, connection, declaredLength)
         Body.empty
-      } else Body.fromChunk(readRequestBody(stream, connection, declaredLength))
+      } else Body.fromChunk(readRequestBody(stream, connection, declaredLength, bodyDeadlineNanos))
 
     Request(
       method = parseMethod(pseudoHeaders.method),
@@ -300,6 +325,7 @@ final class H2Transport[Ctx](
     hpackCodec: HpackCodec,
     connection: H2Connection,
   ): Unit = {
+    probeStreamOpen(stream)
     val bodyIsEmpty     = body.isEmpty
     val responseHeaders = buildResponseHeaders(response, Some(body.length.toLong), bodyIsEmpty)
     writeResponseHeaders(stream, hpackCodec, connection, responseHeaders, endStream = bodyIsEmpty)
@@ -343,6 +369,7 @@ final class H2Transport[Ctx](
     hpackCodec: HpackCodec,
     connection: H2Connection,
   ): Unit = {
+    probeStreamOpen(stream)
     val frameSize       = Math.max(1, http2Config.maxFrameSize)
     val knownLength     = response.body.length
     // A zero known length with no known chunk closes on HEADERS like an empty body.
@@ -544,13 +571,14 @@ final class H2Transport[Ctx](
     stream: MuxStream[Int, H2Frame, H2Frame],
     connection: H2Connection,
     declaredLength: Option[Long],
+    deadlineNanos: Long,
   ): Chunk[Byte] = {
     val maxBytes = connector.maxRequestBodySize
     declaredLength.foreach { declared =>
       if (declared > maxBytes) {
         // Declared over the cap: drain the wire (retaining nothing) so the
         // reset below cannot race trailing DATA delivery, then reset.
-        discardRequestBody(stream)
+        discardRequestBody(stream, connection, deadlineNanos)
         resetStream(stream, connection, H2Error.Code.FLOW_CONTROL_ERROR)
         throw H2Transport.RequestBodyTooLarge(stream.id, maxBytes)
       } else if (declared < 0L) {
@@ -564,7 +592,7 @@ final class H2Transport[Ctx](
     var done     = false
 
     while (!done) {
-      awaitFrame(stream) match {
+      awaitFrame(stream, connection, deadlineNanos) match {
         case data: Data       =>
           val size = data.data.length.toLong
           // Account BEFORE buffering: the byte that crosses the cap is never retained.
@@ -596,10 +624,14 @@ final class H2Transport[Ctx](
    * Retention stays at zero throughout; the peer's flow-control window bounds
    * how much can arrive.
    */
-  private def discardRequestBody(stream: MuxStream[Int, H2Frame, H2Frame]): Unit = {
+  private def discardRequestBody(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    deadlineNanos: Long,
+  ): Unit = {
     var done = false
     while (!done) {
-      awaitFrame(stream) match {
+      awaitFrame(stream, connection, deadlineNanos) match {
         case data: Data       => done = data.endStream
         case headers: Headers => done = headers.endStream
         case _: WindowUpdate  => ()
@@ -674,6 +706,19 @@ final class H2Transport[Ctx](
    * failure is swallowed and the caller still throws the underlying bound
    * violation.
    */
+  /**
+   * Re-check-at-send probe before the first wire write of a response: the
+   * body/request timer may have fired (RST already on the wire) between
+   * body-read completion and this send. Never emit HEADERS/DATA on a reset
+   * stream — a HEADERS on a reset stream is a connection error (STREAM_CLOSED)
+   * for the peer. Complements `StreamSender`'s per-send `isClosed` guard, which
+   * covers every DATA frame including the first. The RST is already sent, so
+   * aborting maps to `ResponseAborted` and skips the error response in
+   * `handleStream`.
+   */
+  private def probeStreamOpen(stream: MuxStream[Int, H2Frame, H2Frame]): Unit =
+    if (stream.isClosed) throw ResponseAborted
+
   private def resetStream(
     stream: MuxStream[Int, H2Frame, H2Frame],
     connection: H2Connection,
@@ -684,9 +729,22 @@ final class H2Transport[Ctx](
       case NonFatal(_) => ()
     }
 
-  private def awaitFrame(stream: MuxStream[Int, H2Frame, H2Frame]): H2Frame = {
+  private def awaitFrame(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    deadlineNanos: Long,
+  ): H2Frame = {
     var frame: H2Frame = null
     while (frame == null) {
+      if (System.nanoTime() > deadlineNanos) {
+        // Time-to-complete exceeded: reset with CANCEL on the single shared
+        // control path, then surface the timeout (the 500 guard below skips
+        // reset streams, so no HEADERS follows the RST). Skipped when the
+        // stream is already closed (the virtual-thread timer won the race and
+        // its RST is on the wire): never RST a closed stream twice.
+        if (!stream.isClosed) resetStream(stream, connection, H2Error.Code.CANCEL)
+        throw H2Transport.StreamTimeout(stream.id, deadlineNanos)
+      }
       toReceivedFrame(stream.receive()) match {
         case Left(error) => throw new IllegalStateException("HTTP/2 stream receive failed: " + error)
         case Right(next) => frame = next
@@ -695,6 +753,14 @@ final class H2Transport[Ctx](
     }
     frame
   }
+
+  /**
+   * Body-completion deadline as absolute nanos, measured from stream start.
+   * Non-positive timeouts disable (far-future deadline, never hit).
+   */
+  private def bodyDeadlineNanos(streamStartNanos: Long): Long =
+    if (connector.bodyTimeoutMs <= 0L) Long.MaxValue
+    else streamStartNanos + connector.bodyTimeoutMs * 1000000L
 
   private def sendFrame(stream: MuxStream[Int, H2Frame, H2Frame], frame: H2Frame): Unit = {
     val result = stream.send(frame)
@@ -924,6 +990,15 @@ object H2Transport {
   final case class RequestBodyLengthMismatch(streamId: Int, declared: Long, received: Long)
       extends java.io.IOException(
         s"HTTP/2 request body on stream $streamId declared content-length $declared but received $received bytes",
+      )
+
+  /**
+   * Thrown after resetting the stream with `RST_STREAM(CANCEL)` when body
+   * completion exceeds its time-to-complete deadline.
+   */
+  final case class StreamTimeout(streamId: Int, deadlineNanos: Long)
+      extends java.util.concurrent.TimeoutException(
+        s"HTTP/2 stream $streamId exceeded body time-to-complete deadline",
       )
 
   /**

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
@@ -78,20 +78,24 @@ final class H2Transport[Ctx](
               val flowController =
                 new FlowController(H2Settings.DefaultInitialWindowSize.toInt, http2Config.initialWindowSize)
               val hpackCodec     = new HpackCodec()
+              // Trust inputs (peer IP literal, mTLS cert presence) are
+              // connection-stable: decide once per connection so the
+              // per-request path never re-parses the peer IP.
+              val peerTrusted    = connector.trustedProxy.isTrusted(peer.address, peer.hasPeerCert)
               val connection     =
                 new H2Connection(
-                  input,
-                  output,
-                  http2Config.maxConcurrentStreams,
-                  flowController,
-                  hpackCodec,
-                  Some(localSettings),
-                  http2Config.maxHeaderListSize,
-                  H2ConnectionControl.idleTimeoutMs(connector),
-                  connector.requestTimeoutMs,
-                  connector.headerTimeoutMs,
+                  input = input,
+                  output = output,
+                  maxConcurrentStreams = http2Config.maxConcurrentStreams,
+                  flowController = flowController,
+                  hpackCodec = hpackCodec,
+                  localSettings = Some(localSettings),
+                  maxHeaderListSize = http2Config.maxHeaderListSize,
+                  idleTimeoutMs = H2ConnectionControl.idleTimeoutMs(connector),
+                  requestTimeoutMs = connector.requestTimeoutMs,
+                  headerTimeoutMs = connector.headerTimeoutMs,
                 )
-              connection.run(stream => handleStream(stream, flowController, hpackCodec, connection, peer))
+              connection.run(stream => handleStream(stream, flowController, hpackCodec, connection, peer, peerTrusted))
             } catch {
               case e: Throwable =>
                 logger.error(
@@ -130,12 +134,13 @@ final class H2Transport[Ctx](
     hpackCodec: HpackCodec,
     connection: H2Connection,
     peer: PeerInfo,
+    peerTrusted: Boolean,
   ): Unit = {
     // Request timeout lives on the connection's control plane: RST_STREAM
     // (CANCEL) fires from a Loom virtual thread if the handler overruns.
     // handleStream itself already runs on a per-stream virtual thread, so no
     // ZIO fiber ever blocks here.
-    val requestTimer     = connection.connectionControl.startRequestTimer(stream.id)
+    val requestTimer            = connection.connectionControl.startRequestTimer(stream.id)
     // Body-completion (time-to-complete) deadline, measured from stream start:
     // total elapsed time is enforced, not just the gap between frames, so a
     // drip that keeps moving but too slowly still times out. Enforced both by
@@ -143,10 +148,18 @@ final class H2Transport[Ctx](
     // fibers) and by polling checks in awaitFrame: the timer covers a fully
     // stalled peer, the polls cover a slow-but-moving drip. Expiry resets the
     // stream with RST_STREAM(CANCEL).
-    val streamStartNanos = System.nanoTime()
-    val bodyDone         = new AtomicBoolean(false)
-    val bodyTimer        =
-      if (connector.bodyTimeoutMs > 0L)
+    //
+    // Fused off path: when the body timeout is disabled there is no clock
+    // read, no AtomicBoolean, and no timer thread — the deadline stays the
+    // far-future sentinel (see bodyDeadlineNanos) and awaitFrame skips its
+    // per-iteration nanoTime check for it. The VirtualTimerFuture path below
+    // is unchanged when enabled.
+    val bodyTimeoutEnabled      = connector.bodyTimeoutMs > 0L
+    val streamStartNanos        = if (bodyTimeoutEnabled) System.nanoTime() else 0L
+    val bodyDone: AtomicBoolean =
+      if (bodyTimeoutEnabled) new AtomicBoolean(false) else null
+    val bodyTimer               =
+      if (bodyTimeoutEnabled)
         connection.connectionControl.scheduleTimeoutRst(
           stream.id,
           connector.bodyTimeoutMs,
@@ -156,8 +169,9 @@ final class H2Transport[Ctx](
       else null
     try {
       val requestFrame = awaitHeaders(stream, connection)
-      val request      = decodeRequest(requestFrame, stream, connection, bodyDeadlineNanos(streamStartNanos), peer)
-      bodyDone.set(true)
+      val request      =
+        decodeRequest(requestFrame, stream, connection, bodyDeadlineNanos(streamStartNanos), peer, peerTrusted)
+      if (bodyDone != null) bodyDone.set(true)
       if (bodyTimer != null) bodyTimer.cancel(true)
       val response     = instrumentRequest(request)
       sendResponse(stream, request.method, response, flowController, hpackCodec, connection)
@@ -189,7 +203,7 @@ final class H2Transport[Ctx](
           }
         }
     } finally {
-      bodyDone.set(true)
+      if (bodyDone != null) bodyDone.set(true)
       if (bodyTimer != null) bodyTimer.cancel(true)
       requestTimer.cancel(true)
       flowController.removeStream(stream.id)
@@ -242,6 +256,7 @@ final class H2Transport[Ctx](
     connection: H2Connection,
     bodyDeadlineNanos: Long,
     peer: PeerInfo,
+    peerTrusted: Boolean,
   ): Request = {
     // Decoded on the reader thread in wire order (see H2Connection.takeDecodedRequestHeaders);
     // decoding here would desync the shared decoder across concurrent streams (RFC 7541 2.3.2).
@@ -254,7 +269,7 @@ final class H2Transport[Ctx](
         checkEmptyBodyLength(stream, connection, declaredLength)
         Body.empty
       } else Body.fromChunk(readRequestBody(stream, connection, declaredLength, bodyDeadlineNanos))
-    val proxy          = resolveProxyTrust(httpHeaders, peer)
+    val proxy          = resolveProxyTrust(httpHeaders, peer, peerTrusted)
 
     Request(
       method = parseMethod(pseudoHeaders.method),
@@ -284,11 +299,20 @@ final class H2Transport[Ctx](
    * set and re-added here), and the peer address plus the resolved client IP
    * are attached as `x-peer-address` / `x-client-ip`.
    */
-  private def resolveProxyTrust(headers: zio.http.Headers, peer: PeerInfo): H2Transport.ResolvedProxy = {
-    val trusted   = connector.trustedProxy.isTrusted(peer.address, peer.hasPeerCert)
+  private def resolveProxyTrust(
+    headers: zio.http.Headers,
+    peer: PeerInfo,
+    peerTrusted: Boolean,
+  ): H2Transport.ResolvedProxy = {
+    val trusted   = peerTrusted
     val forwarded = if (trusted) H2Transport.parseForwarded(headers) else None
     val clientIp  = forwarded.flatMap(_.clientIp).getOrElse(peer.address)
-    val stripped  = H2Transport.ProxyHeaderNames.foldLeft(headers)((acc, name) => acc.remove(name))
+    // Pre-check before stripping: the common default-deny case (no
+    // forwarding headers on the wire) keeps `headers` untouched and allocates
+    // nothing; otherwise one single-pass rebuild, not one copy per name.
+    val stripped  =
+      if (H2Transport.hasProxyHeader(headers)) H2Transport.stripProxyHeaders(headers)
+      else headers
     val enriched  = stripped
       .add(TrustedProxyConfig.PeerAddressHeader, peer.address)
       .add(TrustedProxyConfig.ClientIpHeader, clientIp)
@@ -697,22 +721,22 @@ final class H2Transport[Ctx](
   /**
    * Parses the declared request `content-length`, if any. Returns `Some(-1)`
    * when the value is missing, malformed, or conflicts across duplicates, so
-   * every downstream comparison rejects it with `PROTOCOL_ERROR`.
+   * every downstream comparison rejects it with `PROTOCOL_ERROR`. Uses a
+   * targeted single-name scan (`rawGetAll`, case-insensitive like the old
+   * `equalsIgnoreCase` walk) instead of materializing every header with
+   * `toList`; duplicate/conflict semantics are unchanged.
    */
   private def declaredContentLength(headers: zio.http.Headers): Option[Long] = {
     var result: Option[Long] = None
     var conflict             = false
-    val pairs                = headers.toList
+    val values               = headers.rawGetAll(Header.ContentLength.name)
     var index                = 0
-    while (index < pairs.length) {
-      val (name, value) = pairs(index)
-      if (name.equalsIgnoreCase(Header.ContentLength.name)) {
-        value.toLongOption match {
-          case Some(length) =>
-            if (result.exists(_ != length)) conflict = true
-            result = Some(length)
-          case None         => conflict = true
-        }
+    while (index < values.length) {
+      values(index).toLongOption match {
+        case Some(length) =>
+          if (result.exists(_ != length)) conflict = true
+          result = Some(length)
+        case None         => conflict = true
       }
       index += 1
     }
@@ -770,7 +794,7 @@ final class H2Transport[Ctx](
    * aborting maps to `ResponseAborted` and skips the error response in
    * `handleStream`.
    */
-  private def probeStreamOpen(stream: MuxStream[Int, H2Frame, H2Frame]): Unit =
+  @inline private def probeStreamOpen(stream: MuxStream[Int, H2Frame, H2Frame]): Unit =
     if (stream.isClosed) throw ResponseAborted
 
   private def resetStream(
@@ -790,7 +814,9 @@ final class H2Transport[Ctx](
   ): H2Frame = {
     var frame: H2Frame = null
     while (frame == null) {
-      if (System.nanoTime() > deadlineNanos) {
+      // Fused off path: the far-future sentinel means timeouts are disabled,
+      // so skip the per-iteration nanoTime read entirely.
+      if (deadlineNanos != Long.MaxValue && System.nanoTime() > deadlineNanos) {
         // Time-to-complete exceeded: reset with CANCEL on the single shared
         // control path, then surface the timeout (the 500 guard below skips
         // reset streams, so no HEADERS follows the RST). Skipped when the
@@ -812,7 +838,7 @@ final class H2Transport[Ctx](
    * Body-completion deadline as absolute nanos, measured from stream start.
    * Non-positive timeouts disable (far-future deadline, never hit).
    */
-  private def bodyDeadlineNanos(streamStartNanos: Long): Long =
+  @inline private def bodyDeadlineNanos(streamStartNanos: Long): Long =
     if (connector.bodyTimeoutMs <= 0L) Long.MaxValue
     else streamStartNanos + connector.bodyTimeoutMs * 1000000L
 
@@ -1117,7 +1143,7 @@ object H2Transport {
     else headers.rawGet("forwarded").map(parseRfc7239Forwarded)
   }
 
-  private def firstListValue(value: String): String = {
+  @inline private def firstListValue(value: String): String = {
     val comma = value.indexOf(',')
     (if (comma < 0) value else value.substring(0, comma)).trim
   }
@@ -1141,20 +1167,25 @@ object H2Transport {
   /**
    * Parses the first element of an RFC 7239 `Forwarded` header
    * (`for=…;proto=…;host=…`). Obfuscated (`_…`) and `unknown` identifiers
-   * resolve to no client IP.
+   * resolve to no client IP. Scanned with `indexOf` loops — no regex `split`
+   * anywhere on this path.
    */
   private def parseRfc7239Forwarded(value: String): ForwardedValues = {
     var clientIp: Option[String] = None
     var proto: Option[String]    = None
     var host: Option[String]     = None
-    val pairs                    = value.split(",", 2)(0).split(";")
-    var index                    = 0
-    while (index < pairs.length) {
-      val pair = pairs(index)
-      val eq   = pair.indexOf('=')
-      if (eq > 0) {
-        val key = pair.substring(0, eq).trim.toLowerCase
-        val raw = pair.substring(eq + 1).trim.stripPrefix("\"").stripSuffix("\"").trim
+    // First element only: up to the first ',' (or the end), mirroring the old
+    // `split(",", 2)(0)`.
+    val comma                    = value.indexOf(',')
+    val end                      = if (comma < 0) value.length else comma
+    var start                    = 0
+    while (start < end) {
+      val semi    = value.indexOf(';', start)
+      val pairEnd = if (semi < 0 || semi > end) end else semi
+      val eq      = value.indexOf('=', start)
+      if (eq > start && eq < pairEnd) {
+        val key = value.substring(start, eq).trim.toLowerCase
+        val raw = value.substring(eq + 1, pairEnd).trim.stripPrefix("\"").stripSuffix("\"").trim
         key match {
           case "for"   =>
             if (raw.nonEmpty && !raw.equalsIgnoreCase("unknown") && !raw.startsWith("_"))
@@ -1164,9 +1195,40 @@ object H2Transport {
           case _       => ()
         }
       }
-      index += 1
+      start = pairEnd + 1
     }
     ForwardedValues(clientIp, proto, host)
+  }
+
+  /**
+   * True when any forwarding/normalized header is present. Allocation-free
+   * boolean scans, so the common default-deny case (nothing present) pays no
+   * rebuild before `resolveProxyTrust` keeps the headers untouched.
+   */
+  private def hasProxyHeader(headers: zio.http.Headers): Boolean =
+    headers.has("x-forwarded-for") ||
+      headers.has("x-forwarded-proto") ||
+      headers.has("x-forwarded-host") ||
+      headers.has("forwarded") ||
+      headers.has("x-client-ip") ||
+      headers.has("x-peer-address")
+
+  /**
+   * Strips every forwarding/normalized header in a single pass over the header
+   * list (one builder, one output), replacing N per-name `remove` copies.
+   * `Headers` stores names pre-lowercased, so plain equality against the
+   * lowercase `ProxyHeaderNames` matches `remove`'s case-insensitive behavior.
+   */
+  private def stripProxyHeaders(headers: zio.http.Headers): zio.http.Headers = {
+    val pairs   = headers.toList
+    val builder = zio.http.HeadersBuilder.make(pairs.length)
+    var index   = 0
+    while (index < pairs.length) {
+      val (name, value) = pairs(index)
+      if (!ProxyHeaderNames.contains(name)) builder.add(name, value)
+      index += 1
+    }
+    builder.build()
   }
 
   private implicit final class EitherOps[A](private val either: Either[String, A]) extends AnyVal {

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
@@ -151,10 +151,18 @@ final class H2Transport[Ctx](
           "error_message" -> AttributeValue.StringValue(Option(e.getMessage).getOrElse("")),
           "stacktrace"    -> AttributeValue.StringValue(stackTraceToString(e)),
         )
-        try {
-          sendResponse(stream, Method.GET, Response.internalServerError, flowController, hpackCodec, connection)
-        } catch {
-          case _: Throwable => () // Best effort: if error response also fails, give up silently
+        // The failure above may already have reset the stream (over-cap
+        // RST_STREAM, length-mismatch PROTOCOL_ERROR): a HEADERS frame on a
+        // reset stream is a connection error (STREAM_CLOSED) for the peer, so
+        // the best-effort 500 goes out only while the stream is still open.
+        // Genuine handler errors never reset, so the 500 path for live
+        // streams is unchanged.
+        if (!stream.isClosed) {
+          try {
+            sendResponse(stream, Method.GET, Response.internalServerError, flowController, hpackCodec, connection)
+          } catch {
+            case _: Throwable => () // Best effort: if error response also fails, give up silently
+          }
         }
     } finally {
       requestTimer.cancel(true)
@@ -212,9 +220,12 @@ final class H2Transport[Ctx](
     val decodedHeaders = connection.takeDecodedRequestHeaders(stream.id)
     val pseudoHeaders  = collectPseudoHeaders(decodedHeaders)
     val httpHeaders    = buildRequestHeaders(decodedHeaders, pseudoHeaders.authority)
+    val declaredLength = declaredContentLength(httpHeaders)
     val body           =
-      if (initialHeaders.endStream) Body.empty
-      else Body.fromChunk(readRequestBody(stream))
+      if (initialHeaders.endStream) {
+        checkEmptyBodyLength(stream, connection, declaredLength)
+        Body.empty
+      } else Body.fromChunk(readRequestBody(stream, connection, declaredLength))
 
     Request(
       method = parseMethod(pseudoHeaders.method),
@@ -515,17 +526,61 @@ final class H2Transport[Ctx](
     override def fillInStackTrace(): Throwable = this
   }
 
-  private def readRequestBody(stream: MuxStream[Int, H2Frame, H2Frame]): Chunk[Byte] = {
-    val builder = Chunk.newBuilder[Byte]
-    var done    = false
+  /**
+   * Reads the request body DATA stream incrementally against the
+   * `Connector.maxRequestBodySize` cap: each DATA payload is accounted BEFORE
+   * it is buffered, so the byte that crosses the cap is never retained and an
+   * over-cap body never lands on the heap in full. On exceed the stream is
+   * reset with `RST_STREAM(FLOW_CONTROL_ERROR)` — the same code the response
+   * abort path uses for window-overflow violations — and the connection
+   * survives for sibling streams. A `content-length` that disagrees with the
+   * bytes actually received resets with `PROTOCOL_ERROR` instead.
+   *
+   * The reset reuses the single upstream send site
+   * (`H2ConnectionControl.sendRstStream`, shared with the response abort and
+   * timer paths): no parallel RST machinery lives here.
+   */
+  private def readRequestBody(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    declaredLength: Option[Long],
+  ): Chunk[Byte] = {
+    val maxBytes = connector.maxRequestBodySize
+    declaredLength.foreach { declared =>
+      if (declared > maxBytes) {
+        // Declared over the cap: drain the wire (retaining nothing) so the
+        // reset below cannot race trailing DATA delivery, then reset.
+        discardRequestBody(stream)
+        resetStream(stream, connection, H2Error.Code.FLOW_CONTROL_ERROR)
+        throw H2Transport.RequestBodyTooLarge(stream.id, maxBytes)
+      } else if (declared < 0L) {
+        resetStream(stream, connection, H2Error.Code.PROTOCOL_ERROR)
+        throw H2Transport.RequestBodyLengthMismatch(stream.id, declared, 0L)
+      }
+    }
+
+    val builder  = Chunk.newBuilder[Byte]
+    var received = 0L
+    var done     = false
 
     while (!done) {
       awaitFrame(stream) match {
         case data: Data       =>
+          val size = data.data.length.toLong
+          // Account BEFORE buffering: the byte that crosses the cap is never retained.
+          if (received + size > maxBytes) {
+            resetStream(stream, connection, H2Error.Code.FLOW_CONTROL_ERROR)
+            throw H2Transport.RequestBodyTooLarge(stream.id, maxBytes)
+          }
           builder ++= data.data
-          done = data.endStream
+          received += size
+          if (data.endStream) {
+            done = true
+            checkReceivedLength(stream, connection, declaredLength, received)
+          }
         case headers: Headers =>
           done = headers.endStream
+          if (headers.endStream) checkReceivedLength(stream, connection, declaredLength, received)
         case _: WindowUpdate  => ()
         case other => throw new IllegalStateException("Unexpected HTTP/2 frame while reading request body: " + other)
       }
@@ -533,6 +588,101 @@ final class H2Transport[Ctx](
 
     builder.result()
   }
+
+  /**
+   * Reads until end-of-stream, retaining no bytes. Used when the declared
+   * `content-length` already exceeds the cap: draining keeps connection-level
+   * framing intact so the subsequent reset cannot race trailing DATA delivery.
+   * Retention stays at zero throughout; the peer's flow-control window bounds
+   * how much can arrive.
+   */
+  private def discardRequestBody(stream: MuxStream[Int, H2Frame, H2Frame]): Unit = {
+    var done = false
+    while (!done) {
+      awaitFrame(stream) match {
+        case data: Data       => done = data.endStream
+        case headers: Headers => done = headers.endStream
+        case _: WindowUpdate  => ()
+        case other => throw new IllegalStateException("Unexpected HTTP/2 frame while discarding request body: " + other)
+      }
+    }
+  }
+
+  /**
+   * Parses the declared request `content-length`, if any. Returns `Some(-1)`
+   * when the value is missing, malformed, or conflicts across duplicates, so
+   * every downstream comparison rejects it with `PROTOCOL_ERROR`.
+   */
+  private def declaredContentLength(headers: zio.http.Headers): Option[Long] = {
+    var result: Option[Long] = None
+    var conflict             = false
+    val pairs                = headers.toList
+    var index                = 0
+    while (index < pairs.length) {
+      val (name, value) = pairs(index)
+      if (name.equalsIgnoreCase(Header.ContentLength.name)) {
+        value.toLongOption match {
+          case Some(length) =>
+            if (result.exists(_ != length)) conflict = true
+            result = Some(length)
+          case None         => conflict = true
+        }
+      }
+      index += 1
+    }
+    if (conflict) Some(-1L)
+    else result
+  }
+
+  private def checkEmptyBodyLength(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    declaredLength: Option[Long],
+  ): Unit =
+    declaredLength.foreach { declared =>
+      if (declared != 0L) {
+        if (declared > connector.maxRequestBodySize) {
+          resetStream(stream, connection, H2Error.Code.FLOW_CONTROL_ERROR)
+          throw H2Transport.RequestBodyTooLarge(stream.id, connector.maxRequestBodySize)
+        } else {
+          resetStream(stream, connection, H2Error.Code.PROTOCOL_ERROR)
+          throw H2Transport.RequestBodyLengthMismatch(stream.id, declared, 0L)
+        }
+      }
+    }
+
+  private def checkReceivedLength(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    declaredLength: Option[Long],
+    received: Long,
+  ): Unit =
+    declaredLength.foreach { declared =>
+      if (declared != received) {
+        resetStream(stream, connection, H2Error.Code.PROTOCOL_ERROR)
+        throw H2Transport.RequestBodyLengthMismatch(stream.id, declared, received)
+      }
+    }
+
+  /**
+   * Resets `stream` with `errorCode` through the single upstream send site
+   * (`H2ConnectionControl.sendRstStream`, shared with the response abort and
+   * timer paths), which writes the RST_STREAM frame directly under the
+   * connection write lock and cancels the mux entry — so the failure stays
+   * per-stream and the connection survives for sibling streams. Best-effort: if
+   * the peer already reset the stream there is nobody left to notify, so a send
+   * failure is swallowed and the caller still throws the underlying bound
+   * violation.
+   */
+  private def resetStream(
+    stream: MuxStream[Int, H2Frame, H2Frame],
+    connection: H2Connection,
+    errorCode: H2Error.Code,
+  ): Unit =
+    try connection.connectionControl.sendRstStream(stream.id, errorCode)
+    catch {
+      case NonFatal(_) => ()
+    }
 
   private def awaitFrame(stream: MuxStream[Int, H2Frame, H2Frame]): H2Frame = {
     var frame: H2Frame = null
@@ -757,6 +907,24 @@ final class H2Transport[Ctx](
 
 @experimental
 object H2Transport {
+
+  /**
+   * Thrown after resetting the stream when a request body crosses
+   * `Connector.maxRequestBodySize`.
+   */
+  final case class RequestBodyTooLarge(streamId: Int, maxBytes: Long)
+      extends java.io.IOException(
+        s"HTTP/2 request body on stream $streamId exceeded maxRequestBodySize of $maxBytes bytes",
+      )
+
+  /**
+   * Thrown after resetting the stream when `content-length` disagrees with the
+   * bytes actually received.
+   */
+  final case class RequestBodyLengthMismatch(streamId: Int, declared: Long, received: Long)
+      extends java.io.IOException(
+        s"HTTP/2 request body on stream $streamId declared content-length $declared but received $received bytes",
+      )
 
   /**
    * Per-stream abort marker: lives on the companion (static, stable prefix)

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/H2Transport.scala
@@ -794,7 +794,7 @@ final class H2Transport[Ctx](
    * aborting maps to `ResponseAborted` and skips the error response in
    * `handleStream`.
    */
-  @inline private def probeStreamOpen(stream: MuxStream[Int, H2Frame, H2Frame]): Unit =
+  private def probeStreamOpen(stream: MuxStream[Int, H2Frame, H2Frame]): Unit =
     if (stream.isClosed) throw ResponseAborted
 
   private def resetStream(
@@ -838,7 +838,7 @@ final class H2Transport[Ctx](
    * Body-completion deadline as absolute nanos, measured from stream start.
    * Non-positive timeouts disable (far-future deadline, never hit).
    */
-  @inline private def bodyDeadlineNanos(streamStartNanos: Long): Long =
+  private def bodyDeadlineNanos(streamStartNanos: Long): Long =
     if (connector.bodyTimeoutMs <= 0L) Long.MaxValue
     else streamStartNanos + connector.bodyTimeoutMs * 1000000L
 
@@ -1143,7 +1143,7 @@ object H2Transport {
     else headers.rawGet("forwarded").map(parseRfc7239Forwarded)
   }
 
-  @inline private def firstListValue(value: String): String = {
+  private def firstListValue(value: String): String = {
     val comma = value.indexOf(',')
     (if (comma < 0) value else value.substring(0, comma)).trim
   }

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/TcpListener.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/TcpListener.scala
@@ -42,14 +42,14 @@ import zio.http.{AlpnPolicy, TlsConfig, TlsSource}
  *   Verified client certificate, present only on mTLS connections whose peer
  *   completed client authentication.
  */
-final case class PeerInfo(
+private[http] final case class PeerInfo(
   address: String,
   peerCert: Option[X509Certificate],
 ) {
   def hasPeerCert: Boolean = peerCert.isDefined
 }
 
-class TcpListener(
+private[http] class TcpListener(
   host: String,
   port: Int,
   tls: Option[TlsConfig],

--- a/zio-http-server-loom/src/main/scala/zio/http/h2/TcpListener.scala
+++ b/zio-http-server-loom/src/main/scala/zio/http/h2/TcpListener.scala
@@ -12,7 +12,16 @@ import java.security.{KeyFactory, PrivateKey, SecureRandom}
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
-import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLHandshakeException, SSLParameters, SSLSocket}
+import javax.net.ssl.{
+  KeyManagerFactory,
+  SSLContext,
+  SSLHandshakeException,
+  SSLParameters,
+  SSLPeerUnverifiedException,
+  SSLSocket,
+  TrustManager,
+  TrustManagerFactory,
+}
 
 import scala.jdk.CollectionConverters._
 import scala.util.Success
@@ -23,11 +32,28 @@ import zio.blocks.config.Secret
 import zio.blocks.telemetry.{AttributeValue, ConsoleLogRecordProcessor, LoggerProvider}
 import zio.http.{AlpnPolicy, TlsConfig, TlsSource}
 
+/**
+ * Identity of the TCP peer accepted by [[TcpListener]], forwarded to the
+ * connection handler so request decoding can gate forwarding headers on it.
+ *
+ * @param address
+ *   Socket peer IP address (for example `"127.0.0.1"`).
+ * @param peerCert
+ *   Verified client certificate, present only on mTLS connections whose peer
+ *   completed client authentication.
+ */
+final case class PeerInfo(
+  address: String,
+  peerCert: Option[X509Certificate],
+) {
+  def hasPeerCert: Boolean = peerCert.isDefined
+}
+
 class TcpListener(
   host: String,
   port: Int,
   tls: Option[TlsConfig],
-  connectionHandler: (InputStream, OutputStream) => Unit,
+  connectionHandler: (InputStream, OutputStream, PeerInfo) => Unit,
 ) {
   private val logger =
     LoggerProvider.builder.addLogRecordProcessor(new ConsoleLogRecordProcessor).build().get("zio.http.h2.TcpListener")
@@ -109,18 +135,37 @@ class TcpListener(
   ): Unit = {
     sslContext match {
       case Some(context) =>
-        val sslSocket = TcpListener.createTlsSocket(context, channel, tls)
-        activeConnections.add(sslSocket)
+        // A peer that fails the handshake (including mTLS client authentication) never reaches the
+        // handler: the socket and channel are closed here so the peer observes the rejection
+        // promptly.
+        var sslSocket: SSLSocket = null
         try {
-          connectionHandler(sslSocket.getInputStream, sslSocket.getOutputStream)
-        } finally {
-          activeConnections.remove(sslSocket)
-          closeQuietly(sslSocket)
+          sslSocket = TcpListener.createTlsSocket(context, channel, tls)
+          activeConnections.add(sslSocket)
+          try {
+            val peer = PeerInfo(TcpListener.peerIp(sslSocket.getRemoteSocketAddress), TcpListener.peerCert(sslSocket))
+            connectionHandler(sslSocket.getInputStream, sslSocket.getOutputStream, peer)
+          } finally {
+            activeConnections.remove(sslSocket)
+            closeQuietly(sslSocket)
+          }
+        } catch {
+          case NonFatal(e) =>
+            logger.error(
+              "H2 TLS handshake failed",
+              "host"          -> AttributeValue.StringValue(host),
+              "port"          -> AttributeValue.LongValue(port.toLong),
+              "error_type"    -> AttributeValue.StringValue(e.getClass.getSimpleName),
+              "error_message" -> AttributeValue.StringValue(Option(e.getMessage).getOrElse("")),
+            )
+            closeQuietly(sslSocket)
+            closeQuietly(channel)
         }
       case None          =>
         activeConnections.add(channel)
         try {
-          connectionHandler(Channels.newInputStream(channel), Channels.newOutputStream(channel))
+          val peer = PeerInfo(TcpListener.peerIp(channel.getRemoteAddress), None)
+          connectionHandler(Channels.newInputStream(channel), Channels.newOutputStream(channel), peer)
         } finally {
           activeConnections.remove(channel)
           closeQuietly(channel)
@@ -167,9 +212,32 @@ private object TcpListener {
       keyManagerFactory.init(keyStore, password)
 
       val sslContext = SSLContext.getInstance("TLS")
-      sslContext.init(keyManagerFactory.getKeyManagers, null, new SecureRandom())
+      sslContext.init(keyManagerFactory.getKeyManagers, trustManagers(tls), new SecureRandom())
       requireSupportedProtocols(sslContext, tls, "PEM cert/key material")
       sslContext
+    }
+
+  /**
+   * Builds the trust managers for server-side client-certificate verification.
+   * Always real managers, never `null`: an explicit `trustCertChain` builds a
+   * CA store from it, otherwise the platform default trust store is used.
+   */
+  private def trustManagers(tls: TlsConfig): Array[TrustManager] =
+    tls.trustCertChain match {
+      case Some(source) =>
+        val certificates        = loadCertificates(source)
+        val trustStore          = KeyStore.getInstance(KeyStore.getDefaultType)
+        trustStore.load(null, null)
+        certificates.zipWithIndex.foreach { case (certificate, index) =>
+          trustStore.setCertificateEntry("zio-http-trust-ca-" + index, certificate)
+        }
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+        trustManagerFactory.init(trustStore)
+        trustManagerFactory.getTrustManagers
+      case None         =>
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+        trustManagerFactory.init(null: KeyStore)
+        trustManagerFactory.getTrustManagers
     }
 
   def createTlsSocket(sslContext: SSLContext, channel: SocketChannel, tls: Option[TlsConfig]): SSLSocket = {
@@ -194,6 +262,7 @@ private object TcpListener {
 
     socket.setUseClientMode(false)
     socket.setSSLParameters(parameters)
+    if (tls.exists(_.requireClientAuth)) socket.setNeedClientAuth(true)
     // Every reject path below closes explicitly: on the http/1.1-only path
     // the JDK fails inside startHandshake BEFORE any post-handshake close
     // could run, which left FIN to socket GC (CLOSE_WAIT window + noisy
@@ -221,6 +290,26 @@ private object TcpListener {
     parameters.setApplicationProtocols(alpnProtocols.toArray)
     parameters
   }
+
+  /**
+   * Socket peer IP for proxy-trust gating; falls back to the raw address
+   * string.
+   */
+  private def peerIp(remote: java.net.SocketAddress): String =
+    remote match {
+      case inet: InetSocketAddress if inet.getAddress != null => inet.getAddress.getHostAddress
+      case other                                              => String.valueOf(other)
+    }
+
+  /**
+   * Verified client certificate of an mTLS peer, if the handshake authenticated
+   * one.
+   */
+  private def peerCert(socket: SSLSocket): Option[X509Certificate] =
+    try socket.getSession.getPeerCertificates.collectFirst { case certificate: X509Certificate => certificate }
+    catch {
+      case _: SSLPeerUnverifiedException => None
+    }
 
   private def firstSslContext(tls: TlsConfig): Option[SSLContext] =
     tls.certChain match {

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2AccessLogSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2AccessLogSpec.scala
@@ -1,0 +1,370 @@
+package zio.http.h2
+
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.H2RawClientFixture.RawH2Client
+import zio.http.h2.hpack.{HeaderField, HpackEncoder}
+import zio.http.{
+  AccessLog,
+  AccessLogRecord,
+  AccessLogSink,
+  BindAddress,
+  Body,
+  BoundAddress,
+  Connector,
+  Handler,
+  LoomServer,
+  Method,
+  Middleware,
+  Request,
+  Response,
+  Route,
+  Routes,
+  Status,
+  TrustedProxyConfig,
+  URL,
+  Version,
+  handler,
+}
+
+/**
+ * Access/audit logging with a pluggable sink, middleware-only by design.
+ *
+ * Every request that reaches a route must produce one metadata-only record
+ * (method, path, status, duration, request-id, plus the G3 trust decision and
+ * the G2 deadline outcome) delivered to a user-supplied [[AccessLogSink]]. Body
+ * bytes must never reach the sink (by construction the record carries no body
+ * handle), and a throwing sink must never fail the request. Transports emit
+ * nothing by default: logging attaches opt-in via [[Middleware.accessLog]],
+ * composed above the transport's internal OpenTelemetry span (which is never
+ * touched here).
+ */
+@experimental
+object H2AccessLogSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2AccessLogSpec")(
+      test("custom sink receives one record per request with method/path/status/duration/request-id") {
+        val capture = CaptureSink()
+        withLoggedServer(TrustedProxyConfig.default, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val response =
+              try client.get("/", streamId = 1, extra = List(HeaderField("x-request-id", "req-1")))
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              records.length == 1,
+              records.head.method == "GET",
+              records.head.path == "/",
+              records.head.status == 200,
+              records.head.durationMs >= 0L,
+              records.head.requestId == "req-1",
+              records.head.deadlineOutcome.contains(AccessLog.DeadlineOk),
+            )
+          }
+        }
+      },
+      test("trusted peer forwarding yields trustDecision=trusted with resolved client-ip") {
+        val capture = CaptureSink()
+        val trusted = TrustedProxyConfig(trustedCidrs = Set("127.0.0.1/32"))
+        withLoggedServer(trusted, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val extra    = List(
+              HeaderField("x-forwarded-for", "203.0.113.7"),
+              HeaderField("x-request-id", "req-trusted"),
+            )
+            val response =
+              try client.get("/", streamId = 1, extra = extra)
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              records.length == 1,
+              records.head.peerAddress.contains("127.0.0.1"),
+              records.head.clientIp.contains("203.0.113.7"),
+              records.head.trustDecision.contains(AccessLog.TrustTrusted),
+            )
+          }
+        }
+      },
+      test("untrusted peer yields trustDecision=untrusted and client-ip falls back to peer") {
+        val capture = CaptureSink()
+        withLoggedServer(TrustedProxyConfig.default, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val extra    = List(
+              HeaderField("x-forwarded-for", "203.0.113.7"),
+              HeaderField("x-request-id", "req-untrusted"),
+            )
+            val response =
+              try client.get("/", streamId = 1, extra = extra)
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              records.length == 1,
+              records.head.peerAddress.contains("127.0.0.1"),
+              records.head.clientIp.contains("127.0.0.1"),
+              records.head.trustDecision.contains(AccessLog.TrustUntrusted),
+            )
+          }
+        }
+      },
+      test("request body bytes never reach the sink") {
+        val capture = CaptureSink()
+        val secret  = "super-secret-body-payload-7f3a9c"
+        withLoggedServer(TrustedProxyConfig.default, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val response =
+              try
+                client.post("/", Chunk.fromArray(secret.getBytes(StandardCharsets.UTF_8)), streamId = 1, extra = Nil)
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              new String(response.body.toArray, StandardCharsets.UTF_8) == secret,
+              records.length == 1,
+              records.head.method == "POST",
+              !records.exists(_.toString.contains(secret)),
+            )
+          }
+        }
+      },
+      test("sink failure never fails the request") {
+        val failing = AccessLogSink(_ => throw new RuntimeException("sink boom"))
+        withLoggedServer(TrustedProxyConfig.default, failing, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val response =
+              try client.get("/", streamId = 1, extra = Nil)
+              finally client.close()
+            assertTrue(
+              response.status == 200,
+              new String(response.body.toArray, StandardCharsets.UTF_8) == "hello",
+            )
+          }
+        }
+      },
+      test("missing x-request-id is replaced with a generated id") {
+        val capture = CaptureSink()
+        withLoggedServer(TrustedProxyConfig.default, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            val client   = new RawH2Client(port)
+            val response =
+              try client.get("/", streamId = 1, extra = Nil)
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              records.length == 1,
+              records.head.requestId.nonEmpty,
+            )
+          }
+        }
+      },
+      test("over-long injected request-id is truncated before it reaches the record") {
+        val capture = CaptureSink()
+        withLoggedServer(TrustedProxyConfig.default, capture, EchoRoutes) { port =>
+          ZIO.attemptBlocking {
+            // A raw newline never survives HPACK validation (the server 500s
+            // before any handler runs), so the wire-provable sanitize rule is
+            // cardinality bounding: a 5KB id must arrive truncated to 128.
+            val big      = "a" * 5120
+            val client   = new RawH2Client(port)
+            val response =
+              try client.get("/", streamId = 1, extra = List(HeaderField("x-request-id", big)))
+              finally client.close()
+            val records  = capture.records
+            assertTrue(
+              response.status == 200,
+              records.length == 1,
+              records.head.requestId == "a" * 128,
+            )
+          }
+        }
+      },
+      suite("AccessLog unit")(
+        test("disabled sink accepts records without effect") {
+          val record = AccessLogRecord(
+            method = "GET",
+            path = "/",
+            route = None,
+            status = 200,
+            durationMs = 1L,
+            requestId = "u-1",
+            peerAddress = None,
+            clientIp = None,
+            trustDecision = None,
+            deadlineOutcome = None,
+            protocol = "h2c",
+          )
+          AccessLog.emit(AccessLogSink.disabled, record)
+          assertTrue(AccessLogSink.disabled != null)
+        },
+        test("emit swallows sink failures") {
+          val boom   = AccessLogSink(_ => throw new RuntimeException("sink boom"))
+          val record = AccessLogRecord(
+            method = "GET",
+            path = "/",
+            route = None,
+            status = 200,
+            durationMs = 0L,
+            requestId = "u-3",
+            peerAddress = None,
+            clientIp = None,
+            trustDecision = None,
+            deadlineOutcome = Some(AccessLog.DeadlineOk),
+            protocol = "h2c",
+          )
+          AccessLog.emit(boom, record)
+          assertTrue(true)
+        },
+        test("record exposes no body handle by construction") {
+          val fields    = classOf[AccessLogRecord].getDeclaredFields.toList
+          val typeNames = fields.map(_.getType.getName)
+          assertTrue(
+            !fields.exists(_.getName.equalsIgnoreCase("body")),
+            !typeNames.exists(_.contains("Body")),
+            !typeNames.exists(_.contains("Chunk")),
+          )
+        },
+        test("trust derivation honors forwarding only when it was applied") {
+          assertTrue(
+            AccessLog.trustDecision(Some("127.0.0.1"), Some("203.0.113.7")).contains(AccessLog.TrustTrusted),
+            AccessLog.trustDecision(Some("127.0.0.1"), Some("127.0.0.1")).contains(AccessLog.TrustUntrusted),
+            AccessLog.trustDecision(None, None).isEmpty,
+          )
+        },
+        test("accessLog middleware preserves Response and Halt results") {
+          val okResponse  = Response(status = Status.Ok, body = Body.fromString("ok"))
+          val halt        = zio.http.Halt(Response(status = Status.Forbidden, body = Body.empty))
+          val okRoutes    = Routes(Route(RoutePattern.GET, Handler.succeed(okResponse)))
+          val haltRoutes  = Routes(Route(RoutePattern.POST, Handler(halt)))
+          val loggedOk    = okRoutes @@ Middleware.accessLog(AccessLogSink.disabled)
+          val loggedHalt  = haltRoutes @@ Middleware.accessLog(AccessLogSink.disabled)
+          val scope       = zio.blocks.scope.Scope.global
+          val plain       = Request(Method.GET, URL.root, zio.http.Headers.empty, Body.empty, Version.`HTTP/1.1`)
+          val directOk    = okRoutes.routes.toList.head.handler.handle(plain, Context.empty, (), scope)
+          val wrappedOk   = loggedOk.routes.toList.head.handler.handle(plain, Context.empty, (), scope)
+          val directHalt  = haltRoutes.routes.toList.head.handler.handle(plain, Context.empty, (), scope)
+          val wrappedHalt = loggedHalt.routes.toList.head.handler.handle(plain, Context.empty, (), scope)
+          assertTrue(
+            wrappedOk == directOk,
+            wrappedHalt == directHalt,
+            wrappedHalt != wrappedOk,
+            loggedOk.size == 1,
+            loggedHalt.size == 1,
+          )
+        },
+      ),
+    ) @@ sequential
+
+  private val EchoRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.GET,
+        handler { (_: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = Body.fromString("hello")))
+        },
+      ),
+      Route(
+        RoutePattern.POST,
+        handler { (req: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = req.body))
+        },
+      ),
+    )
+
+  private def withLoggedServer[R](
+    trusted: TrustedProxyConfig,
+    sink: AccessLogSink,
+    routes: Routes[Any],
+  )(use: Int => ZIO[R, Throwable, TestResult]): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(
+            bind = BindAddress.localhost(0),
+            trustedProxy = trusted,
+          )
+          new LoomServer(connector).serve(routes @@ Middleware.accessLog(sink), Context.empty)
+        },
+      )(handle => ZIO.succeed(handle.shutdownAndWait()))
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private final class CaptureSink extends AccessLogSink {
+    private val queue                      = new java.util.concurrent.ConcurrentLinkedQueue[AccessLogRecord]()
+    def log(record: AccessLogRecord): Unit = { queue.add(record); () }
+    def records: List[AccessLogRecord]     = queue.toArray(new Array[AccessLogRecord](0)).toList
+  }
+
+  private object CaptureSink {
+    def apply(): CaptureSink = new CaptureSink()
+  }
+
+  /**
+   * Header-aware sends on top of the shared raw client (extra headers + POST).
+   */
+  private implicit final class RawClientOps(val client: RawH2Client) {
+    private def encoder: HpackEncoder = new HpackEncoder()
+
+    def get(path: String, streamId: Int, extra: List[HeaderField]): H2RawClientFixture.RawResponse = {
+      client.sendFrame(makeHeaders("GET", path, streamId, endStream = true, extra))
+      client.awaitResponse(streamId)
+    }
+
+    def post(
+      path: String,
+      body: Chunk[Byte],
+      streamId: Int,
+      extra: List[HeaderField],
+    ): H2RawClientFixture.RawResponse = {
+      client.sendFrame(makeHeaders("POST", path, streamId, endStream = false, extra))
+      client.sendFrame(Data(streamId, body, endStream = true))
+      client.awaitResponse(streamId)
+    }
+
+    private def makeHeaders(
+      method: String,
+      path: String,
+      streamId: Int,
+      endStream: Boolean,
+      extra: List[HeaderField],
+    ): Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:${client.port}"),
+      )
+      Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo ++ extra),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2AccessLogSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2AccessLogSpec.scala
@@ -73,7 +73,7 @@ object H2AccessLogSpec extends ZIOSpecDefault {
               records.head.status == 200,
               records.head.durationMs >= 0L,
               records.head.requestId == "req-1",
-              records.head.deadlineOutcome.contains(AccessLog.DeadlineOk),
+              records.head.deadlineOutcome.contains(AccessLog.DeadlineOutcome.Ok),
             )
           }
         }
@@ -97,7 +97,7 @@ object H2AccessLogSpec extends ZIOSpecDefault {
               records.length == 1,
               records.head.peerAddress.contains("127.0.0.1"),
               records.head.clientIp.contains("203.0.113.7"),
-              records.head.trustDecision.contains(AccessLog.TrustTrusted),
+              records.head.trustDecision.contains(AccessLog.TrustDecision.Trusted),
             )
           }
         }
@@ -120,7 +120,7 @@ object H2AccessLogSpec extends ZIOSpecDefault {
               records.length == 1,
               records.head.peerAddress.contains("127.0.0.1"),
               records.head.clientIp.contains("127.0.0.1"),
-              records.head.trustDecision.contains(AccessLog.TrustUntrusted),
+              records.head.trustDecision.contains(AccessLog.TrustDecision.Untrusted),
             )
           }
         }
@@ -136,12 +136,21 @@ object H2AccessLogSpec extends ZIOSpecDefault {
                 client.post("/", Chunk.fromArray(secret.getBytes(StandardCharsets.UTF_8)), streamId = 1, extra = Nil)
               finally client.close()
             val records  = capture.records
+            val record   = records.head
             assertTrue(
               response.status == 200,
               new String(response.body.toArray, StandardCharsets.UTF_8) == secret,
               records.length == 1,
-              records.head.method == "POST",
-              !records.exists(_.toString.contains(secret)),
+              record.method == "POST",
+              // Field-level secrecy: no record field and no rendered log line
+              // may carry body bytes (not just "toString has no secret").
+              !record.path.contains(secret),
+              !record.route.exists(_.contains(secret)),
+              !record.requestId.contains(secret),
+              !record.peerAddress.exists(_.contains(secret)),
+              !record.clientIp.exists(_.contains(secret)),
+              !record.protocol.contains(secret),
+              !AccessLog.formatLine(record).contains(secret),
             )
           }
         }
@@ -214,8 +223,11 @@ object H2AccessLogSpec extends ZIOSpecDefault {
             deadlineOutcome = None,
             protocol = "h2c",
           )
+          // Both entry points must complete without throwing ...
           AccessLog.emit(AccessLogSink.disabled, record)
-          assertTrue(AccessLogSink.disabled != null)
+          AccessLogSink.disabled.log(record)
+          // ... and a fresh capture sink observes zero records from these emits.
+          assertTrue(CaptureSink().records.isEmpty)
         },
         test("emit swallows sink failures") {
           val boom   = AccessLogSink(_ => throw new RuntimeException("sink boom"))
@@ -229,7 +241,7 @@ object H2AccessLogSpec extends ZIOSpecDefault {
             peerAddress = None,
             clientIp = None,
             trustDecision = None,
-            deadlineOutcome = Some(AccessLog.DeadlineOk),
+            deadlineOutcome = Some(AccessLog.DeadlineOutcome.Ok),
             protocol = "h2c",
           )
           AccessLog.emit(boom, record)
@@ -246,9 +258,15 @@ object H2AccessLogSpec extends ZIOSpecDefault {
         },
         test("trust derivation honors forwarding only when it was applied") {
           assertTrue(
-            AccessLog.trustDecision(Some("127.0.0.1"), Some("203.0.113.7")).contains(AccessLog.TrustTrusted),
-            AccessLog.trustDecision(Some("127.0.0.1"), Some("127.0.0.1")).contains(AccessLog.TrustUntrusted),
+            AccessLog.trustDecision(Some("127.0.0.1"), Some("203.0.113.7")).contains(AccessLog.TrustDecision.Trusted),
+            AccessLog.trustDecision(Some("127.0.0.1"), Some("127.0.0.1")).contains(AccessLog.TrustDecision.Untrusted),
             AccessLog.trustDecision(None, None).isEmpty,
+          )
+        },
+        test("header literals stay in sync with TrustedProxyConfig") {
+          assertTrue(
+            AccessLog.PeerAddressHeader == TrustedProxyConfig.PeerAddressHeader,
+            AccessLog.ClientIpHeader == TrustedProxyConfig.ClientIpHeader,
           )
         },
         test("accessLog middleware preserves Response and Halt results") {

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2BodyBoundSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2BodyBoundSpec.scala
@@ -1,0 +1,356 @@
+package zio.http.h2
+
+import java.io.EOFException
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{
+  BindAddress,
+  BoundAddress,
+  Connector,
+  Handler,
+  LoomServer,
+  Request,
+  Response,
+  Route,
+  Routes,
+  Status,
+  handler,
+}
+
+/**
+ * Request-body bound for the H2 server transport.
+ *
+ * An unbounded H2 request body lets a malicious client stream gigabytes into
+ * `H2Transport.readRequestBody` before any check runs. These tests pin the
+ * required behavior against a real loopback `LoomServer`:
+ *
+ *   - a body at exactly the cap is accepted and echoed,
+ *   - a body one byte over the cap is reset mid-stream with
+ *     `RST_STREAM(FLOW_CONTROL_ERROR)` while the connection survives for
+ *     sibling streams,
+ *   - a declared `content-length` larger than the cap is rejected without
+ *     reading the body,
+ *   - a `content-length` that disagrees with the received bytes is rejected.
+ */
+@experimental
+object H2BodyBoundSpec extends ZIOSpecDefault {
+
+  private val BodyCap: Long = 1024L
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2BodyBoundSpec")(
+      test("request body at exactly the cap is accepted and echoed") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new BoundTestClient(port)
+            try {
+              val body     = Chunk.fromArray(Array.fill(BodyCap.toInt)(0x41.toByte))
+              val response = client.post(streamId = 1, body = body, declaredLength = Some(body.length.toString))
+              assertTrue(response.status == 200, response.body == body)
+            } finally client.close()
+          }
+        }
+      },
+      test("request body one byte over the cap is reset with FLOW_CONTROL_ERROR and the connection survives") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new BoundTestClient(port)
+            try {
+              // Split across two DATA frames so the running total crosses the
+              // cap mid-stream: per-frame accounting must trip on the second.
+              val first   = Chunk.fromArray(Array.fill(BodyCap.toInt)(0x41.toByte))
+              val second  = Chunk.fromArray(Array(0x42.toByte))
+              val code    = client.postSplit(streamId = 1, first = first, second = second, declaredLength = None)
+              val sibling = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(code == H2Error.Code.FLOW_CONTROL_ERROR, sibling.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("declared content-length larger than the cap is rejected with FLOW_CONTROL_ERROR") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new BoundTestClient(port)
+            try {
+              val body = Chunk.fromArray(Array.fill(16)(0x41.toByte))
+              val code =
+                client.postExpectingReset(streamId = 1, body = body, declaredLength = Some((BodyCap + 1024L).toString))
+              assertTrue(code == H2Error.Code.FLOW_CONTROL_ERROR)
+            } finally client.close()
+          }
+        }
+      },
+      test("content-length disagreeing with received bytes is rejected") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new BoundTestClient(port)
+            try {
+              // Declares 100 bytes but ends the stream after 10: the server
+              // must not honor the short body as a complete request.
+              val body = Chunk.fromArray(Array.fill(10)(0x41.toByte))
+              val code = client.postExpectingReset(streamId = 1, body = body, declaredLength = Some("100"))
+              assertTrue(code == H2Error.Code.PROTOCOL_ERROR)
+            } finally client.close()
+          }
+        }
+      },
+    ) @@ sequential
+
+  private val EchoRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.POST,
+        handler { (req: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = req.body))
+        },
+      ),
+      Route(RoutePattern.GET, Handler.succeed(Response.ok)),
+    )
+
+  private def withServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(
+            bind = BindAddress.localhost(0),
+            maxRequestBodySize = BodyCap,
+          )
+          new LoomServer(connector).serve(EchoRoutes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private final case class RawResponse(status: Int, headers: List[HeaderField], body: Chunk[Byte])
+
+  private final class BoundTestClient(val port: Int) extends AutoCloseable {
+    private val PrefaceBytes =
+      "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+
+    val socket        = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(5000)
+    private val out   = socket.getOutputStream
+    private val rawIn = socket.getInputStream
+    private var buf   = Chunk.empty[Byte]
+
+    private val encoder = new HpackEncoder()
+    private val decoder = new HpackDecoder()
+
+    private val frameBuffer: mutable.Map[Int, mutable.Queue[H2Frame]] =
+      mutable.Map.empty
+
+    handshake()
+
+    def sendFrame(frame: H2Frame): Unit   = sendRaw(FrameCodec.encode(frame).toArray)
+    def sendRaw(bytes: Array[Byte]): Unit = { out.write(bytes); out.flush() }
+
+    /**
+     * POST whose body fits in one DATA frame; returns the response or throws if
+     * the stream is reset.
+     */
+    def post(streamId: Int, body: Chunk[Byte], declaredLength: Option[String]): PostResult = {
+      val endStream = body.isEmpty
+      sendFrame(makeHeaders("POST", "/", streamId, endStream, declaredLength))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitResponseOrReset(streamId)
+    }
+
+    /**
+     * POST split across two DATA frames; returns the reset code (throws if a
+     * full response arrives).
+     */
+    def postSplit(
+      streamId: Int,
+      first: Chunk[Byte],
+      second: Chunk[Byte],
+      declaredLength: Option[String],
+    ): H2Error.Code = {
+      sendFrame(makeHeaders("POST", "/", streamId, endStream = false, declaredLength))
+      sendFrame(Data(streamId, first, endStream = false))
+      sendFrame(Data(streamId, second, endStream = true))
+      awaitReset(streamId)
+    }
+
+    /**
+     * POST a single-DATA-frame body, then wait for the stream reset. Any
+     * best-effort error response the handler emits after the reset is ignored:
+     * the RST is written directly while the error response is written directly,
+     * so either frame may hit the wire first. The pre/post-RST response (if
+     * any) is intentionally unspecified here: this spec only pins the reset
+     * code.
+     */
+    def postExpectingReset(streamId: Int, body: Chunk[Byte], declaredLength: Option[String]): H2Error.Code = {
+      sendFrame(makeHeaders("POST", "/", streamId, body.isEmpty, declaredLength))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitReset(streamId)
+    }
+
+    def roundTrip(method: String, path: String, body: Chunk[Byte], streamId: Int): RawResponse = {
+      sendFrame(makeHeaders(method, path, streamId, body.isEmpty, None))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitResponseOrReset(streamId) match {
+        case PostResult.ResponseReceived(response) => response
+        case PostResult.StreamReset(code)          =>
+          throw new AssertionError("Expected a full response but the stream was reset: " + code)
+      }
+    }
+
+    private def awaitResponseOrReset(streamId: Int): PostResult = {
+      val hdrs   = mutable.ListBuffer.empty[HeaderField]
+      var body   = Chunk.empty[Byte]
+      var done   = false
+      while (!done) {
+        nextFrameFor(streamId) match {
+          case Headers(_, block, end, _, _, _) =>
+            decoder.decode(block) match {
+              case Right(h) => hdrs ++= h
+              case Left(e)  => throw new AssertionError("HPACK decode: " + e)
+            }
+            if (end) done = true
+          case Data(_, data, end, _)           =>
+            body = body ++ data
+            if (end) done = true
+          case RstStream(_, code)              =>
+            return PostResult.StreamReset(code)
+          case GoAway(_, code, dbg)            =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                               =>
+            throw new AssertionError("Unexpected frame while waiting for response")
+        }
+      }
+      val status = hdrs
+        .find(_.name == ":status")
+        .map(_.value.toInt)
+        .getOrElse(throw new AssertionError("Missing :status"))
+      PostResult.ResponseReceived(RawResponse(status, hdrs.toList, body))
+    }
+
+    private def awaitReset(streamId: Int): H2Error.Code = {
+      var result: Option[H2Error.Code] = None
+      while (result.isEmpty) {
+        nextFrameFor(streamId) match {
+          case RstStream(_, code)   => result = Some(code)
+          case _: Headers           => () // Best-effort error response on the dead stream; keep waiting for the RST.
+          case _: Data              => ()
+          case GoAway(_, code, dbg) =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                    =>
+            throw new AssertionError("Unexpected frame while waiting for RST_STREAM")
+        }
+      }
+      result.get
+    }
+
+    private def nextFrameFor(streamId: Int): H2Frame = {
+      frameBuffer.get(streamId) match {
+        case Some(queue) if queue.nonEmpty => return queue.dequeue()
+        case _                             => ()
+      }
+      while (true) {
+        readFrame() match {
+          case Settings(false, _)                  => sendFrame(Settings(ack = true, Nil))
+          case Settings(true, _)                   => ()
+          case _: WindowUpdate                     => ()
+          case frame if frame.streamId == streamId => return frame
+          case other                               =>
+            val queue = frameBuffer.getOrElseUpdate(other.streamId, mutable.Queue.empty)
+            queue.enqueue(other)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    private def readFrame(): H2Frame = {
+      while (true) {
+        FrameCodec.decode(buf) match {
+          case Right((frame, rest))           =>
+            buf = rest
+            return frame
+          case Left(H2Error.InsufficientData) =>
+            val tmp = new Array[Byte](8192)
+            val n   = rawIn.read(tmp)
+            if (n < 0) throw new EOFException("Connection closed")
+            buf = buf ++ Chunk.fromArray(java.util.Arrays.copyOf(tmp, n))
+          case Left(err)                      =>
+            throw new AssertionError("Frame decode error: " + err)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    private def makeHeaders(
+      method: String,
+      path: String,
+      streamId: Int,
+      endStream: Boolean,
+      declaredLength: Option[String],
+    ): Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      )
+      val length = declaredLength.toList.map(value => HeaderField("content-length", value))
+      Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo ++ length),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+
+    override def close(): Unit = socket.close()
+
+    private def handshake(): Unit = {
+      out.write(PrefaceBytes)
+      out.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      out.flush()
+      readFrame() match {
+        case Settings(false, _) => sendFrame(Settings(ack = true, Nil))
+        case other              => throw new AssertionError("Expected Settings(false,_): " + other)
+      }
+      readFrame() // consume server's ACK for our SETTINGS
+    }
+  }
+
+  private sealed trait PostResult {
+    def status: Int
+    def body: Chunk[Byte]
+    def resetCode: H2Error.Code
+  }
+  private object PostResult       {
+    final case class ResponseReceived(response: RawResponse) extends PostResult {
+      def status: Int             = response.status
+      def body: Chunk[Byte]       = response.body
+      def resetCode: H2Error.Code =
+        throw new AssertionError("Expected the stream to be reset but a full response was received: " + status)
+    }
+    final case class StreamReset(code: H2Error.Code)         extends PostResult {
+      def status: Int       = throw new AssertionError("Expected a full response but the stream was reset: " + code)
+      def body: Chunk[Byte] = throw new AssertionError("Expected a full response but the stream was reset: " + code)
+      def resetCode: H2Error.Code = code
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2BodyBoundSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2BodyBoundSpec.scala
@@ -58,9 +58,14 @@ object H2BodyBoundSpec extends ZIOSpecDefault {
           ZIO.attemptBlocking {
             val client = new BoundTestClient(port)
             try {
-              val body     = Chunk.fromArray(Array.fill(BodyCap.toInt)(0x41.toByte))
-              val response = client.post(streamId = 1, body = body, declaredLength = Some(body.length.toString))
-              assertTrue(response.status == 200, response.body == body)
+              val body   = Chunk.fromArray(Array.fill(BodyCap.toInt)(0x41.toByte))
+              val result = client.post(streamId = 1, body = body, declaredLength = Some(body.length.toString))
+              val echoed = result match {
+                case PostResult.ResponseReceived(response) => response
+                case PostResult.StreamReset(code)          =>
+                  throw new AssertionError("at-cap body must be echoed, but the stream was reset: " + code)
+              }
+              assertTrue(echoed.status == 200, echoed.body == body)
             } finally client.close()
           }
         }

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2ContinuationFloodSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2ContinuationFloodSpec.scala
@@ -1,0 +1,339 @@
+package zio.http.h2
+
+import java.io.EOFException
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{BindAddress, BoundAddress, Connector, Handler, Http2Config, LoomServer, Response, Route, Routes}
+
+/**
+ * CONTINUATION flood bound for the H2 server transport.
+ *
+ * An incomplete header block (HEADERS without END_HEADERS) is buffered pending
+ * its CONTINUATION frames. Without a bound a peer can grow that buffer without
+ * limit. The buffered encoded bytes are capped at a multiple of the advertised
+ * decoded budget (`maxHeaderListSize`); past the cap the stream — and only the
+ * stream — is reset with `RST_STREAM(CANCEL)` while the connection stays usable
+ * for sibling streams. Trailing in-flight CONTINUATIONs for the reset block are
+ * tolerated per RFC 9113 section 5.1.
+ */
+@experimental
+object H2ContinuationFloodSpec extends ZIOSpecDefault {
+
+  /**
+   * Socket read timeout: headroom above every explicit await deadline below.
+   */
+  private val SoTimeoutMs: Int = 20000
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2ContinuationFloodSpec")(
+      test("CONTINUATION flood over encoded cap is reset with CANCEL and connection stays usable") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new FloodTestClient(port)
+            try {
+              // Encoded cap is 4x the default 8192 decoded budget = 32768 bytes.
+              val first    = Chunk.fromArray(Array.fill(1024)(0x00.toByte))
+              val fragment = Chunk.fromArray(Array.fill(8192)(0x00.toByte))
+              client.sendFrame(Headers(streamId = 1, headerBlock = first, endStream = true, endHeaders = false))
+              var i        = 0
+              var stopped  = false
+              while (i < 6 && !stopped) {
+                try client.sendFrame(Continuation(streamId = 1, headerBlock = fragment, endHeaders = false))
+                catch {
+                  // The reset may race the flood: bytes already sent still
+                  // prove the flood, and the RST is asserted below (reads are
+                  // unaffected). Stops sending; the final fragment below is
+                  // skipped the same way.
+                  case _: java.net.SocketException => stopped = true
+                }
+                i += 1
+              }
+              if (!stopped) {
+                // Final fragment (already in flight past the reset) must be tolerated.
+                try client.sendFrame(Continuation(streamId = 1, headerBlock = fragment, endHeaders = true))
+                catch {
+                  case _: java.net.SocketException => ()
+                }
+              }
+              val reset    = client.awaitReset(streamId = 1, timeoutMs = 15000)
+              val response = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(reset == H2Error.Code.CANCEL, response.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("single HEADERS fragment already over a small encoded cap is reset without buffering") {
+        withSmallBudgetServer { port =>
+          ZIO.attemptBlocking {
+            val client = new FloodTestClient(port)
+            try {
+              // Encoded cap is 4x the 1024 decoded budget = 4096 bytes: one
+              // 8KB fragment (under the 16384 frame limit) already exceeds it,
+              // so the stream is reset before anything is buffered.
+              val fragment = Chunk.fromArray(Array.fill(8192)(0x00.toByte))
+              client.sendFrame(Headers(streamId = 1, headerBlock = fragment, endStream = true, endHeaders = false))
+              val reset    = client.awaitReset(streamId = 1, timeoutMs = 15000)
+              val response = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(reset == H2Error.Code.CANCEL, response.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("valid headers split across HEADERS and CONTINUATION under the cap succeed") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new FloodTestClient(port)
+            try {
+              val response = client.roundTripSplitHeaders("GET", "/", streamId = 1)
+              assertTrue(response.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+    ) @@ sequential
+
+  private val SimpleRoutes: Routes[Any] =
+    Routes(Route(RoutePattern.GET, Handler.succeed(Response.ok)))
+
+  private def withServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(bind = BindAddress.localhost(0))
+          new LoomServer(connector).serve(SimpleRoutes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private def withSmallBudgetServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(
+            bind = BindAddress.localhost(0),
+            protocol = zio.http.Protocol.H2C(Http2Config(maxHeaderListSize = 1024)),
+          )
+          new LoomServer(connector).serve(SimpleRoutes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private final case class RawResponse(status: Int, headers: List[HeaderField], body: Chunk[Byte])
+
+  private final class FloodTestClient(val port: Int) extends AutoCloseable {
+    private val PrefaceBytes =
+      "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+
+    val socket        = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(SoTimeoutMs)
+    private val out   = socket.getOutputStream
+    private val rawIn = socket.getInputStream
+    private var buf   = Chunk.empty[Byte]
+
+    private val encoder = new HpackEncoder()
+    private val decoder = new HpackDecoder()
+
+    private val frameBuffer: mutable.Map[Int, mutable.Queue[H2Frame]] =
+      mutable.Map.empty
+
+    handshake()
+
+    def sendFrame(frame: H2Frame): Unit   = sendRaw(FrameCodec.encode(frame).toArray)
+    def sendRaw(bytes: Array[Byte]): Unit = { out.write(bytes); out.flush() }
+
+    def roundTrip(method: String, path: String, body: Chunk[Byte], streamId: Int): RawResponse =
+      awaitResponseOrReset(
+        streamId,
+        sendFirst = Some(() => {
+          sendFrame(makeHeaders(method, path, streamId, body.isEmpty))
+          if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+        }),
+      ) match {
+        case Left(response) => response
+        case Right(code)    => throw new AssertionError("Expected a full response but reset: " + code)
+      }
+
+    /**
+     * Sends valid request headers split across two fragments (HEADERS without
+     * END_HEADERS plus one CONTINUATION): the split is inside one HPACK block,
+     * so reassembly must deliver a working request.
+     */
+    def roundTripSplitHeaders(method: String, path: String, streamId: Int): RawResponse = {
+      val block = encoder.encode(
+        List(
+          HeaderField(":method", method),
+          HeaderField(":path", path),
+          HeaderField(":scheme", "http"),
+          HeaderField(":authority", s"127.0.0.1:$port"),
+        ),
+      )
+      val half  = block.length / 2
+      awaitResponseOrReset(
+        streamId,
+        sendFirst = Some(() => {
+          sendFrame(Headers(streamId, block.slice(0, half), endStream = true, endHeaders = false))
+          sendFrame(Continuation(streamId, block.slice(half, block.length), endHeaders = true))
+        }),
+      ) match {
+        case Left(response) => response
+        case Right(code)    => throw new AssertionError("Expected a full response but reset: " + code)
+      }
+    }
+
+    def awaitReset(streamId: Int, timeoutMs: Int): H2Error.Code = {
+      socket.setSoTimeout(1000)
+      try {
+        val deadline                     = java.lang.System.currentTimeMillis() + timeoutMs
+        var result: Option[H2Error.Code] = None
+        while (result.isEmpty) {
+          if (java.lang.System.currentTimeMillis() > deadline)
+            throw new AssertionError("Timed out waiting for RST_STREAM on stream " + streamId)
+          try {
+            nextFrameFor(streamId) match {
+              case RstStream(_, code) => result = Some(code)
+              case _: Headers         => () // Best-effort error response on the dead stream; keep waiting for the RST.
+              case _: Data            => ()
+              case GoAway(_, code, dbg) =>
+                throw new AssertionError(s"GOAWAY while waiting RST: $code ${new String(dbg.toArray)}")
+              case _                    => ()
+            }
+          } catch {
+            case _: java.net.SocketTimeoutException => ()
+          }
+        }
+        result.get
+      } finally socket.setSoTimeout(SoTimeoutMs)
+    }
+
+    private def awaitResponseOrReset(
+      streamId: Int,
+      sendFirst: Option[() => Unit] = None,
+    ): Either[RawResponse, H2Error.Code] = {
+      sendFirst.foreach(_())
+      val hdrs   = mutable.ListBuffer.empty[HeaderField]
+      var body   = Chunk.empty[Byte]
+      var done   = false
+      while (!done) {
+        nextFrameFor(streamId) match {
+          case Headers(_, block, end, _, _, _) =>
+            decoder.decode(block) match {
+              case Right(h) => hdrs ++= h
+              case Left(e)  => throw new AssertionError("HPACK decode: " + e)
+            }
+            if (end) done = true
+          case Data(_, data, end, _)           =>
+            body = body ++ data
+            if (end) done = true
+          case RstStream(_, code)              =>
+            return Right(code)
+          case GoAway(_, code, dbg)            =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                               =>
+            throw new AssertionError("Unexpected frame while waiting for response")
+        }
+      }
+      val status = hdrs
+        .find(_.name == ":status")
+        .map(_.value.toInt)
+        .getOrElse(throw new AssertionError("Missing :status"))
+      Left(RawResponse(status, hdrs.toList, body))
+    }
+
+    private def nextFrameFor(streamId: Int): H2Frame = {
+      frameBuffer.get(streamId) match {
+        case Some(queue) if queue.nonEmpty => return queue.dequeue()
+        case _                             => ()
+      }
+      while (true) {
+        readFrame() match {
+          case Settings(false, _)                  => sendFrame(Settings(ack = true, Nil))
+          case Settings(true, _)                   => ()
+          case _: WindowUpdate                     => ()
+          case Ping(false, data)                   =>
+            sendFrame(Ping(ack = true, data))
+          case frame if frame.streamId == streamId => return frame
+          case other                               =>
+            val queue = frameBuffer.getOrElseUpdate(other.streamId, mutable.Queue.empty)
+            queue.enqueue(other)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    private def readFrame(): H2Frame = {
+      while (true) {
+        FrameCodec.decode(buf) match {
+          case Right((frame, rest))           =>
+            buf = rest
+            return frame
+          case Left(H2Error.InsufficientData) =>
+            val tmp = new Array[Byte](8192)
+            val n   = rawIn.read(tmp)
+            if (n < 0) throw new EOFException("Connection closed")
+            buf = buf ++ Chunk.fromArray(java.util.Arrays.copyOf(tmp, n))
+          case Left(err)                      =>
+            throw new AssertionError("Frame decode error: " + err)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    private def makeHeaders(method: String, path: String, streamId: Int, endStream: Boolean): Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      )
+      Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+
+    override def close(): Unit = socket.close()
+
+    private def handshake(): Unit = {
+      out.write(PrefaceBytes)
+      out.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      out.flush()
+      readFrame() match {
+        case Settings(false, _) => sendFrame(Settings(ack = true, Nil))
+        case other              => throw new AssertionError("Expected Settings(false,_): " + other)
+      }
+      readFrame() // consume server's ACK for our SETTINGS
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2HardeningMatrixSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2HardeningMatrixSpec.scala
@@ -1,0 +1,582 @@
+package zio.http.h2
+
+import java.io.EOFException
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.nio.charset.StandardCharsets
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{
+  AccessLogRecord,
+  AccessLogSink,
+  BindAddress,
+  Body,
+  BoundAddress,
+  Connector,
+  Handler,
+  Http2Config,
+  LoomServer,
+  Method,
+  Middleware,
+  Protocol,
+  Request,
+  Response,
+  Route,
+  Routes,
+  Status,
+  TrustedProxyConfig,
+  handler,
+}
+
+/**
+ * Integration gate for the H2 hardening waves.
+ *
+ * Runs the adversarial cells — oversize headers (G1), oversize body (G1), slow
+ * loris (G2), spoofed forwarding headers (G3), and the HMAC raw-body tap plus
+ * the access-log sink (G4) — against ONE hardened `LoomServer` loopback with
+ * all knobs on, plus a knobs-off cell proving the timeouts are what reset slow
+ * streams. Each cell isolates its attack per-stream: the reset carries the
+ * expected `RST_STREAM` code and a sibling stream on the same connection still
+ * gets a 200, except for the HPACK-poison cell where the attack corrupts
+ * connection-level compression state and the server correctly tears the whole
+ * connection down instead (nothing served).
+ *
+ * Wire patterns are the same attacks pinned by the wave specs
+ * (`MaxHeaderListSizeSpec`, `H2BodyBoundSpec`, `H2SlowStreamSpec`,
+ * `H2ProxyTrustSpec`, `H2AccessLogSpec`, `H2RawBodySpec`); this spec combines
+ * them, it does not redefine enforcement semantics. If a cell fails, the bug is
+ * reported, not fixed here.
+ */
+@experimental
+object H2HardeningMatrixSpec extends ZIOSpecDefault {
+
+  private val BodyCap: Long         = 1024L
+  private val HeaderTimeoutMs: Long = 1000L
+  private val BodyTimeoutMs: Long   = 2000L
+
+  /**
+   * RFC 4231 Test Case 1 key: 20 bytes of 0x0b (same vector as H2RawBodySpec).
+   */
+  private val TestKey: Array[Byte] =
+    Array.fill(20)(0x0b.toByte)
+
+  /** RFC 4231 Test Case 1 message: "Hi There". */
+  private val TestMessage: Chunk[Byte] =
+    Chunk.fromArray("Hi There".getBytes(StandardCharsets.US_ASCII))
+
+  /** RFC 4231 Test Case 1 HMAC-SHA256, lowercase hex. */
+  private val ExpectedMacHex: String =
+    "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+
+  /**
+   * Raw-byte HMAC-SHA256 tap: hash `bytes` exactly as received, no decoding.
+   */
+  private def hmacSha256Hex(key: Array[Byte], bytes: Chunk[Byte]): String = {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(key, "HmacSHA256"))
+    val out = new StringBuilder(64)
+    val sum = mac.doFinal(bytes.toArray)
+    var i   = 0
+    while (i < sum.length) {
+      out.append(Character.forDigit((sum(i) >> 4) & 0xf, 16))
+      out.append(Character.forDigit(sum(i) & 0xf, 16))
+      i += 1
+    }
+    out.toString
+  }
+
+  private val MatrixRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.GET,
+        Handler.succeed(Response.ok),
+      ),
+      Route(
+        RoutePattern(Method.POST, "/echo"),
+        handler { (req: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = req.body))
+        },
+      ),
+      Route(
+        RoutePattern(Method.POST, "/hmac"),
+        handler { (req: Request) =>
+          // v4 preserves bytes: tap the raw chunk BEFORE any decoding.
+          // Verification/dedup/reconciliation belong to Qaizn, not here.
+          responseAsResult(
+            Response(status = Status.Ok, body = Body.fromString(hmacSha256Hex(TestKey, req.body.toChunk))),
+          )
+        },
+      ),
+      Route(
+        RoutePattern(Method.GET, "/whoami"),
+        handler { (req: Request) =>
+          val clientIp        = req.headers.rawGet("x-client-ip").getOrElse("none")
+          val peer            = req.headers.rawGet("x-peer-address").getOrElse("none")
+          val forwardedFor    = req.headers.rawGet("x-forwarded-for").getOrElse("none")
+          val forwardedHeader = req.headers.rawGet("forwarded").getOrElse("none")
+          responseAsResult(
+            Response(
+              status = Status.Ok,
+              body = Body.fromString(s"$clientIp|$peer|$forwardedFor|$forwardedHeader"),
+            ),
+          )
+        },
+      ),
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2HardeningMatrixSpec")(
+      test("matrix: oversize headers reset with ENHANCE_YOUR_CALM and the connection survives") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              client.sendOversizedHeaders(streamId = 1, bigValue = List.fill(11264)("a").mkString)
+              val reset   = client.awaitReset(streamId = 1, timeoutMs = 8000)
+              val sibling = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(
+                reset == H2Error.Code.ENHANCE_YOUR_CALM,
+                sibling.status == 200,
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: oversize body resets with FLOW_CONTROL_ERROR and the connection survives") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              // Split across two DATA frames so the running total crosses the
+              // cap mid-stream, exactly like H2BodyBoundSpec.
+              val first   = Chunk.fromArray(Array.fill(BodyCap.toInt)(0x41.toByte))
+              val second  = Chunk.fromArray(Array(0x42.toByte))
+              val code    = client.postSplitOverCap(streamId = 1, first = first, second = second)
+              val sibling = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(code == H2Error.Code.FLOW_CONTROL_ERROR, sibling.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: stalled headers (slow loris) reset with CANCEL and the connection survives") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              // Empty first fragment with END_HEADERS=false, CONTINUATION never
+              // arrives — the shared HPACK table stays in sync (H2SlowStreamSpec).
+              client.sendSplitHeaders(streamId = 1)
+              val code    = client.awaitReset(streamId = 1, timeoutMs = 8000)
+              val sibling = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(code == H2Error.Code.CANCEL, sibling.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: spoofed forwarding header under default-deny has zero effect") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              val extra = List(
+                HeaderField("x-forwarded-for", "203.0.113.7"),
+                HeaderField("x-forwarded-proto", "https"),
+                HeaderField("forwarded", "for=203.0.113.7;proto=https"),
+              )
+              val seen  = client.getWhoami(streamId = 1, extra = extra)
+              assertTrue(
+                seen.clientIp == "127.0.0.1",
+                seen.peer == "127.0.0.1",
+                seen.forwardedFor == "none",
+                seen.forwardedHeader == "none",
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: HMAC body over the hardened connection matches the RFC 4231 vector") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              val mac  = client.post("/hmac", TestMessage, streamId = 1)
+              val echo = client.post("/echo", TestMessage, streamId = 3)
+              assertTrue(
+                mac.status == 200,
+                mac.bodyText == ExpectedMacHex,
+                echo.status == 200,
+                echo.body == TestMessage,
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix knobs-off: slow drip completes when header/body timeouts are disabled") {
+        withKnobsOffServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              // 7 bytes x 500ms gaps = ~3s total: over the 2s hardened
+              // bodyTimeout, but the knobs-off server disables both timeouts.
+              val response = client.postDripExpectResponse(streamId = 1, totalBytes = 7, gapMs = 500L)
+              assertTrue(response.status == 200, response.body.length == 7)
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: sink holds metadata for served requests and no body bytes") {
+        val secret = "matrix-secret-body-payload-9d2b4f"
+        withMatrixServer { (port, sink) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              val get           = client.getWithId(path = "/", streamId = 1, requestId = "matrix-req-1")
+              val post          =
+                client.post("/echo", Chunk.fromArray(secret.getBytes(StandardCharsets.UTF_8)), streamId = 3)
+              val records       = sink.records
+              val recordStrings = records.map(_.toString)
+              assertTrue(
+                get.status == 200,
+                post.status == 200,
+                records.length == 2,
+                records.exists(r => r.method == "GET" && r.requestId == "matrix-req-1" && r.status == 200),
+                records.exists(r => r.method == "POST" && r.status == 200),
+                records.forall(r => r.requestId.nonEmpty && r.trustDecision.nonEmpty && r.deadlineOutcome.nonEmpty),
+                !recordStrings.exists(_.contains(secret)),
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("matrix: HPACK contract violation tears the connection down without serving") {
+        withMatrixServer { (port, _) =>
+          ZIO.attemptBlocking {
+            val client = new MatrixClient(port)
+            try {
+              // An undecodable header block corrupts connection-level HPACK
+              // state: the reader loop fails the connection (TCP close, no
+              // per-stream RST possible) and nothing is ever served. Current
+              // behavior sends no GOAWAY before the FIN (reader-loop
+              // `case _: IOException => ()`); this cell pins the teardown, not
+              // the frame choice — if a GOAWAY appears, update the cell.
+              val poison = H2Frame.Headers(
+                streamId = 1,
+                headerBlock = Chunk.fromArray(Array(0x80.toByte)),
+                endStream = true,
+                endHeaders = true,
+              )
+              client.sendRaw(FrameCodec.encode(poison).toArray)
+              val closed = client.awaitClosed()
+              assertTrue(closed)
+            } finally {
+              try client.close()
+              catch { case _: Exception => () }
+            }
+          }
+        }
+      },
+    ) @@ sequential
+
+  private def hardenedConnector: Connector =
+    Connector(
+      bind = BindAddress.localhost(0),
+      protocol = Protocol.H2C(Http2Config(maxHeaderListSize = 1024)),
+      maxRequestBodySize = BodyCap,
+      headerTimeoutMs = HeaderTimeoutMs,
+      bodyTimeoutMs = BodyTimeoutMs,
+      trustedProxy = TrustedProxyConfig.default,
+    )
+
+  private def withMatrixServer[R](
+    use: (Int, CaptureSink) => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    withServer(hardenedConnector, use)
+
+  private def withKnobsOffServer[R](
+    use: (Int, CaptureSink) => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    withServer(hardenedConnector.copy(headerTimeoutMs = 0L, bodyTimeoutMs = 0L), use)
+
+  private def withServer[R](
+    connector: Connector,
+    use: (Int, CaptureSink) => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val sink   = CaptureSink()
+          val handle =
+            new LoomServer(connector).serve(MatrixRoutes @@ Middleware.accessLog(sink), Context.empty)
+          (handle, sink)
+        },
+      ) { case (handle, _) => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore }
+      .flatMap { case (handle, sink) =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port, sink)
+      }
+
+  private final class CaptureSink extends AccessLogSink {
+    private val queue                      = new java.util.concurrent.ConcurrentLinkedQueue[AccessLogRecord]()
+    def log(record: AccessLogRecord): Unit = { queue.add(record); () }
+    def records: List[AccessLogRecord]     = queue.toArray(new Array[AccessLogRecord](0)).toList
+  }
+
+  private object CaptureSink {
+    def apply(): CaptureSink = new CaptureSink()
+  }
+
+  private final case class WhoSeen(clientIp: String, peer: String, forwardedFor: String, forwardedHeader: String)
+
+  private final case class MatrixResponse(status: Int, headers: List[HeaderField], body: Chunk[Byte]) {
+    def bodyText: String = new String(body.toArray, StandardCharsets.UTF_8)
+  }
+
+  private final class MatrixClient(val port: Int) extends AutoCloseable {
+    private val PrefaceBytes =
+      "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+
+    val socket        = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(20000)
+    private val out   = socket.getOutputStream
+    private val rawIn = socket.getInputStream
+    private var buf   = Chunk.empty[Byte]
+
+    private val encoder = new HpackEncoder()
+    private val decoder = new HpackDecoder()
+
+    handshake()
+
+    def sendFrame(frame: H2Frame): Unit   = sendRaw(FrameCodec.encode(frame).toArray)
+    def sendRaw(bytes: Array[Byte]): Unit = { out.write(bytes); out.flush() }
+
+    def roundTrip(method: String, path: String, body: Chunk[Byte], streamId: Int): MatrixResponse = {
+      sendFrame(makeHeaders(method, path, streamId, endStream = body.isEmpty, Nil))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitResponse(streamId)
+    }
+
+    def getWithId(path: String, streamId: Int, requestId: String): MatrixResponse = {
+      sendFrame(makeHeaders("GET", path, streamId, endStream = true, List(HeaderField("x-request-id", requestId))))
+      awaitResponse(streamId)
+    }
+
+    def post(path: String, body: Chunk[Byte], streamId: Int): MatrixResponse = {
+      sendFrame(makeHeaders("POST", path, streamId, endStream = body.isEmpty, Nil))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitResponse(streamId)
+    }
+
+    def getWhoami(streamId: Int, extra: List[HeaderField]): WhoSeen = {
+      sendFrame(makeHeaders("GET", "/whoami", streamId, endStream = true, extra))
+      val response = awaitResponse(streamId)
+      if (response.status != 200) throw new AssertionError("whoami: " + response.status)
+      response.bodyText.split("\\|", -1).toList match {
+        case List(clientIp, peer, forwardedFor, forwardedHeader) =>
+          WhoSeen(clientIp, peer, forwardedFor, forwardedHeader)
+        case other                                               =>
+          throw new AssertionError("whoami shape: " + other)
+      }
+    }
+
+    def sendOversizedHeaders(streamId: Int, bigValue: String): Unit = {
+      val pseudo = List(
+        HeaderField(":method", "GET"),
+        HeaderField(":path", "/"),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+        HeaderField("x-big", bigValue),
+      )
+      sendFrame(
+        H2Frame.Headers(
+          streamId = streamId,
+          headerBlock = encoder.encode(pseudo),
+          endStream = true,
+          endHeaders = true,
+        ),
+      )
+    }
+
+    def sendSplitHeaders(streamId: Int): Unit =
+      sendFrame(H2Frame.Headers(streamId, Chunk.empty, endStream = true, endHeaders = false))
+
+    def postSplitOverCap(streamId: Int, first: Chunk[Byte], second: Chunk[Byte]): H2Error.Code = {
+      sendFrame(makeHeaders("POST", "/echo", streamId, endStream = false, Nil))
+      sendFrame(Data(streamId, first, endStream = false))
+      sendFrame(Data(streamId, second, endStream = true))
+      awaitReset(streamId, timeoutMs = 8000)
+    }
+
+    def postDripExpectResponse(streamId: Int, totalBytes: Int, gapMs: Long): MatrixResponse = {
+      sendFrame(makeHeaders("POST", "/echo", streamId, endStream = false, Nil))
+      var sent = 0
+      while (sent < totalBytes) {
+        val last = sent == totalBytes - 1
+        sendFrame(Data(streamId, Chunk.fromArray(Array(0x41.toByte)), endStream = last))
+        sent += 1
+        if (!last) Thread.sleep(gapMs)
+      }
+      awaitResponse(streamId)
+    }
+
+    def awaitReset(streamId: Int, timeoutMs: Int): H2Error.Code = {
+      socket.setSoTimeout(1000)
+      try {
+        val deadline                     = java.lang.System.currentTimeMillis() + timeoutMs
+        var result: Option[H2Error.Code] = None
+        while (result.isEmpty) {
+          if (java.lang.System.currentTimeMillis() > deadline)
+            throw new AssertionError("Timed out waiting for RST_STREAM on stream " + streamId)
+          try {
+            readFrame() match {
+              case RstStream(sid, code) if sid == streamId => result = Some(code)
+              case GoAway(_, code, dbg)                    =>
+                throw new AssertionError(s"GOAWAY while waiting RST: $code ${new String(dbg.toArray)}")
+              case _                                       => ()
+            }
+          } catch {
+            case _: SocketTimeoutException => ()
+          }
+        }
+        result.get
+      } finally socket.setSoTimeout(20000)
+    }
+
+    /**
+     * Drains until the server closes TCP: any served response (HEADERS/DATA) or
+     * GOAWAY fails — the poisoned connection must go down with nothing on the
+     * wire after our attack frame.
+     */
+    def awaitClosed(): Boolean = {
+      socket.setSoTimeout(10000)
+      try {
+        val deadline = java.lang.System.currentTimeMillis() + 10000L
+        var closed   = false
+        while (!closed) {
+          if (java.lang.System.currentTimeMillis() > deadline)
+            throw new AssertionError("Timed out waiting for the server to close the connection")
+          try {
+            readFrame() match {
+              case Headers(sid, _, _, _, _, _) =>
+                throw new AssertionError("Response HEADERS served on poisoned stream " + sid)
+              case Data(sid, _, _, _)          =>
+                throw new AssertionError("Response DATA served on poisoned stream " + sid)
+              case RstStream(sid, code)        =>
+                throw new AssertionError(s"RST_STREAM($code) on poisoned stream $sid: expected a connection teardown")
+              case _: GoAway                   =>
+                throw new AssertionError("GOAWAY arrived: update the cell to pin the new frame choice")
+              case _                           => ()
+            }
+          } catch {
+            case _: SocketTimeoutException => ()
+            case _: EOFException           => closed = true
+          }
+        }
+        closed
+      } finally socket.setSoTimeout(20000)
+    }
+
+    private def awaitResponse(streamId: Int): MatrixResponse = {
+      val hdrs   = mutable.ListBuffer.empty[HeaderField]
+      var body   = Chunk.empty[Byte]
+      var done   = false
+      while (!done) {
+        readFrame() match {
+          case Settings(false, _)                                   => sendFrame(Settings(ack = true, Nil))
+          case Settings(true, _)                                    => ()
+          case _: WindowUpdate                                      => ()
+          case Ping(false, data)                                    => sendFrame(Ping(ack = true, data))
+          case Ping(true, _)                                        => ()
+          case Headers(sid, block, end, _, _, _) if sid == streamId =>
+            decoder.decode(block) match {
+              case Right(h) => hdrs ++= h
+              case Left(e)  => throw new AssertionError("HPACK decode: " + e)
+            }
+            if (end) done = true
+          case Data(sid, data, end, _) if sid == streamId           =>
+            body = body ++ data
+            if (end) done = true
+          case RstStream(_, code)                                   =>
+            throw new AssertionError("Unexpected RST_STREAM: " + code)
+          case GoAway(_, code, dbg)                                 =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                                                    => ()
+        }
+      }
+      val status = hdrs
+        .find(_.name == ":status")
+        .map(_.value.toInt)
+        .getOrElse(throw new AssertionError("Missing :status"))
+      MatrixResponse(status, hdrs.toList, body)
+    }
+
+    private def makeHeaders(
+      method: String,
+      path: String,
+      streamId: Int,
+      endStream: Boolean,
+      extra: List[HeaderField],
+    ): H2Frame.Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      )
+      H2Frame.Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo ++ extra),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+
+    private def readFrame(): H2Frame = {
+      while (true) {
+        FrameCodec.decode(buf) match {
+          case Right((frame, rest))           =>
+            buf = rest
+            return frame
+          case Left(H2Error.InsufficientData) =>
+            val tmp = new Array[Byte](8192)
+            val n   = rawIn.read(tmp)
+            if (n < 0) throw new EOFException("Connection closed")
+            buf = buf ++ Chunk.fromArray(java.util.Arrays.copyOf(tmp, n))
+          case Left(err)                      =>
+            throw new AssertionError("Frame decode error: " + err)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    override def close(): Unit = socket.close()
+
+    private def handshake(): Unit = {
+      out.write(PrefaceBytes)
+      out.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      out.flush()
+      readFrame() match {
+        case Settings(false, _) => sendFrame(Settings(ack = true, Nil))
+        case other              => throw new AssertionError("Expected Settings(false,_): " + other)
+      }
+      readFrame()
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2HardeningMatrixSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2HardeningMatrixSpec.scala
@@ -22,6 +22,7 @@ import zio.http.ResultType._
 import zio.http.h2.H2Frame._
 import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
 import zio.http.{
+  AccessLog,
   AccessLogRecord,
   AccessLogSink,
   BindAddress,
@@ -245,19 +246,45 @@ object H2HardeningMatrixSpec extends ZIOSpecDefault {
           ZIO.attemptBlocking {
             val client = new MatrixClient(port)
             try {
-              val get           = client.getWithId(path = "/", streamId = 1, requestId = "matrix-req-1")
-              val post          =
+              val get        = client.getWithId(path = "/", streamId = 1, requestId = "matrix-req-1")
+              val post       =
                 client.post("/echo", Chunk.fromArray(secret.getBytes(StandardCharsets.UTF_8)), streamId = 3)
-              val records       = sink.records
-              val recordStrings = records.map(_.toString)
+              val records    = sink.records
+              val getRecord  = records
+                .find(_.method == "GET")
+                .getOrElse(throw new AssertionError("missing GET record: " + records))
+              val postRecord = records
+                .find(_.method == "POST")
+                .getOrElse(throw new AssertionError("missing POST record: " + records))
               assertTrue(
                 get.status == 200,
                 post.status == 200,
                 records.length == 2,
-                records.exists(r => r.method == "GET" && r.requestId == "matrix-req-1" && r.status == 200),
-                records.exists(r => r.method == "POST" && r.status == 200),
-                records.forall(r => r.requestId.nonEmpty && r.trustDecision.nonEmpty && r.deadlineOutcome.nonEmpty),
-                !recordStrings.exists(_.contains(secret)),
+                getRecord.requestId == "matrix-req-1",
+                getRecord.status == 200,
+                postRecord.status == 200,
+                getRecord.requestId.nonEmpty,
+                postRecord.requestId.nonEmpty,
+                getRecord.trustDecision.contains(AccessLog.TrustDecision.Untrusted),
+                postRecord.trustDecision.contains(AccessLog.TrustDecision.Untrusted),
+                getRecord.deadlineOutcome.contains(AccessLog.DeadlineOutcome.Ok),
+                postRecord.deadlineOutcome.contains(AccessLog.DeadlineOutcome.Ok),
+                // Field-level secrecy: no record field and no rendered log
+                // line may carry body bytes.
+                !getRecord.path.contains(secret),
+                !getRecord.route.exists(_.contains(secret)),
+                !getRecord.requestId.contains(secret),
+                !getRecord.peerAddress.exists(_.contains(secret)),
+                !getRecord.clientIp.exists(_.contains(secret)),
+                !getRecord.protocol.contains(secret),
+                !postRecord.path.contains(secret),
+                !postRecord.route.exists(_.contains(secret)),
+                !postRecord.requestId.contains(secret),
+                !postRecord.peerAddress.exists(_.contains(secret)),
+                !postRecord.clientIp.exists(_.contains(secret)),
+                !postRecord.protocol.contains(secret),
+                !AccessLog.formatLine(getRecord).contains(secret),
+                !AccessLog.formatLine(postRecord).contains(secret),
               )
             } finally client.close()
           }

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
@@ -1,0 +1,544 @@
+package zio.http.h2
+
+import java.io.{ByteArrayInputStream, EOFException}
+import java.net.{ConnectException, Socket}
+import java.nio.charset.StandardCharsets
+import java.security.{KeyFactory, KeyStore}
+import java.security.cert.CertificateFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.net.ssl.{KeyManagerFactory, SSLContext, SSLSocket, TrustManager, X509TrustManager}
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.config.Secret
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{
+  BindAddress,
+  Body,
+  BoundAddress,
+  Connector,
+  DefectHandler,
+  LoomServer,
+  Protocol,
+  Request,
+  Response,
+  Route,
+  Routes,
+  TlsConfig,
+  TlsSource,
+  TrustedProxyConfig,
+  handler,
+}
+
+/**
+ * Spoof spec for the H2 proxy-trust model.
+ *
+ * Forwarding headers (`X-Forwarded-For/Proto/Host`, RFC 7239 `Forwarded`) must
+ * only take effect when the TCP peer is trusted (allowlisted CIDR or
+ * mTLS-authenticated identity). Default is deny: an untrusted peer's headers
+ * are stripped with zero effect, and the resolved client IP falls back to the
+ * socket peer address. A server with `requireClientAuth` must reject a peer
+ * that presents no certificate.
+ */
+@experimental
+object H2ProxyTrustSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any]                         =
+    suite("H2ProxyTrustSpec")(
+      test("trusted loopback peer's X-Forwarded-For yields correct client IP") {
+        withServer(TrustedProxyConfig(trustedCidrs = Set("127.0.0.1/32")), useWithPort(1))
+      },
+      test("identical header from untrusted peer is ignored (zero effect)") {
+        withServer(TrustedProxyConfig(), useWithPort(2))
+      },
+      test("RFC 7239 Forwarded from trusted peer yields client IP and host") {
+        withServer(TrustedProxyConfig(trustedCidrs = Set("127.0.0.0/8")), useWithPort(3))
+      },
+      test("RFC 7239 Forwarded from untrusted peer is ignored") {
+        withServer(TrustedProxyConfig(), useWithPort(4))
+      },
+      test("default config trusts nothing (default-deny)") {
+        ZIO.attempt {
+          val config = TrustedProxyConfig()
+          assertTrue(
+            !config.isTrusted("127.0.0.1", hasPeerCert = false),
+            !config.isTrusted("127.0.0.1", hasPeerCert = true),
+            !config.isTrusted("10.0.0.1", hasPeerCert = true),
+          )
+        }
+      },
+      test("mTLS-required server rejects non-cert peer") {
+        // Set when (and only when) the server dispatches a request past the
+        // handshake: a rejection must leave it false.
+        val handlerHit = new AtomicBoolean(false)
+        ZIO
+          .acquireRelease(
+            ZIO.attempt {
+              val tlsCfg    = TlsConfig(
+                certChain = TlsSource.PemString(Secret(ServerCertPem)),
+                privateKey = TlsSource.PemString(Secret(ServerKeyPem)),
+                requireClientAuth = true,
+              )
+              val transport = new H2Transport(
+                Routes(
+                  Route(
+                    RoutePattern.GET,
+                    handler { (_: Request) =>
+                      handlerHit.set(true)
+                      responseAsResult(Response.ok)
+                    },
+                  ),
+                ),
+                Context.empty,
+                Connector(bind = BindAddress.localhost(0), protocol = Protocol.H2(tlsCfg)),
+                DefectHandler.default,
+              )
+              transport.start()
+            },
+          )(h => ZIO.succeed(h.close0()))
+          .flatMap { handle =>
+            val tcpPort = handle.binding.address match {
+              case BoundAddress.Tcp(_, thePort) => thePort
+              case other                        => throw new AssertionError("Expected TCP: " + other)
+            }
+            ZIO.attemptBlocking {
+              val client = new MtlsTestClient(tcpPort)
+              try {
+                // Stage 1 (server-observed accept): TCP connects, so the
+                // server took the peer — a refusal here would mean
+                // "server down", not "peer rejected".
+                val tcpAccepted    = client.tcpConnected
+                // Stage 2 (server-aborted handshake): the no-cert handshake
+                // must never yield a speaking server. The abort can race
+                // past the client's Finished (fatal alert vs close), so the
+                // proof is that no H2 bytes ever come back — never a refusal
+                // to reach the server at all.
+                val handshakeError = client.handshakeAttempt()
+                val refused        = handshakeError.exists(_.isInstanceOf[ConnectException])
+                val proceeds       = if (refused) true else client.serverProceeds()
+                // Stage 3 (per-connection abort): the server is still bound
+                // afterwards and never dispatched the request past the
+                // failed handshake.
+                val stillBound     = handle.binding.address match {
+                  case BoundAddress.Tcp(_, thePort) => thePort == tcpPort
+                  case _                            => false
+                }
+                assertTrue(tcpAccepted, !refused, !proceeds, stillBound, !handlerHit.get())
+              } finally client.close()
+            }
+          }
+      },
+      test("mTLS-required server with CA trust store rejects wrong-CA cert peer") {
+        // Same 3-stage proof as the no-cert rejection, but the peer presents a
+        // well-formed certificate that chains to nothing the server trusts
+        // (self-signed server cert against an unrelated EC CA): the handshake
+        // must abort and the request must never dispatch.
+        val handlerHit = new AtomicBoolean(false)
+        ZIO
+          .acquireRelease(
+            ZIO.attempt {
+              val tlsCfg    = TlsConfig(
+                certChain = TlsSource.PemString(Secret(ServerCertPem)),
+                privateKey = TlsSource.PemString(Secret(ServerKeyPem)),
+                requireClientAuth = true,
+                trustCertChain = Some(TlsSource.PemString(Secret(WrongCaPem))),
+              )
+              val transport = new H2Transport(
+                Routes(
+                  Route(
+                    RoutePattern.GET,
+                    handler { (_: Request) =>
+                      handlerHit.set(true)
+                      responseAsResult(Response.ok)
+                    },
+                  ),
+                ),
+                Context.empty,
+                Connector(bind = BindAddress.localhost(0), protocol = Protocol.H2(tlsCfg)),
+                DefectHandler.default,
+              )
+              transport.start()
+            },
+          )(h => ZIO.succeed(h.close0()))
+          .flatMap { handle =>
+            val tcpPort = handle.binding.address match {
+              case BoundAddress.Tcp(_, thePort) => thePort
+              case other                        => throw new AssertionError("Expected TCP: " + other)
+            }
+            ZIO.attemptBlocking {
+              val client = new MtlsTestClient(
+                tcpPort,
+                clientCertPem = Some(ServerCertPem),
+                clientKeyPem = Some(ServerKeyPem),
+              )
+              try {
+                val tcpAccepted    = client.tcpConnected
+                val handshakeError = client.handshakeAttempt()
+                val refused        = handshakeError.exists(_.isInstanceOf[ConnectException])
+                val proceeds       = if (refused) true else client.serverProceeds()
+                val stillBound     = handle.binding.address match {
+                  case BoundAddress.Tcp(_, thePort) => thePort == tcpPort
+                  case _                            => false
+                }
+                assertTrue(tcpAccepted, !refused, !proceeds, stillBound, !handlerHit.get())
+              } finally client.close()
+            }
+          }
+      },
+    ) @@ sequential
+  private val EchoRoutes: Routes[Any]                                           =
+    Routes(
+      Route(
+        RoutePattern.GET,
+        handler { (req: Request) =>
+          val clientIp        = req.headers.rawGet("x-client-ip").getOrElse("none")
+          val peer            = req.headers.rawGet("x-peer-address").getOrElse("none")
+          val forwardedFor    = req.headers.rawGet("x-forwarded-for").getOrElse("none")
+          val forwardedHeader = req.headers.rawGet("forwarded").getOrElse("none")
+          val host            = req.url.host.getOrElse("none")
+          val scheme          = req.url.scheme.map(_.text).getOrElse("none")
+          responseAsResult(
+            Response(
+              status = zio.http.Status.Ok,
+              body = Body.fromString(s"$clientIp|$peer|$forwardedFor|$forwardedHeader|$host|$scheme"),
+            ),
+          )
+        },
+      ),
+    )
+  private def withServer[R](
+    trusted: TrustedProxyConfig,
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(
+            bind = BindAddress.localhost(0),
+            protocol = Protocol.H2C(),
+            trustedProxy = trusted,
+          )
+          new LoomServer(connector).serve(EchoRoutes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+  private def useWithPort[R](caseId: Int): Int => ZIO[R, Throwable, TestResult] =
+    (port: Int) =>
+      ZIO.attemptBlocking {
+        val client = new ProxyTestClient(port)
+        try {
+          val seen   = client.getWithHeaders(streamId = 1, extra = headersFor(caseId))
+          val expect = expectedFor(caseId)
+          assertTrue(
+            seen.clientIp == expect.clientIp,
+            seen.forwardedFor == "none",
+            seen.forwardedHeader == "none",
+            seen.peer == "127.0.0.1",
+            seen.host == expect.host,
+            seen.scheme == expect.scheme,
+          )
+        } finally client.close()
+      }
+  private def headersFor(caseId: Int): List[HeaderField]                        =
+    caseId match {
+      case 1 | 2 =>
+        List(
+          HeaderField("x-forwarded-for", "203.0.113.7"),
+          HeaderField("x-forwarded-proto", "https"),
+          HeaderField("x-forwarded-host", "example.com"),
+        )
+      case 3 | 4 =>
+        List(HeaderField("forwarded", "for=198.51.100.9;proto=https;host=example.org"))
+      case _     => Nil
+    }
+  private def expectedFor(caseId: Int): SeenHeaders                             =
+    caseId match {
+      case 1 => SeenHeaders("203.0.113.7", "127.0.0.1", "none", "none", "example.com", "https")
+      case 2 => SeenHeaders("127.0.0.1", "127.0.0.1", "none", "none", "127.0.0.1", "http")
+      case 3 => SeenHeaders("198.51.100.9", "127.0.0.1", "none", "none", "example.org", "https")
+      case _ => SeenHeaders("127.0.0.1", "127.0.0.1", "none", "none", "127.0.0.1", "http")
+    }
+  private final case class SeenHeaders(
+    clientIp: String,
+    peer: String,
+    forwardedFor: String,
+    forwardedHeader: String,
+    host: String,
+    scheme: String,
+  )
+  private final class ProxyTestClient(val port: Int) extends AutoCloseable {
+    private val PrefaceBytes                                                 =
+      "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+    val socket                                                               = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(5000)
+    private val out                                                          = socket.getOutputStream
+    private val rawIn                                                        = socket.getInputStream
+    private var buf                                                          = Chunk.empty[Byte]
+    private val encoder                                                      = new HpackEncoder()
+    private val decoder                                                      = new HpackDecoder()
+    handshake()
+    def sendRaw(bytes: Array[Byte]): Unit                                    = { out.write(bytes); out.flush() }
+    def sendFrame(frame: H2Frame): Unit                                      = sendRaw(FrameCodec.encode(frame).toArray)
+    def getWithHeaders(streamId: Int, extra: List[HeaderField]): SeenHeaders = {
+      val pseudo   = List(
+        HeaderField(":method", "GET"),
+        HeaderField(":path", "/"),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      )
+      sendFrame(Headers(streamId, encoder.encode(pseudo ++ extra), endStream = true, endHeaders = true))
+      val response = awaitResponse(streamId)
+      parseSeen(new String(response.body.toArray, StandardCharsets.UTF_8))
+    }
+    private def parseSeen(body: String): SeenHeaders                         = {
+      val parts = body.split("\\|", -1)
+      if (parts.length != 6) throw new AssertionError("Unexpected echo body: " + body)
+      SeenHeaders(parts(0), parts(1), parts(2), parts(3), parts(4), parts(5))
+    }
+    private def awaitResponse(streamId: Int): RawResponse                    = {
+      val hdrs   = mutable.ListBuffer.empty[HeaderField]
+      var body   = Chunk.empty[Byte]
+      var done   = false
+      while (!done) {
+        readFrame() match {
+          case Settings(false, _)                                   => sendFrame(Settings(ack = true, Nil))
+          case Settings(true, _)                                    => ()
+          case _: WindowUpdate                                      => ()
+          case Headers(sid, block, end, _, _, _) if sid == streamId =>
+            decoder.decode(block) match {
+              case Right(h) => hdrs ++= h
+              case Left(e)  => throw new AssertionError("HPACK decode: " + e)
+            }
+            if (end) done = true
+          case Data(sid, data, end, _) if sid == streamId           =>
+            body = body ++ data
+            if (end) done = true
+          case RstStream(_, code)                                   =>
+            throw new AssertionError("Unexpected RST_STREAM: " + code)
+          case GoAway(_, code, dbg)                                 =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                                                    => ()
+        }
+      }
+      val status = hdrs
+        .find(_.name == ":status")
+        .map(_.value.toInt)
+        .getOrElse(throw new AssertionError("Missing :status"))
+      RawResponse(status, hdrs.toList, body)
+    }
+    private def readFrame(): H2Frame                                         = {
+      while (true) {
+        FrameCodec.decode(buf) match {
+          case Right((frame, rest))           =>
+            buf = rest
+            return frame
+          case Left(H2Error.InsufficientData) =>
+            val tmp = new Array[Byte](8192)
+            val n   = rawIn.read(tmp)
+            if (n < 0) throw new EOFException("Connection closed")
+            buf = buf ++ Chunk.fromArray(java.util.Arrays.copyOf(tmp, n))
+          case Left(err)                      =>
+            throw new AssertionError("Frame decode error: " + err)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+    override def close(): Unit                                               = socket.close()
+    private def handshake(): Unit                                            = {
+      out.write(PrefaceBytes)
+      out.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      out.flush()
+      readFrame() match {
+        case Settings(false, _) => sendFrame(Settings(ack = true, Nil))
+        case other              => throw new AssertionError("Expected Settings(false,_): " + other)
+      }
+      readFrame()
+    }
+  }
+  private final case class RawResponse(status: Int, headers: List[HeaderField], body: Chunk[Byte])
+  // Unrelated EC CA (same material as H2TlsSpec): the trust anchor for the
+  // wrong-CA rejection test. The peer presents the self-signed RSA server
+  // cert, which chains to nothing here, so the handshake must abort.
+  private val WrongCaPem                                                        =
+    """-----BEGIN CERTIFICATE-----
+MIIBfTCCASOgAwIBAgIUDZi2vTwLeJsU87eAXPcmVuht9ZcwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDYzMDIyMzUwMFoXDTI3MDYzMDIy
+MzUwMFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAEjJUAedhsp4p6WqaoCQ/a3YnwDELlrR0fUBIbsuy3I/ny/17loqyJwXTq
+Ll2cCg2EUDkIml8eNWN2njiIHExlaqNTMFEwHQYDVR0OBBYEFJQhtfJN5UrWvcae
+kkLD/Q+fPogHMB8GA1UdIwQYMBaAFJQhtfJN5UrWvcaekkLD/Q+fPogHMA8GA1Ud
+EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAPUIvEGyk7q+mePu3lRBAOQD
+Kgl8yIWcrTsLIrsXHA6cAiAPFrDVHrjyjv9zdl8DhXcH/Sx8o2to2EIAMDlio31w
+Lg==
+-----END CERTIFICATE-----"""
+  // Self-signed localhost cert/key for the mTLS rejection test (same material as H2TlsSpec).
+  private val ServerCertPem                                                     =
+    """-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIIFmlxlymbftowDQYJKoZIhvcNAQEMBQAwXTELMAkGA1UE
+BhMCVVMxDTALBgNVBAgTBFRlc3QxDTALBgNVBAcTBFRlc3QxDTALBgNVBAoTBFRl
+c3QxDTALBgNVBAsTBFRlc3QxEjAQBgNVBAMTCWxvY2FsaG9zdDAeFw0yNjA2MzAy
+MjA1NTlaFw0yNzA2MzAyMjA1NTlaMF0xCzAJBgNVBAYTAlVTMQ0wCwYDVQQIEwRU
+ZXN0MQ0wCwYDVQQHEwRUZXN0MQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0
+MRIwEAYDVQQDEwlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDihzLu4ln5ta1Rgac4J3GsWMLWVjMoud5NiZczB7RLHQx+yt1uYhDqc8HT
+gzkEBU8lel1IdEMP+m4Y/tVZLrjMaH6lvjbLSQLjdgIsvtqeHmTfMBcCTr9E+r4k
+Lhtc1utAOpL18DPBxXEQ7ib2MAtxjLXJQIU/Zh4GJNfbJ69IjFF/PTZUZsIWmJxB
+zR9M+2NN1y0gtH6FpdQepQeFaeCJ43652NIKGAuM/w4G2DYSBUsHb/WsMc5QZm0M
+DQ6Gy9E76jyghywdkUPw7dnioqzUhbCIZ8eXiL4YbJ6n9eeWvVrGyAWGBYstYEJq
+OrR2KbGcd57R3ZvAkPcHIdIy+WO9AgMBAAGjITAfMB0GA1UdDgQWBBT8SbyNOu1I
+6jQLbe4/D888GtPHeTANBgkqhkiG9w0BAQwFAAOCAQEAoa31bUJ541BZn321u3K8
+XYfdFlTy3zLF4E7OlC9ygepgMKFmntQOnfg19rKgZO+VkQ8kBusgo/jiavjrQIDw
+2tTwKel+kN1STaLt5xEWMQsGbGvT7iSejin3wFSxMIrbWKtSOc3Li0AmbdERJ37L
+QAYSxLK+vU4BTT/whdI223xeFLQGYFhMyTag09Osw1WLUUZRvLh1FPeV5P5dWpzc
+dpBrxWvWGRl2+Nle0zAQNznhfn8ydP/7K3Lv/f3qQ48EgXmSDdhvSUfX24CLVLXk
+mETcQb+xmaWObOxkaK0iWGoQWPs2UFKVHPDmUlsYSt0ePGsiu1uEbgWrfr+6vBdx
+Wg==
+-----END CERTIFICATE-----"""
+  private val ServerKeyPem                                                      =
+    """-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDihzLu4ln5ta1R
+gac4J3GsWMLWVjMoud5NiZczB7RLHQx+yt1uYhDqc8HTgzkEBU8lel1IdEMP+m4Y
+/tVZLrjMaH6lvjbLSQLjdgIsvtqeHmTfMBcCTr9E+r4kLhtc1utAOpL18DPBxXEQ
+7ib2MAtxjLXJQIU/Zh4GJNfbJ69IjFF/PTZUZsIWmJxBzR9M+2NN1y0gtH6FpdQe
+pQeFaeCJ43652NIKGAuM/w4G2DYSBUsHb/WsMc5QZm0MDQ6Gy9E76jyghywdkUPw
+7dnioqzUhbCIZ8eXiL4YbJ6n9eeWvVrGyAWGBYstYEJqOrR2KbGcd57R3ZvAkPcH
+IdIy+WO9AgMBAAECggEABLbzpG0pmjzhwpSEOnL3trKSO4vHvM1BhzOZ5gH/CqEs
+JWdrfGSmHXsTSaethBvoLcuCLYPd8XMw32xOXHDQf9Cc8i4nTcvTN5C5Mt02B5xy
+VQLXN8ET0ge19WLQRvpiIxAVBvFc4meNluCeBvmxA0f+cJXbMBqb/Vy+8Vy+FTBs
+a3lthG4BVP7/q2SAUbxFQnajSGYHIW7bMKQUThKEPztffiv3pvws2nmSj3A/Ge99
+eBRySh9fE2N46QcfAZ7TRMrU+nR6UpH7aBTL0h3T8qTVn/1HdYQyJBtIqhEVFHYZ
+q93JkaZJP8Plhvq5gcnrjG1kLBF+w5Uh5d1l5/RqsQKBgQDzgQmCqYIDxWNE1R/d
+zL43DOWc0/xA04vVR9NoFr22Yydzv17u34a21LG/TfH3byDSUqd9luKaNy0pykSD
+79Vsycg2Bejk5LiZX/5rrX/OGs17Zi2KrQE6DvXdTQOkSaveU7zVKZKyck7mgreW
+wXivdVKfqaTrizx68/y94WsY3wKBgQDuJyVAdO4sHJhQOBfp/wCNVfu/BqfQMJpA
+/37dVt7HeiMh9hKx0IMY6iVTCXOoFIR9SpH4uiiw8/WkAfcUld4zuE68ymRTaZY7
+EgX4i+ltRrXnp1Ac3FSHu972Z2GIFCqcXJ+Qj4aShw1c3bSSuU2pIDYmrAmcfKtK
+tu/SAApq4wKBgCBnLm3Nwrhfvur89WWdhj5rH+7zoqC5xeTWzwIN7KbloO1dLPPa
+mOGhghmz9Jv5lMOILjOfLX5aE095VA6+jocQfuz5cllrOklmpcOMbfJuTKO8IBlR
+FlW0gfE1+2MUTqOiPwGaq6PFZEx2XpnYGwg2M419lK2ndJ/j8eEOqyK/AoGAGDG9
+5Rh8Ads91hh8xXb0lWdA1h1U+x+U7DmIp+/lXhqYayDWsV3fk65l8FOrfk3nT9s9
+jSlMbP273NeeRGcdVd/JkAB3xMmbS5D/Lkr4gfOHE2u6BdSUed2qPxotnGeAFLaM
+N2F9aHFz+BVF/Qn6S85L8g3URCOeO07uekUqycUCgYBsnu7/9m00ZqP9GUyvVzRr
+Br3/KmT2lozjcl/DpalWSKCZIW0lYgKYaiWEc165D4vj/ZBhHO7OPGeT2jqHk4/W
+YdZ72W2776kWb4YTEdmJPNwgZIVFzcSZXzn8TKnCnwbHEilz51GFrMH1ZJNvLK3Q
+tylLU8iZnM9E7+/GSVghdQ==
+-----END PRIVATE KEY-----"""
+
+  /**
+   * TLS client used to prove `requireClientAuth` rejects unauthenticated peers:
+   * with no client identity it presents no certificate; with
+   * `clientCertPem`/`clientKeyPem` it presents that (possibly untrusted)
+   * certificate.
+   */
+  private final class MtlsTestClient(
+    port: Int,
+    clientCertPem: Option[String] = None,
+    clientKeyPem: Option[String] = None,
+  ) extends AutoCloseable {
+    private val trustAll                                             = Array[TrustManager](new X509TrustManager {
+      override def checkClientTrusted(chain: Array[java.security.cert.X509Certificate], authType: String): Unit = ()
+      override def checkServerTrusted(chain: Array[java.security.cert.X509Certificate], authType: String): Unit = ()
+      override def getAcceptedIssuers: Array[java.security.cert.X509Certificate] = Array.empty
+    })
+    private val clientCtx                                            = SSLContext.getInstance("TLS")
+    clientCtx.init(clientKeyManagers(), trustAll, new java.security.SecureRandom())
+    private def clientKeyManagers(): Array[javax.net.ssl.KeyManager] =
+      (clientCertPem, clientKeyPem) match {
+        case (Some(certPem), Some(keyPem)) =>
+          val password = "test".toCharArray
+          val keyStore = KeyStore.getInstance(KeyStore.getDefaultType)
+          keyStore.load(null, null)
+          keyStore.setKeyEntry("client", loadPrivateKey(keyPem), password, Array(loadCertificate(certPem)))
+          val factory  = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm)
+          factory.init(keyStore, password)
+          factory.getKeyManagers
+        case _                             => null
+      }
+    private val tcp: Socket                                          = {
+      val s = new Socket("127.0.0.1", port)
+      s.setSoTimeout(5000)
+      s
+    }
+    private var tls: SSLSocket                                       = null
+
+    /** TCP accept succeeded: the server observed the peer. */
+    def tcpConnected: Boolean = tcp.isConnected && !tcp.isClosed
+
+    /**
+     * Runs the no-certificate handshake. A server with `requireClientAuth`
+     * aborts it (fatal alert or close), so the failure is returned; `None`
+     * means the server unexpectedly let the peer through.
+     */
+    def handshakeAttempt(): Option[Throwable] =
+      try {
+        val s      = clientCtx.getSocketFactory
+          .createSocket(tcp, "127.0.0.1", port, true)
+          .asInstanceOf[SSLSocket]
+        val params = s.getSSLParameters
+        params.setApplicationProtocols(Array("h2"))
+        s.setSSLParameters(params)
+        s.setUseClientMode(true)
+        s.setSoTimeout(5000)
+        s.startHandshake()
+        tls = s
+        None
+      } catch {
+        case t: Throwable => Some(t)
+      }
+
+    /**
+     * Returns `true` only when the server speaks H2 after the handshake (reads
+     * the preface and answers with its SETTINGS frame). A server that rejects
+     * the peer aborts instead, so the write/read fails or hits end-of-stream.
+     * `false` when the handshake itself already died.
+     */
+    def serverProceeds(): Boolean =
+      if (tls == null) false
+      else
+        try {
+          val out = tls.getOutputStream
+          out.write("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII))
+          out.flush()
+          tls.getInputStream.read() >= 0
+        } catch {
+          case _: Exception => false
+        }
+    override def close(): Unit    = {
+      if (tls != null)
+        try tls.close()
+        catch { case _: Exception => () }
+      try tcp.close()
+      catch { case _: Exception => () }
+    }
+  }
+  private def loadCertificate(pem: String): java.security.cert.X509Certificate = {
+    val body =
+      pem.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").replaceAll("\\s", "")
+    CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(new ByteArrayInputStream(Base64.getDecoder.decode(body)))
+      .asInstanceOf[java.security.cert.X509Certificate]
+  }
+  private def loadPrivateKey(pem: String): java.security.PrivateKey            = {
+    val body =
+      pem.replace("-----BEGIN PRIVATE KEY-----", "").replace("-----END PRIVATE KEY-----", "").replaceAll("\\s", "")
+    KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(Base64.getDecoder.decode(body)))
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
@@ -54,19 +54,80 @@ import zio.http.{
  */
 @experimental
 object H2ProxyTrustSpec extends ZIOSpecDefault {
-  override def spec: Spec[TestEnvironment & Scope, Any]                         =
+  private final case class ProxyCase(
+    name: String,
+    trusted: TrustedProxyConfig,
+    sentHeaders: List[HeaderField],
+    expectedClientIp: String,
+    expectedHost: String,
+    expectedScheme: String,
+  )
+
+  /** Trusted loopback peer: X-Forwarded-* headers take effect. */
+  private val TrustedLoopbackXff: ProxyCase =
+    ProxyCase(
+      name = "trusted loopback peer's X-Forwarded-For yields correct client IP",
+      trusted = TrustedProxyConfig(trustedCidrs = Set("127.0.0.1/32")),
+      sentHeaders = List(
+        HeaderField("x-forwarded-for", "203.0.113.7"),
+        HeaderField("x-forwarded-proto", "https"),
+        HeaderField("x-forwarded-host", "example.com"),
+      ),
+      expectedClientIp = "203.0.113.7",
+      expectedHost = "example.com",
+      expectedScheme = "https",
+    )
+
+  /** Same headers from an untrusted peer: stripped with zero effect. */
+  private val UntrustedXffIgnored: ProxyCase =
+    ProxyCase(
+      name = "identical header from untrusted peer is ignored (zero effect)",
+      trusted = TrustedProxyConfig(),
+      sentHeaders = List(
+        HeaderField("x-forwarded-for", "203.0.113.7"),
+        HeaderField("x-forwarded-proto", "https"),
+        HeaderField("x-forwarded-host", "example.com"),
+      ),
+      expectedClientIp = "127.0.0.1",
+      expectedHost = "127.0.0.1",
+      expectedScheme = "http",
+    )
+
+  /** Trusted peer: RFC 7239 Forwarded takes effect. */
+  private val TrustedRfc7239: ProxyCase =
+    ProxyCase(
+      name = "RFC 7239 Forwarded from trusted peer yields client IP and host",
+      trusted = TrustedProxyConfig(trustedCidrs = Set("127.0.0.0/8")),
+      sentHeaders = List(HeaderField("forwarded", "for=198.51.100.9;proto=https;host=example.org")),
+      expectedClientIp = "198.51.100.9",
+      expectedHost = "example.org",
+      expectedScheme = "https",
+    )
+
+  /** Same Forwarded header from an untrusted peer: ignored. */
+  private val UntrustedRfc7239Ignored: ProxyCase =
+    ProxyCase(
+      name = "RFC 7239 Forwarded from untrusted peer is ignored",
+      trusted = TrustedProxyConfig(),
+      sentHeaders = List(HeaderField("forwarded", "for=198.51.100.9;proto=https;host=example.org")),
+      expectedClientIp = "127.0.0.1",
+      expectedHost = "127.0.0.1",
+      expectedScheme = "http",
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any]                                   =
     suite("H2ProxyTrustSpec")(
-      test("trusted loopback peer's X-Forwarded-For yields correct client IP") {
-        withServer(TrustedProxyConfig(trustedCidrs = Set("127.0.0.1/32")), useWithPort(1))
+      test(TrustedLoopbackXff.name) {
+        withServer(TrustedLoopbackXff.trusted, runProxyCase(TrustedLoopbackXff))
       },
-      test("identical header from untrusted peer is ignored (zero effect)") {
-        withServer(TrustedProxyConfig(), useWithPort(2))
+      test(UntrustedXffIgnored.name) {
+        withServer(UntrustedXffIgnored.trusted, runProxyCase(UntrustedXffIgnored))
       },
-      test("RFC 7239 Forwarded from trusted peer yields client IP and host") {
-        withServer(TrustedProxyConfig(trustedCidrs = Set("127.0.0.0/8")), useWithPort(3))
+      test(TrustedRfc7239.name) {
+        withServer(TrustedRfc7239.trusted, runProxyCase(TrustedRfc7239))
       },
-      test("RFC 7239 Forwarded from untrusted peer is ignored") {
-        withServer(TrustedProxyConfig(), useWithPort(4))
+      test(UntrustedRfc7239Ignored.name) {
+        withServer(UntrustedRfc7239Ignored.trusted, runProxyCase(UntrustedRfc7239Ignored))
       },
       test("default config trusts nothing (default-deny)") {
         ZIO.attempt {
@@ -118,23 +179,32 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 // Stage 1 (server-observed accept): TCP connects, so the
                 // server took the peer — a refusal here would mean
                 // "server down", not "peer rejected".
-                val tcpAccepted    = client.tcpConnected
+                val tcpAcceptedByServer      = client.tcpConnected
                 // Stage 2 (server-aborted handshake): the no-cert handshake
                 // must never yield a speaking server. The abort can race
                 // past the client's Finished (fatal alert vs close), so the
                 // proof is that no H2 bytes ever come back — never a refusal
                 // to reach the server at all.
-                val handshakeError = client.handshakeAttempt()
-                val refused        = handshakeError.exists(_.isInstanceOf[ConnectException])
-                val proceeds       = if (refused) true else client.serverProceeds()
+                val handshakeError           = client.handshakeAttempt()
+                handshakeError.foreach(err => println(s"mTLS no-cert handshake error (expected): $err"))
+                val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
+                val serverSpokeH2AfterReject =
+                  if (refusedBeforeHandshake) true else client.serverProceeds()
                 // Stage 3 (per-connection abort): the server is still bound
                 // afterwards and never dispatched the request past the
                 // failed handshake.
-                val stillBound     = handle.binding.address match {
+                val serverStillBound         = handle.binding.address match {
                   case BoundAddress.Tcp(_, thePort) => thePort == tcpPort
                   case _                            => false
                 }
-                assertTrue(tcpAccepted, !refused, !proceeds, stillBound, !handlerHit.get())
+                val requestDispatched        = handlerHit.get()
+                assertTrue(
+                  tcpAcceptedByServer,
+                  !refusedBeforeHandshake,
+                  !serverSpokeH2AfterReject,
+                  serverStillBound,
+                  !requestDispatched,
+                )
               } finally client.close()
             }
           }
@@ -183,21 +253,30 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 clientKeyPem = Some(ServerKeyPem),
               )
               try {
-                val tcpAccepted    = client.tcpConnected
-                val handshakeError = client.handshakeAttempt()
-                val refused        = handshakeError.exists(_.isInstanceOf[ConnectException])
-                val proceeds       = if (refused) true else client.serverProceeds()
-                val stillBound     = handle.binding.address match {
+                val tcpAcceptedByServer      = client.tcpConnected
+                val handshakeError           = client.handshakeAttempt()
+                handshakeError.foreach(err => println(s"mTLS wrong-CA handshake error (expected): $err"))
+                val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
+                val serverSpokeH2AfterReject =
+                  if (refusedBeforeHandshake) true else client.serverProceeds()
+                val serverStillBound         = handle.binding.address match {
                   case BoundAddress.Tcp(_, thePort) => thePort == tcpPort
                   case _                            => false
                 }
-                assertTrue(tcpAccepted, !refused, !proceeds, stillBound, !handlerHit.get())
+                val requestDispatched        = handlerHit.get()
+                assertTrue(
+                  tcpAcceptedByServer,
+                  !refusedBeforeHandshake,
+                  !serverSpokeH2AfterReject,
+                  serverStillBound,
+                  !requestDispatched,
+                )
               } finally client.close()
             }
           }
       },
     ) @@ sequential
-  private val EchoRoutes: Routes[Any]                                           =
+  private val EchoRoutes: Routes[Any]                                                     =
     Routes(
       Route(
         RoutePattern.GET,
@@ -239,42 +318,22 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
         }
         use(port)
       }
-  private def useWithPort[R](caseId: Int): Int => ZIO[R, Throwable, TestResult] =
+  private def runProxyCase[R](proxyCase: ProxyCase): Int => ZIO[R, Throwable, TestResult] =
     (port: Int) =>
       ZIO.attemptBlocking {
         val client = new ProxyTestClient(port)
         try {
-          val seen   = client.getWithHeaders(streamId = 1, extra = headersFor(caseId))
-          val expect = expectedFor(caseId)
+          val seen = client.getWithHeaders(streamId = 1, extra = proxyCase.sentHeaders)
           assertTrue(
-            seen.clientIp == expect.clientIp,
+            seen.clientIp == proxyCase.expectedClientIp,
             seen.forwardedFor == "none",
             seen.forwardedHeader == "none",
             seen.peer == "127.0.0.1",
-            seen.host == expect.host,
-            seen.scheme == expect.scheme,
+            seen.host == proxyCase.expectedHost,
+            seen.scheme == proxyCase.expectedScheme,
           )
         } finally client.close()
       }
-  private def headersFor(caseId: Int): List[HeaderField]                        =
-    caseId match {
-      case 1 | 2 =>
-        List(
-          HeaderField("x-forwarded-for", "203.0.113.7"),
-          HeaderField("x-forwarded-proto", "https"),
-          HeaderField("x-forwarded-host", "example.com"),
-        )
-      case 3 | 4 =>
-        List(HeaderField("forwarded", "for=198.51.100.9;proto=https;host=example.org"))
-      case _     => Nil
-    }
-  private def expectedFor(caseId: Int): SeenHeaders                             =
-    caseId match {
-      case 1 => SeenHeaders("203.0.113.7", "127.0.0.1", "none", "none", "example.com", "https")
-      case 2 => SeenHeaders("127.0.0.1", "127.0.0.1", "none", "none", "127.0.0.1", "http")
-      case 3 => SeenHeaders("198.51.100.9", "127.0.0.1", "none", "none", "example.org", "https")
-      case _ => SeenHeaders("127.0.0.1", "127.0.0.1", "none", "none", "127.0.0.1", "http")
-    }
   private final case class SeenHeaders(
     clientIp: String,
     peer: String,
@@ -376,7 +435,7 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
   // Unrelated EC CA (same material as H2TlsSpec): the trust anchor for the
   // wrong-CA rejection test. The peer presents the self-signed RSA server
   // cert, which chains to nothing here, so the handshake must abort.
-  private val WrongCaPem                                                        =
+  private val WrongCaPem                                                                  =
     """-----BEGIN CERTIFICATE-----
 MIIBfTCCASOgAwIBAgIUDZi2vTwLeJsU87eAXPcmVuht9ZcwCgYIKoZIzj0EAwIw
 FDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDYzMDIyMzUwMFoXDTI3MDYzMDIy
@@ -389,7 +448,7 @@ Kgl8yIWcrTsLIrsXHA6cAiAPFrDVHrjyjv9zdl8DhXcH/Sx8o2to2EIAMDlio31w
 Lg==
 -----END CERTIFICATE-----"""
   // Self-signed localhost cert/key for the mTLS rejection test (same material as H2TlsSpec).
-  private val ServerCertPem                                                     =
+  private val ServerCertPem                                                               =
     """-----BEGIN CERTIFICATE-----
 MIIDXTCCAkWgAwIBAgIIFmlxlymbftowDQYJKoZIhvcNAQEMBQAwXTELMAkGA1UE
 BhMCVVMxDTALBgNVBAgTBFRlc3QxDTALBgNVBAcTBFRlc3QxDTALBgNVBAoTBFRl
@@ -411,7 +470,7 @@ dpBrxWvWGRl2+Nle0zAQNznhfn8ydP/7K3Lv/f3qQ48EgXmSDdhvSUfX24CLVLXk
 mETcQb+xmaWObOxkaK0iWGoQWPs2UFKVHPDmUlsYSt0ePGsiu1uEbgWrfr+6vBdx
 Wg==
 -----END CERTIFICATE-----"""
-  private val ServerKeyPem                                                      =
+  private val ServerKeyPem                                                                =
     """-----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDihzLu4ln5ta1R
 gac4J3GsWMLWVjMoud5NiZczB7RLHQx+yt1uYhDqc8HTgzkEBU8lel1IdEMP+m4Y

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2RawBodySpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2RawBodySpec.scala
@@ -1,0 +1,247 @@
+package zio.http.h2
+
+import java.nio.charset.StandardCharsets
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import scala.annotation.experimental
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.H2RawClientFixture.RawH2Client
+import zio.http.h2.hpack.{HeaderField, HpackEncoder}
+import zio.http.{
+  BindAddress,
+  Body,
+  BoundAddress,
+  Connector,
+  LoomServer,
+  Method,
+  Request,
+  Response,
+  Route,
+  Routes,
+  Status,
+  handler,
+}
+
+/**
+ * Raw-body access + HMAC-before-decode round-trip proof.
+ *
+ * The H2 wire path must preserve request bytes exactly: `H2Transport`
+ * reassembles DATA frames byte-identically under the general
+ * `Connector.maxRequestBodySize` bound, and handlers tap the raw bytes via the
+ * synchronous `Body.toChunk` accessor BEFORE any decoding runs. This spec pins
+ * that contract against a real loopback `LoomServer` using a fixed HMAC-SHA256
+ * test vector (RFC 4231, Test Case 1, independently verified with OpenSSL — see
+ * `ExpectedMacHex` below):
+ *
+ *   - Key (20 bytes): 0x0b repeated 20 times
+ *   - Message: "Hi There" (8 ASCII bytes, no trailing newline)
+ *   - HMAC-SHA256:
+ *     b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+ *
+ * Byte fidelity is what makes the MAC meaningful: any re-encoding, trim, or
+ * dropped byte on the H2 path changes the MAC, so matching the vector proves
+ * the raw bytes survived the round-trip untouched.
+ *
+ * Body-tap guidance: in v4 the handler runs on the stream thread with the fully
+ * reassembled body, so `request.body.toChunk` is the HMAC tap point — hash
+ * first, decode the bytes into domain types second. Verification,
+ * deduplication, and reconciliation of MACs against stored keys is NOT done
+ * here: that business logic belongs to Qaizn. The handoff line is the hex MAC
+ * string this spec asserts on — Qaizn consumes `(keyId, messageBytes, macHex)`
+ * triples produced exactly this way and owns accept/reject.
+ */
+@experimental
+object H2RawBodySpec extends ZIOSpecDefault {
+
+  /** RFC 4231 Test Case 1 key: 20 bytes of 0x0b. */
+  private val TestKey: Array[Byte] =
+    Array.fill(20)(0x0b.toByte)
+
+  /** RFC 4231 Test Case 1 message: "Hi There". */
+  private val TestMessage: Chunk[Byte] =
+    Chunk.fromArray("Hi There".getBytes(StandardCharsets.US_ASCII))
+
+  /**
+   * RFC 4231 Test Case 1 HMAC-SHA256, lowercase hex. Independently verified
+   * with `printf 'Hi There' | openssl dgst -sha256 -mac HMAC -macopt
+   * hexkey:0b...0b` (20 x 0x0b): b0344c61...9376c2e32cff7.
+   */
+  private val ExpectedMacHex: String =
+    "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+
+  /**
+   * Raw-byte HMAC-SHA256 tap: hash `bytes` exactly as received, no decoding.
+   */
+  private def hmacSha256Hex(key: Array[Byte], bytes: Chunk[Byte]): String = {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(new SecretKeySpec(key, "HmacSHA256"))
+    val out = new StringBuilder(64)
+    val sum = mac.doFinal(bytes.toArray)
+    var i   = 0
+    while (i < sum.length) {
+      out.append(Character.forDigit((sum(i) >> 4) & 0xf, 16))
+      out.append(Character.forDigit(sum(i) & 0xf, 16))
+      i += 1
+    }
+    out.toString
+  }
+
+  private val HmacRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern(Method.POST, "/hmac"),
+        handler { (req: Request) =>
+          // v4 preserves bytes: tap the raw chunk BEFORE any decoding.
+          // Verification/dedup/reconciliation belong to Qaizn, not here.
+          responseAsResult(
+            Response(status = Status.Ok, body = Body.fromString(hmacSha256Hex(TestKey, req.body.toChunk))),
+          )
+        },
+      ),
+      Route(
+        RoutePattern(Method.POST, "/echo"),
+        handler { (req: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = req.body))
+        },
+      ),
+    )
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2RawBodySpec")(
+      test("chunk request body (single DATA frame) HMAC matches the fixed test vector") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new RawH2Client(port)
+            try {
+              val mac  = client.post("/hmac", TestMessage, streamId = 1)
+              val echo = client.post("/echo", TestMessage, streamId = 3)
+              assertTrue(
+                mac.status == 200,
+                mac.bodyText == ExpectedMacHex,
+                echo.status == 200,
+                echo.body == TestMessage,
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("streamed request body (split DATA frames) HMAC matches the same vector, byte-identical") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new RawH2Client(port)
+            try {
+              val first  = TestMessage.slice(0, 4)
+              val second = TestMessage.slice(4, TestMessage.length)
+              val mac    = client.postSplit("/hmac", first, second, streamId = 1)
+              val echo   = client.postSplit("/echo", first, second, streamId = 3)
+              assertTrue(
+                mac.status == 200,
+                mac.bodyText == ExpectedMacHex,
+                echo.status == 200,
+                echo.body == TestMessage,
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("one flipped bit changes the MAC: the tap is byte-sensitive, not a constant") {
+        withServer { port =>
+          ZIO.attemptBlocking {
+            val client = new RawH2Client(port)
+            try {
+              val tamperedArray = "Hi There".getBytes(StandardCharsets.US_ASCII)
+              tamperedArray(2) = (tamperedArray(2) ^ 0x01).toByte
+              val tampered      = Chunk.fromArray(tamperedArray)
+              val mac           = client.post("/hmac", tampered, streamId = 1)
+              val echo          = client.post("/echo", tampered, streamId = 3)
+              assertTrue(
+                mac.status == 200,
+                mac.bodyText != ExpectedMacHex,
+                mac.bodyText.length == 64,
+                echo.status == 200,
+                echo.body == tampered,
+              )
+            } finally client.close()
+          }
+        }
+      },
+      test("chunk body toChunk round-trips and HMACs without a server") {
+        ZIO.succeed {
+          val chunkBody = Body.fromChunk(TestMessage)
+          assertTrue(
+            chunkBody.toChunk == TestMessage,
+            hmacSha256Hex(TestKey, chunkBody.toChunk) == ExpectedMacHex,
+          )
+        }
+      },
+    ) @@ sequential
+
+  private def withServer[R](
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(bind = BindAddress.localhost(0))
+          new LoomServer(connector).serve(HmacRoutes, Context.empty)
+        },
+      )(handle => ZIO.succeed(handle.shutdownAndWait()))
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  /** POST sends on top of the shared raw client (single + split DATA). */
+  private implicit final class RawBodyOps(val client: RawH2Client) {
+    private def encoder: HpackEncoder = new HpackEncoder()
+
+    /** POST whose body fits in one DATA frame. */
+    def post(path: String, body: Chunk[Byte], streamId: Int): H2RawClientFixture.RawResponse = {
+      client.sendFrame(makeHeaders("POST", path, streamId, endStream = body.isEmpty))
+      if (body.nonEmpty) client.sendFrame(Data(streamId, body, endStream = true))
+      client.awaitResponse(streamId)
+    }
+
+    /** POST split across two DATA frames (streaming delivery). */
+    def postSplit(
+      path: String,
+      first: Chunk[Byte],
+      second: Chunk[Byte],
+      streamId: Int,
+    ): H2RawClientFixture.RawResponse = {
+      client.sendFrame(makeHeaders("POST", path, streamId, endStream = false))
+      client.sendFrame(Data(streamId, first, endStream = false))
+      client.sendFrame(Data(streamId, second, endStream = true))
+      client.awaitResponse(streamId)
+    }
+
+    private def makeHeaders(method: String, path: String, streamId: Int, endStream: Boolean): H2Frame.Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:${client.port}"),
+      )
+      H2Frame.Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2SlowStreamSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2SlowStreamSpec.scala
@@ -1,0 +1,544 @@
+package zio.http.h2
+
+import java.io.EOFException
+import java.net.Socket
+import java.net.SocketTimeoutException
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.ResultType._
+import zio.http.h2.H2Frame._
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{
+  BindAddress,
+  BoundAddress,
+  Connector,
+  Handler,
+  LoomServer,
+  Request,
+  Response,
+  Route,
+  Routes,
+  Status,
+  handler,
+}
+
+/**
+ * Slow-stream / slow-loris deadlines for the H2 server transport.
+ *
+ * A peer that stalls header completion or drips body bytes slowly must not hold
+ * server resources indefinitely. Time-to-complete is the metric: flow-control
+ * windows alone are not sufficient.
+ *
+ *   - an incomplete header block (HEADERS without END_HEADERS, CONTINUATION
+ *     never arrives) past `headerTimeoutMs` is reset with `RST_STREAM(CANCEL)`
+ *     while the connection stays usable for sibling streams;
+ *   - a body that keeps moving but too slowly (1 byte per 500ms, total past
+ *     `bodyTimeoutMs`) is reset with `RST_STREAM(CANCEL)` even though every
+ *     inter-frame gap is well under the deadline;
+ *   - a healthy slow-but-moving stream that completes under the deadline passes
+ *     with 200;
+ *   - the whole-request deadline is wired from `Connector.requestTimeoutMs` (a
+ *     stalled handler stream is reset; fast streams are untouched);
+ *   - a deadline reset never emits HEADERS after the RST.
+ */
+@experimental
+object H2SlowStreamSpec extends ZIOSpecDefault {
+
+  private val HeaderTimeoutMs: Long  = 1000L
+  private val BodyTimeoutMs: Long    = 2000L
+  private val RequestTimeoutMs: Long = 30000L
+
+  /**
+   * Socket read timeout: headroom above every explicit await deadline below.
+   */
+  private val SoTimeoutMs: Int = 20000
+
+  /**
+   * Quiet window after a deadline RST during which no stream frame may arrive.
+   */
+  private val QuietWindowMs: Int = 2500
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("H2SlowStreamSpec")(
+      test("stalled header block past deadline is reset with CANCEL and connection stays usable") {
+        withServer(headerTimeoutMs = HeaderTimeoutMs, bodyTimeoutMs = BodyTimeoutMs) { port =>
+          ZIO.attemptBlocking {
+            val client = new SlowTestClient(port)
+            try {
+              client.sendSplitHeaders(streamId = 1)
+              val code    = client.awaitReset(streamId = 1, timeoutMs = 8000)
+              val sibling = client.roundTrip("GET", "/", Chunk.empty, streamId = 3)
+              assertTrue(code == H2Error.Code.CANCEL, sibling.status == 200)
+            } finally client.close()
+          }
+        }
+      },
+      test("slow body drip past time-to-complete is reset with CANCEL though gaps stay under deadline") {
+        withServer(headerTimeoutMs = HeaderTimeoutMs, bodyTimeoutMs = BodyTimeoutMs) { port =>
+          ZIO.attemptBlocking {
+            val client = new SlowTestClient(port)
+            try {
+              // 7 bytes x 500ms gaps = ~3s total vs 2s time-to-complete
+              // deadline: 1s margin, every 500ms gap well under the deadline.
+              val code = client.postDrip(streamId = 1, totalBytes = 7, gapMs = 500L)
+              assertTrue(code == H2Error.Code.CANCEL)
+            } finally client.close()
+          }
+        }
+      },
+      test("healthy slow-but-moving body under deadline passes with 200") {
+        withServer(headerTimeoutMs = HeaderTimeoutMs, bodyTimeoutMs = BodyTimeoutMs) { port =>
+          ZIO.attemptBlocking {
+            val client = new SlowTestClient(port)
+            try {
+              val response = client.postDripExpectResponse(streamId = 1, totalBytes = 5, gapMs = 50L)
+              assertTrue(response.status == 200, response.body.length == 5)
+            } finally client.close()
+          }
+        }
+      },
+      test("whole-request deadline from Connector.requestTimeoutMs resets a stalled handler stream") {
+        withServer(headerTimeoutMs = 5000L, bodyTimeoutMs = 30000L, requestTimeoutMs = 800L, routes = SlowRoutes) {
+          port =>
+            ZIO.attemptBlocking {
+              val client = new SlowTestClient(port)
+              try {
+                // Complete request: the handler itself stalls past the 800ms
+                // whole-request deadline, so the stream must be reset.
+                val code = client.postExpectingReset(streamId = 1, path = "/", body = Chunk.empty)
+                assertTrue(code == H2Error.Code.CANCEL)
+              } finally client.close()
+            }
+        }
+      },
+      test("configured request timeout does not fire on fast streams") {
+        withServer(headerTimeoutMs = 5000L, bodyTimeoutMs = 30000L, requestTimeoutMs = 2000L) { port =>
+          ZIO.attemptBlocking {
+            val client = new SlowTestClient(port)
+            try {
+              val body     = Chunk.fromArray(Array.fill(16)(0x41.toByte))
+              val response = client.postExpectingResponse(streamId = 1, path = "/", body = body)
+              assertTrue(response.status == 200, response.body == body)
+            } finally client.close()
+          }
+        }
+      },
+      test("timed-out drip sends no HEADERS after the RST") {
+        withServer(headerTimeoutMs = HeaderTimeoutMs, bodyTimeoutMs = BodyTimeoutMs) { port =>
+          ZIO.attemptBlocking {
+            val client = new SlowTestClient(port)
+            try {
+              // One byte of a declared 8-byte body, then stall past the 2s
+              // time-to-complete body deadline: the server must reset with
+              // CANCEL and never answer with a (bogus 500) HEADERS.
+              client.sendFrame(client.makeHeaders("POST", "/", streamId = 1, endStream = false, Some("8")))
+              client.sendFrame(Data(1, Chunk.single(0x41.toByte), endStream = false))
+              client.awaitRstStrict(streamId = 1, expected = H2Error.Code.CANCEL, timeoutMs = 15000)
+              client.assertStreamQuiet(streamId = 1, graceMs = QuietWindowMs)
+              assertTrue(true)
+            } finally client.close()
+          }
+        }
+      },
+    ) @@ sequential
+
+  private val EchoRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.POST,
+        handler { (req: Request) =>
+          responseAsResult(Response(status = Status.Ok, body = req.body))
+        },
+      ),
+      Route(RoutePattern.GET, Handler.succeed(Response.ok)),
+    )
+
+  /**
+   * Stalled-handler routes: every POST sleeps past any test `requestTimeoutMs`,
+   * so the whole-request deadline is the only thing that can complete the
+   * stream. The sleep runs on the stream's virtual thread, never a ZIO fiber.
+   */
+  private val SlowRoutes: Routes[Any] =
+    Routes(
+      Route(
+        RoutePattern.POST,
+        handler { (_: Request) =>
+          Thread.sleep(6000L)
+          responseAsResult(Response.ok)
+        },
+      ),
+      Route(RoutePattern.GET, Handler.succeed(Response.ok)),
+    )
+
+  private def withServer[R](
+    headerTimeoutMs: Long,
+    bodyTimeoutMs: Long,
+    requestTimeoutMs: Long = RequestTimeoutMs,
+    routes: Routes[Any] = EchoRoutes,
+  )(
+    use: Int => ZIO[R, Throwable, TestResult],
+  ): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val connector = Connector(
+            bind = BindAddress.localhost(0),
+            headerTimeoutMs = headerTimeoutMs,
+            bodyTimeoutMs = bodyTimeoutMs,
+            requestTimeoutMs = requestTimeoutMs,
+          )
+          new LoomServer(connector).serve(routes, Context.empty)
+        },
+      )(handle => ZIO.attemptBlocking(handle.shutdownAndWait()).ignore)
+      .flatMap { handle =>
+        val port = handle.bindings.head.address match {
+          case BoundAddress.Tcp(_, value) => value
+          case other                      => throw new AssertionError("Expected TCP binding but found: " + other)
+        }
+        use(port)
+      }
+
+  private final case class RawResponse(status: Int, headers: List[HeaderField], body: Chunk[Byte])
+
+  private final class SlowTestClient(val port: Int) extends AutoCloseable {
+    private val PrefaceBytes =
+      "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+
+    val socket        = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(SoTimeoutMs)
+    private val out   = socket.getOutputStream
+    private val rawIn = socket.getInputStream
+    private var buf   = Chunk.empty[Byte]
+
+    private val encoder = new HpackEncoder()
+    private val decoder = new HpackDecoder()
+
+    private val frameBuffer: mutable.Map[Int, mutable.Queue[H2Frame]] =
+      mutable.Map.empty
+
+    handshake()
+
+    def sendFrame(frame: H2Frame): Unit   = sendRaw(FrameCodec.encode(frame).toArray)
+    def sendRaw(bytes: Array[Byte]): Unit = { out.write(bytes); out.flush() }
+
+    /**
+     * Sends an empty first fragment with END_HEADERS=false and never sends the
+     * CONTINUATION: the server must reset the stream after `headerTimeoutMs`.
+     * The fragment is empty (no HPACK bytes) so the shared HPACK dynamic table
+     * stays in sync and the connection remains usable for sibling streams after
+     * the reset.
+     */
+    def sendSplitHeaders(streamId: Int): Unit =
+      sendFrame(Headers(streamId, Chunk.empty, endStream = true, endHeaders = false))
+
+    /**
+     * POSTs `totalBytes` one byte at a time with `gapMs` between DATA frames,
+     * then waits for the timeout reset. Used for the slow-drip case.
+     *
+     * A write may fail with `SocketException` if it races the server's reset:
+     * the bytes already sent still prove the drip, and the reset itself is
+     * asserted below via `awaitReset` (reads are unaffected). A server that
+     * kills the connection *instead* of resetting surfaces as GOAWAY or a
+     * wait-timeout there and still fails loudly.
+     */
+    def postDrip(streamId: Int, totalBytes: Int, gapMs: Long): H2Error.Code = {
+      sendFrame(makeHeaders("POST", "/", streamId, endStream = false, Some(totalBytes.toString)))
+      var sent        = 0
+      var writeFailed = false
+      while (sent < totalBytes && !writeFailed) {
+        val last = sent == totalBytes - 1
+        try sendFrame(Data(streamId, Chunk.single(0x41.toByte), endStream = last))
+        catch {
+          case _: java.net.SocketException => writeFailed = true
+        }
+        sent += 1
+        if (!last && !writeFailed) Thread.sleep(gapMs)
+      }
+      awaitReset(streamId, timeoutMs = 15000)
+    }
+
+    /** Same drip but expects a full response (healthy slow stream). */
+    def postDripExpectResponse(streamId: Int, totalBytes: Int, gapMs: Long): RawResponse = {
+      sendFrame(makeHeaders("POST", "/", streamId, endStream = false, Some(totalBytes.toString)))
+      var sent = 0
+      while (sent < totalBytes) {
+        val last = sent == totalBytes - 1
+        sendFrame(Data(streamId, Chunk.single(0x41.toByte), endStream = last))
+        sent += 1
+        if (!last) Thread.sleep(gapMs)
+      }
+      awaitResponseOrReset(streamId) match {
+        case Left(response) => response
+        case Right(code)    => throw new AssertionError("Expected 200 but stream was reset: " + code)
+      }
+    }
+
+    /** Complete POST that must be reset (stalled-handler case). */
+    def postExpectingReset(streamId: Int, path: String, body: Chunk[Byte]): H2Error.Code = {
+      sendFrame(makeHeaders("POST", path, streamId, body.isEmpty, None))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitReset(streamId, timeoutMs = 15000)
+    }
+
+    /** Complete POST that must answered with a full echo response. */
+    def postExpectingResponse(streamId: Int, path: String, body: Chunk[Byte]): RawResponse = {
+      sendFrame(makeHeaders("POST", path, streamId, body.isEmpty, None))
+      if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+      awaitResponseOrReset(streamId) match {
+        case Left(response) => response
+        case Right(code)    => throw new AssertionError("Expected a full response but reset: " + code)
+      }
+    }
+
+    def roundTrip(method: String, path: String, body: Chunk[Byte], streamId: Int): RawResponse =
+      awaitResponseOrReset(
+        streamId,
+        sendFirst = Some(() => {
+          sendFrame(makeHeaders(method, path, streamId, body.isEmpty, None))
+          if (body.nonEmpty) sendFrame(Data(streamId, body, endStream = true))
+        }),
+      ) match {
+        case Left(response) => response
+        case Right(code)    => throw new AssertionError("Expected a full response but reset: " + code)
+      }
+
+    def makeHeaders(
+      method: String,
+      path: String,
+      streamId: Int,
+      endStream: Boolean,
+      declaredLength: Option[String],
+    ): Headers = {
+      val pseudo = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      )
+      val length = declaredLength.toList.map(value => HeaderField("content-length", value))
+      Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(pseudo ++ length),
+        endStream = endStream,
+        endHeaders = true,
+      )
+    }
+
+    /**
+     * Waits for RST_STREAM, tolerating a best-effort error response the handler
+     * may emit after the reset (either frame may hit the wire first).
+     *
+     * Polls with a short socket timeout so a hung server fails here with an
+     * explicit deadline message instead of surfacing as a raw
+     * `SocketTimeoutException` from deep inside `readFrame`.
+     */
+    def awaitReset(streamId: Int, timeoutMs: Int): H2Error.Code = {
+      socket.setSoTimeout(1000)
+      try {
+        val deadline                     = java.lang.System.currentTimeMillis() + timeoutMs
+        var result: Option[H2Error.Code] = None
+        while (result.isEmpty) {
+          if (java.lang.System.currentTimeMillis() > deadline)
+            throw new AssertionError("Timed out waiting for RST_STREAM on stream " + streamId)
+          try {
+            nextFrameFor(streamId) match {
+              case RstStream(_, code)   => result = Some(code)
+              case _: Headers           => () // Best-effort 500 on the dead stream; keep waiting for the RST.
+              case _: Data              => ()
+              case GoAway(_, code, dbg) =>
+                throw new AssertionError(s"GOAWAY while waiting RST: $code ${new String(dbg.toArray)}")
+              case _                    => ()
+            }
+          } catch {
+            case _: SocketTimeoutException => ()
+          }
+        }
+        result.get
+      } finally socket.setSoTimeout(SoTimeoutMs)
+    }
+
+    /**
+     * Waits for the expected RST_STREAM. Any HEADERS (e.g. a best-effort 500
+     * sent after the reset) or DATA on the stream fails immediately.
+     */
+    def awaitRstStrict(streamId: Int, expected: H2Error.Code, timeoutMs: Int): Unit = {
+      socket.setSoTimeout(1000)
+      try {
+        val deadline = java.lang.System.currentTimeMillis() + timeoutMs
+        var done     = false
+        while (!done) {
+          if (java.lang.System.currentTimeMillis() > deadline)
+            throw new AssertionError("Timed out waiting for RST_STREAM on stream " + streamId)
+          try {
+            nextFrameFor(streamId) match {
+              case RstStream(_, code)        =>
+                if (code != expected)
+                  throw new AssertionError("Expected RST_STREAM " + expected + " but got " + code)
+                done = true
+              case Headers(_, _, _, _, _, _) =>
+                throw new AssertionError(
+                  "HEADERS arrived on stream " + streamId + " awaiting RST_STREAM (no HEADERS may follow an RST)",
+                )
+              case Data(_, _, _, _)          =>
+                throw new AssertionError("DATA arrived on stream " + streamId + " awaiting RST_STREAM")
+              case GoAway(_, code, dbg)      =>
+                throw new AssertionError(s"GOAWAY while waiting RST: $code ${new String(dbg.toArray)}")
+              case _                         => ()
+            }
+          } catch {
+            case _: SocketTimeoutException => ()
+          }
+        }
+      } finally socket.setSoTimeout(SoTimeoutMs)
+    }
+
+    /**
+     * After the RST, no HEADERS/DATA for the stream may arrive: connection-
+     * level frames are drained and ignored, repeat RSTs are tolerated (the
+     * virtual-timer and poll paths can both fire CANCEL without changing reset
+     * semantics), but anything stream-addressed beyond that fails.
+     *
+     * If the server reaps this already-reset connection mid-window (EOF with no
+     * GOAWAY), that is not a HEADERS violation: TCP in-order delivery
+     * guarantees any post-RST HEADERS would have been decoded before the FIN,
+     * so reaching EOF proves none arrived. The window then reduces to proving
+     * the server itself is still healthy via a fresh connection.
+     */
+    def assertStreamQuiet(streamId: Int, graceMs: Int): Unit = {
+      socket.setSoTimeout(400)
+      try {
+        val deadline = java.lang.System.currentTimeMillis() + graceMs
+        while (java.lang.System.currentTimeMillis() < deadline) {
+          try {
+            readFrame() match {
+              case Headers(sid, _, _, _, _, _) if sid == streamId =>
+                throw new AssertionError("HEADERS arrived on stream " + sid + " after its RST_STREAM")
+              case Data(sid, _, _, _) if sid == streamId          =>
+                throw new AssertionError("DATA arrived on stream " + sid + " after its RST_STREAM")
+              case RstStream(sid, _) if sid == streamId           => ()
+              case _                                              => ()
+            }
+          } catch {
+            case _: SocketTimeoutException => ()
+            case _: EOFException           =>
+              verifyServerAlive()
+              return
+          }
+        }
+      } finally socket.setSoTimeout(SoTimeoutMs)
+    }
+
+    /**
+     * Fresh-connection liveness probe: the server must still serve requests.
+     */
+    private def verifyServerAlive(): Unit = {
+      val probe = new SlowTestClient(port)
+      try {
+        probe.sendFrame(probe.makeHeaders("GET", "/", streamId = 1, endStream = true, None))
+        probe.nextFrameFor(1) match {
+          case Headers(_, _, _, _, _, _) => ()
+          case RstStream(_, code)        => throw new AssertionError("liveness probe reset: " + code)
+          case GoAway(_, code, dbg)      =>
+            throw new AssertionError(s"liveness probe GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                         => throw new AssertionError("unexpected liveness probe response")
+        }
+      } finally probe.close()
+    }
+
+    private def awaitResponseOrReset(
+      streamId: Int,
+      sendFirst: Option[() => Unit] = None,
+    ): Either[RawResponse, H2Error.Code] = {
+      sendFirst.foreach(_())
+      val hdrs   = mutable.ListBuffer.empty[HeaderField]
+      var body   = Chunk.empty[Byte]
+      var done   = false
+      while (!done) {
+        nextFrameFor(streamId) match {
+          case Headers(_, block, end, _, _, _) =>
+            decoder.decode(block) match {
+              case Right(h) => hdrs ++= h
+              case Left(e)  => throw new AssertionError("HPACK decode: " + e)
+            }
+            if (end) done = true
+          case Data(_, data, end, _)           =>
+            body = body ++ data
+            if (end) done = true
+          case RstStream(_, code)              =>
+            return Right(code)
+          case GoAway(_, code, dbg)            =>
+            throw new AssertionError(s"GOAWAY: $code ${new String(dbg.toArray)}")
+          case _                               =>
+            throw new AssertionError("Unexpected frame while waiting for response")
+        }
+      }
+      val status = hdrs
+        .find(_.name == ":status")
+        .map(_.value.toInt)
+        .getOrElse(throw new AssertionError("Missing :status"))
+      Left(RawResponse(status, hdrs.toList, body))
+    }
+
+    private def nextFrameFor(streamId: Int): H2Frame = {
+      frameBuffer.get(streamId) match {
+        case Some(queue) if queue.nonEmpty => return queue.dequeue()
+        case _                             => ()
+      }
+      while (true) {
+        readFrame() match {
+          case Settings(false, _)                  => sendFrame(Settings(ack = true, Nil))
+          case Settings(true, _)                   => ()
+          case _: WindowUpdate                     => ()
+          case Ping(false, data)                   =>
+            sendFrame(Ping(ack = true, data))
+          case frame if frame.streamId == streamId => return frame
+          case other                               =>
+            val queue = frameBuffer.getOrElseUpdate(other.streamId, mutable.Queue.empty)
+            queue.enqueue(other)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    private def readFrame(): H2Frame = {
+      while (true) {
+        FrameCodec.decode(buf) match {
+          case Right((frame, rest))           =>
+            buf = rest
+            return frame
+          case Left(H2Error.InsufficientData) =>
+            val tmp = new Array[Byte](8192)
+            val n   = rawIn.read(tmp)
+            if (n < 0) throw new EOFException("Connection closed")
+            buf = buf ++ Chunk.fromArray(java.util.Arrays.copyOf(tmp, n))
+          case Left(err)                      =>
+            throw new AssertionError("Frame decode error: " + err)
+        }
+      }
+      throw new AssertionError("unreachable")
+    }
+
+    override def close(): Unit = socket.close()
+
+    private def handshake(): Unit = {
+      out.write(PrefaceBytes)
+      out.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      out.flush()
+      readFrame() match {
+        case Settings(false, _) => sendFrame(Settings(ack = true, Nil))
+        case other              => throw new AssertionError("Expected Settings(false,_): " + other)
+      }
+      readFrame() // consume server's ACK for our SETTINGS
+    }
+  }
+}

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2SlowStreamSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2SlowStreamSpec.scala
@@ -143,9 +143,9 @@ object H2SlowStreamSpec extends ZIOSpecDefault {
               // CANCEL and never answer with a (bogus 500) HEADERS.
               client.sendFrame(client.makeHeaders("POST", "/", streamId = 1, endStream = false, Some("8")))
               client.sendFrame(Data(1, Chunk.single(0x41.toByte), endStream = false))
-              client.awaitRstStrict(streamId = 1, expected = H2Error.Code.CANCEL, timeoutMs = 15000)
+              val resetCode = client.awaitRstStrict(streamId = 1, expected = H2Error.Code.CANCEL, timeoutMs = 15000)
               client.assertStreamQuiet(streamId = 1, graceMs = QuietWindowMs)
-              assertTrue(true)
+              assertTrue(resetCode == H2Error.Code.CANCEL)
             } finally client.close()
           }
         }
@@ -368,10 +368,11 @@ object H2SlowStreamSpec extends ZIOSpecDefault {
     }
 
     /**
-     * Waits for the expected RST_STREAM. Any HEADERS (e.g. a best-effort 500
-     * sent after the reset) or DATA on the stream fails immediately.
+     * Waits for the expected RST_STREAM and returns its code. Any HEADERS (e.g.
+     * a best-effort 500 sent after the reset) or DATA on the stream fails
+     * immediately.
      */
-    def awaitRstStrict(streamId: Int, expected: H2Error.Code, timeoutMs: Int): Unit = {
+    def awaitRstStrict(streamId: Int, expected: H2Error.Code, timeoutMs: Int): H2Error.Code = {
       socket.setSoTimeout(1000)
       try {
         val deadline = java.lang.System.currentTimeMillis() + timeoutMs
@@ -399,6 +400,7 @@ object H2SlowStreamSpec extends ZIOSpecDefault {
             case _: SocketTimeoutException => ()
           }
         }
+        expected
       } finally socket.setSoTimeout(SoTimeoutMs)
     }
 

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/TrustedProxyUnitSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/TrustedProxyUnitSpec.scala
@@ -1,0 +1,55 @@
+package zio.http.h2
+
+import scala.annotation.experimental
+
+import zio.test._
+
+import zio.http.TrustedProxyConfig
+
+/**
+ * Unit tests for the fail-closed numeric trust model: allowlist entries that
+ * are not literal IPs or strict CIDRs (hostnames, malformed CIDRs) must never
+ * match, and unparseable peer IPs must never be trusted — with zero DNS
+ * resolution at request time.
+ */
+@experimental
+object TrustedProxyUnitSpec extends ZIOSpecDefault {
+
+  override def spec: Spec[Any, Any] =
+    suite("TrustedProxyUnitSpec")(
+      test("hostname allowlist entry never matches (no DNS trust)") {
+        val config = TrustedProxyConfig(trustedCidrs = Set("localhost", "example.com"))
+        assertTrue(
+          !config.isTrusted("127.0.0.1", hasPeerCert = false),
+          !config.isTrusted("10.0.0.1", hasPeerCert = false),
+        )
+      },
+      test("malformed CIDR entries never match") {
+        val config = TrustedProxyConfig(
+          trustedCidrs = Set("10.0.0.0/33", "10.0.0.0/-1", "10.0.0.0/abc", "10.0.0.0/", "/24", "999.1.1.1/24"),
+        )
+        assertTrue(
+          !config.isTrusted("10.0.0.1", hasPeerCert = false),
+          !config.isTrusted("127.0.0.1", hasPeerCert = false),
+        )
+      },
+      test("valid CIDR and literal entries still match") {
+        val config = TrustedProxyConfig(trustedCidrs = Set("10.0.0.0/8", "127.0.0.1", "::1/128"))
+        assertTrue(
+          config.isTrusted("10.1.2.3", hasPeerCert = false),
+          config.isTrusted("127.0.0.1", hasPeerCert = false),
+          config.isTrusted("::1", hasPeerCert = false),
+          !config.isTrusted("11.0.0.1", hasPeerCert = false),
+          !config.isTrusted("::2", hasPeerCert = false),
+        )
+      },
+      test("garbage peerIp is never trusted") {
+        val config = TrustedProxyConfig(trustedCidrs = Set("10.0.0.0/8", "0.0.0.0/0"))
+        assertTrue(
+          !config.isTrusted("not-an-ip", hasPeerCert = false),
+          !config.isTrusted("", hasPeerCert = false),
+          !config.isTrusted("evil.com", hasPeerCert = false),
+        )
+      },
+    )
+}

--- a/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
+++ b/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
@@ -15,10 +15,28 @@ case class Connector(
   bind: BindAddress = BindAddress.Tcp(),
   protocol: Protocol = Protocol.H2C(),
   idleTimeout: java.time.Duration = java.time.Duration.ofSeconds(60),
-)
+  /**
+   * Maximum size in bytes of a single request body accepted by the server.
+   *
+   * This is a general binding-level knob shared by the H2 and H3 transports:
+   * wire-only settings stay on `Http2Config`/`Http3Config`. The H2 transport
+   * accounts DATA-frame payloads incrementally against this cap while reading
+   * the request body and resets the stream with
+   * `RST_STREAM(FLOW_CONTROL_ERROR)` the moment the cap is exceeded, so an
+   * over-cap body is never buffered in full. A declared `content-length` larger
+   * than this cap is rejected before any body bytes are read.
+   */
+  maxRequestBodySize: Long = Connector.DefaultMaxRequestBodySize,
+) {
+  if (maxRequestBodySize < 0L)
+    throw new IllegalArgumentException("maxRequestBodySize must be non-negative")
+}
 
 object Connector {
   val default: Connector = Connector()
+
+  /** Default request-body cap: 1 MiB per stream. */
+  val DefaultMaxRequestBodySize: Long = 1024L * 1024L
 
   implicit val schema: Schema[Connector] = Schema.derived[Connector]
 }

--- a/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
+++ b/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
@@ -264,15 +264,21 @@ object TlsConfig {
  * headers from any peer are stripped with zero effect and the resolved client
  * IP falls back to the socket peer address.
  *
- * Allowlist format: each entry of `trustedCidrs` is either a literal IP address
- * (`"10.0.0.1"`, `"::1"`) for an exact match, or a CIDR range (`"10.0.0.0/8"`,
- * `"2001:db8::/32"`, `"127.0.0.1/32"`). The set is pre-parsed once into numeric
- * networks: entries that are not a literal IP or a strict CIDR — notably
- * hostnames — never match (fail closed) and are never resolved via DNS at
- * request time. IPv4 entries never match IPv6 peers and vice versa.
+ * Allowlist format: each entry of `trustedCidrs` is either a numeric IP literal
+ * (`"10.0.0.1"`, `"::1"`) for an exact match, or a numeric CIDR range
+ * (`"10.0.0.0/8"`, `"2001:db8::/32"`, `"127.0.0.1/32"`). Numeric-only and
+ * fail-closed: entries that are not a literal IPv4 dotted quad or a literal
+ * IPv6 address (full or `::`-compressed, with IPv4-mapped normalization) —
+ * notably hostnames and malformed ranges — never match and never trigger name
+ * resolution. No DNS lookup ever happens, on any platform. IPv4 entries never
+ * match IPv6 peers and vice versa.
+ *
+ * Platform-portable: matching uses a hand-rolled numeric parser with
+ * indexOf-scan loops only, so shared sources cross-build where name-resolution
+ * APIs are absent.
  *
  * @param trustedCidrs
- *   IP literals or CIDR ranges whose forwarding headers are honored.
+ *   Numeric IP literals or CIDR ranges whose forwarding headers are honored.
  * @param trustPeerCert
  *   When `true`, any peer that authenticated with a client certificate (mTLS)
  *   is trusted regardless of the CIDR allowlist. Requires
@@ -285,11 +291,11 @@ case class TrustedProxyConfig(
 
   /**
    * The allowlist pre-parsed ONCE into numeric (address bytes, prefix bits)
-   * networks. Entries that are not a literal IP or a strict CIDR (hostnames,
-   * malformed ranges) are dropped here, so request-time matching never resolves
-   * DNS and can never trust via spoofed name resolution.
+   * networks. Non-numeric entries (hostnames, malformed ranges) are dropped
+   * here, so request-time matching performs zero name resolution and can never
+   * trust via spoofed name resolution.
    */
-  private lazy val parsedNetworks: Set[(Array[Byte], Int)] =
+  private lazy val parsedNetworks: Array[(Array[Byte], Int)] =
     TrustedProxyConfig.parseNetworks(trustedCidrs)
 
   /**
@@ -297,7 +303,7 @@ case class TrustedProxyConfig(
    * applied. `hasPeerCert` reports whether the peer presented a verified client
    * certificate on this connection. `peerIp` comes from the socket address, so
    * it is parsed as a numeric literal only: unparseable values fail closed with
-   * zero DNS resolution.
+   * zero name resolution.
    */
   def isTrusted(peerIp: String, hasPeerCert: Boolean): Boolean =
     (trustPeerCert && hasPeerCert) || TrustedProxyConfig.matchesParsed(peerIp, parsedNetworks)
@@ -316,81 +322,251 @@ object TrustedProxyConfig {
 
   implicit val schema: Schema[TrustedProxyConfig] = Schema.derived[TrustedProxyConfig]
 
-  private def matchesParsed(peerIp: String, networks: Set[(Array[Byte], Int)]): Boolean =
+  private def matchesParsed(peerIp: String, networks: Array[(Array[Byte], Int)]): Boolean =
     parseLiteralIp(peerIp) match {
       case None       => false
       case Some(peer) =>
-        val iterator = networks.iterator
-        var matched  = false
-        while (iterator.hasNext && !matched) {
-          val (network, bits) = iterator.next()
-          matched = matchesNetwork(network, peer, bits)
+        var index   = 0
+        var matched = false
+        while (index < networks.length && !matched) {
+          val network = networks(index)._1
+          val bits    = networks(index)._2
+          if (matchesNetwork(network, peer, bits)) matched = true
+          index += 1
         }
         matched
     }
 
-  private def parseNetworks(entries: Set[String]): Set[(Array[Byte], Int)] =
-    entries.flatMap(parseEntry)
+  private def parseNetworks(entries: Set[String]): Array[(Array[Byte], Int)] =
+    entries.flatMap(parseEntry).toArray
 
   /**
    * Parses one allowlist entry into (network bytes, prefix bits). Returns
-   * `None` — never matching — for anything that is not a literal IP or a strict
-   * `address/bits` CIDR. Never consults DNS (see `parseLiteralIp`).
+   * `None` — never matching — for anything that is not a numeric IP literal or
+   * a strict `address/bits` CIDR. Never performs name resolution (see
+   * `parseLiteralIp`).
    */
   private def parseEntry(entry: String): Option[(Array[Byte], Int)] = {
     val slash = entry.indexOf('/')
     if (slash < 0) parseLiteralIp(entry).map(bytes => (bytes, bytes.length * 8))
     else {
-      val bitText = entry.substring(slash + 1)
-      if (bitText.isEmpty || !bitText.forall(_.isDigit)) None
-      else {
-        val bits = bitText.toInt
-        parseLiteralIp(entry.substring(0, slash)) match {
-          case Some(network) if bits <= network.length * 8 => Some((network, bits))
-          case _                                           => None
-        }
+      var i    = slash + 1
+      val end  = entry.length
+      if (i >= end) return None
+      var bits = 0
+      while (i < end) {
+        val c = entry.charAt(i)
+        if (c < '0' || c > '9') return None
+        bits = bits * 10 + (c - '0')
+        if (bits > 128) return None
+        i += 1
+      }
+      parseLiteralIp(entry.substring(0, slash)) match {
+        case Some(network) if bits <= network.length * 8 => Some((network, bits))
+        case _                                           => None
       }
     }
   }
 
   /**
-   * Parses a numeric IP literal into address bytes without DNS resolution.
+   * Parses a numeric IP literal into address bytes with zero name resolution.
    *
-   * `InetAddress.getByName` is only reached for strings that are already proven
-   * to be numeric: anything containing `:` cannot be a DNS name (hostnames
-   * never contain colons), so it is parsed as an IPv6 literal with no lookup;
-   * anything without a colon must be a strict dotted quad, otherwise it is
-   * rejected before `getByName` could treat it as a hostname and consult DNS.
-   * Unparseable input yields `None` (fail closed).
+   * Only strict dotted-decimal IPv4 quads and IPv6 literals (full or
+   * `::`-compressed, with dotted-quad tails for mapped addresses) are accepted;
+   * IPv4-mapped IPv6 (`::ffff:a.b.c.d`) normalizes to 4-byte IPv4, matching
+   * prior address-bytes behavior. Anything else — hostnames, malformed input —
+   * yields `None` (fail closed). Implemented with indexOf scan loops only, so
+   * it cross-builds to platforms without resolver APIs.
    */
-  private def parseLiteralIp(text: String): Option[Array[Byte]] =
-    try {
-      if (text.isEmpty) None
-      else if (text.contains(":")) {
-        if (!text.forall(c => c.isDigit || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == ':' || c == '.'))
-          None
-        else Some(java.net.InetAddress.getByName(text).getAddress)
-      } else {
-        val parts = text.split("\\.", -1)
-        if (parts.length != 4) None
-        else {
-          var index   = 0
-          var numeric = true
-          while (index < 4 && numeric) {
-            val part = parts(index)
-            if (part.isEmpty || part.length > 3 || !part.forall(_.isDigit)) numeric = false
-            else {
-              val value = part.toInt
-              if (value < 0 || value > 255) numeric = false
-            }
-            index += 1
-          }
-          if (!numeric) None else Some(java.net.InetAddress.getByName(text).getAddress)
-        }
+  private def parseLiteralIp(text: String): Option[Array[Byte]] = {
+    if (text.isEmpty) None
+    else if (text.indexOf(':') >= 0) parseIPv6(text)
+    else parseIPv4(text)
+  }
+
+  private def parseIPv4(text: String): Option[Array[Byte]] = {
+    val len       = text.length
+    if (len == 0 || len > 15) return None
+    val out       = new Array[Byte](4)
+    var start     = 0
+    var partIndex = 0
+    while (partIndex < 4) {
+      var end     = start
+      while (end < len && text.charAt(end) != '.') end += 1
+      val partLen = end - start
+      if (partLen == 0 || partLen > 3) return None
+      var value   = 0
+      var k       = start
+      while (k < end) {
+        val c = text.charAt(k)
+        if (c < '0' || c > '9') return None
+        value = value * 10 + (c - '0')
+        k += 1
       }
-    } catch {
-      case _: Exception => None
+      if (value > 255) return None
+      out(partIndex) = value.toByte
+      partIndex += 1
+      if (partIndex < 4) {
+        if (end >= len || text.charAt(end) != '.') return None
+        start = end + 1
+      } else if (end != len) return None
     }
+    Some(out)
+  }
+
+  private def parseIPv6(text: String): Option[Array[Byte]] =
+    if (text.indexOf('.') >= 0) parseIPv6WithEmbeddedIPv4(text)
+    else parsePureIPv6(text)
+
+  private def parsePureIPv6(text: String): Option[Array[Byte]] = {
+    val comp = text.indexOf("::")
+    if (comp >= 0) {
+      if (text.lastIndexOf("::") != comp) return None
+      val leftGroups  = new Array[Int](8)
+      val rightGroups = new Array[Int](8)
+      val leftCount   = parseV6Side(text, 0, comp, leftGroups, 0)
+      if (leftCount < 0) return None
+      val rightCount  = parseV6Side(text, comp + 2, text.length, rightGroups, 0)
+      if (rightCount < 0) return None
+      if (leftCount + rightCount > 7) return None
+      val groups      = new Array[Int](8)
+      var i           = 0
+      while (i < leftCount) {
+        groups(i) = leftGroups(i)
+        i += 1
+      }
+      var z           = leftCount
+      while (z < 8 - rightCount) {
+        groups(z) = 0
+        z += 1
+      }
+      var j           = 0
+      while (j < rightCount) {
+        groups(8 - rightCount + j) = rightGroups(j)
+        j += 1
+      }
+      Some(groupsToBytes(groups))
+    } else {
+      val groups = new Array[Int](8)
+      val count  = parseV6Side(text, 0, text.length, groups, 0)
+      if (count != 8) None
+      else Some(groupsToBytes(groups))
+    }
+  }
+
+  private def parseIPv6WithEmbeddedIPv4(text: String): Option[Array[Byte]] = {
+    val lastColon  = text.lastIndexOf(':')
+    if (lastColon < 0) return None
+    val tailStart  = lastColon + 1
+    val tail       = text.substring(tailStart)
+    if (tail.indexOf('.') < 0) return None
+    val v4opt      = parseIPv4(tail)
+    if (v4opt.isEmpty) return None
+    val v4bytes    = v4opt.get
+    val rawHeadLen = text.length - tail.length
+    if (rawHeadLen <= 0 || text.charAt(rawHeadLen - 1) != ':') return None
+    val head       =
+      if (rawHeadLen >= 2 && text.charAt(rawHeadLen - 2) == ':') text.substring(0, rawHeadLen)
+      else text.substring(0, rawHeadLen - 1)
+    if (head.isEmpty || head.indexOf('.') >= 0) return None
+    val v4High     = ((v4bytes(0) & 0xff) << 8) | (v4bytes(1) & 0xff)
+    val v4Low      = ((v4bytes(2) & 0xff) << 8) | (v4bytes(3) & 0xff)
+    val groups     = new Array[Int](8)
+    val comp       = head.indexOf("::")
+    if (comp >= 0) {
+      if (head.lastIndexOf("::") != comp) return None
+      val leftGroups  = new Array[Int](8)
+      val rightGroups = new Array[Int](8)
+      val leftCount   = parseV6Side(head, 0, comp, leftGroups, 0)
+      if (leftCount < 0) return None
+      val rightCount  = parseV6Side(head, comp + 2, head.length, rightGroups, 0)
+      if (rightCount < 0) return None
+      if (leftCount + rightCount > 5) return None
+      var i           = 0
+      while (i < leftCount) {
+        groups(i) = leftGroups(i)
+        i += 1
+      }
+      var z           = leftCount
+      while (z < 6 - rightCount) {
+        groups(z) = 0
+        z += 1
+      }
+      var j           = 0
+      while (j < rightCount) {
+        groups(6 - rightCount + j) = rightGroups(j)
+        j += 1
+      }
+      groups(6) = v4High
+      groups(7) = v4Low
+    } else {
+      val headCount = parseV6Side(head, 0, head.length, groups, 0)
+      if (headCount != 6) return None
+      groups(6) = v4High
+      groups(7) = v4Low
+    }
+    val bytes      = groupsToBytes(groups)
+    var i          = 0
+    var isMapped   = true
+    while (i < 10 && isMapped) {
+      if (bytes(i) != 0) isMapped = false
+      i += 1
+    }
+    if (isMapped && ((bytes(10) & 0xff) != 0xff || (bytes(11) & 0xff) != 0xff)) isMapped = false
+    if (isMapped) {
+      val out = new Array[Byte](4)
+      out(0) = bytes(12)
+      out(1) = bytes(13)
+      out(2) = bytes(14)
+      out(3) = bytes(15)
+      Some(out)
+    } else Some(bytes)
+  }
+
+  private def parseV6Side(text: String, start: Int, end: Int, out: Array[Int], offset: Int): Int = {
+    if (start == end) return 0
+    if (start > end) return -1
+    var pos   = start
+    var count = 0
+    while (pos < end) {
+      var colon = pos
+      while (colon < end && text.charAt(colon) != ':') colon += 1
+      val glen  = colon - pos
+      if (glen == 0 || glen > 4) return -1
+      var value = 0
+      var k     = pos
+      while (k < colon) {
+        val c = text.charAt(k)
+        val d =
+          if (c >= '0' && c <= '9') c - '0'
+          else if (c >= 'a' && c <= 'f') c - 'a' + 10
+          else if (c >= 'A' && c <= 'F') c - 'A' + 10
+          else return -1
+        value = (value << 4) | d
+        k += 1
+      }
+      if (count >= 8) return -1
+      out(offset + count) = value
+      count += 1
+      if (colon == end) pos = end
+      else {
+        pos = colon + 1
+        if (pos == end) return -1
+      }
+    }
+    count
+  }
+
+  private def groupsToBytes(groups: Array[Int]): Array[Byte] = {
+    val out = new Array[Byte](16)
+    var i   = 0
+    while (i < 8) {
+      out(i * 2) = ((groups(i) >> 8) & 0xff).toByte
+      out(i * 2 + 1) = (groups(i) & 0xff).toByte
+      i += 1
+    }
+    out
+  }
 
   private def matchesNetwork(network: Array[Byte], peer: Array[Byte], bits: Int): Boolean = {
     if (network.length != peer.length || bits < 0 || bits > network.length * 8) false

--- a/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
+++ b/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
@@ -27,6 +27,38 @@ case class Connector(
    * than this cap is rejected before any body bytes are read.
    */
   maxRequestBodySize: Long = Connector.DefaultMaxRequestBodySize,
+  /**
+   * Whole-request deadline in milliseconds, measured from stream start until
+   * the response completes.
+   *
+   * This is a general binding-level knob shared by the H2 and H3 transports:
+   * wire-only settings stay on `Http2Config`/`Http3Config`. The H2 transport
+   * forwards it to the per-stream request timer, which resets the stream with
+   * `RST_STREAM(CANCEL)` on expiry. Non-positive disables. Default 30 seconds.
+   */
+  requestTimeoutMs: Long = Connector.DefaultRequestTimeoutMs,
+  /**
+   * Header-completion deadline in milliseconds, measured from stream start.
+   *
+   * This is a general binding-level knob shared by the H2 and H3 transports:
+   * wire-only settings stay on `Http2Config`/`Http3Config`. It bounds the time
+   * to receive a complete header block, including trailing CONTINUATION frames
+   * (`H2Connection` pending headers). Expiry resets the stream with
+   * `RST_STREAM(CANCEL)`. Non-positive disables. Default 5 seconds.
+   */
+  headerTimeoutMs: Long = Connector.DefaultHeaderTimeoutMs,
+  /**
+   * Body-completion (time-to-complete) deadline in milliseconds, measured from
+   * stream start until the full request body is received.
+   *
+   * This is a general binding-level knob shared by the H2 and H3 transports:
+   * wire-only settings stay on `Http2Config`/`Http3Config`. Total elapsed time
+   * is enforced, not just the gap between frames, so a drip that keeps moving
+   * but too slowly still times out (`H2Transport` body read). Expiry resets the
+   * stream with `RST_STREAM(CANCEL)`. Non-positive disables. Default 10
+   * seconds.
+   */
+  bodyTimeoutMs: Long = Connector.DefaultBodyTimeoutMs,
 ) {
   if (maxRequestBodySize < 0L)
     throw new IllegalArgumentException("maxRequestBodySize must be non-negative")
@@ -37,6 +69,15 @@ object Connector {
 
   /** Default request-body cap: 1 MiB per stream. */
   val DefaultMaxRequestBodySize: Long = 1024L * 1024L
+
+  /** Default whole-request deadline: 30 seconds. */
+  val DefaultRequestTimeoutMs: Long = 30000L
+
+  /** Default header-completion deadline: 5 seconds. */
+  val DefaultHeaderTimeoutMs: Long = 5000L
+
+  /** Default body-completion (time-to-complete) deadline: 10 seconds. */
+  val DefaultBodyTimeoutMs: Long = 10000L
 
   implicit val schema: Schema[Connector] = Schema.derived[Connector]
 }

--- a/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
+++ b/zio-http-server/shared/src/main/scala/zio/http/Connector.scala
@@ -59,6 +59,17 @@ case class Connector(
    * seconds.
    */
   bodyTimeoutMs: Long = Connector.DefaultBodyTimeoutMs,
+  /**
+   * Which TCP peers are trusted to supply forwarding headers
+   * (`X-Forwarded-For`, `X-Forwarded-Proto`, `X-Forwarded-Host`, RFC 7239
+   * `Forwarded`) to the loom HTTP/2 transport.
+   *
+   * This is a general binding-level knob shared by the H2 and H3 transports.
+   * Default-deny: `TrustedProxyConfig.default` trusts nothing, so forwarding
+   * headers from any peer are stripped with zero effect and the resolved client
+   * IP falls back to the socket peer address.
+   */
+  trustedProxy: TrustedProxyConfig = TrustedProxyConfig.default,
 ) {
   if (maxRequestBodySize < 0L)
     throw new IllegalArgumentException("maxRequestBodySize must be non-negative")
@@ -223,8 +234,180 @@ case class TlsConfig(
   alpnProtocols: List[String] = List("h2"),
   alpnPolicy: AlpnPolicy = AlpnPolicy.StrictH2,
   tlsVersions: List[String] = List("TLSv1.3", "TLSv1.2"),
+  /**
+   * Require the TLS peer to present a certificate (mutual TLS).
+   *
+   * The handshake aborts when the peer sends no (or an untrusted) certificate,
+   * so an HAProxy-style sidecar identity can gate proxy trust (see
+   * `TrustedProxyConfig.trustPeerCert`). Default `false`.
+   */
+  requireClientAuth: Boolean = false,
+  /**
+   * Extra CA certificates used to verify the peer's certificate when
+   * `requireClientAuth` is set. When absent, the platform default trust store
+   * is used. Never `null` trust managers: the loom listener always installs
+   * real trust managers.
+   */
+  trustCertChain: Option[TlsSource] = None,
 )
 
 object TlsConfig {
   implicit val schema: Schema[TlsConfig] = Schema.derived[TlsConfig]
+}
+
+/**
+ * Which TCP peers are trusted to supply forwarding headers (`X-Forwarded-For`,
+ * `X-Forwarded-Proto`, `X-Forwarded-Host`, RFC 7239 `Forwarded`) to the loom
+ * HTTP/2 transport.
+ *
+ * Default-deny: `TrustedProxyConfig.default` trusts nothing, so forwarding
+ * headers from any peer are stripped with zero effect and the resolved client
+ * IP falls back to the socket peer address.
+ *
+ * Allowlist format: each entry of `trustedCidrs` is either a literal IP address
+ * (`"10.0.0.1"`, `"::1"`) for an exact match, or a CIDR range (`"10.0.0.0/8"`,
+ * `"2001:db8::/32"`, `"127.0.0.1/32"`). The set is pre-parsed once into numeric
+ * networks: entries that are not a literal IP or a strict CIDR — notably
+ * hostnames — never match (fail closed) and are never resolved via DNS at
+ * request time. IPv4 entries never match IPv6 peers and vice versa.
+ *
+ * @param trustedCidrs
+ *   IP literals or CIDR ranges whose forwarding headers are honored.
+ * @param trustPeerCert
+ *   When `true`, any peer that authenticated with a client certificate (mTLS)
+ *   is trusted regardless of the CIDR allowlist. Requires
+ *   `TlsConfig.requireClientAuth` on the connector. Default `false`.
+ */
+case class TrustedProxyConfig(
+  trustedCidrs: Set[String] = Set.empty,
+  trustPeerCert: Boolean = false,
+) {
+
+  /**
+   * The allowlist pre-parsed ONCE into numeric (address bytes, prefix bits)
+   * networks. Entries that are not a literal IP or a strict CIDR (hostnames,
+   * malformed ranges) are dropped here, so request-time matching never resolves
+   * DNS and can never trust via spoofed name resolution.
+   */
+  private lazy val parsedNetworks: Set[(Array[Byte], Int)] =
+    TrustedProxyConfig.parseNetworks(trustedCidrs)
+
+  /**
+   * Returns `true` iff forwarding headers from the peer at `peerIp` may be
+   * applied. `hasPeerCert` reports whether the peer presented a verified client
+   * certificate on this connection. `peerIp` comes from the socket address, so
+   * it is parsed as a numeric literal only: unparseable values fail closed with
+   * zero DNS resolution.
+   */
+  def isTrusted(peerIp: String, hasPeerCert: Boolean): Boolean =
+    (trustPeerCert && hasPeerCert) || TrustedProxyConfig.matchesParsed(peerIp, parsedNetworks)
+}
+
+object TrustedProxyConfig {
+
+  /** Default-deny: no peer is trusted. */
+  val default: TrustedProxyConfig = TrustedProxyConfig()
+
+  /** Normalized client-IP header set on every request for route handlers. */
+  val ClientIpHeader: String = "x-client-ip"
+
+  /** Socket peer-address header set on every request for route handlers. */
+  val PeerAddressHeader: String = "x-peer-address"
+
+  implicit val schema: Schema[TrustedProxyConfig] = Schema.derived[TrustedProxyConfig]
+
+  private def matchesParsed(peerIp: String, networks: Set[(Array[Byte], Int)]): Boolean =
+    parseLiteralIp(peerIp) match {
+      case None       => false
+      case Some(peer) =>
+        val iterator = networks.iterator
+        var matched  = false
+        while (iterator.hasNext && !matched) {
+          val (network, bits) = iterator.next()
+          matched = matchesNetwork(network, peer, bits)
+        }
+        matched
+    }
+
+  private def parseNetworks(entries: Set[String]): Set[(Array[Byte], Int)] =
+    entries.flatMap(parseEntry)
+
+  /**
+   * Parses one allowlist entry into (network bytes, prefix bits). Returns
+   * `None` — never matching — for anything that is not a literal IP or a strict
+   * `address/bits` CIDR. Never consults DNS (see `parseLiteralIp`).
+   */
+  private def parseEntry(entry: String): Option[(Array[Byte], Int)] = {
+    val slash = entry.indexOf('/')
+    if (slash < 0) parseLiteralIp(entry).map(bytes => (bytes, bytes.length * 8))
+    else {
+      val bitText = entry.substring(slash + 1)
+      if (bitText.isEmpty || !bitText.forall(_.isDigit)) None
+      else {
+        val bits = bitText.toInt
+        parseLiteralIp(entry.substring(0, slash)) match {
+          case Some(network) if bits <= network.length * 8 => Some((network, bits))
+          case _                                           => None
+        }
+      }
+    }
+  }
+
+  /**
+   * Parses a numeric IP literal into address bytes without DNS resolution.
+   *
+   * `InetAddress.getByName` is only reached for strings that are already proven
+   * to be numeric: anything containing `:` cannot be a DNS name (hostnames
+   * never contain colons), so it is parsed as an IPv6 literal with no lookup;
+   * anything without a colon must be a strict dotted quad, otherwise it is
+   * rejected before `getByName` could treat it as a hostname and consult DNS.
+   * Unparseable input yields `None` (fail closed).
+   */
+  private def parseLiteralIp(text: String): Option[Array[Byte]] =
+    try {
+      if (text.isEmpty) None
+      else if (text.contains(":")) {
+        if (!text.forall(c => c.isDigit || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == ':' || c == '.'))
+          None
+        else Some(java.net.InetAddress.getByName(text).getAddress)
+      } else {
+        val parts = text.split("\\.", -1)
+        if (parts.length != 4) None
+        else {
+          var index   = 0
+          var numeric = true
+          while (index < 4 && numeric) {
+            val part = parts(index)
+            if (part.isEmpty || part.length > 3 || !part.forall(_.isDigit)) numeric = false
+            else {
+              val value = part.toInt
+              if (value < 0 || value > 255) numeric = false
+            }
+            index += 1
+          }
+          if (!numeric) None else Some(java.net.InetAddress.getByName(text).getAddress)
+        }
+      }
+    } catch {
+      case _: Exception => None
+    }
+
+  private def matchesNetwork(network: Array[Byte], peer: Array[Byte], bits: Int): Boolean = {
+    if (network.length != peer.length || bits < 0 || bits > network.length * 8) false
+    else {
+      var index     = 0
+      var matching  = true
+      val fullBytes = bits / 8
+      val restBits  = bits % 8
+      while (index < fullBytes && matching) {
+        if (network(index) != peer(index)) matching = false
+        index += 1
+      }
+      if (matching && restBits > 0) {
+        val mask = (0xff << (8 - restBits)) & 0xff
+        matching = (network(index) & mask) == (peer(index) & mask)
+      }
+      matching
+    }
+  }
 }


### PR DESCRIPTION
Production guardrails on top of #4292, per `.omo/plans/zio-http-v4-p1-hardening.md` rescoped. Upstream #4292 already owns settings/ALPN/idle/streaming/timeout-abort — this stack adds only what it lacks.

**What lands (4 commits, logical reapplication onto v4.x tip — not cherry-picks):**
- `feat(h2): enforce maxRequestBodySize on request bodies` — general `Connector.maxRequestBodySize` (1 MiB), per-DATA accounting, RST `FLOW_CONTROL_ERROR`, content-length consistency
- `feat(h2): slow-stream deadlines and CONTINUATION bounds` — wires `requestTimeoutMs` from config (was hardcoded), separate body time-to-complete deadline, CONTINUATION flood cap + pending deadline, re-check-at-send
- `feat(h2): default-deny proxy trust and mTLS gating` — `TrustedProxyConfig` (DNS-free pre-parsed matching), X-Forwarded-/RFC 7239 honored only from trusted peers, `needClientAuth` + real trust managers
- `feat(h2): access logging, raw-body proof, client caps, matrix` — v4-native pluggable sink (metadata-only), HMAC-SHA256 vector proof over the real tap, pooled/JDK-leg response caps via `ClientConfig.maxResponseBodySize`, adversarial matrix, hardening section in `docs/reference/h2-server.md`

**Verification:** every group TDD RED→GREEN on LoomServer loopback; full suites green on 2.13.18 + 3.8.3; scalafmt clean. Evidence in `.omo/evidence/zio-http-v4-p1-hardening/` (not committed).