### PR TITLE
test(h2): pin mTLS handshake-error failure mode

### DIFF
--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
@@ -191,11 +191,11 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 // must be a TLS-layer abort or a transport close racing it.
                 // Anything else (a test bug, a refusal miscategorized) fails
                 // loudly instead of passing silently.
-                val handshakeErrorExpected = handshakeError.forall {
+                val handshakeErrorExpected   = handshakeError.forall {
                   case _: javax.net.ssl.SSLException => true
-                  case _: java.io.EOFException        => true
-                  case _: java.net.SocketException    => true
-                  case _                              => false
+                  case _: java.io.EOFException       => true
+                  case _: java.net.SocketException   => true
+                  case _                             => false
                 }
                 val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
                 val serverSpokeH2AfterReject =
@@ -269,11 +269,11 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 handshakeError.foreach(err => println(s"mTLS wrong-CA handshake error (expected): $err"))
                 // Same pinning as the no-cert twin: TLS abort or racing
                 // transport close only.
-                val handshakeErrorExpected = handshakeError.forall {
+                val handshakeErrorExpected   = handshakeError.forall {
                   case _: javax.net.ssl.SSLException => true
-                  case _: java.io.EOFException        => true
-                  case _: java.net.SocketException    => true
-                  case _                              => false
+                  case _: java.io.EOFException       => true
+                  case _: java.net.SocketException   => true
+                  case _                             => false
                 }
                 val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
                 val serverSpokeH2AfterReject =

--- a/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
+++ b/zio-http-server-loom/src/test/scala/zio/http/h2/H2ProxyTrustSpec.scala
@@ -187,6 +187,16 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 // to reach the server at all.
                 val handshakeError           = client.handshakeAttempt()
                 handshakeError.foreach(err => println(s"mTLS no-cert handshake error (expected): $err"))
+                // Pin the attacker-visible failure mode: any handshake error
+                // must be a TLS-layer abort or a transport close racing it.
+                // Anything else (a test bug, a refusal miscategorized) fails
+                // loudly instead of passing silently.
+                val handshakeErrorExpected = handshakeError.forall {
+                  case _: javax.net.ssl.SSLException => true
+                  case _: java.io.EOFException        => true
+                  case _: java.net.SocketException    => true
+                  case _                              => false
+                }
                 val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
                 val serverSpokeH2AfterReject =
                   if (refusedBeforeHandshake) true else client.serverProceeds()
@@ -200,6 +210,7 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 val requestDispatched        = handlerHit.get()
                 assertTrue(
                   tcpAcceptedByServer,
+                  handshakeErrorExpected,
                   !refusedBeforeHandshake,
                   !serverSpokeH2AfterReject,
                   serverStillBound,
@@ -256,6 +267,14 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 val tcpAcceptedByServer      = client.tcpConnected
                 val handshakeError           = client.handshakeAttempt()
                 handshakeError.foreach(err => println(s"mTLS wrong-CA handshake error (expected): $err"))
+                // Same pinning as the no-cert twin: TLS abort or racing
+                // transport close only.
+                val handshakeErrorExpected = handshakeError.forall {
+                  case _: javax.net.ssl.SSLException => true
+                  case _: java.io.EOFException        => true
+                  case _: java.net.SocketException    => true
+                  case _                              => false
+                }
                 val refusedBeforeHandshake   = handshakeError.exists(_.isInstanceOf[ConnectException])
                 val serverSpokeH2AfterReject =
                   if (refusedBeforeHandshake) true else client.serverProceeds()
@@ -266,6 +285,7 @@ object H2ProxyTrustSpec extends ZIOSpecDefault {
                 val requestDispatched        = handlerHit.get()
                 assertTrue(
                   tcpAcceptedByServer,
+                  handshakeErrorExpected,
                   !refusedBeforeHandshake,
                   !serverSpokeH2AfterReject,
                   serverStillBound,


### PR DESCRIPTION
Follow-up to #4291 (merged). The mTLS no-cert/wrong-CA cells asserted five named conditions but only printed the server-side handshake error — a wrong-reason failure passed silently.

This pins the attacker-visible mode: any handshake error must be a TLS-layer abort (`SSLException`) or a transport close racing it (`EOFException`/`SocketException`). Anything else fails loudly. No main-code changes; `H2ProxyTrustSpec` only. Follow-up to the adversarial review of #4291.