### PR TITLE
Fix publishing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,6 @@ jobs:
           PUBLISH_SHADED: true
         run: sbt '++ ${{ matrix.scala }}; zioHttpShadedTests/test'
 
-      - name: Compress target directories
-        run: tar cf targets.tar zio-http-datastar-sdk/target sbt-zio-http-grpc/target zio-http-cli/target zio-http-metrics/target target zio-http/jvm/target zio-http-docs/target sbt-zio-http-grpc-tests/target zio-http-stomp/target zio-http-gen/target zio-http-example-datastar-chat/target zio-http-benchmarks/target zio-http-tools/target zio-http-example/target zio-http-testkit/target zio-http/js/target zio-http-htmx/target project/target
-
-      - name: Upload target directories
-        uses: actions/upload-artifact@v7
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.scala }}-${{ matrix.java }}
-          path: targets.tar
-
   publish:
     name: Publish Artifacts
     needs: [build]
@@ -147,36 +138,6 @@ jobs:
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
-
-      - name: Download target directories (2.12.21)
-        uses: actions/download-artifact@v8
-        with:
-          name: target-${{ matrix.os }}-2.12.21-${{ matrix.java }}
-
-      - name: Inflate target directories (2.12.21)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (2.13.18)
-        uses: actions/download-artifact@v8
-        with:
-          name: target-${{ matrix.os }}-2.13.18-${{ matrix.java }}
-
-      - name: Inflate target directories (2.13.18)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3.3.7)
-        uses: actions/download-artifact@v8
-        with:
-          name: target-${{ matrix.os }}-3.3.7-${{ matrix.java }}
-
-      - name: Inflate target directories (3.3.7)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
 
       - uses: coursier/setup-action@v3
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,13 @@ ThisBuild / githubWorkflowAddedJobs :=
     ),
   ) ++ ScoverageWorkFlow(50, 60) ++ JmhBenchmarkWorkflow(1) ++ BenchmarkWorkFlow()
 
+// The publish job runs `ci-release`, which builds what it needs, so it does not
+// need the build jobs' target directories. Passing them through artifacts only
+// made the release fragile: re-running the publish job discards the previous
+// attempt's artifacts, so the download then fails and the release cannot be
+// retried without re-running the whole matrix.
+ThisBuild / githubWorkflowArtifactUpload  := false
+
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches += RefPredicate.StartsWith(Ref.Tag("v"))
 ThisBuild / githubWorkflowPublishPreamble := Seq(coursierSetup)


### PR DESCRIPTION
## The failure

[The v3.11.5 release](https://github.com/zio/zio-http/actions/runs/34545464173) failed in `Publish Artifacts`, on its very first step:

```
Artifact not found for name: target-ubuntu-latest-2.12.21-graal_graalvm@25
```

Nothing was wrong with the build. All nine `Build and Test` jobs passed, and that artifact **was** uploaded successfully (`Artifact ID 101790783`, "successfully uploaded"). Querying that ID now returns `404` — it was deleted while the release was still running.

## What deleted it

`.github/workflows/clean.yml`. It runs **on every push, on every branch**, and deletes **every artifact in the repository**, unconditionally — it pages through `/actions/artifacts` and `DELETE`s each one. It has no idea another workflow run is mid-flight and still needs them.

During the release, four Scala Steward branches were pushed, each firing a `Clean` run:

| time | event |
|---|---|
| 00:21:58 | release uploads `target-…-2.12.21-graal_graalvm@25` |
| 00:25:23 – 00:26:11 | **four `Clean` runs** delete all repository artifacts |
| 00:35–00:41 | three later build jobs upload theirs (after the last Clean) |
| 00:49:58 | publish looks for the 00:21:58 artifact — gone |

Of the nine artifacts, exactly the three uploaded after 00:26:11 survived. The two the publish job still needed were among the six destroyed.

So any push to any branch during a release can break that release. With Scala Steward opening PRs on a schedule, that is not a rare window.

## The fix

The publish job never needed those targets. It runs `ci-release`, which builds whatever it requires from a clean checkout, so passing `target/` directories between jobs was only ever a build cache — one that costs a ~39-line upload/download dance and makes releases hostage to unrelated pushes.

`ThisBuild / githubWorkflowArtifactUpload := false` drops it. The publish job becomes checkout → setup JDK/sbt → `ci-release`, which is how the rest of our libraries publish.

The generated diff is pure deletion:

- build jobs lose `Compress target directories` / `Upload target directories`
- the publish job loses three `Download target directories` / `Inflate target directories` pairs

## Trade-off

The publish job no longer starts from the build jobs' compiled output, so it compiles from scratch. That costs time on release only, in exchange for a release that cannot be broken by someone else pushing a branch.

## Follow-up worth considering (not in this PR)

`clean.yml` still deletes every artifact in the repo on every push. After this change the only remaining artifacts are the JMH benchmark ones, which are uploaded and then downloaded for comparison — so the same race can presumably break a benchmark run. Either scoping the cleanup to old artifacts or dropping the workflow (`githubWorkflowIncludeClean := false`) looks worth doing separately.

## Verification

- `githubWorkflowGenerate` produces the committed `ci.yml`
- `githubWorkflowCheck` passes, so the "Check that workflows are up to date" step in every build job stays green
