### PR TITLE
Fix unbounded memory use in StreamingForm for streamed multipart parts

### DIFF
--- a/zio-http/jvm/src/test/scala/zio/http/FormSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/FormSpec.scala
@@ -403,6 +403,52 @@ object FormSpec extends ZIOHttpSpec {
           assertTrue(s.contains(content))
         }
       },
+      test("streaming a large binary part without line breaks") {
+        // Regression test for #4283: the whole part used to be accumulated by the parser
+        val N        = 16 * 1024 * 1024
+        val boundary = Boundary("X-INSOMNIA-BOUNDARY")
+        val form     = Form(
+          FormField.streamingBinaryField(
+            name = "file",
+            data = ZStream.repeat(1.toByte).rechunk(64 * 1024).take(N.toLong),
+            mediaType = MediaType.application.`octet-stream`,
+            filename = Some("file.bin"),
+          ),
+          FormField.Simple("after", "the file"),
+        )
+        val fields   = StreamingForm(form.multipartBytes(boundary).rechunk(64 * 1024), boundary).fields
+        fields.mapZIO {
+          case sb: FormField.StreamingBinary =>
+            sb.data.runFold((0L, true)) { case ((count, allOnes), b) => (count + 1, allOnes && b == 1) }.map {
+              case (count, allOnes) => (sb.name, count, allOnes)
+            }
+          case other                         => ZIO.succeed((other.name, 0L, true))
+        }.runCollect.map { collected =>
+          assertTrue(collected == Chunk(("file", N.toLong, true), ("after", 0L, true)))
+        }
+      } @@ timeout(60.seconds),
+      test("streaming a binary part whose lines look like boundaries") {
+        val boundary = Boundary("X-INSOMNIA-BOUNDARY")
+        // strict prefixes of the delimiter, dashes and bare CRs are all legal content
+        val line     = "--X-INSOMNIA-BOUNDAR\r\n-\r\n--\r\n\r\n\r--X-INSOMNI\r\n--"
+        val bytes    = Chunk.fromArray(Array.fill(200)(line).mkString.getBytes(StandardCharsets.UTF_8))
+        val form     = Form(
+          FormField.binaryField("file", bytes, MediaType.application.`octet-stream`),
+          FormField.Simple("after", "the file"),
+        )
+        check(Gen.int(1, 4096)) { chunkSize =>
+          val stream = form.multipartBytes(boundary).rechunk(chunkSize)
+          for {
+            streamed  <- StreamingForm(stream, boundary).fields.mapZIO(_.asChunk).runCollect
+            collected <- StreamingForm(stream, boundary).collectAll
+          } yield assertTrue(
+            streamed.size == 2,
+            streamed(0) == bytes,
+            collected.get("file").get.asInstanceOf[FormField.Binary].data == bytes,
+            collected.get("after").get.stringValue.contains("the file"),
+          )
+        }
+      } @@ samples(10),
     ) @@ sequential
 
   def spec =

--- a/zio-http/jvm/src/test/scala/zio/http/internal/FormStateSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/internal/FormStateSpec.scala
@@ -38,7 +38,40 @@ object FormStateSpec extends ZIOHttpSpec {
                          |${CR}
                          |... contents of file1.txt ...${CR}
                          |--AaB03x--${CR}""".stripMargin.getBytes(StandardCharsets.UTF_8)
-  def spec         = suite("FormStateSpec")(
+  private val CRLF = s"$CR\n"
+
+  private val partHeaders =
+    s"""Content-Disposition: form-data; name="file"; filename="file.bin"$CRLF""" +
+      s"Content-Type: application/octet-stream$CRLF" +
+      CRLF
+
+  /**
+   * Feeds `bytes` to `state` one by one, returning the last state. Stops early
+   * if a boundary state is reached.
+   */
+  private def feed(state: FormState, bytes: Array[Byte]): FormState = {
+    var current = state
+    var i       = 0
+    while (i < bytes.length) {
+      current match {
+        case buffer: FormState.FormStateBuffer =>
+          current = buffer.append(bytes(i))
+          i += 1
+        case _                                 =>
+          i = bytes.length
+      }
+    }
+    current
+  }
+
+  private def bytesOf(s: String): Array[Byte] = s.getBytes(StandardCharsets.UTF_8)
+
+  private def contentNodes(tree: Chunk[FormAST]): Int = tree.count {
+    case FormAST.Content(_) | FormAST.EoL => true
+    case _                                => false
+  }
+
+  def spec = suite("FormStateSpec")(
     test("FormStateAccum") {
 
       val lastByte = Some('\r')
@@ -56,6 +89,68 @@ object FormStateSpec extends ZIOHttpSpec {
         boundary.isClosing(end),
       )
     },
+    suite("ignoring contents (#4283)")(
+      test("content lines are recorded in the tree by default") {
+        val boundary = Boundary("AaB03x")
+        val state    = new FormState.FormStateBuffer(boundary)
+        val headers  = feed(state, bytesOf(partHeaders))
+        val before   = state.tree
+        val after    = feed(state, bytesOf(s"line 1${CRLF}line 2${CRLF}line 3$CRLF"))
+        assertTrue(
+          headers eq state,
+          after eq state,
+          state.phase == FormState.Phase.Part2,
+          // three content lines, each followed by an EoL node
+          contentNodes(state.tree) == contentNodes(before) + 6,
+        )
+      },
+      test("content lines are not recorded in the tree once contents are ignored") {
+        val boundary = Boundary("AaB03x")
+        val state    = new FormState.FormStateBuffer(boundary)
+        feed(state, bytesOf(partHeaders))
+        val before   = state.tree
+        state.startIgnoringContents
+        val lines    = Array.fill(10000)(s"payload line$CRLF").mkString
+        val after    = feed(state, bytesOf(lines))
+        val closed   = feed(state, bytesOf(s"--AaB03x--"))
+        assertTrue(
+          after eq state,
+          state.tree == before,
+          closed == FormState.BoundaryClosed(before),
+        )
+      },
+      test("a content line without line breaks is not buffered once contents are ignored") {
+        val boundary     = Boundary("AaB03x")
+        val state        = new FormState.FormStateBuffer(boundary)
+        feed(state, bytesOf(partHeaders))
+        val before       = state.tree
+        state.startIgnoringContents
+        val after        = feed(state, Array.fill[Byte](1024 * 1024)('x'))
+        val buffered     = state.bufferedBytes
+        // a line that starts like the closing boundary but is longer is still content
+        val lookalike    = feed(state, bytesOf(s"$CRLF--AaB03xyz$CRLF"))
+        val encapsulated = feed(state, bytesOf(s"--AaB03x$CRLF"))
+        assertTrue(
+          after eq state,
+          buffered <= boundary.closingBoundaryBytes.size + 1,
+          lookalike eq state,
+          state.tree == before,
+          encapsulated == FormState.BoundaryEncapsulated(before),
+        )
+      },
+      test("reset re-enables recording of contents") {
+        val boundary = Boundary("AaB03x")
+        val state    = new FormState.FormStateBuffer(boundary)
+        feed(state, bytesOf(partHeaders))
+        state.startIgnoringContents
+        feed(state, bytesOf(s"dropped$CRLF"))
+        state.reset()
+        feed(state, bytesOf(partHeaders))
+        val before   = state.tree
+        feed(state, bytesOf(s"kept$CRLF"))
+        assertTrue(contentNodes(state.tree) == contentNodes(before) + 2)
+      },
+    ),
   )
 
 }

--- a/zio-http/shared/src/main/scala/zio/http/StreamingForm.scala
+++ b/zio-http/shared/src/main/scala/zio/http/StreamingForm.scala
@@ -107,6 +107,10 @@ final case class StreamingForm(source: ZStream[Any, Throwable, Byte], boundary: 
                                 .incomingStreamingBinary(newFormState.tree, newQueue)
                                 .mapError(_.asException)
                               _ = state.withCurrentQueue(newQueue)
+                              // The content of this part is forwarded through `buffer` and `newQueue`, so the
+                              // state machine only has to keep detecting boundaries. Without this it would also
+                              // accumulate the whole part in memory (#4283).
+                              _ = newFormState.startIgnoringContents
                             } yield Some(streamingFormData)
                           }.getOrThrowFiberFailure()
                         } else {

--- a/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
+++ b/zio-http/shared/src/main/scala/zio/http/internal/FormState.scala
@@ -91,7 +91,7 @@ private[http] object FormState {
         ast match {
           case content: Content         =>
             flush(content)
-            addToTree(EoL) // preserving EoL for multiline content
+            if (!dropContents) addToTree(EoL) // preserving EoL for multiline content
             self
           case EncapsulatingBoundary(_) => BoundaryEncapsulated(tree)
           case ClosingBoundary(_)       => BoundaryClosed(tree)
@@ -99,8 +99,13 @@ private[http] object FormState {
       } else {
         if (!lastByte.isEmpty) {
           if (isBufferEmpty) isBufferEmpty = false
-          buffer += lastByte.get
-          bufferSize += 1
+          // While contents are dropped, only the first bytes of a line are needed to tell a boundary delimiter
+          // from content: a line longer than the closing boundary can never be one. Not buffering past that point
+          // keeps memory bounded for arbitrarily large (e.g. newline-free) binary parts (#4283).
+          if (!dropContents || bufferSize <= closingBoundaryBytesSize) {
+            buffer += lastByte.get
+            bufferSize += 1
+          }
         }
         lastByte = OptionalByte.Some(byte)
         self
@@ -108,10 +113,21 @@ private[http] object FormState {
 
     }
 
+    /**
+     * Stops recording the content of the current part in the tree. Boundaries
+     * and headers are still tracked, but content lines are neither kept in the
+     * tree nor buffered beyond what boundary detection needs. Use this when the
+     * content is consumed elsewhere (e.g. streamed to the user) so that the
+     * memory used by the state machine stays bounded regardless of the part's
+     * size.
+     */
     def startIgnoringContents: FormStateBuffer = {
       if (!dropContents) dropContents = true
       self
     }
+
+    /** Number of bytes currently buffered for the line being parsed. */
+    private[http] def bufferedBytes: Int = bufferSize
 
     def reset(): Unit = {
       tree0.clear()


### PR DESCRIPTION
Fixes #4283

## Problem

With `RequestStreaming.Enabled`, `request.body.asMultipartFormStream` is meant to let a handler stream a multipart upload of arbitrary size. In practice the server ran out of heap after ~3.8 GB of a 5 GB upload (see the issue). The bug is independent of Netty: it reproduces with `StreamingForm(bytes, boundary).fields` fed from an in-memory stream.

`StreamingForm` drives two structures for every byte of a part:

- `StreamingForm.Buffer`, which forwards the part's content to the `FormField.StreamingBinary` stream, and
- `FormState.FormStateBuffer`, the parser state machine that finds part headers and boundary lines.

The state machine keeps the whole current *line* in a `ChunkBuilder[Byte]` and, at every CRLF, appends a `Content` and an `EoL` node to its AST. For a streamed binary part that work is redundant, and it is unbounded: a binary payload with no CRLF is one multi-gigabyte "line", and a payload with many CRLFs grows the AST instead. `FormStateBuffer.startIgnoringContents` was added for exactly this purpose in #2062 but has never been called from anywhere, so every streamed part was also accumulated in full by the parser.

## Fix

- `StreamingForm`: call `startIgnoringContents` on the state machine as soon as a part is set up for streaming (`state.withCurrentQueue`), for both `fields` and `collectAll`. The part's bytes are already forwarded through `Buffer`/the queue; the state machine only has to keep detecting boundaries.
- `FormState.FormStateBuffer`, while contents are ignored:
  - stop buffering a line once it is longer than the closing boundary (`--boundary--`). Such a line can never be a boundary, so `makePart2` still classifies it as `Content` and boundary detection is unaffected. This also keeps `bufferSize` from overflowing `Int` on lines longer than 2 GiB.
  - do not record `EoL` nodes for dropped content lines (previously `Content` nodes were skipped but `EoL` was still appended for each line).

Behaviour for non-streamed parts (text fields, `Form.fromMultipartBytes`) is unchanged: `dropContents` is `false` there and is reset per part by `reset()`.

## Measurements

Pure-parser reproduction: a single `application/octet-stream` part streamed through `StreamingForm.fields`, JVM started with `-Xmx256m -XX:+ExitOnOutOfMemoryError`, 1 GiB payload.

| build | payload | result |
| --- | --- | --- |
| zio-http 3.11.4 (Maven) | 1 GiB, no CRLF | `OutOfMemoryError: Java heap space` |
| `main` @ 19030e7d | 1 GiB, no CRLF | `OutOfMemoryError: Java heap space` |
| `main` @ 19030e7d | 1 GiB, CRLF every 64 bytes | `OutOfMemoryError: Java heap space` |
| this branch | 1 GiB, no CRLF | parsed all 1073741824 bytes in 256 MiB heap |
| this branch | 1 GiB, CRLF every 64 bytes | parsed all 1073741824 bytes in 256 MiB heap |

## Tests

- `FormStateSpec`: new suite `ignoring contents (#4283)` — content lines are recorded by default; once ignored, neither the AST nor the line buffer grows (a 1 MiB CRLF-free line leaves at most `closingBoundary.size + 1` bytes buffered), closing/encapsulating boundaries and boundary look-alikes are still classified correctly, and `reset()` restores recording. The "line buffer" test needs the new package-private `FormStateBuffer.bufferedBytes` accessor; the other tests only use the existing API. The buffer and AST assertions fail on `main`.
- `FormSpec`: streams a 16 MiB CRLF-free part through `fields` and checks every byte arrives (this used to work only because the test heap is large), and round-trips a part whose lines are strict prefixes of the delimiter, dashes and bare CRs, across random chunk sizes, through both `fields` and `collectAll`.
- `sbt zioHttpJVM/test` (Scala 2.13): 1707 passed, 40 failed, 4 ignored. The 40 failures are all in ten suites that bind the default port 8080 (`Server.default` / `Server.Config.default` / hard-coded `localhost:8080`: `AuthSpec`, `ForwardHeaderSpec`, `MethodAnyHeadSpec`, `ServerSpec`, `ServerRuntimeSpec`, `ServerErrorLoggingSpec`, `security.*`), which is occupied by another process on my machine; they fail identically (same 40 tests, `bind(..) failed: Address already in use`) on unpatched `main`, so I am relying on CI for those.
- `zioHttpJVM/Test/compile` passes on Scala 2.12.21, 2.13.18 and 3.3.7 with `-Xfatal-warnings` (`CI=true`).
- `sbt ++2.13.18 fmtCheck` (scalafmt + scalafix OrganizeImports, as in CI) passes locally.

## Notes / out of scope

- Throughput of the byte-at-a-time parser is unchanged (~11 MB/s for CRLF-free data on my machine); this PR only fixes the memory growth.
- `StreamingForm.Buffer` in `fields` mode only flushes at a chunk end whose last byte is not `-` and does not look like the start of a delimiter. A part consisting entirely of `-` bytes would therefore still be buffered until its boundary. That is a separate, far narrower edge and I left it alone here.
- Text (non-binary) parts are always materialised, as required by `FormField.Text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
