### PR TITLE
fix(testkit): fail TestChannel send after shutdown

### DIFF
--- a/zio-http-testkit/src/main/scala/zio/http/TestChannel.scala
+++ b/zio-http-testkit/src/main/scala/zio/http/TestChannel.scala
@@ -1,5 +1,7 @@
 package zio.http
 
+import java.nio.channels.ClosedChannelException
+
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -27,10 +29,16 @@ case class TestChannel(
     loop
   }
   def send(in: WebSocketChannelEvent)(implicit trace: Trace): Task[Unit]              =
-    out.offer(in).unit
+    whenOpen(out.offer(in).unit)
   def sendAll(in: Iterable[WebSocketChannelEvent])(implicit trace: Trace): Task[Unit] =
-    out.offerAll(in).unit
-  def shutdown(implicit trace: Trace): UIO[Unit]                                      =
+    whenOpen(out.offerAll(in).unit)
+
+  private def whenOpen[A](zio: => Task[A])(implicit trace: Trace): Task[A] =
+    promise.isDone.flatMap {
+      case true  => ZIO.fail(new ClosedChannelException)
+      case false => zio
+    }
+  def shutdown(implicit trace: Trace): UIO[Unit]                           =
     in.offer(ChannelEvent.Unregistered) *>
       out.offer(ChannelEvent.Unregistered) *>
       promise.succeed(()).unit

--- a/zio-http-testkit/src/test/scala/zio/http/TestChannelSpec.scala
+++ b/zio-http-testkit/src/test/scala/zio/http/TestChannelSpec.scala
@@ -1,0 +1,42 @@
+package zio.http
+
+import java.nio.channels.ClosedChannelException
+
+import zio._
+import zio.test._
+
+import zio.http.ChannelEvent.Read
+
+object TestChannelSpec extends ZIOHttpSpec {
+
+  def spec =
+    suite("TestChannel")(
+      test("send fails after shutdown") {
+        for {
+          in      <- Queue.unbounded[WebSocketChannelEvent]
+          out     <- Queue.unbounded[WebSocketChannelEvent]
+          promise <- Promise.make[Nothing, Unit]
+          channel <- TestChannel.make(in, out, promise)
+          _       <- channel.shutdown
+          result  <- channel.send(Read(WebSocketFrame.text("after shutdown"))).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.isInstanceOf[ClosedChannelException]),
+        )
+      },
+      test("sendAll fails after shutdown") {
+        for {
+          in      <- Queue.unbounded[WebSocketChannelEvent]
+          out     <- Queue.unbounded[WebSocketChannelEvent]
+          promise <- Promise.make[Nothing, Unit]
+          channel <- TestChannel.make(in, out, promise)
+          _       <- channel.shutdown
+          result  <- channel.sendAll(Iterable(Read(WebSocketFrame.text("after shutdown")))).either
+        } yield assertTrue(
+          result.isLeft,
+          result.left.exists(_.isInstanceOf[ClosedChannelException]),
+        )
+      },
+    )
+
+}


### PR DESCRIPTION
## Summary

- `TestChannel.send` and `sendAll` now fail with `ClosedChannelException` after `shutdown` completes (via the existing shutdown `promise`), instead of always succeeding through `Queue#offer`.
- Adds `TestChannelSpec` covering post-shutdown `send` and `sendAll`.

Fixes #4222

## Test plan

- [x] `sbt "zioHttpTestkit/testOnly zio.http.TestChannelSpec"` (Java 21)
- [x] `sbt zioHttpTestkit/scalafmt`