### PR TITLE
Force request handlers to be interruptible regardless of Server-layer build context

### DIFF
--- a/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
+++ b/zio-http/jvm/src/main/scala/zio/http/netty/server/package.scala
@@ -30,7 +30,18 @@ package object server {
     val empty: UIO[RoutesRef] = {
       implicit val trace: Trace = Trace.empty
       // Environment will be populated when we `install` the app
-      ZIO.runtime[Any].map(rt => new AtomicReference((Routes.empty, rt.mapEnvironment(_ => ZEnvironment.empty))))
+      ZIO.runtime[Any].map { rt =>
+        // Request handlers are forked from this runtime (see `NettyRuntime.run`), and its runtime
+        // flags are captured here, at layer-build time, then preserved by `NettyDriver.addApp`.
+        // The `Interruption` flag must be forced on: if the `Server` layer happens to be built in
+        // an uninterruptible region (e.g. from zio-test's `beforeAll`, which runs as an
+        // `acquireRelease` acquire), every handler would otherwise inherit `Interruption = off` and
+        // could never be interrupted. That silently defeats `NettyRuntime.closeListener`, which
+        // interrupts the handler when the connection closes, so an in-flight handler keeps the
+        // connection (and graceful shutdown) alive forever (#4240).
+        val flags = RuntimeFlags.enable(rt.runtimeFlags)(RuntimeFlag.Interruption)
+        new AtomicReference((Routes.empty, Runtime(ZEnvironment.empty, rt.fiberRefs, flags)))
+      }
     }
   }
 

--- a/zio-http/jvm/src/test/scala/zio/http/ServerRuntimeSpec.scala
+++ b/zio-http/jvm/src/test/scala/zio/http/ServerRuntimeSpec.scala
@@ -115,7 +115,27 @@ object ServerRuntimeSpec extends RoutesRunnableSpec {
             .zipRight(routes.deploy.body.run(path = Path.root / "test", method = Method.GET))
             .flatMap(_.asString(Charsets.Utf8))
             .map(b => assertTrue(b == "ok")) *> ref.get.map { v => assertTrue(v == 1) }
-        } @@ TestAspect.flaky
+        } @@ TestAspect.flaky +
+        test("handlers are interruptible even when the Server layer is built uninterruptibly (#4240)") {
+          // The runtime used to fork request handlers is captured at Server-layer build time. If the
+          // layer is built inside an uninterruptible region (e.g. zio-test's `beforeAll`, which runs
+          // as an `acquireRelease` acquire), handlers must still be interruptible, otherwise
+          // `NettyRuntime` can never cancel them on connection close.
+          val routes      = Routes(
+            Method.GET / "check" -> handler(ZIO.checkInterruptible(s => ZIO.succeed(Response.text(s.toString)))),
+          )
+          val serverLayer = ZLayer.succeed(Server.Config.default.onAnyOpenPort) >>> Server.live
+          ZIO.scoped {
+            for {
+              env  <- ZIO.uninterruptible(serverLayer.build)
+              port <- Server.installRoutes(routes).provideEnvironment(env)
+              body <- Client
+                .batched(Request.get(s"http://localhost:$port/check"))
+                .flatMap(_.body.asString(Charsets.Utf8))
+                .provide(Client.default)
+            } yield assertTrue(body == "Interruptible")
+          }
+        }
     }
       .provide(
         Scope.default,


### PR DESCRIPTION
Fixes #4240

## Problem

The `Runtime` used to fork request handlers is captured **once, at `Server`-layer build time**, in `AppRef.empty`:

```scala
ZIO.runtime[Any].map(rt => new AtomicReference((Routes.empty, rt.mapEnvironment(_ => ZEnvironment.empty))))
```

`ZIO.runtime[Any]` snapshots the *calling fiber's* runtime flags, and `NettyDriver.addApp` then preserves them verbatim (`Runtime(updatedEnv, updatedFibRefs, oldRt.runtimeFlags)`). `NettyRuntime.run` forks every handler from that runtime.

So if the `Server` layer is built inside an **uninterruptible** region, every handler inherits `Interruption = off`. The easiest way to land there by accident is zio-test's `TestAspect.beforeAll`, which runs its effect as an `acquireRelease` acquire — a very common place to start a server for an E2E suite. Consequences:

- `NettyRuntime.closeListener` interrupts the handler when the connection closes — a **no-op** on an uninterruptible fiber, so a handler blocked in `race`/`timeout`/`ZIO.never` is never cancelled;
- the in-flight request count never drops, so the server's shutdown finalizer waits on the blocked handler forever and the JVM never exits.

This was reported as a question (is the inheritance intended?). Inheriting fiber refs (loggers, environment) at build time is sensible; inheriting the *interruption* flag is not — interruptibility of a forked server handler should be a property of the server, and the transport layer depends on it.

## Fix

Force the `Interruption` runtime flag on when capturing the handler-forking runtime in `AppRef.empty`:

```scala
val flags = RuntimeFlags.enable(rt.runtimeFlags)(RuntimeFlag.Interruption)
new AtomicReference((Routes.empty, Runtime(ZEnvironment.empty, rt.fiberRefs, flags)))
```

`addApp` preserves these flags, so the normalization propagates to every installed app. All other flags and all fiber refs are still inherited; only interruption is pinned. In the normal (interruptible) build path the flag is already on, so this is a no-op.

## Tests

- `ServerRuntimeSpec`: new test *"handlers are interruptible even when the Server layer is built uninterruptibly (#4240)"* — builds the `Server` layer inside `ZIO.uninterruptible`, installs a route that reports `ZIO.checkInterruptible`, and asserts the handler runs `Interruptible`. Fails on `main` (`Uninterruptible`), passes with the fix.
- The existing *"runtime flags are propagated"* test still holds: I verified out-of-band that with an interruptible build the handler's full runtime-flag set is byte-identical to the outer fiber's before and after this change (`161 == 161`), i.e. the fix changes nothing on the normal path.

## Notes / out of scope

- The client driver's runtime (`NettyRuntime.live`) captures flags the same way and has the same latent behavior, but it is not part of the reported issue; I left it alone. Happy to normalize it too in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
