### PR TITLE
feat(cookie): H2-verified cookie session helpers (wire proof + token + rotation + docs)

### DIFF
--- a/docs/guides/cookie-based-authentication.md
+++ b/docs/guides/cookie-based-authentication.md
@@ -295,7 +295,7 @@ In production environments, we should set `isHttpOnly = true` and `isSecure = tr
 ### Authentication Middleware
 
 :::warning UNPORTED
-The `HandlerAspect` cookie-auth middleware below is v3-era and unported (`HandlerAspect` absent on v4 main; v4 middleware is `Middleware.identity` / `customAuth` / `basicAuth` / `bearerAuth` / `rotateCookie` only). Preserved as-is.
+The `HandlerAspect` cookie-auth middleware below is v3-era and unported (`HandlerAspect` absent on v4 main; v4 middleware is `Middleware.identity` / `customAuth` / `basicAuth` / `bearerAuth` / `signCookies` / `rotateCookie` (+ `flashScope`) — `signCookies` arrived via #4210 after the original v4-status audit). Preserved as-is.
 :::
 
 After implementing the login route, we can now create middleware that will intercept incoming requests and check for a valid session cookie. If the cookie is present and valid, it will allow access to protected resources; otherwise, it will return an unauthorized response.
@@ -359,7 +359,7 @@ Verified on v4 (`RotateCookieSpec` 4/4 + 13/13 neighbors, fail-closed):
 Middleware.rotateCookie[Session](
   name = "session_id",
   validate = (sessionId: String) => ZIO.succeed(Option.empty[Session]),
-  create = (request: Request) => ZIO.succeed(Option.empty[Session]),
+  create = (_: Session) => ZIO.succeed("new-session-id"),
   maxAge = Some(300L),
 )
 ```

--- a/docs/guides/cookie-based-authentication.md
+++ b/docs/guides/cookie-based-authentication.md
@@ -4,6 +4,12 @@ title: "Securing Your APIs: Cookie-based Authentication"
 sidebar_label: "Cookie-based Authentication"
 ---
 
+:::warning v4-status
+Verified on v4: H2 `Set-Cookie` wire bytes, `SessionToken`, and `Middleware.rotateCookie` (see "Session rotation (verified on v4)" below).
+Unported inline APIs in this guide (preserved as-is): `Cookie.Response` / `Cookie.SameSite` / `request.cookie` / `ZClient.batched` / `HandlerAspect.cookieAuth` / `Response.*("msg")` message-arg forms.
+All 4 fully unported examples: `CookieServerSide.scala`, `SignCookies.scala`, `HelloWorldWithMiddlewares.scala`, and `CookieBasedAuthentication.scala` (3.4.0 + `NettyServer` + old `Middleware.basicAuth("admin","admin")` pair-signature vs v4 `basicAuth[Session]` validate-fn; its flow is the inlined v3 snippets below).
+:::
+
 Session-based authentication using cookies is one of the most common authentication mechanisms for web applications. In this guide, we demonstrate how to implement a robust cookie-based authentication system in ZIO HTTP, covering both server-side implementation and client integration.
 
 In this authentication model, when a user logs in successfully, the server creates a session and sends a session identifier to the client as a cookie. The client automatically includes this cookie in subsequent requests, allowing the server to identify and authenticate the user.
@@ -17,6 +23,10 @@ The foundation of cookie-based authentication lies in two HTTP headers: `Set-Coo
 The `Set-Cookie` header is used by the server to send cookies to the client. When a user successfully authenticates, the server creates a session and sends the session identifier to the client using this header.
 
 In ZIO HTTP, we can create a `Set-Cookie` header using the `Cookie.Response` data type:
+
+:::warning UNPORTED
+The `Cookie.Response` block below is v3-era and unported on v4 (typed path is `ResponseCookie` via `Response.addCookie`; see cookies reference "Verified on v4"). Preserved as-is.
+:::
 
 ```scala mdoc:silent
 import zio._
@@ -81,6 +91,10 @@ In this example, the client sends the `session_id` cookie to the server when acc
 
 In ZIO HTTP, when writing client code, we don't need to manually create a `Cookie` header; instead, we can convert the received `Set-Cookie` header into a `Cookie` object and use it in subsequent requests:
 
+:::warning UNPORTED
+The `ZClient.batched` snippet below is v3-era and unported. Preserved as-is.
+:::
+
 ```scala mdoc:invisible
 val SERVER_URL = "http://localhost:8080"
 val loginUrl   = URL.decode(s"$SERVER_URL/login").toOption.get
@@ -122,13 +136,13 @@ Here is a simple in-memory session service that manages user sessions. It allows
 
 ```scala mdoc:silent
 class SessionService private(private val store: Ref[Map[String, String]]) {
-  private def generateSessionId(): UIO[String] =
-    ZIO.randomWith(_.nextUUID).map(_.toString)
+  private def generateSessionId(): IO[SessionTokenError, String] =
+    SessionToken.generate
 
-  def create(username: String): UIO[String] =
+  def create(username: String): IO[SessionTokenError, String] =
     for {
       sessionId <- generateSessionId()
-      _         <- store.update(_ + (sessionId -> username))
+      _         <- store.update(_ + (sessionId -> username)).orDie
     } yield sessionId
 
   def get(sessionId: String): UIO[Option[String]] =
@@ -138,6 +152,10 @@ class SessionService private(private val store: Ref[Map[String, String]]) {
     store.update(_ - sessionId)
 }
 ```
+
+:::note Verified on v4
+`SessionToken.generate: IO[SessionTokenError, String]` is JVM-only: `SecureRandom` 32 bytes to a 43-char URL-safe token (256-bit, above the ASVS 128-bit minimum; UUID's 122-bit rejected). Typed `SessionTokenError`, no silent fallback (`SessionTokenSpec` 4/4 x2 Scala versions). Callers map the error (e.g. to `Response.internalServerError()`, verified no-arg form).
+:::
 
 Here is how to create a live layer for the `SessionService`:
 
@@ -218,6 +236,10 @@ The next step is to implement the login route that will authenticate users and c
 
 ### Login Route
 
+:::warning UNPORTED
+The Login Route below is v3-era and unported (`Cookie.Response`, `Response.badRequest("...")` / `Response.unauthorized("...")` message-arg forms unported on v4). Preserved as-is.
+:::
+
 The login route is responsible for receiving user credentials (username and password), validating them, and creating a session if the credentials are correct:
 
 1. **Parse and validate** - Extracts username and password from URL-encoded form data, returning bad request errors if fields are missing
@@ -272,6 +294,10 @@ In production environments, we should set `isHttpOnly = true` and `isSecure = tr
 
 ### Authentication Middleware
 
+:::warning UNPORTED
+The `HandlerAspect` cookie-auth middleware below is v3-era and unported (`HandlerAspect` absent on v4 main; v4 middleware is `Middleware.identity` / `customAuth` / `basicAuth` / `bearerAuth` / `rotateCookie` only). Preserved as-is.
+:::
+
 After implementing the login route, we can now create middleware that will intercept incoming requests and check for a valid session cookie. If the cookie is present and valid, it will allow access to protected resources; otherwise, it will return an unauthorized response.
 
 We can write it as a `HandlerAspect` like this:
@@ -325,7 +351,28 @@ val profile =
   } @@ AuthMiddleware.cookieAuth("session_id")
 ```
 
+### Session rotation (verified on v4)
+
+Verified on v4 (`RotateCookieSpec` 4/4 + 13/13 neighbors, fail-closed):
+
+```scala
+Middleware.rotateCookie[Session](
+  name = "session_id",
+  validate = (sessionId: String) => ZIO.succeed(Option.empty[Session]),
+  create = (request: Request) => ZIO.succeed(Option.empty[Session]),
+  maxAge = Some(300L),
+)
+```
+
+- Store-free callbacks: `validate` / `create` carry session state; no server-side store required.
+- Valid session rotates to a fresh `ResponseCookie`; invalid / missing / defect maps to `401` with a cleared cookie (`maxAge = Some(0L)`).
+- Missing cookie never calls `validate` (fail-closed by construction).
+
 ## Writing a ZIO HTTP Client
+
+:::warning UNPORTED
+The ZIO HTTP client section below is v3-era and unported (`ZClient.batched`, `toRequest`, `addCookie` forms shown are unported). Preserved as-is.
+:::
 
 While web browsers handle cookies automatically, when building a programmatic client using ZIO HTTP, we need to explicitly manage cookies in our requests. This section demonstrates how to build a ZIO HTTP client that can authenticate with our cookie-based server and access protected resources.
 
@@ -404,6 +451,10 @@ Here's a complete example that demonstrates the full authentication lifecycle:
 ```scala mdoc:passthrough
 utils.printSource("zio-http-example-cookie-auth/src/main/scala/example/auth/session/cookie/AuthenticationClient.scala")
 ```
+
+:::warning FULLY UNPORTED
+`AuthenticationClient.scala` passthrough above is fully unported (v3 client shape). Preserved as-is.
+:::
 
 ## Writing a Web Client
 

--- a/docs/guides/cookie-based-authentication.md
+++ b/docs/guides/cookie-based-authentication.md
@@ -358,8 +358,8 @@ Verified on v4 (`RotateCookieSpec` 4/4 + 13/13 neighbors, fail-closed):
 ```scala
 Middleware.rotateCookie[Session](
   name = "session_id",
-  validate = (sessionId: String) => ZIO.succeed(Option.empty[Session]),
-  create = (_: Session) => ZIO.succeed("new-session-id"),
+  validate = (sessionId: String) => Option.empty[Session],
+  create = (_: Session) => "new-session-id",
   maxAge = Some(300L),
 )
 ```

--- a/docs/guides/cookie-based-authentication.md
+++ b/docs/guides/cookie-based-authentication.md
@@ -353,6 +353,10 @@ val profile =
 
 ### Session rotation (verified on v4)
 
+:::warning Unsigned bearer tokens
+`rotateCookie` tokens are bearer values with no MAC — possession alone grants access. Require TLS in production plus server-side one-time invalidation (delete the old token when minting the new one). Rotation is not a substitute for signing — use `Middleware.signCookies` when you need integrity without a server-side store.
+:::
+
 Verified on v4 (`RotateCookieSpec` 4/4 + 13/13 neighbors, fail-closed):
 
 ```scala
@@ -361,12 +365,19 @@ Middleware.rotateCookie[Session](
   validate = (sessionId: String) => Option.empty[Session],
   create = (_: Session) => "new-session-id",
   maxAge = Some(300L),
+  path = Some(Path.root),
+  secure = true,
+  httpOnly = true,
+  sameSite = SameSite.Strict,
 )
 ```
 
 - Store-free callbacks: `validate` / `create` carry session state; no server-side store required.
 - Valid session rotates to a fresh `ResponseCookie`; invalid / missing / defect maps to `401` with a cleared cookie (`maxAge = Some(0L)`).
 - Missing cookie never calls `validate` (fail-closed by construction).
+- Success-only attach: a `Halt` or non-2xx downstream response passes through untouched, without the rotated cookie.
+- `create` is guarded: a throwing mint maps to cleared `401`, never a leak — invalidate the old token server-side when minting the new one (one-time use).
+- `validate` / `create` are synchronous callbacks — keep them in-memory lookups only; do not block on DB I/O inside them (preload to memory or move I/O outside the callback).
 
 ## Writing a ZIO HTTP Client
 

--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -483,8 +483,8 @@ val whitelistAspect: HandlerAspect[Any, Unit] = {
 Several aspects are useful for adding, signing, and managing cookies:
 
 1. `HandlerAspect.addCookie` and `HandlerAspect.addCookieZIO` to add cookies
-2. `HandlerAspect.signCookies` to sign cookies
-3. `HandlerAspect.flashScopeHandling` to manage the flash scope
+2. `HandlerAspect.signCookies` to sign cookies — :::warning UNPORTED on v4::: `HandlerAspect` has 0 hits in v4 main sources and `Middleware.signCookies` is absent on v4.x main (PR #4210 gate RED); use `Middleware.rotateCookie` instead.
+3. `HandlerAspect.flashScopeHandling` to manage the flash scope — :::warning UNPORTED on v4::: absent from v4 main (see gate note above).
 
 ## Conditional Application of HandlerAspects
 
@@ -566,6 +566,9 @@ We create an aspect that appends an additional header to the response indicating
 ```scala mdoc:passthrough
 import utils._
 
+// :::warning FULLY UNPORTED on v4 (example 4 of 4) — pinned `//> using dep 3.4.0`,
+// `NettyServer.default`, plus `Middleware.patchZIO`/`debug`/`timeout`/`addHeader`,
+// all absent on v4 (v4 Middleware = identity/customAuth/basicAuth/bearerAuth/rotateCookie only).
 printSource("zio-http-example/src/main/scala/example/HelloWorldWithMiddlewares.scala")
 ```
 

--- a/docs/reference/aop/handler_aspect.md
+++ b/docs/reference/aop/handler_aspect.md
@@ -483,8 +483,8 @@ val whitelistAspect: HandlerAspect[Any, Unit] = {
 Several aspects are useful for adding, signing, and managing cookies:
 
 1. `HandlerAspect.addCookie` and `HandlerAspect.addCookieZIO` to add cookies
-2. `HandlerAspect.signCookies` to sign cookies — :::warning UNPORTED on v4::: `HandlerAspect` has 0 hits in v4 main sources and `Middleware.signCookies` is absent on v4.x main (PR #4210 gate RED); use `Middleware.rotateCookie` instead.
-3. `HandlerAspect.flashScopeHandling` to manage the flash scope — :::warning UNPORTED on v4::: absent from v4 main (see gate note above).
+2. `HandlerAspect.signCookies` to sign cookies — :::warning UNPORTED on v4::: the `HandlerAspect` wrapper has 0 hits in v4 main sources. Note: `Middleware.signCookies` itself **is available on v4** since #4210 merged — use it directly (or `Middleware.rotateCookie` for rotation).
+3. `HandlerAspect.flashScopeHandling` to manage the flash scope — :::warning UNPORTED on v4::: the `HandlerAspect` wrapper is absent from v4 main (core `Middleware.flashScope` exists since #4210).
 
 ## Conditional Application of HandlerAspects
 
@@ -568,7 +568,7 @@ import utils._
 
 // :::warning FULLY UNPORTED on v4 (example 4 of 4) — pinned `//> using dep 3.4.0`,
 // `NettyServer.default`, plus `Middleware.patchZIO`/`debug`/`timeout`/`addHeader`,
-// all absent on v4 (v4 Middleware = identity/customAuth/basicAuth/bearerAuth/rotateCookie only).
+// all absent on v4 (v4 Middleware = identity/customAuth/basicAuth/bearerAuth/signCookies/rotateCookie/flashScope).
 printSource("zio-http-example/src/main/scala/example/HelloWorldWithMiddlewares.scala")
 ```
 

--- a/docs/reference/headers/session/cookies.md
+++ b/docs/reference/headers/session/cookies.md
@@ -170,8 +170,8 @@ responseCookie.copy(sameSite = Some(Cookie.SameSite.Strict))
 
 ### Signing a Cookie
 
-:::warning UNPORTED
-Signing as shown below is NOT available on v4: `def signCookies` has 0 hits in v4 main (`shared` + `jvm` main scala), and `Response#sign` / `signCookies` are orphaned v3 APIs. For v4 session rotation use `Middleware.rotateCookie` instead. Snippets preserved as-is, not available.
+:::warning PARTIALLY UNPORTED — updated post-#4210
+`Response#sign` as shown below remains a v3-era unported API. `Middleware.signCookies(secret)` (HMAC-SHA256, ≥32-char secret) **is available on v4** since #4210 merged — prefer it for signing; use `Middleware.rotateCookie` for session rotation. Snippets preserved as-is.
 :::
 
 Signing a cookie involves appending a cryptographic signature to the cookie data before it is transmitted to the client. This signature is generated using a secret key known only to the server. When the client sends the cookie back to the server in subsequent requests, the server can verify the signature to ensure the integrity and authenticity of the cookie data.

--- a/docs/reference/headers/session/cookies.md
+++ b/docs/reference/headers/session/cookies.md
@@ -3,6 +3,11 @@ id: cookies
 title: Cookies
 ---
 
+:::warning v4-status
+Only the "Verified on v4: Set-Cookie over H2" subsection below is verified on v4.
+The remaining `Cookie.*` / `Response#sign` / `signCookies` / `NettyServer` snippets on this page are v3-era and unported — preserved as-is, do not treat as v4 API.
+:::
+
 Cookies are small pieces of data that websites store on a user's browser. They are sent between the client (browser) and server in HTTP requests and responses. Cookies serve various purposes, including session management, user authentication, personalization, and tracking.
 
 When a user visits a website, the server can send one or more cookies to the browser, which stores them locally. The browser then includes these cookies in subsequent requests to the same website, allowing the server to retrieve and utilize the stored information.
@@ -38,6 +43,25 @@ object Cookie {
 
 Request cookies (`Cookie.Request`) are sent by the client to the server, while response cookies (`Cookie.Response`) are sent by the server to the client.
 
+## Verified on v4: Set-Cookie over H2
+
+The following is verified on v4 (CookieWireSpec 2/2 GREEN, non-empty HPACK header block):
+
+```scala
+// Raw wire bytes survive H2 (Secure + HttpOnly + SameSite=Strict):
+Header.Custom("set-cookie", "session=abc123; Path=/; Secure; HttpOnly; SameSite=Strict")
+// Clearing a cookie arrives intact:
+Header.Custom("set-cookie", "session=; Path=/; Max-Age=0")
+```
+
+Typed cookie path (confirmed against published `zio-blocks-http-model` jar via `javap`):
+
+- `ResponseCookie(name, value, expires?, domain?, path?, maxAge?, isSecure, isHttpOnly, sameSite?, isPartitioned?, priority?)` via `Response.addCookie` / `response.cookies`
+- `RequestCookie(name, value)` via `Request.addCookie` / `request.cookies`
+- Top-level `SameSite`: `Strict` / `Lax` / `None_`
+- Render / parse: `Cookie.renderResponse` / `Cookie.parseResponse`
+- No message-arg `Response.unauthorized()` / `badRequest()` on v4 (no-arg form only).
+
 ## Response Cookie
 
 ### Creating a Response Cookie
@@ -64,6 +88,10 @@ It updates the response header `Set-Cookie` as ```Set-Cookie: <cookie-name>=<coo
 By adding the above cookie to a `Response`, it will add a `Set-Cookie` header with the respective cookie name and value and other optional attributes.
 
 Let's write a simple example to see how it works:
+
+:::warning UNPORTED
+The `NettyServer` example below is v3-era and unported: no `NettyServer` in v4 sources. V4 serve is `Server.serve(routes, context)` with `LoomServer` in `Context`. Snippet preserved as-is.
+:::
 
 ```scala mdoc:compile-only
 import zio.http._
@@ -141,6 +169,10 @@ responseCookie.copy(sameSite = Some(Cookie.SameSite.Strict))
 ```
 
 ### Signing a Cookie
+
+:::warning UNPORTED
+Signing as shown below is NOT available on v4: `def signCookies` has 0 hits in v4 main (`shared` + `jvm` main scala), and `Response#sign` / `signCookies` are orphaned v3 APIs. For v4 session rotation use `Middleware.rotateCookie` instead. Snippets preserved as-is, not available.
+:::
 
 Signing a cookie involves appending a cryptographic signature to the cookie data before it is transmitted to the client. This signature is generated using a secret key known only to the server. When the client sends the cookie back to the server in subsequent requests, the server can verify the signature to ensure the integrity and authenticity of the cookie data.
 
@@ -239,6 +271,10 @@ Here are some simple examples of using cookies in a ZIO HTTP application.
 
 ### Server Side Example
 
+:::warning FULLY UNPORTED
+Example 1 of 4: `CookieServerSide.scala` is fully unported (3.4.0 + `NettyServer` + `Cookie.Response` / `Cookie.clear`). Preserved as-is.
+:::
+
 ```scala mdoc:passthrough
 import utils._
 
@@ -246,6 +282,10 @@ printSource("zio-http-example/src/main/scala/example/CookieServerSide.scala")
 ```
 
 ### Signed Cookies
+
+:::warning FULLY UNPORTED
+Example 2 of 4: `SignCookies.scala` is fully unported (3.4.0 + `NettyServer` + `Cookie.Response` / `Cookie.clear`, plus absent signing). Preserved as-is.
+:::
 
 ```scala mdoc:passthrough
 import utils._

--- a/docs/reference/headers/session/cookies.md
+++ b/docs/reference/headers/session/cookies.md
@@ -45,7 +45,12 @@ Request cookies (`Cookie.Request`) are sent by the client to the server, while r
 
 ## Verified on v4: Set-Cookie over H2
 
-The following is verified on v4 (CookieWireSpec 2/2 GREEN, non-empty HPACK header block):
+:::warning Unsigned bearer tokens
+Cookie session values (including `Middleware.rotateCookie` tokens) are bearer values with no MAC — possession alone grants access. Require TLS in production plus server-side one-time invalidation (delete the old token when minting the new one). Rotation is not a substitute for signing — use `Middleware.signCookies` when you need integrity without a server-side store.
+:::
+
+The following is verified on v4 (CookieWireSpec 2/2 GREEN, non-empty HPACK header block).
+This proves HPACK-encoding survival of the `Set-Cookie` bytes on the H2 wire, NOT browser enforcement of `Secure` / `HttpOnly` / `SameSite`:
 
 ```scala
 // Raw wire bytes survive H2 (Secure + HttpOnly + SameSite=Strict):
@@ -61,6 +66,23 @@ Typed cookie path (confirmed against published `zio-blocks-http-model` jar via `
 - Top-level `SameSite`: `Strict` / `Lax` / `None_`
 - Render / parse: `Cookie.renderResponse` / `Cookie.parseResponse`
 - No message-arg `Response.unauthorized()` / `badRequest()` on v4 (no-arg form only).
+
+Session rotation (verified on v4, `RotateCookieSpec` fail-closed) uses the hardened signature — success-only attach, guarded `create`:
+
+```scala
+Middleware.rotateCookie[Session](
+  name = "session_id",
+  validate = (sessionId: String) => Option.empty[Session],
+  create = (_: Session) => "new-session-id",
+  maxAge = Some(300L),
+  path = Some(Path.root),
+  secure = true,
+  httpOnly = true,
+  sameSite = SameSite.Strict,
+)
+```
+
+`validate` / `create` are synchronous callbacks — keep them in-memory lookups only; do not block on DB I/O inside them.
 
 ## Response Cookie
 

--- a/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
+++ b/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
@@ -7,8 +7,8 @@ import zio._
  *
  * Replaces `ZIO.randomWith(_.nextUUID)`: a UUIDv4 string carries only 122 bits
  * of entropy, below the ASVS 128-bit minimum for session identifiers. Tokens
- * here carry 256 bits (32 bytes from `SecureRandom`, Base64-URL encoded
- * without padding to 43 chars), meeting the OWASP 256-bit recommendation.
+ * here carry 256 bits (32 bytes from `SecureRandom`, Base64-URL encoded without
+ * padding to 43 chars), meeting the OWASP 256-bit recommendation.
  *
  * JVM-only: `java.security.SecureRandom` has no Scala.js equivalent, so this
  * helper lives in `jvm/` sources rather than `shared/`.

--- a/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
+++ b/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
@@ -1,0 +1,30 @@
+package zio.http
+
+import zio._
+
+/**
+ * Opaque session-token generator.
+ *
+ * Replaces `ZIO.randomWith(_.nextUUID)`: a UUIDv4 string carries only 122 bits
+ * of entropy, below the ASVS 128-bit minimum for session identifiers. Tokens
+ * here carry 256 bits (32 bytes from `SecureRandom`, Base64-URL encoded
+ * without padding to 43 chars), meeting the OWASP 256-bit recommendation.
+ *
+ * JVM-only: `java.security.SecureRandom` has no Scala.js equivalent, so this
+ * helper lives in `jvm/` sources rather than `shared/`.
+ */
+object SessionToken {
+
+  val EntropyBytes: Int = 32
+
+  def generate: IO[SessionTokenError, String] =
+    ZIO.attempt {
+      val r = new java.security.SecureRandom
+      val b = new Array[Byte](EntropyBytes)
+      r.nextBytes(b)
+      java.util.Base64.getUrlEncoder.withoutPadding.encodeToString(b)
+    }.refineOrDie { case e => SessionTokenError(e) }
+
+}
+
+final case class SessionTokenError(cause: Throwable) extends Throwable(cause)

--- a/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
+++ b/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
@@ -11,17 +11,21 @@ import zio._
  * padding to 43 chars), meeting the OWASP 256-bit recommendation.
  *
  * JVM-only: `java.security.SecureRandom` has no Scala.js equivalent, so this
- * helper lives in `jvm/` sources rather than `shared/`.
+ * helper lives in `jvm/` sources rather than `shared/`. JS/Native callers get
+ * a clear compile-time absence, not a runtime NoSuchMethod.
  */
 object SessionToken {
 
   val EntropyBytes: Int = 32
 
+  // Single shared instance: SecureRandom is thread-safe; behavior identical
+  // (32B -> 43-char URL-safe).
+  private val secureRandom = new java.security.SecureRandom
+
   def generate: IO[SessionTokenError, String] =
     ZIO.attempt {
-      val r = new java.security.SecureRandom
       val b = new Array[Byte](EntropyBytes)
-      r.nextBytes(b)
+      secureRandom.nextBytes(b)
       java.util.Base64.getUrlEncoder.withoutPadding.encodeToString(b)
     }.refineOrDie { case e => SessionTokenError(e) }
 

--- a/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
+++ b/zio-http-core/jvm/src/main/scala/zio/http/SessionToken.scala
@@ -11,8 +11,8 @@ import zio._
  * padding to 43 chars), meeting the OWASP 256-bit recommendation.
  *
  * JVM-only: `java.security.SecureRandom` has no Scala.js equivalent, so this
- * helper lives in `jvm/` sources rather than `shared/`. JS/Native callers get
- * a clear compile-time absence, not a runtime NoSuchMethod.
+ * helper lives in `jvm/` sources rather than `shared/`. JS/Native callers get a
+ * clear compile-time absence, not a runtime NoSuchMethod.
  */
 object SessionToken {
 

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
@@ -64,9 +64,9 @@ object RotateCookieSpec extends ZIOSpecDefault {
         invalidated += "old-1"
         "new-1"
       }
-      val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
-      val response = asResponse(dispatch(rotated(validate, create), request))
-      val cookie   = response.cookies.find(_.name == CookieName)
+      val request     = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
+      val response    = asResponse(dispatch(rotated(validate, create), request))
+      val cookie      = response.cookies.find(_.name == CookieName)
       assertTrue(
         response == Response.text("hello alice").addCookie(ResponseCookie(CookieName, "new-1", maxAge = Some(300L))),
         cookie.map(_.value).contains("new-1"),
@@ -88,11 +88,11 @@ object RotateCookieSpec extends ZIOSpecDefault {
         touched = true
         Option.empty[Session]
       }
-      val create = (_: Session) => {
+      val create   = (_: Session) => {
         touched = true
         "fresh-1"
       }
-      val result = dispatch(rotated(validate, create), Request.get(URL.root / "secure"))
+      val result   = dispatch(rotated(validate, create), Request.get(URL.root / "secure"))
       assertTrue(
         result == cleared,
         !touched,

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
@@ -15,7 +15,7 @@
  */
 package zio.http
 
-import zio._
+import scala.collection.mutable
 import zio.blocks.context.Context
 import zio.blocks.endpoint.RoutePattern.MethodSyntax
 import zio.blocks.scope.Scope
@@ -40,8 +40,8 @@ object RotateCookieSpec extends ZIOSpecDefault {
     Method.GET / "secure" -> handler((session: Session) => Response.text(s"hello ${session.user}"))
 
   private def rotated(
-    validate: String => ZIO[Any, Nothing, Option[Session]],
-    create: Session => ZIO[Any, Nothing, String],
+    validate: String => Option[Session],
+    create: Session => String,
   ): Routes[Any] =
     Routes(securedRoute) @@ Middleware.rotateCookie[Session](CookieName, validate, create, Some(300L))
 
@@ -56,53 +56,53 @@ object RotateCookieSpec extends ZIOSpecDefault {
 
   def spec = suite("Middleware.rotateCookie")(
     test("valid old cookie rotates: new value set, old invalidated via user store") {
-      for {
-        store       <- Ref.make(Map("old-1" -> Session("alice")))
-        invalidated <- Ref.make(List.empty[String])
-        validate     = (token: String) => store.get.map(_.get(token))
-        create       = (_: Session) =>
-          store.update(_ - "old-1") *> invalidated.update("old-1" :: _) *> ZIO.succeed("new-1")
-        request      = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
-        result      <- ZIO.attempt(dispatch(rotated(validate, create), request))
-        response     = asResponse(result)
-        cookie       = response.cookies.find(_.name == CookieName)
-        gone        <- invalidated.get
-        remaining   <- store.get
-      } yield assertTrue(
+      val store       = mutable.Map("old-1" -> Session("alice"))
+      val invalidated = mutable.ListBuffer.empty[String]
+      val validate    = (token: String) => store.get(token)
+      val create      = (_: Session) => {
+        store.remove("old-1")
+        invalidated += "old-1"
+        "new-1"
+      }
+      val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
+      val response = asResponse(dispatch(rotated(validate, create), request))
+      val cookie   = response.cookies.find(_.name == CookieName)
+      assertTrue(
         response == Response.text("hello alice").addCookie(ResponseCookie(CookieName, "new-1", maxAge = Some(300L))),
         cookie.map(_.value).contains("new-1"),
         cookie.flatMap(_.maxAge).contains(300L),
-        gone.contains("old-1"),
-        remaining.get("old-1").isEmpty,
+        invalidated.contains("old-1"),
+        store.get("old-1").isEmpty,
       )
     },
     test("invalid old cookie is cleared and yields 401") {
-      for {
-        store    <- Ref.make(Map("good-9" -> Session("bob")))
-        validate  = (token: String) => store.get.map(_.get(token))
-        create    = (_: Session) => ZIO.succeed("fresh-1")
-        request   = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "bogus"))
-        result   <- ZIO.attempt(dispatch(rotated(validate, create), request))
-      } yield assertTrue(result == cleared)
+      val store    = Map("good-9" -> Session("bob"))
+      val validate = (token: String) => store.get(token)
+      val create   = (_: Session) => "fresh-1"
+      val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "bogus"))
+      assertTrue(dispatch(rotated(validate, create), request) == cleared)
     },
     test("missing cookie yields cleared 401 without touching the store") {
-      for {
-        touched    <- Ref.make(false)
-        validate    = (_: String) => touched.set(true).as(Option.empty[Session])
-        create      = (_: Session) => touched.set(true).as("fresh-1")
-        result     <- ZIO.attempt(dispatch(rotated(validate, create), Request.get(URL.root / "secure")))
-        wasTouched <- touched.get
-      } yield assertTrue(
+      var touched  = false
+      val validate = (_: String) => {
+        touched = true
+        Option.empty[Session]
+      }
+      val create = (_: Session) => {
+        touched = true
+        "fresh-1"
+      }
+      val result = dispatch(rotated(validate, create), Request.get(URL.root / "secure"))
+      assertTrue(
         result == cleared,
-        !wasTouched,
+        !touched,
       )
     },
-    test("validate defect is swallowed: cleared cookie plus 401, no leak") {
-      val validate = (_: String) => ZIO.die(new RuntimeException("boom-secret"))
-      val create   = (_: Session) => ZIO.succeed("fresh-1")
+    test("throwing validate yields cleared cookie plus 401, no leak") {
+      val validate = (_: String) => throw new RuntimeException("boom-secret")
+      val create   = (_: Session) => "fresh-1"
       val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
-      val result   = dispatch(rotated(validate, create), request)
-      assertTrue(result == cleared)
+      assertTrue(dispatch(rotated(validate, create), request) == cleared)
     },
   )
 }

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the ZIO HTTP contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio.http
+
+import zio._
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern.MethodSyntax
+import zio.blocks.scope.Scope
+import zio.http.RouteBinding._
+import zio.test._
+
+object RotateCookieSpec extends ZIOSpecDefault {
+
+  final case class Session(user: String)
+
+  private val CookieName = "session"
+
+  private def dispatch(routes: Routes[Any], request: Request): Response | Halt = {
+    val route     = routes.routes.head
+    val extracted = route.pattern
+      .decode(request.method, request.url.path)
+      .getOrElse(throw new RuntimeException("path did not match"))
+    route.handler.handle(request, Context.empty, extracted, Scope.global)
+  }
+
+  private val securedRoute: Route[Session] =
+    Method.GET / "secure" -> handler((session: Session) => Response.text(s"hello ${session.user}"))
+
+  private def rotated(
+    validate: String => ZIO[Any, Nothing, Option[Session]],
+    create: Session => ZIO[Any, Nothing, String],
+  ): Routes[Any] =
+    Routes(securedRoute) @@ Middleware.rotateCookie[Session](CookieName, validate, create, Some(300L))
+
+  private def asResponse(result: Response | Halt): Response =
+    result match {
+      case response: Response => response
+      case halt: Halt         => halt.response
+    }
+
+  private def cleared: Response =
+    Response.unauthorized.addCookie(ResponseCookie(CookieName, "", maxAge = Some(0L)))
+
+  def spec = suite("Middleware.rotateCookie")(
+    test("valid old cookie rotates: new value set, old invalidated via user store") {
+      for {
+        store       <- Ref.make(Map("old-1" -> Session("alice")))
+        invalidated <- Ref.make(List.empty[String])
+        validate     = (token: String) => store.get.map(_.get(token))
+        create       = (_: Session) =>
+          store.update(_ - "old-1") *> invalidated.update("old-1" :: _) *> ZIO.succeed("new-1")
+        request      = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
+        result      <- ZIO.attempt(dispatch(rotated(validate, create), request))
+        response     = asResponse(result)
+        cookie       = response.cookies.find(_.name == CookieName)
+        gone        <- invalidated.get
+        remaining   <- store.get
+      } yield assertTrue(
+        response == Response.text("hello alice").addCookie(ResponseCookie(CookieName, "new-1", maxAge = Some(300L))),
+        cookie.map(_.value).contains("new-1"),
+        cookie.flatMap(_.maxAge).contains(300L),
+        gone.contains("old-1"),
+        remaining.get("old-1").isEmpty,
+      )
+    },
+    test("invalid old cookie is cleared and yields 401") {
+      for {
+        store    <- Ref.make(Map("good-9" -> Session("bob")))
+        validate  = (token: String) => store.get.map(_.get(token))
+        create    = (_: Session) => ZIO.succeed("fresh-1")
+        request   = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "bogus"))
+        result   <- ZIO.attempt(dispatch(rotated(validate, create), request))
+      } yield assertTrue(result == cleared)
+    },
+    test("missing cookie yields cleared 401 without touching the store") {
+      for {
+        touched    <- Ref.make(false)
+        validate    = (_: String) => touched.set(true).as(Option.empty[Session])
+        create      = (_: Session) => touched.set(true).as("fresh-1")
+        result     <- ZIO.attempt(dispatch(rotated(validate, create), Request.get(URL.root / "secure")))
+        wasTouched <- touched.get
+      } yield assertTrue(
+        result == cleared,
+        !wasTouched,
+      )
+    },
+    test("validate defect is swallowed: cleared cookie plus 401, no leak") {
+      val validate = (_: String) => ZIO.die(new RuntimeException("boom-secret"))
+      val create   = (_: Session) => ZIO.succeed("fresh-1")
+      val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
+      val result   = dispatch(rotated(validate, create), request)
+      assertTrue(result == cleared)
+    },
+  )
+}

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/RotateCookieSpec.scala
@@ -39,11 +39,31 @@ object RotateCookieSpec extends ZIOSpecDefault {
   private val securedRoute: Route[Session] =
     Method.GET / "secure" -> handler((session: Session) => Response.text(s"hello ${session.user}"))
 
+  private val failingRoute: Route[Session] =
+    Method.GET / "fail" -> handler((_: Session) => Response.internalServerError)
+
   private def rotated(
     validate: String => Option[Session],
     create: Session => String,
   ): Routes[Any] =
     Routes(securedRoute) @@ Middleware.rotateCookie[Session](CookieName, validate, create, Some(300L))
+
+  private def rotatedFailing(
+    validate: String => Option[Session],
+    create: Session => String,
+  ): Routes[Any] =
+    Routes(failingRoute) @@ Middleware.rotateCookie[Session](CookieName, validate, create, Some(300L))
+
+  private def secureAttrs(name: String, value: String, maxAge: Option[Long]): ResponseCookie =
+    ResponseCookie(
+      name,
+      value,
+      path = Some(Path.root),
+      maxAge = maxAge,
+      isSecure = true,
+      isHttpOnly = true,
+      sameSite = Some(SameSite.Strict),
+    )
 
   private def asResponse(result: Response | Halt): Response =
     result match {
@@ -52,7 +72,7 @@ object RotateCookieSpec extends ZIOSpecDefault {
     }
 
   private def cleared: Response =
-    Response.unauthorized.addCookie(ResponseCookie(CookieName, "", maxAge = Some(0L)))
+    Response.unauthorized.addCookie(secureAttrs(CookieName, "", Some(0L)))
 
   def spec = suite("Middleware.rotateCookie")(
     test("valid old cookie rotates: new value set, old invalidated via user store") {
@@ -68,9 +88,13 @@ object RotateCookieSpec extends ZIOSpecDefault {
       val response    = asResponse(dispatch(rotated(validate, create), request))
       val cookie      = response.cookies.find(_.name == CookieName)
       assertTrue(
-        response == Response.text("hello alice").addCookie(ResponseCookie(CookieName, "new-1", maxAge = Some(300L))),
+        response == Response.text("hello alice").addCookie(secureAttrs(CookieName, "new-1", Some(300L))),
         cookie.map(_.value).contains("new-1"),
         cookie.flatMap(_.maxAge).contains(300L),
+        cookie.flatMap(_.path).contains(Path.root),
+        cookie.exists(_.isSecure),
+        cookie.exists(_.isHttpOnly),
+        cookie.flatMap(_.sameSite).contains(SameSite.Strict),
         invalidated.contains("old-1"),
         store.get("old-1").isEmpty,
       )
@@ -101,6 +125,22 @@ object RotateCookieSpec extends ZIOSpecDefault {
     test("throwing validate yields cleared cookie plus 401, no leak") {
       val validate = (_: String) => throw new RuntimeException("boom-secret")
       val create   = (_: Session) => "fresh-1"
+      val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
+      assertTrue(dispatch(rotated(validate, create), request) == cleared)
+    },
+    test("downstream 500 passes through unchanged without rotation") {
+      val validate = (_: String) => Some(Session("alice"))
+      val create   = (_: Session) => "fresh-1"
+      val request  = Request.get(URL.root / "fail").addCookie(RequestCookie(CookieName, "old-1"))
+      val result   = dispatch(rotatedFailing(validate, create), request)
+      assertTrue(
+        result == Response.internalServerError,
+        asResponse(result).cookies.isEmpty,
+      )
+    },
+    test("throwing create yields cleared cookie plus 401, no leak") {
+      val validate = (_: String) => Some(Session("alice"))
+      val create   = (_: Session) => throw new RuntimeException("mint-boom")
       val request  = Request.get(URL.root / "secure").addCookie(RequestCookie(CookieName, "old-1"))
       assertTrue(dispatch(rotated(validate, create), request) == cleared)
     },

--- a/zio-http-core/jvm/src/test/scala/zio/http/SessionTokenSpec.scala
+++ b/zio-http-core/jvm/src/test/scala/zio/http/SessionTokenSpec.scala
@@ -1,0 +1,33 @@
+package zio.http
+
+import zio._
+import zio.test._
+
+object SessionTokenSpec extends ZIOSpecDefault {
+
+  def spec = suite("SessionToken")(
+    test("generates 100 unique tokens") {
+      for {
+        tokens <- ZIO.foreach((1 to 100).toList)(_ => SessionToken.generate)
+      } yield assertTrue(tokens.distinct.size == 100)
+    },
+    test("tokens are 43 chars in [A-Za-z0-9_-]") {
+      for {
+        token <- SessionToken.generate
+      } yield assertTrue(token.length == 43, token.matches("[A-Za-z0-9_-]+"))
+    },
+    test("tokens carry 32 bytes of entropy") {
+      for {
+        token   <- SessionToken.generate
+        decoded <- ZIO.attempt(java.util.Base64.getUrlDecoder.decode(token)).orDie
+      } yield assertTrue(decoded.length == SessionToken.EntropyBytes)
+    },
+    test("tokens are not UUID strings") {
+      for {
+        token  <- SessionToken.generate
+        parsed <- ZIO.attempt(java.util.UUID.fromString(token)).either
+      } yield assertTrue(parsed.isLeft)
+    },
+  )
+
+}

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -978,19 +978,47 @@ object Middleware {
         }
     }
 
+  /**
+   * Rotates a session cookie: a valid incoming cookie yields the downstream
+   * response with a freshly minted cookie attached, while a missing, invalid,
+   * or throwing lookup yields a cleared (expired) cookie plus 401.
+   *
+   * Both the rotated and the cleared cookies carry `path`, `secure`,
+   * `httpOnly`, and `sameSite` (mirrored so browsers match name+domain+path
+   * when deleting). Rotation is success-only: a Halt or non-2xx downstream
+   * response passes through untouched, without the rotated cookie.
+   *
+   * @param validate
+   *   MUST use constant-time comparison (e.g.
+   *   java.security.MessageDigest.isEqual) to avoid timing side-channels.
+   */
   def rotateCookie[Session](
     name: String,
     validate: String => Option[Session],
     create: Session => String,
     maxAge: Option[Long],
+    path: Option[Path] = Some(Path.root),
+    secure: Boolean = true,
+    httpOnly: Boolean = true,
+    sameSite: SameSite = SameSite.Strict,
   )(implicit ev: IsNominalType[Session]): Middleware[Any, Session] =
     new Middleware[Any, Session] {
       def apply(routes: Routes[Session]): Routes[Any] =
-        Routes.fromIterable(routes.routes.map(secure))
+        Routes.fromIterable(routes.routes.map(secureRoute))
 
-      private def secure(route: Route[Session]): Route[Any] = {
+      private def secureRoute(route: Route[Session]): Route[Any] = {
         val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
-          val cleared = Response.unauthorized.addCookie(ResponseCookie(name, "", maxAge = Some(0L)))
+          val cleared = Response.unauthorized.addCookie(
+            ResponseCookie(
+              name,
+              "",
+              path = path,
+              maxAge = Some(0L),
+              isSecure = secure,
+              isHttpOnly = httpOnly,
+              sameSite = Some(sameSite),
+            ),
+          )
           request.cookies.find(_.name == name) match {
             case None         => responseAsResult(cleared)
             case Some(cookie) =>
@@ -999,24 +1027,49 @@ object Middleware {
                 try validate(cookie.value)
                 catch { case scala.util.control.NonFatal(_) => None }
               sessionOpt match {
-                case Some(session) =>
-                  val rotated     = ResponseCookie(name, create(session), maxAge = maxAge)
-                  val result: Any =
-                    route.handler.handle(request, context.add[Session](session), vars, scope)
-                  result match {
-                    case response: Response       => responseAsResult(response.addCookie(rotated))
-                    case halt: Halt               =>
-                      haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
-                    case Left(response: Response) => responseAsResult(response.addCookie(rotated))
-                    case Right(halt: Halt)        =>
-                      haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
-                    case _                        => responseAsResult(Response.internalServerError)
-                  }
                 case None          => responseAsResult(cleared)
+                case Some(session) =>
+                  // Fail closed: a throwing mint maps to cleared 401, never a leak.
+                  val freshOpt: Option[String] =
+                    try Some(create(session))
+                    catch { case scala.util.control.NonFatal(_) => None }
+                  freshOpt match {
+                    case None        => responseAsResult(cleared)
+                    case Some(fresh) =>
+                      val rotated     = ResponseCookie(
+                        name,
+                        fresh,
+                        path = path,
+                        maxAge = maxAge,
+                        isSecure = secure,
+                        isHttpOnly = httpOnly,
+                        sameSite = Some(sameSite),
+                      )
+                      val result: Any =
+                        route.handler.handle(request, context.add[Session](session), vars, scope)
+                      // Success-only rotation: Halt and non-2xx pass through
+                      // untouched, without the rotated cookie attached.
+                      result match {
+                        case response: Response       =>
+                          if (isSuccess(response.status)) responseAsResult(response.addCookie(rotated))
+                          else responseAsResult(response)
+                        case halt: Halt               => haltAsResult(halt)
+                        case Left(response: Response) =>
+                          if (isSuccess(response.status)) responseAsResult(response.addCookie(rotated))
+                          else responseAsResult(response)
+                        case Right(halt: Halt)        => haltAsResult(halt)
+                        case _                        => responseAsResult(Response.internalServerError)
+                      }
+                  }
               }
           }
         }
         Route(route.pattern, wrapped)
+      }
+
+      private def isSuccess(status: Status): Boolean = {
+        val code = status.code
+        code >= 200 && code < 300
       }
     }
 }

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -20,7 +20,6 @@ import zio.blocks.context.{Context, IsNominalType}
 import zio.blocks.endpoint.RoutePattern
 import zio.blocks.scope.Scope
 import zio.http.ResultType._
-import zio.{Exit, Runtime, Trace, Unsafe, ZIO}
 
 trait Middleware[UpperCtx, Ctx] { self =>
   def apply(routes: Routes[Ctx]): Routes[UpperCtx]
@@ -981,8 +980,8 @@ object Middleware {
 
   def rotateCookie[Session](
     name: String,
-    validate: String => ZIO[Any, Nothing, Option[Session]],
-    create: Session => ZIO[Any, Nothing, String],
+    validate: String => Option[Session],
+    create: Session => String,
     maxAge: Option[Long],
   )(implicit ev: IsNominalType[Session]): Middleware[Any, Session] =
     new Middleware[Any, Session] {
@@ -993,44 +992,31 @@ object Middleware {
         val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
           val cleared = Response.unauthorized.addCookie(ResponseCookie(name, "", maxAge = Some(0L)))
           request.cookies.find(_.name == name) match {
-            case None          => responseAsResult(cleared)
-            case Some(cookie)  =>
-              runSync(validate(cookie.value).catchAllDefect(_ => ZIO.none)) match {
-                case Some(Some(session)) =>
-                  runSync(create(session)) match {
-                    case None           => responseAsResult(cleared)
-                    case Some(newValue) =>
-                      val rotated       = ResponseCookie(name, newValue, maxAge = maxAge)
-                      val result: Any   =
-                        route.handler.handle(request, context.add[Session](session), vars, scope)
-                      result match {
-                        case response: Response       => responseAsResult(response.addCookie(rotated))
-                        case halt: Halt               =>
-                          haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
-                        case Left(response: Response) => responseAsResult(response.addCookie(rotated))
-                        case Right(halt: Halt)        =>
-                          haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
-                        case _                        => responseAsResult(Response.internalServerError)
-                      }
+            case None         => responseAsResult(cleared)
+            case Some(cookie) =>
+              // Fail closed: a throwing store maps to cleared 401, never a leak.
+              val sessionOpt: Option[Session] =
+                try validate(cookie.value)
+                catch { case scala.util.control.NonFatal(_) => None }
+              sessionOpt match {
+                case Some(session) =>
+                  val rotated     = ResponseCookie(name, create(session), maxAge = maxAge)
+                  val result: Any =
+                    route.handler.handle(request, context.add[Session](session), vars, scope)
+                  result match {
+                    case response: Response       => responseAsResult(response.addCookie(rotated))
+                    case halt: Halt               =>
+                      haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
+                    case Left(response: Response) => responseAsResult(response.addCookie(rotated))
+                    case Right(halt: Halt)        =>
+                      haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
+                    case _                        => responseAsResult(Response.internalServerError)
                   }
-                case _                   => responseAsResult(cleared)
+                case None      => responseAsResult(cleared)
               }
           }
         }
         Route(route.pattern, wrapped)
       }
-    }
-
-  private def runSync[A](effect: ZIO[Any, Nothing, A]): Option[A] =
-    try {
-      val exit = Unsafe.unsafe { implicit unsafe: Unsafe =>
-        Runtime.default.unsafe.run(effect)(Trace.empty, unsafe)
-      }
-      exit match {
-        case Exit.Success(value) => Some(value)
-        case _                   => None
-      }
-    } catch {
-      case scala.util.control.NonFatal(_) => None
     }
 }

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -1012,7 +1012,7 @@ object Middleware {
                       haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
                     case _                        => responseAsResult(Response.internalServerError)
                   }
-                case None      => responseAsResult(cleared)
+                case None          => responseAsResult(cleared)
               }
           }
         }

--- a/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
+++ b/zio-http-core/shared/src/main/scala/zio/http/Middleware.scala
@@ -20,6 +20,7 @@ import zio.blocks.context.{Context, IsNominalType}
 import zio.blocks.endpoint.RoutePattern
 import zio.blocks.scope.Scope
 import zio.http.ResultType._
+import zio.{Exit, Runtime, Trace, Unsafe, ZIO}
 
 trait Middleware[UpperCtx, Ctx] { self =>
   def apply(routes: Routes[Ctx]): Routes[UpperCtx]
@@ -976,5 +977,60 @@ object Middleware {
           }
           foldResult(result)(logAndTap, h => { logger(s"── Halt ──"); h })
         }
+    }
+
+  def rotateCookie[Session](
+    name: String,
+    validate: String => ZIO[Any, Nothing, Option[Session]],
+    create: Session => ZIO[Any, Nothing, String],
+    maxAge: Option[Long],
+  )(implicit ev: IsNominalType[Session]): Middleware[Any, Session] =
+    new Middleware[Any, Session] {
+      def apply(routes: Routes[Session]): Routes[Any] =
+        Routes.fromIterable(routes.routes.map(secure))
+
+      private def secure(route: Route[Session]): Route[Any] = {
+        val wrapped = Handler.extracted[Any, Any] { (request, context, vars, scope) =>
+          val cleared = Response.unauthorized.addCookie(ResponseCookie(name, "", maxAge = Some(0L)))
+          request.cookies.find(_.name == name) match {
+            case None          => responseAsResult(cleared)
+            case Some(cookie)  =>
+              runSync(validate(cookie.value).catchAllDefect(_ => ZIO.none)) match {
+                case Some(Some(session)) =>
+                  runSync(create(session)) match {
+                    case None           => responseAsResult(cleared)
+                    case Some(newValue) =>
+                      val rotated       = ResponseCookie(name, newValue, maxAge = maxAge)
+                      val result: Any   =
+                        route.handler.handle(request, context.add[Session](session), vars, scope)
+                      result match {
+                        case response: Response       => responseAsResult(response.addCookie(rotated))
+                        case halt: Halt               =>
+                          haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
+                        case Left(response: Response) => responseAsResult(response.addCookie(rotated))
+                        case Right(halt: Halt)        =>
+                          haltAsResult(halt.copy(response = halt.response.addCookie(rotated)))
+                        case _                        => responseAsResult(Response.internalServerError)
+                      }
+                  }
+                case _                   => responseAsResult(cleared)
+              }
+          }
+        }
+        Route(route.pattern, wrapped)
+      }
+    }
+
+  private def runSync[A](effect: ZIO[Any, Nothing, A]): Option[A] =
+    try {
+      val exit = Unsafe.unsafe { implicit unsafe: Unsafe =>
+        Runtime.default.unsafe.run(effect)(Trace.empty, unsafe)
+      }
+      exit match {
+        case Exit.Success(value) => Some(value)
+        case _                   => None
+      }
+    } catch {
+      case scala.util.control.NonFatal(_) => None
     }
 }

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/CookieWireSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/CookieWireSpec.scala
@@ -1,0 +1,296 @@
+package zio.http.h2
+
+import java.io.InputStream
+import java.net.{InetSocketAddress, Socket}
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.experimental
+import scala.collection.mutable
+
+import zio._
+import zio.blocks.chunk.Chunk
+import zio.blocks.context.Context
+import zio.blocks.endpoint.RoutePattern
+import zio.test.TestAspect.sequential
+import zio.test._
+
+import zio.http.h2.H2Frame.{Data, GoAway, Headers, Settings, WindowUpdate}
+import zio.http.h2.hpack.{HeaderField, HpackDecoder, HpackEncoder}
+import zio.http.{
+  BindAddress,
+  BoundAddress,
+  Connector,
+  DefectHandler,
+  Handler,
+  Method,
+  Response,
+  Route,
+  Routes,
+  ServerHandle,
+}
+
+// NOTE: Cookie.Response / Cookie.clear are absent from v4 main sources
+// (grep `Cookie` in zio-http-core + server-loom main sources yields no hits;
+// only docs/dormant v3-era examples reference them and do not compile against
+// v4 core). Header.Custom therefore carries the exact Set-Cookie bytes that
+// Cookie.Response(isSecure = true, isHttpOnly = true, sameSite = Strict) and
+// Cookie.clear would emit, so the H2 wire passthrough is asserted byte-exact.
+@experimental
+object CookieWireSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CookieWireSpec")(
+      test("set-cookie with Secure/HttpOnly/SameSite=Strict survives H2 transport") {
+        withServer(routes) { port =>
+          withClient(port) { client =>
+            for {
+              response <- ZIO.attemptBlocking(
+                client.roundTrip(method = "GET", path = "/set", body = Chunk.empty, streamId = 1),
+              )
+            } yield assertTrue(
+              response.status == 200,
+              response.headerValue("set-cookie").exists(_.contains("Secure")),
+              response.headerValue("set-cookie").exists(_.contains("HttpOnly")),
+              response.headerValue("set-cookie").exists(_.contains("SameSite=Strict")),
+              response.rawHeaderBlock.nonEmpty,
+            )
+          }
+        }
+      },
+      test("clear-cookie yields expired Max-Age=0 set-cookie on H2 wire") {
+        withServer(routes) { port =>
+          withClient(port) { client =>
+            for {
+              response <- ZIO.attemptBlocking(
+                client.roundTrip(method = "GET", path = "/clear", body = Chunk.empty, streamId = 1),
+              )
+            } yield assertTrue(
+              response.status == 200,
+              response.headerValue("set-cookie").exists(_.contains("Max-Age=0")),
+              response.rawHeaderBlock.nonEmpty,
+            )
+          }
+        }
+      },
+    ) @@ sequential
+
+  private val routes: Routes[Any] = Routes(
+    Route(
+      RoutePattern(Method.GET, "/set"),
+      Handler.succeed(
+        Response.ok.addHeader(
+          zio.http.Header.Custom("set-cookie", "session=abc123; Path=/; Secure; HttpOnly; SameSite=Strict"),
+        ),
+      ),
+    ),
+    Route(
+      RoutePattern(Method.GET, "/clear"),
+      Handler.succeed(
+        Response.ok.addHeader(
+          zio.http.Header.Custom(
+            "set-cookie",
+            "session=deleted; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0",
+          ),
+        ),
+      ),
+    ),
+  )
+
+  private def withServer[R](
+    routes: Routes[Any],
+    defectHandler: DefectHandler = DefectHandler.default,
+  )(use: Int => ZIO[R, Throwable, TestResult]): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(startServer(routes, defectHandler)) { handle =>
+        ZIO.succeed(handle.shutdownAndWait())
+      }
+      .flatMap(handle => use(tcpPort(handle)))
+
+  private def withClient[R](
+    port: Int,
+  )(use: RawH2Client => ZIO[R, Throwable, TestResult]): ZIO[R & Scope, Throwable, TestResult] =
+    ZIO
+      .acquireRelease(
+        ZIO.attemptBlocking(new RawH2Client(port)),
+      )(client => ZIO.succeed(client.close()))
+      .flatMap(use)
+
+  private def startServer(
+    routes: Routes[Any],
+    defectHandler: DefectHandler = DefectHandler.default,
+  ): Task[ServerHandle] =
+    ZIO.attempt(
+      ServerHandle.live(
+        List(new H2Transport(routes, Context.empty, Connector(bind = BindAddress.localhost(0)), defectHandler).start()),
+      ),
+    )
+
+  private def tcpPort(handle: ServerHandle): Int =
+    handle.bindings.head.address match {
+      case BoundAddress.Tcp(_, port) => port
+      case other                     => throw new AssertionError("Expected TCP binding but found: " + other)
+    }
+
+  private final case class ReceivedResponse(
+    status: Int,
+    headers: List[HeaderField],
+    body: Chunk[Byte],
+    rawHeaderBlock: Chunk[Byte],
+  ) {
+    def bodyText: String = new String(body.toArray, StandardCharsets.UTF_8)
+
+    def headerValue(name: String): Option[String] =
+      headers.find(_.name.equalsIgnoreCase(name)).map(_.value)
+  }
+
+  private object RawH2Client {
+    private val ClientPreface = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(StandardCharsets.US_ASCII)
+  }
+
+  private final class RawH2Client(port: Int) extends AutoCloseable {
+    import RawH2Client._
+
+    private val socket = new Socket("127.0.0.1", port)
+    socket.setSoTimeout(5000)
+
+    private val input   = new FrameReader(socket.getInputStream)
+    private val output  = socket.getOutputStream
+    private val encoder = new HpackEncoder()
+    private val decoder = new HpackDecoder()
+
+    handshake()
+
+    def roundTrip(method: String, path: String, body: Chunk[Byte], streamId: Int): ReceivedResponse = {
+      sendRequest(method, path, body, streamId)
+      awaitResponse(streamId)
+    }
+
+    def sendRequest(method: String, path: String, body: Chunk[Byte], streamId: Int): Unit = {
+      output.write(FrameCodec.encode(requestHeaders(method, path, body, streamId)).toArray)
+      if (body.nonEmpty) output.write(FrameCodec.encode(Data(streamId, body, endStream = true)).toArray)
+      output.flush()
+    }
+
+    def awaitResponse(streamId: Int): ReceivedResponse =
+      awaitResponses(Set(streamId))(streamId)
+
+    def awaitResponses(streamIds: Set[Int]): Map[Int, ReceivedResponse] = {
+      val builders = mutable.Map.empty[Int, ResponseBuilder]
+      val pending  = mutable.Set.empty[Int] ++ streamIds
+
+      while (pending.nonEmpty) {
+        input.readFrame() match {
+          case Settings(true, _)                                                                  => ()
+          case Settings(false, _)                                                                 =>
+            output.write(FrameCodec.encode(Settings(ack = true, Nil)).toArray)
+            output.flush()
+          case Headers(streamId, headerBlock, endStream, _, _, _) if streamIds.contains(streamId) =>
+            val decoded = decodeHeaders(headerBlock)
+            val builder = builders.getOrElseUpdate(streamId, ResponseBuilder.empty(decoded, headerBlock))
+            builders.update(streamId, builder.withHeaders(decoded, headerBlock))
+            if (endStream) pending -= streamId
+          case Data(streamId, data, endStream, _) if streamIds.contains(streamId)                 =>
+            val builder = builders.getOrElseUpdate(streamId, ResponseBuilder.empty(Nil, Chunk.empty))
+            builders.update(streamId, builder.appendBody(data))
+            if (endStream) pending -= streamId
+          case WindowUpdate(_, _)                                                                 => ()
+          case GoAway(_, errorCode, debugData)                                                    =>
+            val debug = new String(debugData.toArray, StandardCharsets.UTF_8)
+            throw new AssertionError(s"Server sent GOAWAY: error=$errorCode debug=$debug")
+          case other                                                                              =>
+            throw new AssertionError("Unexpected frame while waiting for response: " + other)
+        }
+      }
+
+      streamIds.iterator.map { streamId =>
+        val builder = builders.getOrElse(streamId, throw new AssertionError(s"Missing response for stream $streamId"))
+        streamId -> builder.result
+      }.toMap
+    }
+
+    override def close(): Unit = socket.close()
+
+    private def handshake(): Unit = {
+      output.write(ClientPreface)
+      output.write(FrameCodec.encode(Settings(ack = false, Nil)).toArray)
+      output.flush()
+
+      input.readFrame() match {
+        case Settings(false, _) =>
+          output.write(FrameCodec.encode(Settings(ack = true, Nil)).toArray)
+          output.flush()
+        case other              =>
+          throw new AssertionError("Expected server SETTINGS frame but received: " + other)
+      }
+    }
+
+    private def requestHeaders(method: String, path: String, body: Chunk[Byte], streamId: Int): Headers = {
+      val requestHeaders = List(
+        HeaderField(":method", method),
+        HeaderField(":path", path),
+        HeaderField(":scheme", "http"),
+        HeaderField(":authority", s"127.0.0.1:$port"),
+      ) ++ {
+        if (body.isEmpty) Nil
+        else List(HeaderField("content-length", body.length.toString))
+      }
+
+      Headers(
+        streamId = streamId,
+        headerBlock = encoder.encode(requestHeaders),
+        endStream = body.isEmpty,
+        endHeaders = true,
+      )
+    }
+
+    private def decodeHeaders(headerBlock: Chunk[Byte]): List[HeaderField] =
+      decoder.decode(headerBlock) match {
+        case Right(headers) => headers
+        case Left(error)    => throw new AssertionError("Failed to decode response headers: " + error)
+      }
+  }
+
+  private final case class ResponseBuilder(
+    headers: List[HeaderField],
+    body: Chunk[Byte],
+    rawHeaderBlock: Chunk[Byte],
+  ) {
+    def appendBody(chunk: Chunk[Byte]): ResponseBuilder = copy(body = body ++ chunk)
+
+    def withHeaders(value: List[HeaderField], raw: Chunk[Byte]): ResponseBuilder =
+      copy(headers = value, rawHeaderBlock = raw)
+
+    def result: ReceivedResponse = {
+      val status = headers.find(_.name == ":status").map(_.value.toInt).getOrElse {
+        throw new AssertionError("Missing :status response header")
+      }
+      ReceivedResponse(status = status, headers = headers, body = body, rawHeaderBlock = rawHeaderBlock)
+    }
+  }
+
+  private object ResponseBuilder {
+    def empty(headers: List[HeaderField], rawHeaderBlock: Chunk[Byte]): ResponseBuilder =
+      ResponseBuilder(headers, Chunk.empty, rawHeaderBlock)
+  }
+
+  private final class FrameReader(input: InputStream) {
+    private var buffer = Chunk.empty[Byte]
+
+    def readFrame(): H2Frame = {
+      while (true) {
+        FrameCodec.decode(buffer) match {
+          case Right((decoded, rest))         =>
+            buffer = rest
+            return decoded
+          case Left(H2Error.InsufficientData) =>
+            val chunk = new Array[Byte](8192)
+            val read  = input.read(chunk)
+            if (read < 0) throw new AssertionError("Connection closed before an HTTP/2 frame was fully received")
+            buffer = buffer ++ Chunk.fromArray(java.util.Arrays.copyOf(chunk, read))
+          case Left(error)                    =>
+            throw new AssertionError("Failed to decode HTTP/2 frame: " + error)
+        }
+      }
+      throw new AssertionError("Unreachable HTTP/2 frame read state")
+    }
+  }
+}


### PR DESCRIPTION
Implements plan `zio-http-v4-cookie-session-verify`.

## What
- **test(cookie):** `CookieWireSpec` — proves Secure/HttpOnly/SameSite=Strict + Max-Age=0 clear survive real H2 Loom loopback (decoded headerValue + raw HPACK headerBlock asserts). S1 evidence: prior 2/2 GREEN; on current base the serverLoom suite is blocked by pre-existing clientJava breakage (H2WireClient/PooledH2Connection, H2 team's lane, 0 errors in spec) — transport path re-verified unchanged.
- **Gate (verdict-only, no code):** `Middleware.signCookies` (PR #4210) ABSENT on v4.x main, present only on `middleware-v4-final` — merge precondition recorded, zero duplication.
- **feat(cookie):** `SessionToken.generate: IO[SessionTokenError, String]` — SecureRandom 256-bit, Base64-URL-no-pad (43 chars), JVM-only, replaces 122-bit UUID pattern. SessionTokenSpec 4/4 on 3.8.3 + 2.13.18.
- **feat(cookie):** `Middleware.rotateCookie` — store-free validate/create callbacks, fail-closed clear+401. RotateCookieSpec 4/4 + 13/13 neighbors.
- **docs(cookie):** H2-verified pattern rendered; 4 v3-era examples + signCookies/ZClient.batched/NettyServer claims carry UNPORTED banners (docs not wired to mill — no compile target).

## Scope fidelity
No session store/revocation/JWT/OAuth/H1/H3/OpenAPI. Additive helpers only, no wire-format changes.

Evidence: `.omo/evidence/zio-http-v4-cookie-session-verify/` (tasks 1-6, untracked) + notepad /tmp/ulw-20250907-BgL4IL.md.