### PR TITLE
build(scala): upgrade v4 to Scala 3.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ['2.13.18', '3.8.3']
+        scala: ['2.13.18', '3.9.0']
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/build.mill
+++ b/build.mill
@@ -12,7 +12,7 @@ import mill.util.VcsVersion
 
 object Versions {
   val Scala213              = "2.13.18"
-  val Scala3                = "3.8.3"
+  val Scala3                = "3.9.0"
   val ScalaJS               = "1.20.2"
   val Zio                   = "2.1.24"
   val ZioSchema             = "1.8.3"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,5 +32,5 @@ Run the currently configured JVM test suites with:
 
 ```shell
 ./mill core.jvm[2.13.18].test
-./mill core.jvm[3.8.3].test
+./mill core.jvm[3.9.0].test
 ```

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/PathVarHandlerBindingSpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/PathVarHandlerBindingSpec.scala
@@ -269,7 +269,7 @@ pattern -> handler((wrongName: Int) => Response.text("x"))
  * Drives the REAL `dotc` compiler (out-of-process, `-Werror` = the Scala 3
  * spelling of `-Xfatal-warnings`) against a scratch snippet, using this test
  * JVM's own `java.class.path` (the exact classpath mill resolved for
- * `core.jvm[3.8.3].test`) plus the Scala 3 compiler's own jars (located under
+ * `core.jvm[3.9.0].test`) plus the Scala 3 compiler's own jars (located under
  * the same coursier cache the running JVM's `scala-library` jar came from).
  * This proves the unused-PathVar warning is a REAL compiler diagnostic
  * participating in a warnings-as-errors build (Todo 6's deliverable 3) - not an

--- a/zio-http-core/jvm/src/test/scala-3/zio/http/RouteArrowOverloadSafetySpec.scala
+++ b/zio-http-core/jvm/src/test/scala-3/zio/http/RouteArrowOverloadSafetySpec.scala
@@ -96,7 +96,7 @@ object RouteArrowOverloadSafetySpec extends ZIOSpecDefault {
         // finding (the plan's draft wording assumed the latter): the safety net still holds (the
         // compile still fails immediately, with no silent misparse or wrong-behavior compile),
         // but the exact message names `Handler`, not `Route`. Verified via a real
-        // `core.jvm[3.8.3].test.compile` run (not just this typeCheck) - see notepad.
+        // `core.jvm[3.9.0].test.compile` run (not just this typeCheck) - see notepad.
         assertZIO(typeCheck {
           """import zio.blocks.endpoint.PathCodec._
 import zio.blocks.endpoint.RoutePattern.{MethodSyntax, RoutePatternOps}

--- a/zio-http-stomp/README.md
+++ b/zio-http-stomp/README.md
@@ -238,7 +238,7 @@ The module includes comprehensive tests for:
 Run the currently configured mill test suites from the repository root with:
 ```bash
 ./mill core.jvm[2.13.18].test
-./mill core.jvm[3.8.3].test
+./mill core.jvm[3.9.0].test
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Wave 0 baseline (UP-1): makes Scala **3.9.0** the authoritative Scala 3 version for the v4 Mill build while keeping **2.13.18** as the compatibility target. No protocol implementation is included — this is build/CI/docs metadata only, so later protocol waves have a stable baseline to build on.

This transplants the two green Wave 0 commits proven in fork PR 987Nabil/zio-http#2 onto the current upstream `v4.x` head (`df2bee45`, #4300). The only delta since the fork baseline was #4300 (H2ProxyTrustSpec, test-only, disjoint files), so the rebase is conflict-free and content-identical.

## Changes (6 files, one-line version pins each)

- `build.mill`: `Versions.Scala3` `3.8.3` -> `3.9.0`
- `.github/workflows/ci.yml`: `testJvm` matrix `3.8.3` -> `3.9.0`
- `docs/installation.md`, `zio-http-stomp/README.md`: mill example commands retargeted at `core.jvm[3.9.0]`
- `PathVarHandlerBindingSpec.scala`, `RouteArrowOverloadSafetySpec.scala` (scala-3 comments): version references updated

Zero `3.8.3` occurrences remain anywhere in the repo (excluding build output).

## Verification (re-ran after rebase onto `df2bee45`, workspace `zio-http-up1-wave0`)

- `mill mill.scalalib.scalafmt/checkFormatAll` — SUCCESS (503 sources)
- `mill testEngine --scalaVersion 3.9.0` — **1281/1281 SUCCESS**, exit 0
- `mill serverLoom.jvm[2.13.18].test.compile` — SUCCESS, exit 0
- `mill core.jvm[3.9.0].publishArtifacts serverLoom.jvm[3.9.0].publishArtifacts` (snapshot/publish dry-run, no credentials needed) — SUCCESS, exit 0
- `./build.sh` website build — SUCCESS (`[SUCCESS] Generated static files`, exit 0)
- Both commits GPG-signed (EDDSA, Good signature)

## Dependencies

None. This is UP-1 with no prerequisites. Follow-up protocol waves (UP-2..UP-7) will be opened strictly sequentially only after this wave merges, each rebased onto the then-current `v4.x` head.